### PR TITLE
Change event type of Keyboard Event to Event

### DIFF
--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -141,7 +141,8 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     this.allFilteredResourcesCount = this.calculateAllFilteredResourcesCount();
   }
 
-  moveFocus(event: KeyboardEvent): void {
+  moveFocus(genericEvent: Event): void {
+    const event = genericEvent as KeyboardEvent;
     event.preventDefault();
     let nextElement: HTMLElement;
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -99,8 +99,8 @@ export class ProjectsFilterDropdownComponent {
     this.checkInitialEquality();
   }
 
-  handleArrowUp(event: Event) {
-    event.preventDefault();
+  handleArrowUp(genericEvent: Event) {
+    const event = genericEvent as KeyboardEvent;
 
     const element = (event.target as Element).previousElementSibling;
     if (element) {
@@ -108,8 +108,8 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
-  handleArrowDown(event: Event) {
-    event.preventDefault();
+  handleArrowDown(genericEvent: Event) {
+    const event = genericEvent as KeyboardEvent;
 
     const element = (event.target as Element).nextElementSibling;
     if (element) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -101,6 +101,7 @@ export class ProjectsFilterDropdownComponent {
 
   handleArrowUp(genericEvent: Event) {
     const event = genericEvent as KeyboardEvent;
+    event.preventDefault();
 
     const element = (event.target as Element).previousElementSibling;
     if (element) {
@@ -110,6 +111,7 @@ export class ProjectsFilterDropdownComponent {
 
   handleArrowDown(genericEvent: Event) {
     const event = genericEvent as KeyboardEvent;
+    event.preventDefault();
 
     const element = (event.target as Element).nextElementSibling;
     if (element) {

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.ts
@@ -99,7 +99,7 @@ export class ProjectsFilterDropdownComponent {
     this.checkInitialEquality();
   }
 
-  handleArrowUp(event: KeyboardEvent) {
+  handleArrowUp(event: Event) {
     event.preventDefault();
 
     const element = (event.target as Element).previousElementSibling;
@@ -108,7 +108,7 @@ export class ProjectsFilterDropdownComponent {
     }
   }
 
-  handleArrowDown(event: KeyboardEvent) {
+  handleArrowDown(event: Event) {
     event.preventDefault();
 
     const element = (event.target as Element).nextElementSibling;

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -25,13 +25,13 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "strictInputTypes": false,
+    "strictInputTypes": true,
     "strictNullInputTypes": true,
     "strictAttributeTypes": true,
     "strictSafeNavigationTypes": true,
     "strictDomLocalRefTypes": true,
     "strictOutputEventTypes": true,
-    "strictDomEventTypes": false,
+    "strictDomEventTypes": true,
     "strictContextGenerics": true,
     "strictLiteralTypes": true,
     "fullTemplateTypeCheck": true


### PR DESCRIPTION
Opened Draft for feedback

### :nut_and_bolt: Description: What code changed, and why?
error TS2345: Argument of type 'Event' is not assignable to parameter of type 'KeyboardEvent'.

Typescript is complaining about the Event type in both the `handleArrowDown` and `handleArrowUp` functions.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
