### PR TITLE
enable project filtering on nodemanager nodes

### DIFF
--- a/components/compliance-service/api/tests/30_jobs_docker_spec.rb
+++ b/components/compliance-service/api/tests/30_jobs_docker_spec.rb
@@ -468,6 +468,12 @@ describe File.basename(__FILE__) do
             "e69dc612-7e67-43f2-9b19-256afd385820"
           ],
           "state": "RUNNING",
+          "projectsData": [
+            {
+              "key": "environment",
+              "values": ["trouble"]
+            }
+          ],
           "runData": {},
           "scanData": {
             "id": "some-id",
@@ -763,6 +769,12 @@ describe File.basename(__FILE__) do
             "e69dc612-7e67-43f2-9b19-256afd385820"
           ],
           "state": "TERMINATED",
+          "projectsData": [
+            {
+              "key": "environment",
+              "values": ["trouble"]
+            }
+          ],
           "runData": {},
           "scanData": {
             "id": "some-id",

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher.go
@@ -114,9 +114,6 @@ func gatherInfoForNode(in message.Compliance) (*manager.NodeMetadata, error) {
 
 func gatherProjectsData(in *compliance.Report) []*nodes.ProjectsData {
 	projectsData := make([]*nodes.ProjectsData, 0)
-	if len(in.GetJobUuid()) > 0 {
-		return projectsData
-	}
 	if len(in.GetEnvironment()) != 0 {
 		projectsData = append(projectsData, &nodes.ProjectsData{Key: "environment", Values: []string{in.GetEnvironment()}})
 	}

--- a/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
+++ b/components/compliance-service/ingest/pipeline/publisher/node_manager_publisher_test.go
@@ -81,7 +81,7 @@ func TestGatherInfoForNode(t *testing.T) {
 	}, nodeMetadata)
 }
 
-func TestGatherInfoForNodeDoesNotCollectProjectsDataIfScanJob(t *testing.T) {
+func TestGatherInfoForNodeCollectsProjectsDataIfScanJob(t *testing.T) {
 	nowTimeString := "2018-10-25T10:18:41Z"
 	time, err := time.Parse(time.RFC3339, nowTimeString)
 	assert.NoError(t, err)
@@ -91,22 +91,18 @@ func TestGatherInfoForNodeDoesNotCollectProjectsDataIfScanJob(t *testing.T) {
 
 	nodeReport := message.Compliance{
 		Report: compliance.Report{
-			NodeUuid:         "8dcca219-a730-3985-907b-e6b22f9f848d",
-			NodeName:         "chef-load-44",
-			Platform:         &inspec.Platform{Name: "ubuntu", Release: "16.04"},
-			ChefTags:         []string{"application", "database"},
-			OrganizationName: "test-org",
-			SourceFqdn:       "chef-server-2",
-			Roles:            []string{"my-cool-role"},
-			EndTime:          nowTimeString,
-			SourceId:         "i-0aee75f0b4b0d9f22",
-			SourceRegion:     "us-west-2a",
-			ReportUuid:       "123353254545425",
-			JobUuid:          "12335892329454",
+			NodeUuid:     "8dcca219-a730-3985-907b-e6b22f9f848d",
+			NodeName:     "my-node",
+			Platform:     &inspec.Platform{Name: "ubuntu", Release: "16.04"},
+			EndTime:      nowTimeString,
+			SourceId:     "i-0aee75f0b4b0d9f22",
+			SourceRegion: "us-west-2a",
+			ReportUuid:   "123353254545425",
+			JobUuid:      "12335892329454",
+			Environment:  "test-env",
 		},
 		InspecReport: &relaxting.ESInSpecReport{
-			Projects: []string{"tomato", "cucumber"},
-			Status:   "passed",
+			Status: "passed",
 		},
 	}
 
@@ -114,7 +110,7 @@ func TestGatherInfoForNodeDoesNotCollectProjectsDataIfScanJob(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, &manager.NodeMetadata{
 		Uuid:            "8dcca219-a730-3985-907b-e6b22f9f848d",
-		Name:            "chef-load-44",
+		Name:            "my-node",
 		PlatformName:    "ubuntu",
 		PlatformRelease: "16.04",
 		LastContact:     timestampNow,
@@ -125,12 +121,12 @@ func TestGatherInfoForNodeDoesNotCollectProjectsDataIfScanJob(t *testing.T) {
 			EndTime: timestampNow,
 			Status:  nodes.LastContactData_PASSED,
 		},
-		Projects:     []string{"tomato", "cucumber"},
-		JobUuid:      "12335892329454",
-		ProjectsData: []*nodes.ProjectsData{},
+		JobUuid: "12335892329454",
+		ProjectsData: []*nodes.ProjectsData{
+			{Key: "environment", Values: []string{"test-env"}},
+		},
 		Tags: []*common.Kv{
-			{Key: "chef-tag", Value: "application"},
-			{Key: "chef-tag", Value: "database"},
+			{Key: "environment", Value: "test-env"},
 		},
 	}, nodeMetadata)
 }

--- a/components/nodemanager-service/pgdb/filtering.go
+++ b/components/nodemanager-service/pgdb/filtering.go
@@ -275,8 +275,5 @@ func whereProjectsMatch(_ string, arr []string, tableAbbrev string) (string, err
 		}
 	}
 
-	// Or the node is manually added
-	condition = condition + " OR n.manager <> ''"
-
 	return condition, nil
 }

--- a/components/nodemanager-service/pgdb/project_update.go
+++ b/components/nodemanager-service/pgdb/project_update.go
@@ -200,7 +200,6 @@ SELECT
   n.projects_data
 FROM nodes n
 WHERE
-  n.manager = '' AND
   n.id > $1 AND
   n.id < $2
 ORDER BY id asc

--- a/components/nodemanager-service/tests/project_filtering_test.go
+++ b/components/nodemanager-service/tests/project_filtering_test.go
@@ -184,8 +184,7 @@ func TestReadProjectFilteringIngestedNodes(t *testing.T) {
 	}
 }
 
