### PR TITLE
[automate-2700] stabilize team_mgmt cypress tests

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -60,6 +60,7 @@
         </div>
         <div class="dropdown-margin" *ngIf="objectNoun !== 'project'">
           <app-projects-dropdown
+            [checkedProjectIDs]="checkedProjectIDs"
             (onDropdownClosing)="onProjectDropdownClosing($event)"
             [projectsUpdated]="projectsUpdatedEvent">
           </app-projects-dropdown>

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -32,6 +32,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   @Output() createClicked = new EventEmitter<Project[]>();
 
   public projects: ProjectCheckedMap = {};
+  public checkedProjectIDs: string[] = []; // resets project dropdown btwn modal openings
   public policies: PolicyChecked[] = [];
   public modifyID = false; // Whether the edit ID form is open or not.
   public conflictError = false;
@@ -110,11 +111,13 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
 
   closeEvent(): void {
     this.modifyID = false;
+    this.checkedProjectIDs = [];
     this.close.emit();
   }
 
   createObject(): void {
     this.createClicked.emit();
+    this.checkedProjectIDs = [];
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
@@ -117,12 +117,29 @@ describe('team management', () => {
       cy.contains(customTeamID).should('exist');
     });
 
+    it('fails to create a team with a duplicate ID', () => {
+      cy.get('[data-cy=team-create-button]').contains('Create Team').click();
+      cy.get('app-team-management chef-modal').should('exist');
+
+      cy.get('[data-cy=create-name]').type(teamName);
+
+      cy.get('[data-cy=id-label]').contains(generatedTeamID);
+
+      cy.get('[data-cy=save-button]').click();
+      cy.get('app-team-management chef-modal chef-error').contains('already exists')
+        .should('be.visible');
+
+      // here we exit with the chef-modal exit button in the top right corner
+      cy.get('app-team-management chef-modal chef-button.close').first().click();
+    });
+
     it('can cancel creating a team', () => {
       cy.get('[data-cy=team-create-button]').contains('Create Team').click();
       cy.get('app-team-management chef-modal').should('exist');
 
       cy.get('chef-button').contains('Cancel').should('be.visible').click();
 
+      // here we exit with the Cancel button
       cy.get('app-team-management chef-modal').should('not.be.visible');
     });
 

--- a/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
@@ -117,6 +117,15 @@ describe('team management', () => {
       cy.contains(customTeamID).should('exist');
     });
 
+    it('can cancel creating a team', () => {
+      cy.get('[data-cy=team-create-button]').contains('Create Team').click();
+      cy.get('app-team-management chef-modal').should('exist');
+
+      cy.get('chef-button').contains('Cancel').should('be.visible').click();
+
+      cy.get('app-team-management chef-modal').should('not.be.visible');
+    });
+
 
     context('when only the unassigned project is selected', () => {
       beforeEach(() => {

--- a/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
@@ -62,7 +62,7 @@ describe('team management', () => {
 
   describe('teams list page', () => {
     const dropdownNameUntilEllipsisLen = 25;
-    const projectDropdown = 'app-team-management app-projects-dropdown ';
+    const projectDropdownPrefix = 'app-team-management app-projects-dropdown';
 
     it('lists system teams', () => {
       cy.get('[data-cy=team-create-button]').contains('Create Team');
@@ -157,9 +157,9 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(unassignedTeam1ID);
 
         // initial state of dropdown
-        cy.get(projectDropdown + '#resources-selected')
+        cy.get(`${projectDropdownPrefix} #resources-selected`)
           .contains(unassigned);
-        cy.get(projectDropdown + '.dropdown-button')
+        cy.get(`${projectDropdownPrefix} .dropdown-button`)
           .should('have.attr', 'disabled');
 
         // save team
@@ -188,21 +188,21 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(teamIDWithSomeProjects);
 
         // initial state of dropdown
-        cy.get(projectDropdown + '#resources-selected').contains(unassigned);
-        cy.get(projectDropdown + '.dropdown-button').should('not.have.attr', 'disabled');
+        cy.get(`${projectDropdownPrefix} #resources-selected`).contains(unassigned);
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get(projectDropdown + '.dropdown-button').click();
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).click();
 
         // dropdown contains both custom projects, click them both
-        cy.get(projectDropdown + `chef-checkbox[title="${project1Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project1Name}"]`)
           .should('have.attr', 'aria-checked', 'false').click();
-        cy.get(projectDropdown + `chef-checkbox[title="${project2Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project2Name}"]`)
           .should('have.attr', 'aria-checked', 'false').click();
 
         // close projects dropdown
-        cy.get(projectDropdown + '.dropdown-button').click();
-        cy.get(projectDropdown + '#resources-selected')
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).click();
+        cy.get(`${projectDropdownPrefix} #resources-selected`)
           .contains(projectSummary);
 
         // save team
@@ -223,21 +223,21 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(teamIDWithOneProject);
 
         // initial state of dropdown
-        cy.get(projectDropdown + '#resources-selected').contains(unassigned);
-        cy.get(projectDropdown + '.dropdown-button').should('not.have.attr', 'disabled');
+        cy.get(`${projectDropdownPrefix} #resources-selected`).contains(unassigned);
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get(projectDropdown + '.dropdown-button').click();
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).click();
 
         // dropdown contains both custom projects, click one
-        cy.get(projectDropdown + `chef-checkbox[title="${project1Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project1Name}"]`)
           .should('have.attr', 'aria-checked', 'false');
-        cy.get(projectDropdown + `chef-checkbox[title="${project2Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project2Name}"]`)
           .should('have.attr', 'aria-checked', 'false').click();
 
         // close projects dropdown
-        cy.get(projectDropdown + '.dropdown-button').click();
-        cy.get(projectDropdown + '#resources-selected')
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).click();
+        cy.get(`${projectDropdownPrefix} #resources-selected`)
           .contains(`${project2Name.substring(0, dropdownNameUntilEllipsisLen)}...`);
 
         // save team
@@ -260,16 +260,16 @@ describe('team management', () => {
         cy.get('[data-cy=id-label]').contains(unassignedTeam2ID);
 
         // initial state of dropdown
-        cy.get(projectDropdown + '#resources-selected').contains(unassigned);
-        cy.get(projectDropdown + '.dropdown-button').should('not.have.attr', 'disabled');
+        cy.get(`${projectDropdownPrefix} #resources-selected`).contains(unassigned);
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).should('not.have.attr', 'disabled');
 
         // open projects dropdown
-        cy.get(projectDropdown + '.dropdown-button').click();
+        cy.get(`${projectDropdownPrefix} .dropdown-button`).click();
 
         // dropdown contains both custom projects, none clicked
-        cy.get(projectDropdown + `chef-checkbox[title="${project1Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project1Name}"]`)
           .should('have.attr', 'aria-checked', 'false');
-        cy.get(projectDropdown + `chef-checkbox[title="${project2Name}"]`)
+        cy.get(`${projectDropdownPrefix} chef-checkbox[title="${project2Name}"]`)
           .should('have.attr', 'aria-checked', 'false');
 
         // close projects dropdown

--- a/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
@@ -1,5 +1,3 @@
-import { itFlaky } from '../../../support/constants';
-
 describe('team management', () => {
   const now = Cypress.moment().format('MMDDYYhhmm');
   const cypressPrefix = 'test-team-mgmt';
@@ -77,7 +75,7 @@ describe('team management', () => {
     const dropdownNameUntilEllipsisLen = 25;
     const projectDropdown = 'app-team-management app-projects-dropdown ';
 
-    itFlaky('can create a team with a default ID', () => {
+    it('can create a team with a default ID', () => {
       cy.get('[data-cy=team-create-button]').contains('Create Team').click();
       cy.get('app-team-management chef-modal').should('exist');
 
@@ -92,7 +90,7 @@ describe('team management', () => {
       cy.contains(generatedTeamID).should('exist');
     });
 
-    itFlaky('can create a team with a custom ID', () => {
+    it('can create a team with a custom ID', () => {
       cy.get('[data-cy=team-create-button]').contains('Create Team').click();
       cy.get('app-team-management chef-modal').should('exist');
 
@@ -116,7 +114,7 @@ describe('team management', () => {
         cy.applyProjectsFilter([unassigned]);
       });
 
-      itFlaky(`can create a team with no projects (unassigned)
+      it(`can create a team with no projects (unassigned)
         and cannot access projects dropdown`, () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
@@ -153,7 +151,7 @@ describe('team management', () => {
         cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, ['teams']);
       });
 
-      itFlaky('can create a team with multiple projects', () => {
+      it('can create a team with multiple projects', () => {
         const projectSummary = '2 projects';
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
@@ -187,7 +185,7 @@ describe('team management', () => {
         cy.contains(projectSummary).should('exist');
       });
 
-      itFlaky('can create a team with one project selected', () => {
+      it('can create a team with one project selected', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);
@@ -221,7 +219,7 @@ describe('team management', () => {
         cy.contains(project2ID).should('exist');
       });
 
-      itFlaky('can create a team with no projects selected (unassigned)', () => {
+      it('can create a team with no projects selected (unassigned)', () => {
         cy.get('[data-cy=team-create-button]').contains('Create Team').click();
         cy.get('app-team-management chef-modal').should('exist');
         cy.get('[data-cy=create-name]').type(teamName);

--- a/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/team_mgmt.spec.ts
@@ -85,7 +85,12 @@ describe('team management', () => {
 
       cy.get('[data-cy=save-button]').click();
       cy.get('app-team-management chef-modal').should('not.be.visible');
+
+      // verify success notification and then dismiss it
+      // so it doesn't get in the way of subsequent interactions
       cy.get('app-notification.info').should('be.visible');
+      cy.get('app-notification.info chef-icon').click();
+
       cy.contains(teamName).should('exist');
       cy.contains(generatedTeamID).should('exist');
     });
@@ -103,7 +108,10 @@ describe('team management', () => {
 
       cy.get('[data-cy=save-button]').click();
       cy.get('app-team-management chef-modal').should('not.be.visible');
+
       cy.get('app-notification.info').should('be.visible');
+      cy.get('app-notification.info chef-icon').click();
+
       cy.contains(teamName).should('exist');
       cy.contains(customTeamID).should('exist');
     });
@@ -130,7 +138,10 @@ describe('team management', () => {
         // save team
         cy.get('[data-cy=save-button]').click();
         cy.get('app-team-management chef-modal').should('not.be.visible');
+
         cy.get('app-notification.info').should('be.visible');
+        cy.get('app-notification.info chef-icon').click();
+
         cy.contains(teamName).should('exist');
         cy.contains(generatedTeamID).should('exist');
         cy.contains(unassigned).should('exist');
@@ -179,7 +190,10 @@ describe('team management', () => {
         // save team
         cy.get('[data-cy=save-button]').click();
         cy.get('app-team-management chef-modal').should('not.be.visible');
+
         cy.get('app-notification.info').should('be.visible');
+        cy.get('app-notification.info chef-icon').click();
+
         cy.contains(teamName).should('exist');
         cy.contains(generatedTeamID).should('exist');
         cy.contains(projectSummary).should('exist');
@@ -213,7 +227,10 @@ describe('team management', () => {
         cy.get('[data-cy=save-button]').click();
         cy.get('app-team-management chef-modal').should('not.be.visible');
         cy.get('#main-content-wrapper').scrollTo('top');
+
         cy.get('app-notification.info').should('be.visible');
+        cy.get('app-notification.info chef-icon').click();
+
         cy.contains(teamName).should('exist');
         cy.contains(generatedTeamID).should('exist');
         cy.contains(project2ID).should('exist');
@@ -246,7 +263,10 @@ describe('team management', () => {
         cy.get('[data-cy=save-button]').click();
         cy.get('app-team-management app-team-management chef-modal').should('not.be.visible');
         cy.get('#main-content-wrapper').scrollTo('top');
+
         cy.get('app-notification.info').should('be.visible');
+        cy.get('app-notification.info chef-icon').click();
+
         cy.contains(teamName).should('exist');
         cy.contains(generatedTeamID).should('exist');
         cy.contains(unassigned).should('exist');

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -40,9 +40,10 @@ Cypress.Commands.add('logout', () => {
   return cy.url().should('include', '/dex/auth');
 });
 
-// applyProjectsFilter will deselect any selected projects from the filter,
+// applyProjectsFilter will deselect all projects in the filter,
 // check any projects by NAME (not id) passed -- if any -- and apply any changes.
-// if there are no resulting changes to apply, it will simply click out of the filter.
+// Preferring reliability over "natural" user behavior for this helper, we use forced clicks
+// since the state of the dropdown may differ across the tests where it is called.
 Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
   cy.get('app-projects-filter button#projects-filter-button').click();
 

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -45,25 +45,24 @@ Cypress.Commands.add('logout', () => {
 // if there are no resulting changes to apply, it will simply click out of the filter.
 Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
   cy.get('app-projects-filter button#projects-filter-button').click();
-  cy.get('app-projects-filter chef-dropdown#projects-filter-dropdown')
-    .find('chef-checkbox').each(child => {
-    // deselect every checkbox
-    if (child.attr('aria-checked') === 'true') {
-      child.trigger('click');
-    }
-  });
 
-  // check all desired checkboxes
-  projectsToFilterOn.forEach(proj =>
-    cy.get(`app-projects-filter chef-checkbox[title="${proj}"]`).find('chef-icon').click());
+  // deselect all projects
+  // we add the force for when there are already no projects selected
+  // and the Clear Selection button is hidden
+  cy.get('chef-button#projects-filter-clear-selection').click({force : true});
 
-  if (projectsToFilterOn.length === 0) {
-    // no changes to apply, close projects filter
-    cy.get('app-projects-filter button#projects-filter-button').click();
-  } else {
-    // apply projects filter
-    cy.get('app-projects-filter chef-button#projects-filter-apply-changes').click();
+  if (projectsToFilterOn.length > 0) {
+    // check all desired checkboxes
+    projectsToFilterOn.forEach(proj => {
+      cy.get(`app-projects-filter chef-checkbox[title="${proj}"] chef-icon`).click();
+      cy.get(`app-projects-filter chef-checkbox[title="${proj}"]`)
+        .should('have.attr', 'aria-checked', 'true');
+    });
   }
+
+  // apply projects filter
+  cy.get('app-projects-filter chef-button#projects-filter-apply-changes')
+    .should('not.be.disabled').click();
 });
 
 Cypress.Commands.add('generateAdminToken', (idToken: string) => {
@@ -515,7 +514,7 @@ function deleteProjects(projectIdsToDelete: string[], index: number,
   if (projectIdsToDelete.length === index) {
     if (rulesWereDeleted) {
       // Because rules were deleted we must first apply rules to be able to delete the project
-      cy.applyRulesAndWait(100);
+      cy.applyRulesAndWait();
     }
 
     // Delete all the projects after all their rules are deleted

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -54,7 +54,7 @@ Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
   if (projectsToFilterOn.length > 0) {
     // check all desired checkboxes
     projectsToFilterOn.forEach(proj => {
-      cy.get(`app-projects-filter chef-checkbox[title="${proj}"] chef-icon`).click();
+      cy.get(`app-projects-filter chef-checkbox[title="${proj}"]`).click();
       cy.get(`app-projects-filter chef-checkbox[title="${proj}"]`)
         .should('have.attr', 'aria-checked', 'true');
     });
@@ -62,7 +62,11 @@ Cypress.Commands.add('applyProjectsFilter', (projectsToFilterOn: string[]) => {
 
   // apply projects filter
   cy.get('app-projects-filter chef-button#projects-filter-apply-changes')
-    .should('not.be.disabled').click();
+    // we force the click here in case Apply button was disabled due to no net change
+    // i.e. in the case that proj1, proj2 are selected,
+    // selection is cleared,
+    // and proj1, proj2 are selected again
+    .click({force: true});
 });
 
 Cypress.Commands.add('generateAdminToken', (idToken: string) => {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
These rascals are flaky no more 🎊 

Also fixes a minor bug with the Create Object Modal in which the projects dropdown did not reset between modal openings.

### :+1: Definition of Done
- [ ] team_mgmt cypress test suite passes locally and on buildkite consistently

### :athletic_shoe: How to Build and Test the Change

[Make sure prereqs installed](https://github.com/chef/automate/tree/master/e2e#running-cypress-locally)

Opens Cypress test runner with `runFlaky=no`
```
cd e2e
npm run cypress:local
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