-// All manually added nodes should be returned because they are not included in project filtering.
-func TestListProjectFilteringIngestedNodes(t *testing.T) {
+func TestListProjectFilteringAllNodes(t *testing.T) {
 	db, err := createPGDB()
 	require.NoError(t, err)
 
@@ -375,17 +374,10 @@ func TestListProjectFilteringIngestedNodes(t *testing.T) {
 
 				// Get all the node IDs returned.
 				actualNodeIDs := []string{}
-				actualManualNodeIDs := []string{}
 				for _, node := range nodesResponse.Nodes {
-					if node.Manager == "" {
+					if node.Manager == "" || node.Manager == "chef" {
 						actualNodeIDs = append(actualNodeIDs, node.Id)
-					} else {
-						actualManualNodeIDs = append(actualManualNodeIDs, node.Id)
 					}
-				}
-
-				for _, nodeID := range manualNodeIds {
-					assert.Contains(t, actualManualNodeIDs, nodeID)
 				}
 
 				assert.ElementsMatch(t, actualNodeIDs, test.expectedIngestedNodeIDs)

--- a/components/nodemanager-service/tests/project_filtering_test.go
+++ b/components/nodemanager-service/tests/project_filtering_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chef/automate/api/interservice/nodemanager/manager"
 	"github.com/chef/automate/api/interservice/nodemanager/nodes"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -202,7 +203,7 @@ func TestListProjectFilteringAllNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	manualNodeIds := []string{manualNodeID1, manualNodeID2}
-	t.Logf("manual node ids %s %s", manualNodeID1, manualNodeID2)
+	logrus.Infof("manual node ids %s %s", manualNodeID1, manualNodeID2)
 	defer func() {
 		for _, node := range manualNodeIds {
 			db.DeleteNode(node)
@@ -407,12 +408,10 @@ func TestListProjectFilteringAllNodes(t *testing.T) {
 				// Get all the node IDs returned.
 				actualNodeIDs := []string{}
 				for _, node := range nodesResponse.Nodes {
-					// if node.Manager == "" || node.Manager == "chef" {
 					actualNodeIDs = append(actualNodeIDs, node.Id)
-					// }
 				}
-				t.Logf("expected: %v", test.expectedNodeIDs)
-				t.Logf("actual: %v", actualNodeIDs)
+				logrus.Infof("expected: %v", test.expectedNodeIDs)
+				logrus.Infof("actual: %v", actualNodeIDs)
 
 				assert.ElementsMatch(t, actualNodeIDs, test.expectedNodeIDs)
 			})

--- a/components/nodemanager-service/tests/project_filtering_test.go
+++ b/components/nodemanager-service/tests/project_filtering_test.go
@@ -193,6 +193,12 @@ func TestListProjectFilteringAllNodes(t *testing.T) {
 
 	timestamp, err := ptypes.TimestampProto(time.Now())
 
+	// delete all nodes for a clean state
+	nodesResponse, err := nodeManager.List(context.Background(), &nodes.Query{})
+	for _, node := range nodesResponse.GetNodes() {
+		db.DeleteNode(node.Id)
+	}
+
 	// Adding two manual nodes
 	node1 := nodes.Node{Name: "test-manual-node-1"}
 	manualNodeID1, err := db.AddNode(&node1)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

a few weeks ago we introduced the ability to use project filtering
on manually added nodes by supporting the environment tag on those nodes
and appropriately applying it on the node reports.

what we did not do at that time is also apply the project filtering
on the nodemanager nodes, which affects the list present at scan jobs/nodes
and integration/nodes.

this change ensures that we apply the project filtering to the
nodemanager nodes as well.
At this point, nodes will not be "project filtered" until they are ingested at least once.

### :+1: Definition of Done
nodemanager nodes respect project filtering

### :athletic_shoe: How to Build and Test the Change
1-rebuild nodemanager, compliance
2- create a project, rule of environment: test-env
apply the rules
3-run load_scan_jobs, wait for it to complete
3-go to compliance report nodes, see 3 nodes.
filter by project, see 2 nodes.
4-go to automate-url/nodes, see 2 nodes
deselect project filter, see 3 nodes
^ this tests project tagging and filtering. to test project update and filtering, create another project with environment: test-env-local, and after applying the rules, make sure the manually added node is in the correct project by visiting compliance report nodes and automate-url/nodes

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
