### PR TITLE
add load_desktop_reports command

### DIFF
--- a/.studio/ingest-service
+++ b/.studio/ingest-service
@@ -333,6 +333,7 @@ document "load_desktop_reports" <<DOC
   Loads desktop reports.
 DOC
 function load_desktop_reports() {
+  # load some nodes, use an es script to set check in time to a long time ago
   chef_load_nodes 15
   curl -X POST "$ELASTICSEARCH_URL/node-state/_update_by_query?pretty" -H 'Content-Type: application/json' -d'
   {
@@ -342,16 +343,18 @@ function load_desktop_reports() {
   }
   }
   '
-  for file in cat dev-docs/adding-data/sample-reports/desktop-report-{1,2,3}.json; do
-    curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d "$file"
-  end
+  # send in some chef infra run reports from actual desktops
+  for file in dev-docs/adding-data/sample-reports/desktop-report-{1,2,3}.json; do
+    cat $file | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
+  done
+  # send in a bunch of errored infra runs
   for _ in {1..30}; do
     m=$((RANDOM % 4))
     n=$((RANDOM % 10))
     generate_chef_run_failure_example |\
       jq --arg msg "Error $n occurred" \
-        --arg type "Chef::ExampleError$m" \
-        '.error.message = $msg | .error.class = $type' |\
+        --arg errtype "Chef::ExampleError$m" \
+        '.error.message = $msg | .error.class = $errtype' |\
       send_chef_data_raw
   done
 }

--- a/.studio/ingest-service
+++ b/.studio/ingest-service
@@ -342,8 +342,8 @@ function load_desktop_reports() {
   }
   }
   '
-  cat dev-docs/adding-data/sample-reports/desktop-report-1.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
-  cat dev-docs/adding-data/sample-reports/desktop-report-2.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
-  cat dev-docs/adding-data/sample-reports/desktop-report-3.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
+  for file in cat dev-docs/adding-data/sample-reports/desktop-report-{1,2,3}.json; do
+    curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d "$file"
+  end
   for _ in {1..30} ; do   m=$((RANDOM % 4));   n=$((RANDOM % 10));   generate_chef_run_failure_example |     jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' |     send_chef_data_raw; done
 }

--- a/.studio/ingest-service
+++ b/.studio/ingest-service
@@ -345,6 +345,7 @@ function load_desktop_reports() {
   '
   # send in some chef infra run reports from actual desktops
   for file in dev-docs/adding-data/sample-reports/desktop-report-{1,2,3}.json; do
+    # shellcheck disable=SC2002
     cat $file | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
   done
   # send in a bunch of errored infra runs

--- a/.studio/ingest-service
+++ b/.studio/ingest-service
@@ -328,3 +328,22 @@ function ingest_grpcurl_configure_purge() {
     }
   }"
 }
+
+document "load_desktop_reports" <<DOC
+  Loads desktop reports.
+DOC
+function load_desktop_reports() {
+  chef_load_nodes 15
+  curl -X POST "$ELASTICSEARCH_URL/node-state/_update_by_query?pretty" -H 'Content-Type: application/json' -d'
+  {
+  "script": {
+  "source": "ctx._source[\u0027checkin\u0027] = \u00272020-02-15T02:43:43Z\u0027",
+  "lang": "painless"
+  }
+  }
+  '
+  cat dev-docs/adding-data/sample-reports/desktop-report-1.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
+  cat dev-docs/adding-data/sample-reports/desktop-report-2.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
+  cat dev-docs/adding-data/sample-reports/desktop-report-3.json | curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d @-
+  for _ in {1..30} ; do   m=$((RANDOM % 4));   n=$((RANDOM % 10));   generate_chef_run_failure_example |     jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' |     send_chef_data_raw; done
+}

--- a/.studio/ingest-service
+++ b/.studio/ingest-service
@@ -345,5 +345,13 @@ function load_desktop_reports() {
   for file in cat dev-docs/adding-data/sample-reports/desktop-report-{1,2,3}.json; do
     curl --insecure -H "api-token: $(get_admin_token)" -X POST "https://a2-dev.test/data-collector/v0" -H "Content-Type: application/json" -d "$file"
   end
-  for _ in {1..30} ; do   m=$((RANDOM % 4));   n=$((RANDOM % 10));   generate_chef_run_failure_example |     jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' |     send_chef_data_raw; done
+  for _ in {1..30}; do
+    m=$((RANDOM % 4))
+    n=$((RANDOM % 10))
+    generate_chef_run_failure_example |\
+      jq --arg msg "Error $n occurred" \
+        --arg type "Chef::ExampleError$m" \
+        '.error.message = $msg | .error.class = $type' |\
+      send_chef_data_raw
+  done
 }

--- a/dev-docs/adding-data/adding_test_data.md
+++ b/dev-docs/adding-data/adding_test_data.md
@@ -25,6 +25,12 @@ from hab studio:
 
 `applications_populate_database` 
 
+## Adding desktops data to desktops page
+
+from hab studio:
+
+`load_desktop_reports` 
+
 ## Adding nodes to populate compliance reporting
 
 from hab studio:

--- a/dev-docs/adding-data/sample-reports/desktop-report-1.json
+++ b/dev-docs/adding-data/sample-reports/desktop-report-1.json
@@ -1,0 +1,2622 @@
+{
+    "chef_server_fqdn": "api.chef.io",
+    "entity_uuid": "5a5ab7a8-b095-458d-8480-ec27400c1165",
+    "expanded_run_list": {
+        "id": "_policy_node",
+        "run_list": [
+            {
+                "type": "recipe",
+                "name": "ChefDesktop::default",
+                "skipped": false,
+                "version": null
+            }
+        ]
+    },
+    "id": "1a3a47dc-82d0-4869-97b4-a49b47b9c10a",
+    "message_version": "1.1.0",
+    "message_type": "run_converge",
+    "node": {
+        "name": "FVFWM0M8HV2J",
+        "chef_environment": "client_group",
+        "json_class": "Chef::Node",
+        "automatic": {
+            "uptime_seconds": 3964651,
+            "uptime": "45 days 21 hours 17 minutes 31 seconds",
+            "chef_packages": {
+                "chef": {
+                    "version": "15.8.23",
+                    "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib"
+                },
+                "ohai": {
+                    "version": "15.7.4",
+                    "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/ohai-15.7.4/lib/ohai"
+                }
+            },
+            "languages": {
+                "php": {
+                    "version": "7.3.11",
+                    "builddate": "Dec 13 2019 19:21:21",
+                    "zend_engine_version": "3.3.11"
+                },
+                "python": {
+                    "version": "2.7.16",
+                    "builddate": "Dec 13 2019, 18:00:32"
+                },
+                "ruby": {
+                    "platform": "universal.x86_64-darwin19",
+                    "version": "2.6.3",
+                    "release_date": "2019-04-16",
+                    "target": "universal-apple-darwin19",
+                    "target_cpu": "universal",
+                    "target_vendor": "apple",
+                    "target_os": "darwin19",
+                    "host": "x86_64-apple-darwin19",
+                    "host_cpu": "x86_64",
+                    "host_os": "darwin19",
+                    "host_vendor": "apple",
+                    "bin_dir": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin",
+                    "ruby_bin": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby",
+                    "gems_dir": "/Library/Ruby/Gems/2.6.0",
+                    "gem_bin": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/gem"
+                },
+                "perl": {
+                    "version": "5.18.4",
+                    "archname": "darwin-thread-multi-2level"
+                }
+            },
+            "network": {
+                "interfaces": {
+                    "lo0": {
+                        "addresses": {
+                            "127.0.0.1": {
+                                "family": "inet",
+                                "netmask": "255.0.0.0"
+                            },
+                            "::1": {
+                                "family": "inet6",
+                                "prefixlen": "128",
+                                "scope": "Node"
+                            },
+                            "fe80::1": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "16384",
+                        "flags": [
+                            "UP",
+                            "LOOPBACK",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "lo",
+                        "number": "0",
+                        "encapsulation": "Loopback"
+                    },
+                    "gif0": {
+                        "addresses": {},
+                        "mtu": "1280",
+                        "flags": [
+                            "POINTOPOINT",
+                            "MULTICAST"
+                        ],
+                        "type": "gif",
+                        "number": "0",
+                        "encapsulation": "IPIP"
+                    },
+                    "stf0": {
+                        "addresses": {},
+                        "mtu": "1280",
+                        "flags": [],
+                        "type": "stf",
+                        "number": "0",
+                        "encapsulation": "6to4"
+                    },
+                    "en0": {
+                        "addresses": {
+                            "88:e9:fe:63:f2:d0": {
+                                "family": "lladdr"
+                            },
+                            "fe80::46:4ad2:5079:5072": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            },
+                            "192.168.1.53": {
+                                "family": "inet",
+                                "netmask": "255.255.255.0",
+                                "broadcast": "192.168.1.255"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "0",
+                        "encapsulation": "Ethernet",
+                        "arp": {
+                            "192.168.1.1": "18:e8:29:45:19:a",
+                            "192.168.1.45": "dc:3a:5e:96:7:46",
+                            "192.168.1.51": "5c:41:5a:a9:cb:17",
+                            "224.0.0.251": "1:0:5e:0:0:fb",
+                            "239.255.255.250": "1:0:5e:7f:ff:fa"
+                        }
+                    },
+                    "en1": {
+                        "addresses": {
+                            "82:d1:44:22:d4:01": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "1",
+                        "encapsulation": "Ethernet"
+                    },
+                    "en2": {
+                        "addresses": {
+                            "82:d1:44:22:d4:00": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "2",
+                        "encapsulation": "Ethernet"
+                    },
+                    "bridge0": {
+                        "addresses": {
+                            "82:d1:44:22:d4:01": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "bridge",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "p2p0": {
+                        "addresses": {
+                            "0a:e9:fe:63:f2:d0": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "2304",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "p2p",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "awdl0": {
+                        "addresses": {
+                            "e2:02:e5:ab:f5:43": {
+                                "family": "lladdr"
+                            },
+                            "fe80::e002:e5ff:feab:f543": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1484",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "awdl",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "llw0": {
+                        "addresses": {
+                            "e2:02:e5:ab:f5:43": {
+                                "family": "lladdr"
+                            },
+                            "fe80::e002:e5ff:feab:f543": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "llw",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "utun0": {
+                        "addresses": {
+                            "fe80::a2a1:5bc1:b900:db27": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1380",
+                        "flags": [
+                            "UP",
+                            "POINTOPOINT",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "utun",
+                        "number": "0",
+                        "encapsulation": "Unknown"
+                    },
+                    "utun1": {
+                        "addresses": {
+                            "fe80::1698:4647:113a:bbac": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "2000",
+                        "flags": [
+                            "UP",
+                            "POINTOPOINT",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "utun",
+                        "number": "1",
+                        "encapsulation": "Unknown"
+                    }
+                },
+                "default_gateway": "192.168.1.1",
+                "default_interface": "en0",
+                "settings": {
+                    "net.local.stream.sendspace": "8192",
+                    "net.local.stream.recvspace": "8192",
+                    "net.local.stream.tracemdns": "0",
+                    "net.local.dgram.maxdgram": "2048",
+                    "net.local.dgram.recvspace": "4096",
+                    "net.local.inflight": "0",
+                    "net.inet.ip.portrange.lowfirst": "1023",
+                    "net.inet.ip.portrange.lowlast": "600",
+                    "net.inet.ip.portrange.first": "49152",
+                    "net.inet.ip.portrange.last": "65535",
+                    "net.inet.ip.portrange.hifirst": "49152",
+                    "net.inet.ip.portrange.hilast": "65535",
+                    "net.inet.ip.forwarding": "0",
+                    "net.inet.ip.redirect": "1",
+                    "net.inet.ip.ttl": "64",
+                    "net.inet.ip.rtexpire": "1600",
+                    "net.inet.ip.rtminexpire": "10",
+                    "net.inet.ip.rtmaxcache": "128",
+                    "net.inet.ip.sourceroute": "0",
+                    "net.inet.ip.accept_sourceroute": "0",
+                    "net.inet.ip.gifttl": "30",
+                    "net.inet.ip.subnets_are_local": "0",
+                    "net.inet.ip.mcast.maxgrpsrc": "512",
+                    "net.inet.ip.mcast.maxsocksrc": "128",
+                    "net.inet.ip.mcast.loop": "1",
+                    "net.inet.ip.dummynet.hash_size": "64",
+                    "net.inet.ip.dummynet.curr_time": "0",
+                    "net.inet.ip.dummynet.ready_heap": "0",
+                    "net.inet.ip.dummynet.extract_heap": "0",
+                    "net.inet.ip.dummynet.searches": "0",
+                    "net.inet.ip.dummynet.search_steps": "0",
+                    "net.inet.ip.dummynet.expire": "1",
+                    "net.inet.ip.dummynet.max_chain_len": "16",
+                    "net.inet.ip.dummynet.red_lookup_depth": "256",
+                    "net.inet.ip.dummynet.red_avg_pkt_size": "512",
+                    "net.inet.ip.dummynet.red_max_pkt_size": "1500",
+                    "net.inet.ip.dummynet.debug": "0",
+                    "net.inet.ip.random_id_statistics": "0",
+                    "net.inet.ip.random_id_collisions": "0",
+                    "net.inet.ip.random_id_total": "0",
+                    "net.inet.ip.sendsourcequench": "0",
+                    "net.inet.ip.maxfragpackets": "2048",
+                    "net.inet.ip.fragpackets": "0",
+                    "net.inet.ip.maxfragsperpacket": "128",
+                    "net.inet.ip.adj_clear_hwcksum": "0",
+                    "net.inet.ip.adj_partial_sum": "1",
+                    "net.inet.ip.check_interface": "0",
+                    "net.inet.ip.rx_chaining": "1",
+                    "net.inet.ip.rx_chainsz": "6",
+                    "net.inet.ip.linklocal.in.allowbadttl": "1",
+                    "net.inet.ip.random_id": "1",
+                    "net.inet.ip.maxchainsent": "26",
+                    "net.inet.ip.select_srcif_debug": "0",
+                    "net.inet.ip.output_perf": "0",
+                    "net.inet.ip.output_perf_bins": "0",
+                    "net.inet.ip.rfc6864": "1",
+                    "net.inet.icmp.maskrepl": "0",
+                    "net.inet.icmp.icmplim": "250",
+                    "net.inet.icmp.timestamp": "0",
+                    "net.inet.icmp.drop_redirect": "1",
+                    "net.inet.icmp.log_redirect": "0",
+                    "net.inet.icmp.bmcastecho": "1",
+                    "net.inet.igmp.recvifkludge": "1",
+                    "net.inet.igmp.sendra": "1",
+                    "net.inet.igmp.sendlocal": "1",
+                    "net.inet.igmp.v1enable": "1",
+                    "net.inet.igmp.v2enable": "1",
+                    "net.inet.igmp.legacysupp": "0",
+                    "net.inet.igmp.default_version": "3",
+                    "net.inet.igmp.gsrdelay": "10",
+                    "net.inet.igmp.debug": "0",
+                    "net.inet.tcp.rfc1644": "0",
+                    "net.inet.tcp.mssdflt": "512",
+                    "net.inet.tcp.keepidle": "7200000",
+                    "net.inet.tcp.keepintvl": "75000",
+                    "net.inet.tcp.sendspace": "131072",
+                    "net.inet.tcp.recvspace": "131072",
+                    "net.inet.tcp.keepinit": "75000",
+                    "net.inet.tcp.v6mssdflt": "1024",
+                    "net.inet.tcp.backoff_maximum": "65536",
+                    "net.inet.tcp.ecn_timeout": "60",
+                    "net.inet.tcp.disable_tcp_heuristics": "0",
+                    "net.inet.tcp.clear_tfocache": "0",
+                    "net.inet.tcp.log_in_vain": "0",
+                    "net.inet.tcp.blackhole": "0",
+                    "net.inet.tcp.delayed_ack": "3",
+                    "net.inet.tcp.tcp_lq_overflow": "1",
+                    "net.inet.tcp.recvbg": "0",
+                    "net.inet.tcp.drop_synfin": "1",
+                    "net.inet.tcp.reass.overflows": "0",
+                    "net.inet.tcp.slowlink_wsize": "8192",
+                    "net.inet.tcp.maxseg_unacked": "8",
+                    "net.inet.tcp.rfc3465": "1",
+                    "net.inet.tcp.rfc3465_lim2": "1",
+                    "net.inet.tcp.recv_allowed_iaj": "5",
+                    "net.inet.tcp.doautorcvbuf": "1",
+                    "net.inet.tcp.autorcvbufmax": "2097152",
+                    "net.inet.tcp.lro": "0",
+                    "net.inet.tcp.lrodbg": "0",
+                    "net.inet.tcp.lro_startcnt": "4",
+                    "net.inet.tcp.disable_access_to_stats": "1",
+                    "net.inet.tcp.challengeack_limit": "10",
+                    "net.inet.tcp.do_rfc5961": "1",
+                    "net.inet.tcp.rcvsspktcnt": "512",
+                    "net.inet.tcp.rexmt_thresh": "3",
+                    "net.inet.tcp.path_mtu_discovery": "1",
+                    "net.inet.tcp.slowstart_flightsize": "1",
+                    "net.inet.tcp.local_slowstart_flightsize": "8",
+                    "net.inet.tcp.tso": "1",
+                    "net.inet.tcp.ecn_setup_percentage": "100",
+                    "net.inet.tcp.ecn_initiate_out": "2",
+                    "net.inet.tcp.ecn_negotiate_in": "2",
+                    "net.inet.tcp.packetchain": "50",
+                    "net.inet.tcp.socket_unlocked_on_output": "1",
+                    "net.inet.tcp.rfc3390": "1",
+                    "net.inet.tcp.min_iaj_win": "16",
+                    "net.inet.tcp.acc_iaj_react_limit": "200",
+                    "net.inet.tcp.doautosndbuf": "1",
+                    "net.inet.tcp.autosndbufinc": "8192",
+                    "net.inet.tcp.autosndbufmax": "2097152",
+                    "net.inet.tcp.ack_prioritize": "1",
+                    "net.inet.tcp.rtt_recvbg": "1",
+                    "net.inet.tcp.recv_throttle_minwin": "16384",
+                    "net.inet.tcp.enable_tlp": "1",
+                    "net.inet.tcp.sack": "1",
+                    "net.inet.tcp.sack_maxholes": "128",
+                    "net.inet.tcp.sack_globalmaxholes": "65536",
+                    "net.inet.tcp.sack_globalholes": "0",
+                    "net.inet.tcp.fastopen_backlog": "10",
+                    "net.inet.tcp.fastopen": "3",
+                    "net.inet.tcp.now_init": "357713341",
+                    "net.inet.tcp.microuptime_init": "1002126",
+                    "net.inet.tcp.minmss": "216",
+                    "net.inet.tcp.do_tcpdrain": "0",
+                    "net.inet.tcp.pcbcount": "19",
+                    "net.inet.tcp.tw_pcbcount": "0",
+                    "net.inet.tcp.icmp_may_rst": "1",
+                    "net.inet.tcp.rtt_min": "100",
+                    "net.inet.tcp.rexmt_slop": "200",
+                    "net.inet.tcp.randomize_ports": "0",
+                    "net.inet.tcp.win_scale_factor": "3",
+                    "net.inet.tcp.init_rtt_from_cache": "1",
+                    "net.inet.tcp.tcbhashsize": "4096",
+                    "net.inet.tcp.keepcnt": "8",
+                    "net.inet.tcp.msl": "15000",
+                    "net.inet.tcp.max_persist_timeout": "0",
+                    "net.inet.tcp.always_keepalive": "0",
+                    "net.inet.tcp.timer_fastmode_idlemax": "10",
+                    "net.inet.tcp.broken_peer_syn_rexmit_thres": "10",
+                    "net.inet.tcp.tcp_timer_advanced": "0",
+                    "net.inet.tcp.tcp_resched_timerlist": "24889",
+                    "net.inet.tcp.pmtud_blackhole_detection": "1",
+                    "net.inet.tcp.pmtud_blackhole_mss": "1200",
+                    "net.inet.tcp.cc_debug": "0",
+                    "net.inet.tcp.newreno_sockets": "0",
+                    "net.inet.tcp.background_sockets": "0",
+                    "net.inet.tcp.cubic_sockets": "18",
+                    "net.inet.tcp.use_newreno": "0",
+                    "net.inet.tcp.cubic_tcp_friendliness": "0",
+                    "net.inet.tcp.cubic_fast_convergence": "0",
+                    "net.inet.tcp.cubic_use_minrtt": "0",
+                    "net.inet.tcp.lro_sz": "8",
+                    "net.inet.tcp.lro_time": "10",
+                    "net.inet.tcp.bg_target_qdelay": "100",
+                    "net.inet.tcp.bg_allowed_increase": "8",
+                    "net.inet.tcp.bg_tether_shift": "1",
+                    "net.inet.tcp.bg_ss_fltsz": "2",
+                    "net.inet.tcp.log.level_info": "0",
+                    "net.inet.tcp.log.enable": "0",
+                    "net.inet.tcp.log.enable_usage": "connection:0x1 rtt:0x2 ka:0x4 loop:0x10 local:0x20 gw:0x40 syn:0x100 fin:0x200 rst:0x400 dropnecp:0x1000 droppcb:0x2000 droppkt:0x4000 ",
+                    "net.inet.tcp.log.rtt_port": "0",
+                    "net.inet.tcp.log.thflags_if_family": "0",
+                    "net.inet.tcp.log.privacy": "1",
+                    "net.inet.tcp.log.rate_limit": "600",
+                    "net.inet.tcp.log.rate_duration": "60",
+                    "net.inet.tcp.log.rate_max": "0",
+                    "net.inet.tcp.log.rate_exceeded_total": "0",
+                    "net.inet.tcp.log.rate_current": "0",
+                    "net.inet.udp.checksum": "1",
+                    "net.inet.udp.maxdgram": "9216",
+                    "net.inet.udp.recvspace": "786896",
+                    "net.inet.udp.log_in_vain": "0",
+                    "net.inet.udp.blackhole": "0",
+                    "net.inet.udp.pcbcount": "86",
+                    "net.inet.udp.randomize_ports": "1",
+                    "net.inet.ipsec.def_policy": "1",
+                    "net.inet.ipsec.esp_trans_deflev": "1",
+                    "net.inet.ipsec.esp_net_deflev": "1",
+                    "net.inet.ipsec.ah_trans_deflev": "1",
+                    "net.inet.ipsec.ah_net_deflev": "1",
+                    "net.inet.ipsec.ah_cleartos": "1",
+                    "net.inet.ipsec.ah_offsetmask": "0",
+                    "net.inet.ipsec.dfbit": "0",
+                    "net.inet.ipsec.ecn": "0",
+                    "net.inet.ipsec.debug": "0",
+                    "net.inet.ipsec.esp_randpad": "-1",
+                    "net.inet.ipsec.bypass": "1",
+                    "net.inet.ipsec.esp_port": "0",
+                    "net.inet.log_restricted": "0",
+                    "net.inet.raw.maxdgram": "8192",
+                    "net.inet.raw.recvspace": "8192",
+                    "net.inet.raw.pcbcount": "1",
+                    "net.inet.mptcp.enable": "1",
+                    "net.inet.mptcp.mptcp_cap_retr": "4",
+                    "net.inet.mptcp.dss_csum": "0",
+                    "net.inet.mptcp.fail": "1",
+                    "net.inet.mptcp.keepalive": "840",
+                    "net.inet.mptcp.rtthist_thresh": "600",
+                    "net.inet.mptcp.userto": "1",
+                    "net.inet.mptcp.rto_thresh": "1500",
+                    "net.inet.mptcp.probeto": "1000",
+                    "net.inet.mptcp.probecnt": "5",
+                    "net.inet.mptcp.dbg_area": "31",
+                    "net.inet.mptcp.dbg_level": "1",
+                    "net.inet.mptcp.pcbcount": "0",
+                    "net.inet.mptcp.alternate_port": "0",
+                    "net.inet.mptcp.allow_aggregate": "0",
+                    "net.inet.mptcp.expected_progress_headstart": "5000",
+                    "net.inet.mptcp.rto": "3",
+                    "net.inet.mptcp.nrto": "3",
+                    "net.inet.mptcp.tw": "60",
+                    "net.link.generic.system.ifcount": "13",
+                    "net.link.generic.system.if_verbose": "0",
+                    "net.link.generic.system.dlil_verbose": "0",
+                    "net.link.generic.system.sndq_maxlen": "128",
+                    "net.link.generic.system.rcvq_maxlen": "256",
+                    "net.link.generic.system.rxpoll_decay": "2",
+                    "net.link.generic.system.rxpoll_freeze_time": "1000000000",
+                    "net.link.generic.system.rxpoll_sample_time": "10000000",
+                    "net.link.generic.system.rxpoll_interval_time": "1000000",
+                    "net.link.generic.system.rxpoll_interval_pkts": "0",
+                    "net.link.generic.system.rxpoll_wakeups_lowat": "10",
+                    "net.link.generic.system.rxpoll_wakeups_hiwat": "100",
+                    "net.link.generic.system.rxpoll_max": "0",
+                    "net.link.generic.system.rxpoll": "1",
+                    "net.link.generic.system.dlil_input_threads": "12",
+                    "net.link.generic.system.dlil_input_sanity_check": "0",
+                    "net.link.generic.system.flow_advisory": "1",
+                    "net.link.generic.system.delaybased_queue": "1",
+                    "net.link.generic.system.hwcksum_in_invalidated": "0",
+                    "net.link.generic.system.hwcksum_dbg": "0",
+                    "net.link.generic.system.start_delayed": "0",
+                    "net.link.generic.system.start_delay_disabled": "0",
+                    "net.link.generic.system.hwcksum_dbg_mode": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_forced": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_forced_bytes": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_rxoff_forced": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_rxoff_adj": "0",
+                    "net.link.generic.system.hwcksum_dbg_verified": "0",
+                    "net.link.generic.system.hwcksum_dbg_bad_cksum": "0",
+                    "net.link.generic.system.hwcksum_dbg_bad_rxoff": "0",
+                    "net.link.generic.system.hwcksum_dbg_adjusted": "0",
+                    "net.link.generic.system.hwcksum_dbg_finalized_hdr": "0",
+                    "net.link.generic.system.hwcksum_dbg_finalized_data": "0",
+                    "net.link.generic.system.hwcksum_tx": "1",
+                    "net.link.generic.system.hwcksum_rx": "1",
+                    "net.link.generic.system.tx_chain_len_count": "0",
+                    "net.link.generic.system.threshold_notify": "1",
+                    "net.link.generic.system.threshold_interval": "2",
+                    "net.link.generic.system.enable_netagent": "0",
+                    "net.link.generic.system.port_used.entry_count": "0",
+                    "net.link.generic.system.port_used.entry_gen": "0",
+                    "net.link.generic.system.port_used.verbose": "0",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_count": "0",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_last_time": "{ sec = 0, usec = 0 } Wed Dec 31 16:00:00 1969",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_last_if": "",
+                    "net.link.ether.inet.prune_intvl": "300",
+                    "net.link.ether.inet.probe_intvl": "7",
+                    "net.link.ether.inet.max_age": "1200",
+                    "net.link.ether.inet.host_down_time": "20",
+                    "net.link.ether.inet.arp_llreach_base": "120",
+                    "net.link.ether.inet.arp_unicast_lim": "3",
+                    "net.link.ether.inet.maxtries": "5",
+                    "net.link.ether.inet.maxhold": "16",
+                    "net.link.ether.inet.useloopback": "1",
+                    "net.link.ether.inet.proxyall": "0",
+                    "net.link.ether.inet.sendllconflict": "0",
+                    "net.link.ether.inet.log_arp_warnings": "0",
+                    "net.link.ether.inet.keep_announcements": "1",
+                    "net.link.ether.inet.send_conflicting_probes": "1",
+                    "net.link.ether.inet.verbose": "0",
+                    "net.link.ether.inet.maxhold_total": "1024",
+                    "net.link.bridge.inherit_mac": "0",
+                    "net.link.bridge.rtable_prune_period": "300",
+                    "net.link.bridge.rtable_hash_size_max": "2048",
+                    "net.link.bridge.txstart": "0",
+                    "net.link.bridge.debug": "0",
+                    "net.link.loopback.max_dequeue": "256",
+                    "net.link.loopback.sched_model": "0",
+                    "net.link.loopback.dequeue_sc": "0",
+                    "net.link.fake.txstart": "1",
+                    "net.link.fake.hwcsum": "0",
+                    "net.link.fake.nxattach": "0",
+                    "net.link.fake.bsd_mode": "1",
+                    "net.link.fake.debug": "0",
+                    "net.link.fake.wmm_mode": "0",
+                    "net.link.fake.multibuflet": "0",
+                    "net.link.fake.copypkt_mode": "0",
+                    "net.link.fake.tx_headroom": "0",
+                    "net.link.fake.max_mtu": "2048",
+                    "net.link.fake.buflet_size": "512",
+                    "net.link.fake.user_access": "0",
+                    "net.link.fake.if_adv_intvl": "0",
+                    "net.link.fake.tx_drops": "0",
+                    "net.link.bond.debug": "0",
+                    "net.link.iptap.total_tap_count": "0",
+                    "net.link.iptap.log": "0",
+                    "net.link.pktap.total_tap_count": "0",
+                    "net.link.pktap.count_unknown_if_type": "0",
+                    "net.link.pktap.log": "0",
+                    "net.key.debug": "0",
+                    "net.key.spi_trycnt": "1000",
+                    "net.key.spi_minval": "256",
+                    "net.key.spi_maxval": "268435455",
+                    "net.key.int_random": "60",
+                    "net.key.larval_lifetime": "30",
+                    "net.key.blockacq_count": "10",
+                    "net.key.blockacq_lifetime": "20",
+                    "net.key.esp_keymin": "256",
+                    "net.key.esp_auth": "0",
+                    "net.key.ah_keymin": "128",
+                    "net.key.prefered_oldsa": "0",
+                    "net.key.natt_keepalive_interval": "20",
+                    "net.inet6.ip6.forwarding": "0",
+                    "net.inet6.ip6.redirect": "1",
+                    "net.inet6.ip6.hlim": "64",
+                    "net.inet6.ip6.maxfragpackets": "2048",
+                    "net.inet6.ip6.accept_rtadv": "1",
+                    "net.inet6.ip6.keepfaith": "0",
+                    "net.inet6.ip6.log_interval": "5",
+                    "net.inet6.ip6.hdrnestlimit": "15",
+                    "net.inet6.ip6.dad_count": "1",
+                    "net.inet6.ip6.auto_flowlabel": "1",
+                    "net.inet6.ip6.defmcasthlim": "1",
+                    "net.inet6.ip6.gifhlim": "0",
+                    "net.inet6.ip6.kame_version": "2009/apple-darwin",
+                    "net.inet6.ip6.use_deprecated": "1",
+                    "net.inet6.ip6.rr_prune": "5",
+                    "net.inet6.ip6.v6only": "0",
+                    "net.inet6.ip6.rtexpire": "3600",
+                    "net.inet6.ip6.rtminexpire": "10",
+                    "net.inet6.ip6.rtmaxcache": "128",
+                    "net.inet6.ip6.use_tempaddr": "1",
+                    "net.inet6.ip6.temppltime": "86400",
+                    "net.inet6.ip6.tempvltime": "604800",
+                    "net.inet6.ip6.auto_linklocal": "1",
+                    "net.inet6.ip6.prefer_tempaddr": "1",
+                    "net.inet6.ip6.use_defaultzone": "0",
+                    "net.inet6.ip6.maxfrags": "4096",
+                    "net.inet6.ip6.mcast_pmtu": "0",
+                    "net.inet6.ip6.neighborgcthresh": "1024",
+                    "net.inet6.ip6.maxifprefixes": "16",
+                    "net.inet6.ip6.maxifdefrouters": "16",
+                    "net.inet6.ip6.maxdynroutes": "1024",
+                    "net.inet6.ip6.fragpackets": "0",
+                    "net.inet6.ip6.adj_clear_hwcksum": "0",
+                    "net.inet6.ip6.adj_partial_sum": "1",
+                    "net.inet6.ip6.input_perf": "0",
+                    "net.inet6.ip6.input_perf_bins": "0",
+                    "net.inet6.ip6.output_perf": "0",
+                    "net.inet6.ip6.output_perf_bins": "0",
+                    "net.inet6.ip6.select_srcif_debug": "0",
+                    "net.inet6.ip6.select_srcaddr_debug": "0",
+                    "net.inet6.ip6.select_src_expensive_secondary_if": "0",
+                    "net.inet6.ip6.select_src_strong_end": "1",
+                    "net.inet6.ip6.mcast.maxgrpsrc": "512",
+                    "net.inet6.ip6.mcast.maxsocksrc": "128",
+                    "net.inet6.ip6.mcast.loop": "1",
+                    "net.inet6.ip6.only_allow_rfc4193_prefixes": "0",
+                    "net.inet6.ip6.clat_debug": "0",
+                    "net.inet6.ip6.maxchainsent": "1",
+                    "net.inet6.ip6.dad_enhanced": "1",
+                    "net.inet6.ipsec6.def_policy": "1",
+                    "net.inet6.ipsec6.esp_trans_deflev": "1",
+                    "net.inet6.ipsec6.esp_net_deflev": "1",
+                    "net.inet6.ipsec6.ah_trans_deflev": "1",
+                    "net.inet6.ipsec6.ah_net_deflev": "1",
+                    "net.inet6.ipsec6.ecn": "0",
+                    "net.inet6.ipsec6.debug": "0",
+                    "net.inet6.ipsec6.esp_randpad": "-1",
+                    "net.inet6.icmp6.rediraccept": "1",
+                    "net.inet6.icmp6.redirtimeout": "600",
+                    "net.inet6.icmp6.nd6_prune": "1",
+                    "net.inet6.icmp6.nd6_delay": "5",
+                    "net.inet6.icmp6.nd6_umaxtries": "3",
+                    "net.inet6.icmp6.nd6_mmaxtries": "3",
+                    "net.inet6.icmp6.nd6_useloopback": "1",
+                    "net.inet6.icmp6.nodeinfo": "3",
+                    "net.inet6.icmp6.errppslimit": "500",
+                    "net.inet6.icmp6.nd6_debug": "0",
+                    "net.inet6.icmp6.nd6_accept_6to4": "1",
+                    "net.inet6.icmp6.nd6_optimistic_dad": "63",
+                    "net.inet6.icmp6.nd6_onlink_ns_rfc4861": "0",
+                    "net.inet6.icmp6.nd6_prune_lazy": "5",
+                    "net.inet6.icmp6.rappslimit": "10",
+                    "net.inet6.icmp6.nd6_llreach_base": "30",
+                    "net.inet6.icmp6.nd6_maxsolstgt": "8",
+                    "net.inet6.icmp6.nd6_maxproxiedsol": "4",
+                    "net.inet6.icmp6.prproxy_cnt": "0",
+                    "net.inet6.mld.gsrdelay": "10",
+                    "net.inet6.mld.v1enable": "1",
+                    "net.inet6.mld.v2enable": "1",
+                    "net.inet6.mld.use_allow": "1",
+                    "net.inet6.mld.debug": "0",
+                    "net.inet6.send.opmode": "1",
+                    "net.inet6.send.opstate": "1",
+                    "net.systm.kctl.autorcvbufmax": "262144",
+                    "net.systm.kctl.autorcvbufhigh": "0",
+                    "net.systm.kctl.debug": "0",
+                    "net.ndrv_multi_max_count": "1024",
+                    "net.statistics_privcheck": "0",
+                    "net.stats.debug": "0",
+                    "net.stats.sendspace": "2048",
+                    "net.stats.recvspace": "8192",
+                    "net.utun.max_pending_input": "512",
+                    "net.utun.ring_size": "64",
+                    "net.utun.tx_fsw_ring_size": "64",
+                    "net.utun.rx_fsw_ring_size": "128",
+                    "net.ipsec.verify_interface_creation": "0",
+                    "net.ipsec.max_pending_input": "512",
+                    "net.ipsec.ring_size": "64",
+                    "net.ipsec.tx_fsw_ring_size": "64",
+                    "net.ipsec.rx_fsw_ring_size": "128",
+                    "net.ipsec.debug": "0",
+                    "net.necp.drop_all_level": "0",
+                    "net.necp.debug": "0",
+                    "net.necp.pass_loopback": "1",
+                    "net.necp.pass_keepalives": "1",
+                    "net.necp.socket_policy_count": "20",
+                    "net.necp.socket_non_app_policy_count": "20",
+                    "net.necp.ip_policy_count": "8",
+                    "net.necp.session_count": "4",
+                    "net.necp.client_fd_count": "57",
+                    "net.necp.client_count": "53",
+                    "net.necp.arena_count": "0",
+                    "net.necp.nexus_flow_count": "0",
+                    "net.necp.socket_flow_count": "2",
+                    "net.necp.if_flow_count": "0",
+                    "net.necp.observer_fd_count": "0",
+                    "net.necp.observer_message_limit": "256",
+                    "net.necp.sysctl_arena_count": "0",
+                    "net.necp.drop_unentitled_level": "0",
+                    "net.necp.pass_interpose": "1",
+                    "net.necp.drop_dest_debug": "0",
+                    "net.netagent.debug": "5",
+                    "net.netagent.registered_count": "22",
+                    "net.netagent.active_count": "21",
+                    "net.cfil.log": "3",
+                    "net.cfil.debug": "1",
+                    "net.cfil.sock_attached_count": "0",
+                    "net.cfil.active_count": "0",
+                    "net.cfil.close_wait_timeout": "1000",
+                    "net.cfil.sbtrim": "1",
+                    "net.restricted_port.enforced": "1",
+                    "net.restricted_port.verbose": "0",
+                    "net.classq.verbose": "0",
+                    "net.classq.sfb.holdtime": "0",
+                    "net.classq.sfb.pboxtime": "0",
+                    "net.classq.sfb.hinterval": "0",
+                    "net.classq.sfb.increment": "82",
+                    "net.classq.sfb.decrement": "16",
+                    "net.classq.sfb.allocation": "0",
+                    "net.classq.sfb.ratelimit": "0",
+                    "net.classq.target_qdelay": "0",
+                    "net.classq.update_interval": "0",
+                    "net.pktsched.verbose": "0",
+                    "net.qos.reset_dscp_to_wifi_ac_map": "0",
+                    "net.qos.verbose": "0",
+                    "net.qos.policy.restricted": "0",
+                    "net.qos.policy.restrict_avapps": "0",
+                    "net.qos.policy.wifi_enabled": "0",
+                    "net.qos.policy.capable_enabled": "0",
+                    "net.mpklog.enabled": "1",
+                    "net.mpklog.type": "0",
+                    "net.mpklog.version": "1",
+                    "net.alf.loglevel": "55",
+                    "net.alf.perm": "0",
+                    "net.alf.defaultaction": "1",
+                    "net.alf.mqcount": "0",
+                    "net.smb.fs.version": "304100",
+                    "net.smb.fs.loglevel": "0",
+                    "net.smb.fs.kern_deadtimer": "60",
+                    "net.smb.fs.kern_hard_deadtimer": "600",
+                    "net.smb.fs.kern_soft_deadtimer": "30",
+                    "net.smb.fs.tcpsndbuf": "8388608",
+                    "net.smb.fs.tcprcvbuf": "8388608",
+                    "net.smb.fs.maxwrite": "8388608",
+                    "net.smb.fs.maxread": "8388608",
+                    "net.smb.fs.maxsegreadsize": "8388608",
+                    "net.smb.fs.maxsegwritesize": "8388608"
+                }
+            },
+            "counters": {
+                "network": {
+                    "interfaces": {
+                        "lo0": {
+                            "rx": {
+                                "bytes": "71378",
+                                "packets": "0",
+                                "errors": "7996520",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "7996520",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "gif0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "stf0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en0": {
+                            "rx": {
+                                "bytes": "404017587",
+                                "packets": "326454",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "14172880",
+                                "packets": "125124",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en1": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en2": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "bridge0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "p2p0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "awdl0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "6550",
+                                "packets": "56",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "llw0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "utun0": {
+                            "rx": {
+                                "bytes": "2",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "200",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "utun1": {
+                            "rx": {
+                                "bytes": "2",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "200",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "ipaddress": "192.168.1.53",
+            "macaddress": "88:e9:fe:63:f2:d0",
+            "ip6address": "fe80::1",
+            "kernel": {
+                "name": "Darwin",
+                "release": "19.3.0",
+                "version": "Darwin Kernel Version 19.3.0: Thu Jan  9 20:58:23 PST 2020; root:xnu-6153.81.5~1/RELEASE_X86_64",
+                "machine": "x86_64",
+                "processor": "i386",
+                "os": "Darwin",
+                "modules": {
+                    "com.apple.kec.Libm": {
+                        "version": "1",
+                        "size": 65536,
+                        "index": "9",
+                        "refcount": "2"
+                    },
+                    "com.apple.kec.corecrypto": {
+                        "version": "1.0",
+                        "size": 892928,
+                        "index": "10",
+                        "refcount": "11"
+                    },
+                    "com.apple.kec.pthread": {
+                        "version": "1",
+                        "size": 40960,
+                        "index": "11",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOACPIFamily": {
+                        "version": "1.4",
+                        "size": 36864,
+                        "index": "12",
+                        "refcount": "32"
+                    },
+                    "com.apple.iokit.IOPCIFamily": {
+                        "version": "2.9",
+                        "size": 225280,
+                        "index": "13",
+                        "refcount": "39"
+                    },
+                    "com.apple.driver.watchdog": {
+                        "version": "1",
+                        "size": 36864,
+                        "index": "14",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleSMC": {
+                        "version": "3.1.9",
+                        "size": 126976,
+                        "index": "15",
+                        "refcount": "12"
+                    },
+                    "com.apple.driver.AppleACPIPlatform": {
+                        "version": "6.1",
+                        "size": 634880,
+                        "index": "16",
+                        "refcount": "2"
+                    },
+                    "com.apple.iokit.IOReportFamily": {
+                        "version": "47",
+                        "size": 28672,
+                        "index": "17",
+                        "refcount": "9"
+                    },
+                    "com.apple.iokit.IONetworkingFamily": {
+                        "version": "3.4",
+                        "size": 196608,
+                        "index": "18",
+                        "refcount": "11"
+                    },
+                    "com.apple.iokit.IOTimeSyncFamily": {
+                        "version": "810.1",
+                        "size": 258048,
+                        "index": "19",
+                        "refcount": "2"
+                    },
+                    "com.apple.kext.CoreTrust": {
+                        "version": "1",
+                        "size": 49152,
+                        "index": "20",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleMobileFileIntegrity": {
+                        "version": "1.0.5",
+                        "size": 143360,
+                        "index": "21",
+                        "refcount": "8"
+                    },
+                    "com.apple.iokit.EndpointSecurity": {
+                        "version": "1",
+                        "size": 208896,
+                        "index": "22",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.CoreAnalyticsFamily": {
+                        "version": "1",
+                        "size": 57344,
+                        "index": "23",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleBusPowerController": {
+                        "version": "1.0",
+                        "size": 32768,
+                        "index": "24",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBCommon": {
+                        "version": "1.0",
+                        "size": 57344,
+                        "index": "25",
+                        "refcount": "4"
+                    },
+                    "com.apple.driver.AppleUSBHostMergeProperties": {
+                        "version": "1.2",
+                        "size": 16384,
+                        "index": "26",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOUSBHostFamily": {
+                        "version": "1.2",
+                        "size": 1019904,
+                        "index": "27",
+                        "refcount": "10"
+                    },
+                    "com.apple.iokit.IOStorageFamily": {
+                        "version": "2.1",
+                        "size": 163840,
+                        "index": "28",
+                        "refcount": "8"
+                    },
+                    "com.apple.iokit.IOSCSIArchitectureModelFamily": {
+                        "version": "422.0.2",
+                        "size": 176128,
+                        "index": "29",
+                        "refcount": "3"
+                    },
+                    "com.apple.iokit.IOUSBMassStorageDriver": {
+                        "version": "157.40.7",
+                        "size": 196608,
+                        "index": "30",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.IOSlaveProcessor": {
+                        "version": "1",
+                        "size": 28672,
+                        "index": "31",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.AppleSEPManager": {
+                        "version": "1.0.1",
+                        "size": 110592,
+                        "index": "32",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.KernelRelayHost": {
+                        "version": "1",
+                        "size": 118784,
+                        "index": "33",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleCredentialManager": {
+                        "version": "1.0",
+                        "size": 327680,
+                        "index": "34",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSCSIBlockCommandsDevice": {
+                        "version": "422.0.2",
+                        "size": 102400,
+                        "index": "35",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleUSBTDM": {
+                        "version": "489.80.2",
+                        "size": 86016,
+                        "index": "36",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleKeyStore": {
+                        "version": "2",
+                        "size": 507904,
+                        "index": "37",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEffaceableStorage": {
+                        "version": "1.0",
+                        "size": 49152,
+                        "index": "38",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleFDEKeyStore": {
+                        "version": "28.30",
+                        "size": 49152,
+                        "index": "39",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.DiskImages": {
+                        "version": "493.0.0",
+                        "size": 102400,
+                        "index": "40",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.sandbox": {
+                        "version": "300.0",
+                        "size": 368640,
+                        "index": "42",
+                        "refcount": "2"
+                    },
+                    "com.apple.security.quarantine": {
+                        "version": "4",
+                        "size": 49152,
+                        "index": "43",
+                        "refcount": "1"
+                    },
+                    "com.apple.AppleSystemPolicy": {
+                        "version": "2.0.0",
+                        "size": 57344,
+                        "index": "44",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.TMSafetyNet": {
+                        "version": "8",
+                        "size": 8192,
+                        "index": "45",
+                        "refcount": "0"
+                    },
+                    "com.apple.nke.applicationfirewall": {
+                        "version": "303",
+                        "size": 40960,
+                        "index": "46",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.AppleImage4": {
+                        "version": "1",
+                        "size": 69632,
+                        "index": "47",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleAPIC": {
+                        "version": "1.7",
+                        "size": 12288,
+                        "index": "48",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOHIDFamily": {
+                        "version": "2.0.0",
+                        "size": 651264,
+                        "index": "49",
+                        "refcount": "10"
+                    },
+                    "com.apple.iokit.IOSMBusFamily": {
+                        "version": "1.1",
+                        "size": 16384,
+                        "index": "50",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleACPIEC": {
+                        "version": "6.1",
+                        "size": 32768,
+                        "index": "51",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleSMBIOS": {
+                        "version": "2.1",
+                        "size": 16384,
+                        "index": "52",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleRTC": {
+                        "version": "2.0",
+                        "size": 32768,
+                        "index": "53",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleACPIButtons": {
+                        "version": "6.1",
+                        "size": 16384,
+                        "index": "54",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEFIRuntime": {
+                        "version": "2.1",
+                        "size": 20480,
+                        "index": "55",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleEFINVRAM": {
+                        "version": "2.1",
+                        "size": 57344,
+                        "index": "56",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleSmartBatteryManager": {
+                        "version": "161.0.0",
+                        "size": 53248,
+                        "index": "57",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.usb.AppleUSBXHCI": {
+                        "version": "1.2",
+                        "size": 360448,
+                        "index": "58",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBXHCIPCI": {
+                        "version": "1.2",
+                        "size": 204800,
+                        "index": "59",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelLpssI2C": {
+                        "version": "3.0.60",
+                        "size": 40960,
+                        "index": "60",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssGspi": {
+                        "version": "3.0.60",
+                        "size": 45056,
+                        "index": "61",
+                        "refcount": "1"
+                    },
+                    "com.apple.private.KextAudit": {
+                        "version": "1.0",
+                        "size": 12288,
+                        "index": "62",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOUSBFamily": {
+                        "version": "900.4.2",
+                        "size": 630784,
+                        "index": "63",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IONVMeFamily": {
+                        "version": "2.1.0",
+                        "size": 274432,
+                        "index": "65",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelLpssDmac": {
+                        "version": "3.0.60",
+                        "size": 32768,
+                        "index": "66",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleIntelLpssSpiController": {
+                        "version": "3.0.60",
+                        "size": 81920,
+                        "index": "67",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSkywalkFamily": {
+                        "version": "1",
+                        "size": 282624,
+                        "index": "68",
+                        "refcount": "4"
+                    },
+                    "com.apple.driver.corecapture": {
+                        "version": "1.0.4",
+                        "size": 184320,
+                        "index": "69",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AirPort.BrcmNIC": {
+                        "version": "1400.1.1",
+                        "size": 8212480,
+                        "index": "72",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOThunderboltFamily": {
+                        "version": "7.6.0",
+                        "size": 999424,
+                        "index": "73",
+                        "refcount": "6"
+                    },
+                    "com.apple.driver.AppleThunderboltNHI": {
+                        "version": "5.8.6",
+                        "size": 163840,
+                        "index": "74",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHSSPISupport": {
+                        "version": "59",
+                        "size": 102400,
+                        "index": "75",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssI2CController": {
+                        "version": "3.0.60",
+                        "size": 102400,
+                        "index": "76",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleHPM": {
+                        "version": "3.4.4",
+                        "size": 61440,
+                        "index": "77",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltPCIDownAdapter": {
+                        "version": "2.5.4",
+                        "size": 20480,
+                        "index": "78",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltDPAdapterFamily": {
+                        "version": "6.2.5",
+                        "size": 61440,
+                        "index": "79",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleThunderboltDPInAdapter": {
+                        "version": "6.2.5",
+                        "size": 24576,
+                        "index": "80",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHSSPIHIDDriver": {
+                        "version": "59",
+                        "size": 40960,
+                        "index": "81",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleInputDeviceSupport": {
+                        "version": "3430.1",
+                        "size": 106496,
+                        "index": "82",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleMultitouchDriver": {
+                        "version": "3430.1",
+                        "size": 163840,
+                        "index": "83",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleHSBluetoothDriver": {
+                        "version": "3430.1",
+                        "size": 57344,
+                        "index": "87",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleTopCaseHIDEventDriver": {
+                        "version": "3430.1",
+                        "size": 40960,
+                        "index": "88",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHIDKeyboard": {
+                        "version": "209",
+                        "size": 45056,
+                        "index": "90",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleActuatorDriver": {
+                        "version": "3430.1",
+                        "size": 61440,
+                        "index": "91",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.hfs.encodings.kext": {
+                        "version": "1",
+                        "size": 20480,
+                        "index": "92",
+                        "refcount": "1"
+                    },
+                    "com.apple.AppleFSCompression.AppleFSCompressionTypeZlib": {
+                        "version": "1.0.0",
+                        "size": 49152,
+                        "index": "93",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOSurface": {
+                        "version": "269.6",
+                        "size": 188416,
+                        "index": "94",
+                        "refcount": "3"
+                    },
+                    "com.apple.BootCache": {
+                        "version": "40",
+                        "size": 57344,
+                        "index": "95",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.hfs.kext": {
+                        "version": "522.0.9",
+                        "size": 405504,
+                        "index": "97",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSerialFamily": {
+                        "version": "11",
+                        "size": 57344,
+                        "index": "98",
+                        "refcount": "6"
+                    },
+                    "com.apple.vecLib.kext": {
+                        "version": "1.2.0",
+                        "size": 704512,
+                        "index": "99",
+                        "refcount": "2"
+                    },
+                    "com.apple.iokit.IOAudioFamily": {
+                        "version": "300.2",
+                        "size": 258048,
+                        "index": "100",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.AppleVirtIO": {
+                        "version": "1.0",
+                        "size": 110592,
+                        "index": "101",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.apfs": {
+                        "version": "1412.81.1",
+                        "size": 1200128,
+                        "index": "104",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.networking": {
+                        "version": "5.0.0",
+                        "size": 32768,
+                        "index": "107",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOEthernetAVBController": {
+                        "version": "1.1.0",
+                        "size": 28672,
+                        "index": "112",
+                        "refcount": "2"
+                    },
+                    "com.apple.plugin.IOgPTPPlugin": {
+                        "version": "810.1",
+                        "size": 729088,
+                        "index": "113",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOGraphicsFamily": {
+                        "version": "569.4",
+                        "size": 331776,
+                        "index": "114",
+                        "refcount": "16"
+                    },
+                    "com.apple.iokit.IONDRVSupport": {
+                        "version": "569.4",
+                        "size": 65536,
+                        "index": "115",
+                        "refcount": "4"
+                    },
+                    "com.apple.driver.AppleCameraInterface": {
+                        "version": "7.6.0",
+                        "size": 696320,
+                        "index": "118",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelPCHPMC": {
+                        "version": "2.0.1",
+                        "size": 24576,
+                        "index": "122",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOSlowAdaptiveClockingFamily": {
+                        "version": "1.0.0",
+                        "size": 20480,
+                        "index": "124",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelSlowAdaptiveClocking": {
+                        "version": "4.0.0",
+                        "size": 8192,
+                        "index": "125",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.X86PlatformPlugin": {
+                        "version": "1.0.0",
+                        "size": 102400,
+                        "index": "126",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleMCCSControl": {
+                        "version": "1.13",
+                        "size": 61440,
+                        "index": "128",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleOnboardSerial": {
+                        "version": "1.0",
+                        "size": 188416,
+                        "index": "129",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleIntelLpssUARTCommon": {
+                        "version": "3.0.60",
+                        "size": 16384,
+                        "index": "130",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssUARTv1": {
+                        "version": "3.0.60",
+                        "size": 12288,
+                        "index": "131",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOAcceleratorFamily2": {
+                        "version": "438.3.1",
+                        "size": 802816,
+                        "index": "132",
+                        "refcount": "2"
+                    },
+                    "com.apple.AppleGraphicsDeviceControl": {
+                        "version": "4.7.2",
+                        "size": 40960,
+                        "index": "133",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.AppleIntelKBLGraphicsFramebuffer": {
+                        "version": "14.0.4",
+                        "size": 2277376,
+                        "index": "134",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleBacklightExpert": {
+                        "version": "1.1.0",
+                        "size": 24576,
+                        "index": "135",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleBacklight": {
+                        "version": "180.1",
+                        "size": 20480,
+                        "index": "136",
+                        "refcount": "0"
+                    },
+                    "com.apple.AppleGPUWrangler": {
+                        "version": "4.7.2",
+                        "size": 53248,
+                        "index": "139",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltIP": {
+                        "version": "3.1.3",
+                        "size": 90112,
+                        "index": "140",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.pmtelemetry": {
+                        "version": "1",
+                        "size": 90112,
+                        "index": "143",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.eficheck": {
+                        "version": "1",
+                        "size": 12288,
+                        "index": "144",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelKBLGraphics": {
+                        "version": "14.0.4",
+                        "size": 995328,
+                        "index": "145",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOHDAFamily": {
+                        "version": "283.15",
+                        "size": 49152,
+                        "index": "147",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleHDAController": {
+                        "version": "283.15",
+                        "size": 118784,
+                        "index": "148",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleSMCLMU": {
+                        "version": "212",
+                        "size": 20480,
+                        "index": "149",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleSSE": {
+                        "version": "1.0",
+                        "size": 53248,
+                        "index": "150",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOUserEthernet": {
+                        "version": "1.0.1",
+                        "size": 24576,
+                        "index": "151",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHV": {
+                        "version": "1",
+                        "size": 40960,
+                        "index": "154",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOAVBFamily": {
+                        "version": "800.17",
+                        "size": 143360,
+                        "index": "155",
+                        "refcount": "0"
+                    },
+                    "com.apple.AGDCPluginDisplayMetrics": {
+                        "version": "4.7.2",
+                        "size": 12288,
+                        "index": "156",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleGraphicsControl": {
+                        "version": "4.7.2",
+                        "size": 12288,
+                        "index": "157",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleGraphicsDevicePolicy": {
+                        "version": "4.7.2",
+                        "size": 81920,
+                        "index": "158",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.OSvKernDSPLib": {
+                        "version": "529",
+                        "size": 73728,
+                        "index": "159",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.DspFuncLib": {
+                        "version": "283.15",
+                        "size": 1314816,
+                        "index": "160",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleHDA": {
+                        "version": "283.15",
+                        "size": 749568,
+                        "index": "161",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleUpstreamUserClient": {
+                        "version": "3.6.8",
+                        "size": 20480,
+                        "index": "163",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.triggers": {
+                        "version": "1.0",
+                        "size": 20480,
+                        "index": "164",
+                        "refcount": "2"
+                    },
+                    "com.apple.filesystems.autofs": {
+                        "version": "3.0",
+                        "size": 36864,
+                        "index": "165",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.X86PlatformShim": {
+                        "version": "1.0.0",
+                        "size": 28672,
+                        "index": "166",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AGPM": {
+                        "version": "111.4.2",
+                        "size": 135168,
+                        "index": "167",
+                        "refcount": "0"
+                    },
+                    "com.apple.fileutil": {
+                        "version": "20.036.15",
+                        "size": 98304,
+                        "index": "169",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AudioAUUC": {
+                        "version": "1.70",
+                        "size": 20480,
+                        "index": "170",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.smbfs": {
+                        "version": "3.4.1",
+                        "size": 417792,
+                        "index": "171",
+                        "refcount": "0"
+                    }
+                }
+            },
+            "os": "darwin",
+            "os_version": "19.3.0",
+            "platform": "mac_os_x",
+            "platform_version": "10.15.3",
+            "platform_build": "19D76",
+            "platform_family": "mac_os_x",
+            "memory": {
+                "total": "16384MB",
+                "active": "3200MB",
+                "inactive": "844MB",
+                "free": "12338MB"
+            },
+            "dmi": {},
+            "hostname": "Johns-MacBook-Pro",
+            "machinename": "Johns-MacBook-Pro.local",
+            "domain": null,
+            "hardware": {
+                "SMC_version_system": "2.43f7",
+                "boot_rom_version": "204.0.0.0.0",
+                "cpu_type": "Dual-Core Intel Core i7",
+                "current_processor_speed": "2.5 GHz",
+                "l2_cache_core": "256 KB",
+                "l3_cache": "4 MB",
+                "machine_model": "MacBookPro14,1",
+                "machine_name": "MacBook Pro",
+                "number_processors": 2,
+                "packages": 1,
+                "physical_memory": "16 GB",
+                "platform_UUID": "1BF32DB4-4A83-5B9C-8479-5B8320F7808C",
+                "platform_cpu_htt": "htt_enabled",
+                "serial_number": "FVFWM0M8HV2J",
+                "operating_system": "Mac OS X",
+                "operating_system_version": "10.15.3",
+                "build_version": "19D76",
+                "architecture": "x86_64",
+                "storage": [
+                    {
+                        "name": "Macbook - Data",
+                        "bsd_name": "disk1s1",
+                        "capacity": 499963174912
+                    },
+                    {
+                        "name": "Macbook",
+                        "bsd_name": "disk1s5",
+                        "capacity": 499963174912
+                    },
+                    {
+                        "name": "Google Chrome",
+                        "bsd_name": "disk2s2",
+                        "capacity": 230981632
+                    }
+                ],
+                "battery": {
+                    "current_capacity": 587,
+                    "max_capacity": 4642,
+                    "fully_charged": false,
+                    "is_charging": false,
+                    "charge_cycle_count": 72,
+                    "health": "Good",
+                    "serial": "D868167B0TLH06FAZ",
+                    "remaining": 12
+                }
+            },
+            "virtualization": {
+                "systems": {}
+            },
+            "time": {
+                "timezone": "PDT"
+            },
+            "command": {
+                "ps": "ps -ef"
+            },
+            "root_group": "wheel",
+            "shard_seed": 67160980,
+            "keys": {
+                "ssh": {}
+            },
+            "shells": [
+                "/bin/bash",
+                "/bin/csh",
+                "/bin/dash",
+                "/bin/ksh",
+                "/bin/sh",
+                "/bin/tcsh",
+                "/bin/zsh",
+                "/usr/local/bin/pwsh"
+            ],
+            "ohai_time": 1586195579.86403,
+            "cpu": {
+                "cores": 2,
+                "total": 4,
+                "mhz": 2500,
+                "real": 1,
+                "vendor_id": "GenuineIntel",
+                "model_name": "Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz",
+                "family": 6,
+                "model": 142,
+                "stepping": 9,
+                "flags": [
+                    "fpu",
+                    "vme",
+                    "de",
+                    "pse",
+                    "tsc",
+                    "msr",
+                    "pae",
+                    "mce",
+                    "cx8",
+                    "apic",
+                    "sep",
+                    "mtrr",
+                    "pge",
+                    "mca",
+                    "cmov",
+                    "pat",
+                    "pse36",
+                    "clfsh",
+                    "ds",
+                    "acpi",
+                    "mmx",
+                    "fxsr",
+                    "sse",
+                    "sse2",
+                    "ss",
+                    "htt",
+                    "tm",
+                    "pbe",
+                    "sse3",
+                    "pclmulqdq",
+                    "dtes64",
+                    "mon",
+                    "dscpl",
+                    "vmx",
+                    "smx",
+                    "est",
+                    "tm2",
+                    "ssse3",
+                    "fma",
+                    "cx16",
+                    "tpr",
+                    "pdcm",
+                    "sse4.1",
+                    "sse4.2",
+                    "x2apic",
+                    "movbe",
+                    "popcnt",
+                    "aes",
+                    "pcid",
+                    "xsave",
+                    "osxsave",
+                    "seglim64",
+                    "tsctmr",
+                    "avx1.0",
+                    "rdrand",
+                    "f16c"
+                ]
+            },
+            "filesystem": {
+                "by_device": {
+                    "/dev/disk1s5": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "10564184",
+                        "kb_available": "468256532",
+                        "percent_used": "3%",
+                        "inodes_used": "484156",
+                        "inodes_available": "4881968724",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ],
+                        "mounts": [
+                            "/"
+                        ]
+                    },
+                    "devfs": {
+                        "block_size": 512,
+                        "kb_size": "200",
+                        "kb_used": "200",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "706",
+                        "inodes_available": "0",
+                        "total_inodes": "706",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/dev"
+                        ]
+                    },
+                    "/dev/disk1s1": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "5000096",
+                        "kb_available": "468256532",
+                        "percent_used": "2%",
+                        "inodes_used": "55469",
+                        "inodes_available": "4882397411",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/System/Volumes/Data"
+                        ]
+                    },
+                    "/dev/disk1s4": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "3146772",
+                        "kb_available": "468256532",
+                        "percent_used": "1%",
+                        "inodes_used": "4",
+                        "inodes_available": "4882452876",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/private/var/vm"
+                        ]
+                    },
+                    "map auto_home": {
+                        "block_size": 512,
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/System/Volumes/Data/home"
+                        ]
+                    },
+                    "/dev/disk2s2": {
+                        "block_size": 512,
+                        "kb_size": "225568",
+                        "kb_used": "225568",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "353",
+                        "inodes_available": "4294966926",
+                        "total_inodes": "4294967279",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "hfs",
+                        "mount_options": [
+                            "local",
+                            "nodev",
+                            "nosuid",
+                            "read-only",
+                            "noowners",
+                            "quarantine",
+                            "mounted by johnmccrae"
+                        ],
+                        "mounts": [
+                            "/Volumes/Google Chrome"
+                        ]
+                    }
+                },
+                "by_mountpoint": {
+                    "/": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "10564184",
+                        "kb_available": "468256532",
+                        "percent_used": "3%",
+                        "inodes_used": "484156",
+                        "inodes_available": "4881968724",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ],
+                        "devices": [
+                            "/dev/disk1s5"
+                        ]
+                    },
+                    "/dev": {
+                        "block_size": 512,
+                        "kb_size": "200",
+                        "kb_used": "200",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "706",
+                        "inodes_available": "0",
+                        "total_inodes": "706",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "devfs"
+                        ]
+                    },
+                    "/System/Volumes/Data": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "5000096",
+                        "kb_available": "468256532",
+                        "percent_used": "2%",
+                        "inodes_used": "55469",
+                        "inodes_available": "4882397411",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "/dev/disk1s1"
+                        ]
+                    },
+                    "/private/var/vm": {
+                        "block_size": 512,
+                        "kb_size": "488245288",
+                        "kb_used": "3146772",
+                        "kb_available": "468256532",
+                        "percent_used": "1%",
+                        "inodes_used": "4",
+                        "inodes_available": "4882452876",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "/dev/disk1s4"
+                        ]
+                    },
+                    "/System/Volumes/Data/home": {
+                        "block_size": 512,
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "map auto_home"
+                        ]
+                    },
+                    "/Volumes/Google Chrome": {
+                        "block_size": 512,
+                        "kb_size": "225568",
+                        "kb_used": "225568",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "353",
+                        "inodes_available": "4294966926",
+                        "total_inodes": "4294967279",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "hfs",
+                        "mount_options": [
+                            "local",
+                            "nodev",
+                            "nosuid",
+                            "read-only",
+                            "noowners",
+                            "quarantine",
+                            "mounted by johnmccrae"
+                        ],
+                        "devices": [
+                            "/dev/disk2s2"
+                        ]
+                    }
+                },
+                "by_pair": {
+                    "/dev/disk1s5,/": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s5",
+                        "kb_size": "488245288",
+                        "kb_used": "10564184",
+                        "kb_available": "468256532",
+                        "percent_used": "3%",
+                        "inodes_used": "484156",
+                        "inodes_available": "4881968724",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "mount": "/",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ]
+                    },
+                    "devfs,/dev": {
+                        "block_size": 512,
+                        "device": "devfs",
+                        "kb_size": "200",
+                        "kb_used": "200",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "706",
+                        "inodes_available": "0",
+                        "total_inodes": "706",
+                        "inodes_percent_used": "100%",
+                        "mount": "/dev",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ]
+                    },
+                    "/dev/disk1s1,/System/Volumes/Data": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s1",
+                        "kb_size": "488245288",
+                        "kb_used": "5000096",
+                        "kb_available": "468256532",
+                        "percent_used": "2%",
+                        "inodes_used": "55469",
+                        "inodes_available": "4882397411",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "mount": "/System/Volumes/Data",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ]
+                    },
+                    "/dev/disk1s4,/private/var/vm": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s4",
+                        "kb_size": "488245288",
+                        "kb_used": "3146772",
+                        "kb_available": "468256532",
+                        "percent_used": "1%",
+                        "inodes_used": "4",
+                        "inodes_available": "4882452876",
+                        "total_inodes": "4882452880",
+                        "inodes_percent_used": "0%",
+                        "mount": "/private/var/vm",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ]
+                    },
+                    "map auto_home,/System/Volumes/Data/home": {
+                        "block_size": 512,
+                        "device": "map auto_home",
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "mount": "/System/Volumes/Data/home",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ]
+                    },
+                    "/dev/disk2s2,/Volumes/Google Chrome": {
+                        "block_size": 512,
+                        "device": "/dev/disk2s2",
+                        "kb_size": "225568",
+                        "kb_used": "225568",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "353",
+                        "inodes_available": "4294966926",
+                        "total_inodes": "4294967279",
+                        "inodes_percent_used": "0%",
+                        "mount": "/Volumes/Google Chrome",
+                        "fs_type": "hfs",
+                        "mount_options": [
+                            "local",
+                            "nodev",
+                            "nosuid",
+                            "read-only",
+                            "noowners",
+                            "quarantine",
+                            "mounted by johnmccrae"
+                        ]
+                    }
+                }
+            },
+            "cloud": null,
+            "chef_guid": "5a5ab7a8-b095-458d-8480-ec27400c1165",
+            "name": "FVFWM0M8HV2J",
+            "chef_environment": "client_group",
+            "policy_revision": "910243477470e26b073bcdce9316a0db7c6b9f36a4290249b16af3086f048497",
+            "roles": [],
+            "recipes": [
+                "ChefDesktop::default",
+                "chef-client::task"
+            ],
+            "policy_name": "ChefDesktop",
+            "policy_group": "client_group",
+            "cookbooks": {
+                "ChefDesktop": {
+                    "version": "0.1.0"
+                },
+                "chef-client": {
+                    "version": "11.5.0"
+                },
+                "cron": {
+                    "version": "6.2.2"
+                },
+                "logrotate": {
+                    "version": "2.2.2"
+                }
+            }
+        },
+        "normal": {
+            "tags": []
+        },
+        "chef_type": "node",
+        "default": {
+            "cron": {
+                "package_name": [],
+                "service_name": "cron"
+            },
+            "logrotate": {
+                "package": {
+                    "name": "logrotate",
+                    "source": null,
+                    "version": null,
+                    "provider": null,
+                    "action": "upgrade"
+                },
+                "directory": "/etc/logrotate.d",
+                "cron": {
+                    "install": false,
+                    "name": "logrotate",
+                    "command": "/usr/sbin/logrotate /etc/logrotate.conf",
+                    "minute": 35,
+                    "hour": 2
+                },
+                "global": {
+                    "weekly": true,
+                    "rotate": 4,
+                    "create": "",
+                    "/var/log/wtmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0664 root utmp",
+                        "rotate": 1
+                    },
+                    "/var/log/btmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0600 root utmp",
+                        "rotate": 1
+                    }
+                }
+            },
+            "chef_client": {
+                "config": {
+                    "chef_server_url": "https://api.chef.io/organizations/chefit-development",
+                    "validation_client_name": "chefit-development-validator",
+                    "node_name": "FVFWM0M8HV2J",
+                    "verify_api_cert": true,
+                    "start_handlers": [],
+                    "report_handlers": [],
+                    "exception_handlers": []
+                },
+                "chef_license": null,
+                "log_file": "client.log",
+                "interval": "1800",
+                "splay": "300",
+                "conf_dir": "/etc/chef",
+                "bin": "/usr/bin/chef-client",
+                "log_dir": "/Library/Logs/Chef",
+                "log_perm": "640",
+                "cron": {
+                    "minute": "0",
+                    "hour": "0,4,8,12,16,20",
+                    "weekday": "*",
+                    "path": null,
+                    "environment_variables": null,
+                    "log_file": "/dev/null",
+                    "append_log": false,
+                    "use_cron_d": false,
+                    "mailto": null,
+                    "nice_path": "/bin/nice"
+                },
+                "systemd": {
+                    "timer": false,
+                    "timeout": false,
+                    "restart": "always"
+                },
+                "task": {
+                    "frequency": "minute",
+                    "frequency_modifier": 30,
+                    "user": "SYSTEM",
+                    "password": null,
+                    "start_time": null,
+                    "start_date": null,
+                    "name": "chef-client"
+                },
+                "load_gems": {},
+                "reload_config": true,
+                "daemon_options": [],
+                "logrotate": {
+                    "rotate": 12,
+                    "frequency": "weekly"
+                },
+                "init_style": "launchd",
+                "run_path": "/var/run/chef",
+                "cache_path": "/Library/Caches/Chef",
+                "backup_path": "/Library/Caches/Chef/Backup",
+                "launchd_mode": "interval",
+                "log_rotation": {
+                    "options": [
+                        "compress"
+                    ],
+                    "prerotate": null,
+                    "postrotate": "/etc/init.d/chef-client reload >/dev/null || :"
+                }
+            },
+            "ohai": {
+                "disabled_plugins": [],
+                "optional_plugins": [],
+                "plugin_path": null
+            }
+        },
+        "override": {},
+        "run_list": [
+            "recipe[ChefDesktop::default]"
+        ],
+        "policy_name": "ChefDesktop",
+        "policy_group": "client_group"
+    },
+    "node_name": "FVFWM0M8HV2J",
+    "organization_name": "chefit-development",
+    "resources": [],
+    "run_id": "1a3a47dc-82d0-4869-97b4-a49b47b9c10a",
+    "run_list": [
+        "recipe[ChefDesktop::default]"
+    ],
+    "cookbooks": {
+        "ChefDesktop": {
+            "version": "0.1.0"
+        },
+        "chef-client": {
+            "version": "11.5.0"
+        },
+        "cron": {
+            "version": "6.2.2"
+        },
+        "logrotate": {
+            "version": "2.2.2"
+        }
+    },
+    "policy_name": "ChefDesktop",
+    "policy_group": "client_group",
+    "start_time": "2020-04-06T17:53:01Z",
+    "end_time": "2020-04-06T17:53:20Z",
+    "source": "chef_client",
+    "status": "failure",
+    "total_resource_count": 0,
+    "updated_resource_count": 0,
+    "deprecations": [],
+    "error": {
+        "class": "NoMethodError",
+        "message": "undefined method `inherits' for Chef::Resource::Directory",
+        "backtrace": [
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/resource.rb:1334:in `method_missing'",
+            "/var/chef/cache/cookbooks/chef-client/recipes/task.rb:28:in `block in from_file'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/resource_builder.rb:67:in `instance_eval'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/resource_builder.rb:67:in `build'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/dsl/declare_resource.rb:316:in `build_resource'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/dsl/declare_resource.rb:273:in `declare_resource'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/dsl/resources.rb:36:in `directory'",
+            "/var/chef/cache/cookbooks/chef-client/recipes/task.rb:27:in `from_file'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/mixin/from_file.rb:34:in `instance_eval'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/mixin/from_file.rb:34:in `from_file'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/cookbook_version.rb:199:in `load_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:393:in `load_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:349:in `block in include_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:348:in `each'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:348:in `include_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/dsl/include_recipe.rb:26:in `include_recipe'",
+            "/var/chef/cache/cookbooks/ChefDesktop/recipes/default.rb:5:in `from_file'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/mixin/from_file.rb:34:in `instance_eval'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/mixin/from_file.rb:34:in `from_file'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/cookbook_version.rb:199:in `load_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:393:in `load_recipe'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context/cookbook_compiler.rb:166:in `block in compile_recipes'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context/cookbook_compiler.rb:163:in `each'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context/cookbook_compiler.rb:163:in `compile_recipes'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context/cookbook_compiler.rb:79:in `compile'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/run_context.rb:223:in `load'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/policy_builder/policyfile.rb:196:in `setup_run_context'",
+            "/opt/chef/embedded/lib/ruby/2.6.0/forwardable.rb:230:in `setup_run_context'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/client.rb:487:in `setup_run_context'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/client.rb:284:in `run'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/application.rb:320:in `run_with_graceful_exit_option'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/application.rb:296:in `block in run_chef_client'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/local_mode.rb:42:in `with_server_connectivity'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/application.rb:279:in `run_chef_client'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/application/base.rb:330:in `run_application'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23/lib/chef/application.rb:69:in `run'",
+            "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-bin-15.8.23/bin/chef-client:25:in `<top (required)>'",
+            "/usr/local/bin/chef-client:177:in `load'",
+            "/usr/local/bin/chef-client:177:in `<main>'"
+        ],
+        "description": {}
+    }
+}

--- a/dev-docs/adding-data/sample-reports/desktop-report-2.json
+++ b/dev-docs/adding-data/sample-reports/desktop-report-2.json
@@ -1,0 +1,5825 @@
+{
+    "chef_server_fqdn": "api.chef.io",
+    "entity_uuid": "fb180f13-9781-4b16-b41c-62577c2c722d",
+    "expanded_run_list": {
+        "id": "_default",
+        "run_list": [
+            {
+                "type": "role",
+                "name": "cpe_base",
+                "children": [
+                    {
+                        "type": "recipe",
+                        "name": "cpe_init",
+                        "version": null,
+                        "skipped": false
+                    }
+                ],
+                "missing": null,
+                "error": null,
+                "skipped": null
+            }
+        ]
+    },
+    "id": "92c65967-db70-4852-b587-e67225a0bad0",
+    "message_version": "1.1.0",
+    "message_type": "run_converge",
+    "node": {
+        "name": "C02YJ0PLJGH5",
+        "chef_environment": "_default",
+        "json_class": "Chef::Node",
+        "automatic": {
+            "uptime_seconds": 494,
+            "uptime": "8 minutes 14 seconds",
+            "chef_packages": {
+                "chef": {
+                    "version": "15.5.17",
+                    "chef_root": "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/chef-15.5.17/lib"
+                },
+                "ohai": {
+                    "version": "15.3.1",
+                    "ohai_root": "/opt/chef/embedded/lib/ruby/gems/2.6.0/gems/ohai-15.3.1/lib/ohai"
+                }
+            },
+            "languages": {
+                "php": {
+                    "version": "7.3.11",
+                    "builddate": "Dec 13 2019 19:21:21",
+                    "zend_engine_version": "3.3.11"
+                },
+                "python": {
+                    "version": "2.7.16",
+                    "builddate": "Dec 13 2019, 18:00:32"
+                },
+                "ruby": {
+                    "platform": "universal.x86_64-darwin19",
+                    "version": "2.6.3",
+                    "release_date": "2019-04-16",
+                    "target": "universal-apple-darwin19",
+                    "target_cpu": "universal",
+                    "target_vendor": "apple",
+                    "target_os": "darwin19",
+                    "host": "x86_64-apple-darwin19",
+                    "host_cpu": "x86_64",
+                    "host_os": "darwin19",
+                    "host_vendor": "apple",
+                    "bin_dir": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin",
+                    "ruby_bin": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby",
+                    "gems_dir": "/Library/Ruby/Gems/2.6.0",
+                    "gem_bin": "/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/gem"
+                },
+                "perl": {
+                    "version": "5.18.4",
+                    "archname": "darwin-thread-multi-2level"
+                }
+            },
+            "network": {
+                "interfaces": {
+                    "lo0": {
+                        "addresses": {
+                            "127.0.0.1": {
+                                "family": "inet",
+                                "netmask": "255.0.0.0"
+                            },
+                            "::1": {
+                                "family": "inet6",
+                                "prefixlen": "128",
+                                "scope": "Node"
+                            },
+                            "fe80::1": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            },
+                            "127.94.0.2": {
+                                "family": "inet",
+                                "netmask": "255.0.0.0"
+                            },
+                            "127.94.0.1": {
+                                "family": "inet",
+                                "netmask": "255.0.0.0"
+                            }
+                        },
+                        "mtu": "16384",
+                        "flags": [
+                            "UP",
+                            "LOOPBACK",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "lo",
+                        "number": "0",
+                        "encapsulation": "Loopback"
+                    },
+                    "gif0": {
+                        "addresses": {},
+                        "mtu": "1280",
+                        "flags": [
+                            "POINTOPOINT",
+                            "MULTICAST"
+                        ],
+                        "type": "gif",
+                        "number": "0",
+                        "encapsulation": "IPIP"
+                    },
+                    "stf0": {
+                        "addresses": {},
+                        "mtu": "1280",
+                        "flags": [],
+                        "type": "stf",
+                        "number": "0",
+                        "encapsulation": "6to4"
+                    },
+                    "en5": {
+                        "addresses": {
+                            "ac:de:48:00:11:22": {
+                                "family": "lladdr"
+                            },
+                            "fe80::aede:48ff:fe00:1122": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "5",
+                        "encapsulation": "Ethernet"
+                    },
+                    "ap1": {
+                        "addresses": {
+                            "3a:f9:d3:98:72:fa": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "BROADCAST",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "ap",
+                        "number": "1",
+                        "encapsulation": "Ethernet"
+                    },
+                    "en0": {
+                        "addresses": {
+                            "38:f9:d3:98:72:fa": {
+                                "family": "lladdr"
+                            },
+                            "fe80::1c2f:a8b6:9c13:d165": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            },
+                            "2601:602:9200:d56:be:ac91:541:46df": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Global"
+                            },
+                            "2601:602:9200:d56:c1e6:f51:fb25:287e": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Global"
+                            },
+                            "192.168.0.100": {
+                                "family": "inet",
+                                "netmask": "255.255.255.0",
+                                "broadcast": "192.168.0.255"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "0",
+                        "encapsulation": "Ethernet",
+                        "arp": {
+                            "192.168.0.1": "98:de:d0:91:22:c4",
+                            "192.168.0.102": "14:20:5e:4e:e:43",
+                            "192.168.0.103": "8:5:81:27:67:a6",
+                            "192.168.0.255": "ff:ff:ff:ff:ff:ff",
+                            "224.0.0.251": "1:0:5e:0:0:fb",
+                            "239.255.255.250": "1:0:5e:7f:ff:fa"
+                        }
+                    },
+                    "en1": {
+                        "addresses": {
+                            "82:30:a1:00:8c:01": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "1",
+                        "encapsulation": "Ethernet"
+                    },
+                    "en2": {
+                        "addresses": {
+                            "82:30:a1:00:8c:00": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "2",
+                        "encapsulation": "Ethernet"
+                    },
+                    "en3": {
+                        "addresses": {
+                            "82:30:a1:00:8c:05": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "3",
+                        "encapsulation": "Ethernet"
+                    },
+                    "en4": {
+                        "addresses": {
+                            "82:30:a1:00:8c:04": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "en",
+                        "number": "4",
+                        "encapsulation": "Ethernet"
+                    },
+                    "bridge0": {
+                        "addresses": {
+                            "82:30:a1:00:8c:01": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "bridge",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "p2p0": {
+                        "addresses": {
+                            "0a:f9:d3:98:72:fa": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": "2304",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "p2p",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "awdl0": {
+                        "addresses": {
+                            "c2:a5:4d:77:46:57": {
+                                "family": "lladdr"
+                            },
+                            "fe80::c0a5:4dff:fe77:4657": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1484",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "RUNNING",
+                            "PROMISC",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "awdl",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "llw0": {
+                        "addresses": {
+                            "c2:a5:4d:77:46:57": {
+                                "family": "lladdr"
+                            },
+                            "fe80::c0a5:4dff:fe77:4657": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1500",
+                        "flags": [
+                            "UP",
+                            "BROADCAST",
+                            "SMART",
+                            "RUNNING",
+                            "SIMPLEX",
+                            "MULTICAST"
+                        ],
+                        "type": "llw",
+                        "number": "0",
+                        "encapsulation": "Ethernet"
+                    },
+                    "utun0": {
+                        "addresses": {
+                            "fe80::18d2:da22:ef05:2bc": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "1380",
+                        "flags": [
+                            "UP",
+                            "POINTOPOINT",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "utun",
+                        "number": "0",
+                        "encapsulation": "Unknown"
+                    },
+                    "utun1": {
+                        "addresses": {
+                            "fe80::c4a3:9d9:a252:807e": {
+                                "family": "inet6",
+                                "prefixlen": "64",
+                                "scope": "Link"
+                            }
+                        },
+                        "mtu": "2000",
+                        "flags": [
+                            "UP",
+                            "POINTOPOINT",
+                            "RUNNING",
+                            "MULTICAST"
+                        ],
+                        "type": "utun",
+                        "number": "1",
+                        "encapsulation": "Unknown"
+                    }
+                },
+                "default_gateway": "192.168.0.1",
+                "default_interface": "en0",
+                "settings": {
+                    "net.local.stream.sendspace": "8192",
+                    "net.local.stream.recvspace": "8192",
+                    "net.local.stream.tracemdns": "0",
+                    "net.local.dgram.maxdgram": "2048",
+                    "net.local.dgram.recvspace": "4096",
+                    "net.local.inflight": "0",
+                    "net.inet.ip.portrange.lowfirst": "1023",
+                    "net.inet.ip.portrange.lowlast": "600",
+                    "net.inet.ip.portrange.first": "49152",
+                    "net.inet.ip.portrange.last": "65535",
+                    "net.inet.ip.portrange.hifirst": "49152",
+                    "net.inet.ip.portrange.hilast": "65535",
+                    "net.inet.ip.forwarding": "0",
+                    "net.inet.ip.redirect": "1",
+                    "net.inet.ip.ttl": "64",
+                    "net.inet.ip.rtexpire": "3600",
+                    "net.inet.ip.rtminexpire": "10",
+                    "net.inet.ip.rtmaxcache": "128",
+                    "net.inet.ip.sourceroute": "0",
+                    "net.inet.ip.accept_sourceroute": "0",
+                    "net.inet.ip.gifttl": "30",
+                    "net.inet.ip.subnets_are_local": "0",
+                    "net.inet.ip.mcast.maxgrpsrc": "512",
+                    "net.inet.ip.mcast.maxsocksrc": "128",
+                    "net.inet.ip.mcast.loop": "1",
+                    "net.inet.ip.dummynet.hash_size": "64",
+                    "net.inet.ip.dummynet.curr_time": "0",
+                    "net.inet.ip.dummynet.ready_heap": "0",
+                    "net.inet.ip.dummynet.extract_heap": "0",
+                    "net.inet.ip.dummynet.searches": "0",
+                    "net.inet.ip.dummynet.search_steps": "0",
+                    "net.inet.ip.dummynet.expire": "1",
+                    "net.inet.ip.dummynet.max_chain_len": "16",
+                    "net.inet.ip.dummynet.red_lookup_depth": "256",
+                    "net.inet.ip.dummynet.red_avg_pkt_size": "512",
+                    "net.inet.ip.dummynet.red_max_pkt_size": "1500",
+                    "net.inet.ip.dummynet.debug": "0",
+                    "net.inet.ip.random_id_statistics": "0",
+                    "net.inet.ip.random_id_collisions": "0",
+                    "net.inet.ip.random_id_total": "0",
+                    "net.inet.ip.sendsourcequench": "0",
+                    "net.inet.ip.maxfragpackets": "2048",
+                    "net.inet.ip.fragpackets": "0",
+                    "net.inet.ip.maxfragsperpacket": "128",
+                    "net.inet.ip.adj_clear_hwcksum": "0",
+                    "net.inet.ip.adj_partial_sum": "1",
+                    "net.inet.ip.check_interface": "0",
+                    "net.inet.ip.rx_chaining": "1",
+                    "net.inet.ip.rx_chainsz": "6",
+                    "net.inet.ip.linklocal.in.allowbadttl": "1",
+                    "net.inet.ip.random_id": "1",
+                    "net.inet.ip.maxchainsent": "5",
+                    "net.inet.ip.select_srcif_debug": "0",
+                    "net.inet.ip.output_perf": "0",
+                    "net.inet.ip.output_perf_bins": "0",
+                    "net.inet.ip.rfc6864": "1",
+                    "net.inet.icmp.maskrepl": "0",
+                    "net.inet.icmp.icmplim": "250",
+                    "net.inet.icmp.timestamp": "0",
+                    "net.inet.icmp.drop_redirect": "1",
+                    "net.inet.icmp.log_redirect": "0",
+                    "net.inet.icmp.bmcastecho": "1",
+                    "net.inet.igmp.recvifkludge": "1",
+                    "net.inet.igmp.sendra": "1",
+                    "net.inet.igmp.sendlocal": "1",
+                    "net.inet.igmp.v1enable": "1",
+                    "net.inet.igmp.v2enable": "1",
+                    "net.inet.igmp.legacysupp": "0",
+                    "net.inet.igmp.default_version": "3",
+                    "net.inet.igmp.gsrdelay": "10",
+                    "net.inet.igmp.debug": "0",
+                    "net.inet.tcp.rfc1644": "0",
+                    "net.inet.tcp.mssdflt": "512",
+                    "net.inet.tcp.keepidle": "7200000",
+                    "net.inet.tcp.keepintvl": "75000",
+                    "net.inet.tcp.sendspace": "131072",
+                    "net.inet.tcp.recvspace": "131072",
+                    "net.inet.tcp.keepinit": "75000",
+                    "net.inet.tcp.v6mssdflt": "1024",
+                    "net.inet.tcp.backoff_maximum": "65536",
+                    "net.inet.tcp.ecn_timeout": "60",
+                    "net.inet.tcp.disable_tcp_heuristics": "0",
+                    "net.inet.tcp.clear_tfocache": "0",
+                    "net.inet.tcp.log_in_vain": "0",
+                    "net.inet.tcp.blackhole": "0",
+                    "net.inet.tcp.delayed_ack": "3",
+                    "net.inet.tcp.tcp_lq_overflow": "1",
+                    "net.inet.tcp.recvbg": "0",
+                    "net.inet.tcp.drop_synfin": "1",
+                    "net.inet.tcp.reass.overflows": "0",
+                    "net.inet.tcp.slowlink_wsize": "8192",
+                    "net.inet.tcp.maxseg_unacked": "8",
+                    "net.inet.tcp.rfc3465": "1",
+                    "net.inet.tcp.rfc3465_lim2": "1",
+                    "net.inet.tcp.recv_allowed_iaj": "5",
+                    "net.inet.tcp.doautorcvbuf": "1",
+                    "net.inet.tcp.autorcvbufmax": "2097152",
+                    "net.inet.tcp.lro": "0",
+                    "net.inet.tcp.lrodbg": "0",
+                    "net.inet.tcp.lro_startcnt": "4",
+                    "net.inet.tcp.disable_access_to_stats": "1",
+                    "net.inet.tcp.challengeack_limit": "10",
+                    "net.inet.tcp.do_rfc5961": "1",
+                    "net.inet.tcp.rcvsspktcnt": "512",
+                    "net.inet.tcp.rexmt_thresh": "3",
+                    "net.inet.tcp.path_mtu_discovery": "1",
+                    "net.inet.tcp.slowstart_flightsize": "1",
+                    "net.inet.tcp.local_slowstart_flightsize": "8",
+                    "net.inet.tcp.tso": "1",
+                    "net.inet.tcp.ecn_setup_percentage": "100",
+                    "net.inet.tcp.ecn_initiate_out": "2",
+                    "net.inet.tcp.ecn_negotiate_in": "2",
+                    "net.inet.tcp.packetchain": "50",
+                    "net.inet.tcp.socket_unlocked_on_output": "1",
+                    "net.inet.tcp.rfc3390": "1",
+                    "net.inet.tcp.min_iaj_win": "16",
+                    "net.inet.tcp.acc_iaj_react_limit": "200",
+                    "net.inet.tcp.doautosndbuf": "1",
+                    "net.inet.tcp.autosndbufinc": "8192",
+                    "net.inet.tcp.autosndbufmax": "2097152",
+                    "net.inet.tcp.ack_prioritize": "1",
+                    "net.inet.tcp.rtt_recvbg": "1",
+                    "net.inet.tcp.recv_throttle_minwin": "16384",
+                    "net.inet.tcp.enable_tlp": "1",
+                    "net.inet.tcp.sack": "1",
+                    "net.inet.tcp.sack_maxholes": "128",
+                    "net.inet.tcp.sack_globalmaxholes": "65536",
+                    "net.inet.tcp.sack_globalholes": "0",
+                    "net.inet.tcp.fastopen_backlog": "10",
+                    "net.inet.tcp.fastopen": "3",
+                    "net.inet.tcp.now_init": "190550396",
+                    "net.inet.tcp.microuptime_init": "844750",
+                    "net.inet.tcp.minmss": "216",
+                    "net.inet.tcp.do_tcpdrain": "0",
+                    "net.inet.tcp.pcbcount": "55",
+                    "net.inet.tcp.tw_pcbcount": "0",
+                    "net.inet.tcp.icmp_may_rst": "1",
+                    "net.inet.tcp.rtt_min": "100",
+                    "net.inet.tcp.rexmt_slop": "200",
+                    "net.inet.tcp.randomize_ports": "0",
+                    "net.inet.tcp.win_scale_factor": "3",
+                    "net.inet.tcp.init_rtt_from_cache": "1",
+                    "net.inet.tcp.tcbhashsize": "4096",
+                    "net.inet.tcp.keepcnt": "8",
+                    "net.inet.tcp.msl": "15000",
+                    "net.inet.tcp.max_persist_timeout": "0",
+                    "net.inet.tcp.always_keepalive": "0",
+                    "net.inet.tcp.timer_fastmode_idlemax": "10",
+                    "net.inet.tcp.broken_peer_syn_rexmit_thres": "10",
+                    "net.inet.tcp.tcp_timer_advanced": "0",
+                    "net.inet.tcp.tcp_resched_timerlist": "559",
+                    "net.inet.tcp.pmtud_blackhole_detection": "1",
+                    "net.inet.tcp.pmtud_blackhole_mss": "1200",
+                    "net.inet.tcp.cc_debug": "0",
+                    "net.inet.tcp.newreno_sockets": "0",
+                    "net.inet.tcp.background_sockets": "0",
+                    "net.inet.tcp.cubic_sockets": "49",
+                    "net.inet.tcp.use_newreno": "0",
+                    "net.inet.tcp.cubic_tcp_friendliness": "0",
+                    "net.inet.tcp.cubic_fast_convergence": "0",
+                    "net.inet.tcp.cubic_use_minrtt": "0",
+                    "net.inet.tcp.lro_sz": "8",
+                    "net.inet.tcp.lro_time": "10",
+                    "net.inet.tcp.bg_target_qdelay": "100",
+                    "net.inet.tcp.bg_allowed_increase": "8",
+                    "net.inet.tcp.bg_tether_shift": "1",
+                    "net.inet.tcp.bg_ss_fltsz": "2",
+                    "net.inet.tcp.log.level_info": "0",
+                    "net.inet.tcp.log.enable": "0",
+                    "net.inet.tcp.log.enable_usage": "connection:0x1 rtt:0x2 ka:0x4 loop:0x10 local:0x20 gw:0x40 syn:0x100 fin:0x200 rst:0x400 dropnecp:0x1000 droppcb:0x2000 droppkt:0x4000 ",
+                    "net.inet.tcp.log.rtt_port": "0",
+                    "net.inet.tcp.log.thflags_if_family": "0",
+                    "net.inet.tcp.log.privacy": "1",
+                    "net.inet.tcp.log.rate_limit": "600",
+                    "net.inet.tcp.log.rate_duration": "60",
+                    "net.inet.tcp.log.rate_max": "0",
+                    "net.inet.tcp.log.rate_exceeded_total": "0",
+                    "net.inet.tcp.log.rate_current": "0",
+                    "net.inet.udp.checksum": "1",
+                    "net.inet.udp.maxdgram": "9216",
+                    "net.inet.udp.recvspace": "786896",
+                    "net.inet.udp.log_in_vain": "0",
+                    "net.inet.udp.blackhole": "0",
+                    "net.inet.udp.pcbcount": "109",
+                    "net.inet.udp.randomize_ports": "1",
+                    "net.inet.ipsec.def_policy": "1",
+                    "net.inet.ipsec.esp_trans_deflev": "1",
+                    "net.inet.ipsec.esp_net_deflev": "1",
+                    "net.inet.ipsec.ah_trans_deflev": "1",
+                    "net.inet.ipsec.ah_net_deflev": "1",
+                    "net.inet.ipsec.ah_cleartos": "1",
+                    "net.inet.ipsec.ah_offsetmask": "0",
+                    "net.inet.ipsec.dfbit": "0",
+                    "net.inet.ipsec.ecn": "0",
+                    "net.inet.ipsec.debug": "0",
+                    "net.inet.ipsec.esp_randpad": "-1",
+                    "net.inet.ipsec.bypass": "1",
+                    "net.inet.ipsec.esp_port": "0",
+                    "net.inet.log_restricted": "0",
+                    "net.inet.raw.maxdgram": "8192",
+                    "net.inet.raw.recvspace": "8192",
+                    "net.inet.raw.pcbcount": "0",
+                    "net.inet.mptcp.enable": "1",
+                    "net.inet.mptcp.mptcp_cap_retr": "4",
+                    "net.inet.mptcp.dss_csum": "0",
+                    "net.inet.mptcp.fail": "1",
+                    "net.inet.mptcp.keepalive": "840",
+                    "net.inet.mptcp.rtthist_thresh": "600",
+                    "net.inet.mptcp.userto": "1",
+                    "net.inet.mptcp.rto_thresh": "1500",
+                    "net.inet.mptcp.probeto": "1000",
+                    "net.inet.mptcp.probecnt": "5",
+                    "net.inet.mptcp.dbg_area": "31",
+                    "net.inet.mptcp.dbg_level": "1",
+                    "net.inet.mptcp.pcbcount": "0",
+                    "net.inet.mptcp.alternate_port": "0",
+                    "net.inet.mptcp.allow_aggregate": "0",
+                    "net.inet.mptcp.expected_progress_headstart": "5000",
+                    "net.inet.mptcp.rto": "3",
+                    "net.inet.mptcp.nrto": "3",
+                    "net.inet.mptcp.tw": "60",
+                    "net.link.generic.system.ifcount": "16",
+                    "net.link.generic.system.if_verbose": "0",
+                    "net.link.generic.system.dlil_verbose": "0",
+                    "net.link.generic.system.sndq_maxlen": "128",
+                    "net.link.generic.system.rcvq_maxlen": "256",
+                    "net.link.generic.system.rxpoll_decay": "2",
+                    "net.link.generic.system.rxpoll_freeze_time": "1000000000",
+                    "net.link.generic.system.rxpoll_sample_time": "10000000",
+                    "net.link.generic.system.rxpoll_interval_time": "1000000",
+                    "net.link.generic.system.rxpoll_interval_pkts": "0",
+                    "net.link.generic.system.rxpoll_wakeups_lowat": "10",
+                    "net.link.generic.system.rxpoll_wakeups_hiwat": "100",
+                    "net.link.generic.system.rxpoll_max": "0",
+                    "net.link.generic.system.rxpoll": "1",
+                    "net.link.generic.system.dlil_input_threads": "16",
+                    "net.link.generic.system.dlil_input_sanity_check": "0",
+                    "net.link.generic.system.flow_advisory": "1",
+                    "net.link.generic.system.delaybased_queue": "1",
+                    "net.link.generic.system.hwcksum_in_invalidated": "0",
+                    "net.link.generic.system.hwcksum_dbg": "0",
+                    "net.link.generic.system.start_delayed": "0",
+                    "net.link.generic.system.start_delay_disabled": "0",
+                    "net.link.generic.system.hwcksum_dbg_mode": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_forced": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_forced_bytes": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_rxoff_forced": "0",
+                    "net.link.generic.system.hwcksum_dbg_partial_rxoff_adj": "0",
+                    "net.link.generic.system.hwcksum_dbg_verified": "0",
+                    "net.link.generic.system.hwcksum_dbg_bad_cksum": "0",
+                    "net.link.generic.system.hwcksum_dbg_bad_rxoff": "0",
+                    "net.link.generic.system.hwcksum_dbg_adjusted": "0",
+                    "net.link.generic.system.hwcksum_dbg_finalized_hdr": "0",
+                    "net.link.generic.system.hwcksum_dbg_finalized_data": "0",
+                    "net.link.generic.system.hwcksum_tx": "1",
+                    "net.link.generic.system.hwcksum_rx": "1",
+                    "net.link.generic.system.tx_chain_len_count": "0",
+                    "net.link.generic.system.threshold_notify": "1",
+                    "net.link.generic.system.threshold_interval": "2",
+                    "net.link.generic.system.enable_netagent": "0",
+                    "net.link.generic.system.port_used.entry_count": "0",
+                    "net.link.generic.system.port_used.entry_gen": "0",
+                    "net.link.generic.system.port_used.verbose": "0",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_count": "0",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_last_time": "{ sec = 0, usec = 0 } Wed Dec 31 16:00:00 1969",
+                    "net.link.generic.system.port_used.wakeuuid_not_set_last_if": "",
+                    "net.link.ether.inet.prune_intvl": "300",
+                    "net.link.ether.inet.probe_intvl": "7",
+                    "net.link.ether.inet.max_age": "1200",
+                    "net.link.ether.inet.host_down_time": "20",
+                    "net.link.ether.inet.arp_llreach_base": "120",
+                    "net.link.ether.inet.arp_unicast_lim": "3",
+                    "net.link.ether.inet.maxtries": "5",
+                    "net.link.ether.inet.maxhold": "16",
+                    "net.link.ether.inet.useloopback": "1",
+                    "net.link.ether.inet.proxyall": "0",
+                    "net.link.ether.inet.sendllconflict": "0",
+                    "net.link.ether.inet.log_arp_warnings": "0",
+                    "net.link.ether.inet.keep_announcements": "1",
+                    "net.link.ether.inet.send_conflicting_probes": "1",
+                    "net.link.ether.inet.verbose": "0",
+                    "net.link.ether.inet.maxhold_total": "1024",
+                    "net.link.bridge.inherit_mac": "0",
+                    "net.link.bridge.rtable_prune_period": "300",
+                    "net.link.bridge.rtable_hash_size_max": "2048",
+                    "net.link.bridge.txstart": "0",
+                    "net.link.bridge.debug": "0",
+                    "net.link.loopback.max_dequeue": "256",
+                    "net.link.loopback.sched_model": "0",
+                    "net.link.loopback.dequeue_sc": "0",
+                    "net.link.fake.txstart": "1",
+                    "net.link.fake.hwcsum": "0",
+                    "net.link.fake.nxattach": "0",
+                    "net.link.fake.bsd_mode": "1",
+                    "net.link.fake.debug": "0",
+                    "net.link.fake.wmm_mode": "0",
+                    "net.link.fake.multibuflet": "0",
+                    "net.link.fake.copypkt_mode": "0",
+                    "net.link.fake.tx_headroom": "0",
+                    "net.link.fake.max_mtu": "2048",
+                    "net.link.fake.buflet_size": "512",
+                    "net.link.fake.user_access": "0",
+                    "net.link.fake.if_adv_intvl": "0",
+                    "net.link.fake.tx_drops": "0",
+                    "net.link.bond.debug": "0",
+                    "net.link.iptap.total_tap_count": "0",
+                    "net.link.iptap.log": "0",
+                    "net.link.pktap.total_tap_count": "0",
+                    "net.link.pktap.count_unknown_if_type": "0",
+                    "net.link.pktap.log": "0",
+                    "net.key.debug": "0",
+                    "net.key.spi_trycnt": "1000",
+                    "net.key.spi_minval": "256",
+                    "net.key.spi_maxval": "268435455",
+                    "net.key.int_random": "60",
+                    "net.key.larval_lifetime": "30",
+                    "net.key.blockacq_count": "10",
+                    "net.key.blockacq_lifetime": "20",
+                    "net.key.esp_keymin": "256",
+                    "net.key.esp_auth": "0",
+                    "net.key.ah_keymin": "128",
+                    "net.key.prefered_oldsa": "0",
+                    "net.key.natt_keepalive_interval": "20",
+                    "net.inet6.ip6.forwarding": "0",
+                    "net.inet6.ip6.redirect": "1",
+                    "net.inet6.ip6.hlim": "64",
+                    "net.inet6.ip6.maxfragpackets": "2048",
+                    "net.inet6.ip6.accept_rtadv": "1",
+                    "net.inet6.ip6.keepfaith": "0",
+                    "net.inet6.ip6.log_interval": "5",
+                    "net.inet6.ip6.hdrnestlimit": "15",
+                    "net.inet6.ip6.dad_count": "1",
+                    "net.inet6.ip6.auto_flowlabel": "1",
+                    "net.inet6.ip6.defmcasthlim": "1",
+                    "net.inet6.ip6.gifhlim": "0",
+                    "net.inet6.ip6.kame_version": "2009/apple-darwin",
+                    "net.inet6.ip6.use_deprecated": "1",
+                    "net.inet6.ip6.rr_prune": "5",
+                    "net.inet6.ip6.v6only": "0",
+                    "net.inet6.ip6.rtexpire": "3600",
+                    "net.inet6.ip6.rtminexpire": "10",
+                    "net.inet6.ip6.rtmaxcache": "128",
+                    "net.inet6.ip6.use_tempaddr": "1",
+                    "net.inet6.ip6.temppltime": "86400",
+                    "net.inet6.ip6.tempvltime": "604800",
+                    "net.inet6.ip6.auto_linklocal": "1",
+                    "net.inet6.ip6.prefer_tempaddr": "1",
+                    "net.inet6.ip6.use_defaultzone": "0",
+                    "net.inet6.ip6.maxfrags": "4096",
+                    "net.inet6.ip6.mcast_pmtu": "0",
+                    "net.inet6.ip6.neighborgcthresh": "1024",
+                    "net.inet6.ip6.maxifprefixes": "16",
+                    "net.inet6.ip6.maxifdefrouters": "16",
+                    "net.inet6.ip6.maxdynroutes": "1024",
+                    "net.inet6.ip6.fragpackets": "0",
+                    "net.inet6.ip6.adj_clear_hwcksum": "0",
+                    "net.inet6.ip6.adj_partial_sum": "1",
+                    "net.inet6.ip6.input_perf": "0",
+                    "net.inet6.ip6.input_perf_bins": "0",
+                    "net.inet6.ip6.output_perf": "0",
+                    "net.inet6.ip6.output_perf_bins": "0",
+                    "net.inet6.ip6.select_srcif_debug": "0",
+                    "net.inet6.ip6.select_srcaddr_debug": "0",
+                    "net.inet6.ip6.select_src_expensive_secondary_if": "0",
+                    "net.inet6.ip6.select_src_strong_end": "1",
+                    "net.inet6.ip6.mcast.maxgrpsrc": "512",
+                    "net.inet6.ip6.mcast.maxsocksrc": "128",
+                    "net.inet6.ip6.mcast.loop": "1",
+                    "net.inet6.ip6.only_allow_rfc4193_prefixes": "0",
+                    "net.inet6.ip6.clat_debug": "0",
+                    "net.inet6.ip6.maxchainsent": "50",
+                    "net.inet6.ip6.dad_enhanced": "1",
+                    "net.inet6.ipsec6.def_policy": "1",
+                    "net.inet6.ipsec6.esp_trans_deflev": "1",
+                    "net.inet6.ipsec6.esp_net_deflev": "1",
+                    "net.inet6.ipsec6.ah_trans_deflev": "1",
+                    "net.inet6.ipsec6.ah_net_deflev": "1",
+                    "net.inet6.ipsec6.ecn": "0",
+                    "net.inet6.ipsec6.debug": "0",
+                    "net.inet6.ipsec6.esp_randpad": "-1",
+                    "net.inet6.icmp6.rediraccept": "1",
+                    "net.inet6.icmp6.redirtimeout": "600",
+                    "net.inet6.icmp6.nd6_prune": "1",
+                    "net.inet6.icmp6.nd6_delay": "5",
+                    "net.inet6.icmp6.nd6_umaxtries": "3",
+                    "net.inet6.icmp6.nd6_mmaxtries": "3",
+                    "net.inet6.icmp6.nd6_useloopback": "1",
+                    "net.inet6.icmp6.nodeinfo": "3",
+                    "net.inet6.icmp6.errppslimit": "500",
+                    "net.inet6.icmp6.nd6_debug": "0",
+                    "net.inet6.icmp6.nd6_accept_6to4": "1",
+                    "net.inet6.icmp6.nd6_optimistic_dad": "63",
+                    "net.inet6.icmp6.nd6_onlink_ns_rfc4861": "0",
+                    "net.inet6.icmp6.nd6_prune_lazy": "5",
+                    "net.inet6.icmp6.rappslimit": "10",
+                    "net.inet6.icmp6.nd6_llreach_base": "30",
+                    "net.inet6.icmp6.nd6_maxsolstgt": "8",
+                    "net.inet6.icmp6.nd6_maxproxiedsol": "4",
+                    "net.inet6.icmp6.prproxy_cnt": "0",
+                    "net.inet6.mld.gsrdelay": "10",
+                    "net.inet6.mld.v1enable": "1",
+                    "net.inet6.mld.v2enable": "1",
+                    "net.inet6.mld.use_allow": "1",
+                    "net.inet6.mld.debug": "0",
+                    "net.inet6.send.opmode": "1",
+                    "net.inet6.send.opstate": "1",
+                    "net.systm.kctl.autorcvbufmax": "262144",
+                    "net.systm.kctl.autorcvbufhigh": "0",
+                    "net.systm.kctl.debug": "0",
+                    "net.ndrv_multi_max_count": "1024",
+                    "net.statistics_privcheck": "0",
+                    "net.stats.debug": "0",
+                    "net.stats.sendspace": "2048",
+                    "net.stats.recvspace": "8192",
+                    "net.utun.max_pending_input": "512",
+                    "net.utun.ring_size": "64",
+                    "net.utun.tx_fsw_ring_size": "64",
+                    "net.utun.rx_fsw_ring_size": "128",
+                    "net.ipsec.verify_interface_creation": "0",
+                    "net.ipsec.max_pending_input": "512",
+                    "net.ipsec.ring_size": "64",
+                    "net.ipsec.tx_fsw_ring_size": "64",
+                    "net.ipsec.rx_fsw_ring_size": "128",
+                    "net.ipsec.debug": "0",
+                    "net.necp.drop_all_level": "0",
+                    "net.necp.debug": "0",
+                    "net.necp.pass_loopback": "1",
+                    "net.necp.pass_keepalives": "1",
+                    "net.necp.socket_policy_count": "20",
+                    "net.necp.socket_non_app_policy_count": "20",
+                    "net.necp.ip_policy_count": "8",
+                    "net.necp.session_count": "4",
+                    "net.necp.client_fd_count": "79",
+                    "net.necp.client_count": "70",
+                    "net.necp.arena_count": "0",
+                    "net.necp.nexus_flow_count": "0",
+                    "net.necp.socket_flow_count": "14",
+                    "net.necp.if_flow_count": "0",
+                    "net.necp.observer_fd_count": "0",
+                    "net.necp.observer_message_limit": "256",
+                    "net.necp.sysctl_arena_count": "0",
+                    "net.necp.drop_unentitled_level": "0",
+                    "net.necp.pass_interpose": "1",
+                    "net.necp.drop_dest_debug": "0",
+                    "net.netagent.debug": "5",
+                    "net.netagent.registered_count": "27",
+                    "net.netagent.active_count": "26",
+                    "net.cfil.log": "3",
+                    "net.cfil.debug": "1",
+                    "net.cfil.sock_attached_count": "0",
+                    "net.cfil.active_count": "0",
+                    "net.cfil.close_wait_timeout": "1000",
+                    "net.cfil.sbtrim": "1",
+                    "net.restricted_port.enforced": "1",
+                    "net.restricted_port.verbose": "0",
+                    "net.classq.verbose": "0",
+                    "net.classq.sfb.holdtime": "0",
+                    "net.classq.sfb.pboxtime": "0",
+                    "net.classq.sfb.hinterval": "0",
+                    "net.classq.sfb.increment": "82",
+                    "net.classq.sfb.decrement": "16",
+                    "net.classq.sfb.allocation": "0",
+                    "net.classq.sfb.ratelimit": "0",
+                    "net.classq.target_qdelay": "0",
+                    "net.classq.update_interval": "0",
+                    "net.pktsched.verbose": "0",
+                    "net.qos.reset_dscp_to_wifi_ac_map": "0",
+                    "net.qos.verbose": "0",
+                    "net.qos.policy.restricted": "0",
+                    "net.qos.policy.restrict_avapps": "0",
+                    "net.qos.policy.wifi_enabled": "0",
+                    "net.qos.policy.capable_enabled": "0",
+                    "net.mpklog.enabled": "1",
+                    "net.mpklog.type": "0",
+                    "net.mpklog.version": "1",
+                    "net.alf.loglevel": "55",
+                    "net.alf.perm": "1",
+                    "net.alf.defaultaction": "1",
+                    "net.alf.mqcount": "0"
+                }
+            },
+            "counters": {
+                "network": {
+                    "interfaces": {
+                        "lo0": {
+                            "rx": {
+                                "bytes": "743",
+                                "packets": "0",
+                                "errors": "135797",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "135797",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "gif0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "stf0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en5": {
+                            "rx": {
+                                "bytes": "206722",
+                                "packets": "1965",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "3243260",
+                                "packets": "1732",
+                                "errors": "530",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "ap1": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en0": {
+                            "rx": {
+                                "bytes": "98068456",
+                                "packets": "114954",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "114899466",
+                                "packets": "195692",
+                                "errors": "1",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en1": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en2": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en3": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "en4": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "bridge0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "p2p0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "awdl0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "260",
+                                "packets": "2",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "llw0": {
+                            "rx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "utun0": {
+                            "rx": {
+                                "bytes": "2",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "200",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        },
+                        "utun1": {
+                            "rx": {
+                                "bytes": "2",
+                                "packets": "0",
+                                "errors": "0",
+                                "drop": 0,
+                                "overrun": 0,
+                                "frame": 0,
+                                "compressed": 0,
+                                "multicast": 0
+                            },
+                            "tx": {
+                                "bytes": "0",
+                                "packets": "0",
+                                "errors": "200",
+                                "drop": 0,
+                                "overrun": 0,
+                                "collisions": "0",
+                                "carrier": 0,
+                                "compressed": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "ipaddress": "192.168.0.100",
+            "macaddress": "38:f9:d3:98:72:fa",
+            "ip6address": "2601:602:9200:d56:be:ac91:541:46df",
+            "kernel": {
+                "name": "Darwin",
+                "release": "19.3.0",
+                "version": "Darwin Kernel Version 19.3.0: Thu Jan  9 20:58:23 PST 2020; root:xnu-6153.81.5~1/RELEASE_X86_64",
+                "machine": "x86_64",
+                "processor": "i386",
+                "os": "Darwin",
+                "modules": {
+                    "com.apple.kec.Libm": {
+                        "version": "1",
+                        "size": 65536,
+                        "index": "9",
+                        "refcount": "2"
+                    },
+                    "com.apple.kec.corecrypto": {
+                        "version": "1.0",
+                        "size": 892928,
+                        "index": "10",
+                        "refcount": "12"
+                    },
+                    "com.apple.kec.pthread": {
+                        "version": "1",
+                        "size": 40960,
+                        "index": "11",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOACPIFamily": {
+                        "version": "1.4",
+                        "size": 36864,
+                        "index": "12",
+                        "refcount": "35"
+                    },
+                    "com.apple.iokit.IOPCIFamily": {
+                        "version": "2.9",
+                        "size": 225280,
+                        "index": "13",
+                        "refcount": "44"
+                    },
+                    "com.apple.driver.watchdog": {
+                        "version": "1",
+                        "size": 36864,
+                        "index": "14",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleSMC": {
+                        "version": "3.1.9",
+                        "size": 126976,
+                        "index": "15",
+                        "refcount": "12"
+                    },
+                    "com.apple.driver.AppleACPIPlatform": {
+                        "version": "6.1",
+                        "size": 634880,
+                        "index": "16",
+                        "refcount": "2"
+                    },
+                    "com.apple.iokit.IOReportFamily": {
+                        "version": "47",
+                        "size": 28672,
+                        "index": "17",
+                        "refcount": "10"
+                    },
+                    "com.apple.driver.AppleBusPowerController": {
+                        "version": "1.0",
+                        "size": 32768,
+                        "index": "18",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleUSBHostMergeProperties": {
+                        "version": "1.2",
+                        "size": 16384,
+                        "index": "19",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBCommon": {
+                        "version": "1.0",
+                        "size": 57344,
+                        "index": "20",
+                        "refcount": "9"
+                    },
+                    "com.apple.iokit.IOUSBHostFamily": {
+                        "version": "1.2",
+                        "size": 1019904,
+                        "index": "21",
+                        "refcount": "17"
+                    },
+                    "com.apple.iokit.IOStorageFamily": {
+                        "version": "2.1",
+                        "size": 163840,
+                        "index": "22",
+                        "refcount": "8"
+                    },
+                    "com.apple.iokit.IOSCSIArchitectureModelFamily": {
+                        "version": "422.0.2",
+                        "size": 176128,
+                        "index": "23",
+                        "refcount": "3"
+                    },
+                    "com.apple.iokit.IOUSBMassStorageDriver": {
+                        "version": "157.40.7",
+                        "size": 196608,
+                        "index": "24",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.DiskImages": {
+                        "version": "493.0.0",
+                        "size": 102400,
+                        "index": "27",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IONetworkingFamily": {
+                        "version": "3.4",
+                        "size": 196608,
+                        "index": "28",
+                        "refcount": "13"
+                    },
+                    "com.apple.iokit.IOTimeSyncFamily": {
+                        "version": "810.1",
+                        "size": 258048,
+                        "index": "29",
+                        "refcount": "3"
+                    },
+                    "com.apple.iokit.CoreAnalyticsFamily": {
+                        "version": "1",
+                        "size": 57344,
+                        "index": "30",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.CoreTrust": {
+                        "version": "1",
+                        "size": 49152,
+                        "index": "31",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleMobileFileIntegrity": {
+                        "version": "1.0.5",
+                        "size": 143360,
+                        "index": "32",
+                        "refcount": "9"
+                    },
+                    "com.apple.iokit.EndpointSecurity": {
+                        "version": "1",
+                        "size": 208896,
+                        "index": "33",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEffaceableStorage": {
+                        "version": "1.0",
+                        "size": 49152,
+                        "index": "34",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleFDEKeyStore": {
+                        "version": "28.30",
+                        "size": 49152,
+                        "index": "35",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.IOSlaveProcessor": {
+                        "version": "1",
+                        "size": 28672,
+                        "index": "36",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.AppleSEPManager": {
+                        "version": "1.0.1",
+                        "size": 110592,
+                        "index": "37",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.KernelRelayHost": {
+                        "version": "1",
+                        "size": 118784,
+                        "index": "38",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleCredentialManager": {
+                        "version": "1.0",
+                        "size": 327680,
+                        "index": "39",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSCSIBlockCommandsDevice": {
+                        "version": "422.0.2",
+                        "size": 102400,
+                        "index": "40",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleUSBTDM": {
+                        "version": "489.80.2",
+                        "size": 86016,
+                        "index": "41",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleKeyStore": {
+                        "version": "2",
+                        "size": 507904,
+                        "index": "42",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.sandbox": {
+                        "version": "300.0",
+                        "size": 368640,
+                        "index": "44",
+                        "refcount": "2"
+                    },
+                    "com.apple.security.quarantine": {
+                        "version": "4",
+                        "size": 49152,
+                        "index": "45",
+                        "refcount": "1"
+                    },
+                    "com.apple.AppleSystemPolicy": {
+                        "version": "2.0.0",
+                        "size": 57344,
+                        "index": "46",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.TMSafetyNet": {
+                        "version": "8",
+                        "size": 8192,
+                        "index": "47",
+                        "refcount": "0"
+                    },
+                    "com.apple.nke.applicationfirewall": {
+                        "version": "303",
+                        "size": 40960,
+                        "index": "48",
+                        "refcount": "0"
+                    },
+                    "com.apple.security.AppleImage4": {
+                        "version": "1",
+                        "size": 69632,
+                        "index": "49",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleAPIC": {
+                        "version": "1.7",
+                        "size": 12288,
+                        "index": "50",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOHIDFamily": {
+                        "version": "2.0.0",
+                        "size": 651264,
+                        "index": "51",
+                        "refcount": "9"
+                    },
+                    "com.apple.iokit.IOSMBusFamily": {
+                        "version": "1.1",
+                        "size": 16384,
+                        "index": "52",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleACPIEC": {
+                        "version": "6.1",
+                        "size": 32768,
+                        "index": "53",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleSMBIOS": {
+                        "version": "2.1",
+                        "size": 16384,
+                        "index": "54",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleSMCRTC": {
+                        "version": "1.0",
+                        "size": 28672,
+                        "index": "55",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleACPIButtons": {
+                        "version": "6.1",
+                        "size": 16384,
+                        "index": "56",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEFIRuntime": {
+                        "version": "2.1",
+                        "size": 20480,
+                        "index": "57",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleSmartBatteryManager": {
+                        "version": "161.0.0",
+                        "size": 53248,
+                        "index": "58",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEFINVRAM": {
+                        "version": "2.1",
+                        "size": 57344,
+                        "index": "59",
+                        "refcount": "1"
+                    },
+                    "com.apple.private.KextAudit": {
+                        "version": "1.0",
+                        "size": 12288,
+                        "index": "60",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.usb.AppleUSBXHCI": {
+                        "version": "1.2",
+                        "size": 360448,
+                        "index": "61",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBXHCIPCI": {
+                        "version": "1.2",
+                        "size": 204800,
+                        "index": "62",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOUSBFamily": {
+                        "version": "900.4.2",
+                        "size": 630784,
+                        "index": "63",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IONVMeFamily": {
+                        "version": "2.1.0",
+                        "size": 274432,
+                        "index": "65",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOBufferCopyEngineFamily": {
+                        "version": "1",
+                        "size": 65536,
+                        "index": "66",
+                        "refcount": "6"
+                    },
+                    "com.apple.iokit.IOBufferCopyController": {
+                        "version": "1.1.0",
+                        "size": 40960,
+                        "index": "67",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleEffaceableNOR": {
+                        "version": "1.0",
+                        "size": 53248,
+                        "index": "68",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.usb.AppleUSBVHCICommon": {
+                        "version": "1.0",
+                        "size": 36864,
+                        "index": "69",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.usb.AppleUSBVHCICommonBCE": {
+                        "version": "1.0",
+                        "size": 53248,
+                        "index": "70",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBVHCI": {
+                        "version": "1.2",
+                        "size": 163840,
+                        "index": "71",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.AppleUSBVHCIBCE": {
+                        "version": "1.2",
+                        "size": 16384,
+                        "index": "72",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOThunderboltFamily": {
+                        "version": "7.6.0",
+                        "size": 999424,
+                        "index": "73",
+                        "refcount": "6"
+                    },
+                    "com.apple.driver.AppleThunderboltNHI": {
+                        "version": "5.8.6",
+                        "size": 163840,
+                        "index": "74",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.apfs": {
+                        "version": "1412.81.1",
+                        "size": 1200128,
+                        "index": "76",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssI2C": {
+                        "version": "3.0.60",
+                        "size": 40960,
+                        "index": "77",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssDmac": {
+                        "version": "3.0.60",
+                        "size": 32768,
+                        "index": "78",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssI2CController": {
+                        "version": "3.0.60",
+                        "size": 102400,
+                        "index": "79",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleHPM": {
+                        "version": "3.4.4",
+                        "size": 61440,
+                        "index": "80",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltDPAdapterFamily": {
+                        "version": "6.2.5",
+                        "size": 61440,
+                        "index": "81",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleThunderboltDPInAdapter": {
+                        "version": "6.2.5",
+                        "size": 24576,
+                        "index": "82",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltPCIDownAdapter": {
+                        "version": "2.5.4",
+                        "size": 20480,
+                        "index": "83",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOSkywalkFamily": {
+                        "version": "1",
+                        "size": 282624,
+                        "index": "84",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.corecapture": {
+                        "version": "1.0.4",
+                        "size": 184320,
+                        "index": "85",
+                        "refcount": "7"
+                    },
+                    "com.apple.iokit.IOSerialFamily": {
+                        "version": "11",
+                        "size": 57344,
+                        "index": "87",
+                        "refcount": "7"
+                    },
+                    "com.apple.driver.IOImageLoader": {
+                        "version": "1.0.0",
+                        "size": 114688,
+                        "index": "88",
+                        "refcount": "5"
+                    },
+                    "com.apple.driver.AppleBCMWLANCore": {
+                        "version": "1.0.0",
+                        "size": 1900544,
+                        "index": "90",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleBCMWLANBusInterfacePCIe": {
+                        "version": "1",
+                        "size": 335872,
+                        "index": "91",
+                        "refcount": "0"
+                    },
+                    "com.apple.vecLib.kext": {
+                        "version": "1.2.0",
+                        "size": 704512,
+                        "index": "92",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOAudioFamily": {
+                        "version": "300.2",
+                        "size": 258048,
+                        "index": "93",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleVirtIO": {
+                        "version": "1.0",
+                        "size": 110592,
+                        "index": "94",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.hfs.encodings.kext": {
+                        "version": "1",
+                        "size": 20480,
+                        "index": "95",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSurface": {
+                        "version": "269.6",
+                        "size": 188416,
+                        "index": "96",
+                        "refcount": "3"
+                    },
+                    "com.apple.AppleFSCompression.AppleFSCompressionTypeZlib": {
+                        "version": "1.0.0",
+                        "size": 49152,
+                        "index": "97",
+                        "refcount": "0"
+                    },
+                    "com.apple.BootCache": {
+                        "version": "40",
+                        "size": 57344,
+                        "index": "99",
+                        "refcount": "0"
+                    },
+                    "com.apple.filesystems.hfs.kext": {
+                        "version": "522.0.9",
+                        "size": 405504,
+                        "index": "100",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.BCMWLANFirmware4377.Hashstore": {
+                        "version": "1",
+                        "size": 28672,
+                        "index": "102",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.BCMWLANFirmware4364.Hashstore": {
+                        "version": "1",
+                        "size": 45056,
+                        "index": "103",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.BCMWLANFirmware4355.Hashstore": {
+                        "version": "1",
+                        "size": 12288,
+                        "index": "104",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.usb.AppleUSBHostCompositeDevice": {
+                        "version": "1.2",
+                        "size": 32768,
+                        "index": "105",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.usb.networking": {
+                        "version": "5.0.0",
+                        "size": 32768,
+                        "index": "106",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.usb.cdc": {
+                        "version": "5.0.0",
+                        "size": 32768,
+                        "index": "107",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.usb.cdc.ncm": {
+                        "version": "5.0.0",
+                        "size": 69632,
+                        "index": "108",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.triggers": {
+                        "version": "1.0",
+                        "size": 20480,
+                        "index": "111",
+                        "refcount": "1"
+                    },
+                    "com.apple.filesystems.autofs": {
+                        "version": "3.0",
+                        "size": 36864,
+                        "index": "112",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOEthernetAVBController": {
+                        "version": "1.1.0",
+                        "size": 28672,
+                        "index": "113",
+                        "refcount": "2"
+                    },
+                    "com.apple.plugin.IOgPTPPlugin": {
+                        "version": "810.1",
+                        "size": 724992,
+                        "index": "114",
+                        "refcount": "1"
+                    },
+                    "com.apple.iokit.IOSlowAdaptiveClockingFamily": {
+                        "version": "1.0.0",
+                        "size": 20480,
+                        "index": "115",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelSlowAdaptiveClocking": {
+                        "version": "4.0.0",
+                        "size": 8192,
+                        "index": "116",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleGraphicsControl": {
+                        "version": "4.7.2",
+                        "size": 12288,
+                        "index": "117",
+                        "refcount": "2"
+                    },
+                    "com.apple.iokit.IOGraphicsFamily": {
+                        "version": "569.4",
+                        "size": 331776,
+                        "index": "118",
+                        "refcount": "19"
+                    },
+                    "com.apple.AppleGraphicsDeviceControl": {
+                        "version": "4.7.2",
+                        "size": 40960,
+                        "index": "119",
+                        "refcount": "9"
+                    },
+                    "com.apple.driver.AppleMuxControl2": {
+                        "version": "4.7.2",
+                        "size": 86016,
+                        "index": "120",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOAcceleratorFamily2": {
+                        "version": "438.3.1",
+                        "size": 798720,
+                        "index": "121",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleIntelCFLGraphicsFramebuffer": {
+                        "version": "14.0.4",
+                        "size": 2285568,
+                        "index": "122",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDSupport": {
+                        "version": "3.0.5",
+                        "size": 2113536,
+                        "index": "123",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleOnboardSerial": {
+                        "version": "1.0",
+                        "size": 188416,
+                        "index": "124",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleIntelLpssUARTCommon": {
+                        "version": "3.0.60",
+                        "size": 12288,
+                        "index": "125",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleIntelLpssUARTv1": {
+                        "version": "3.0.60",
+                        "size": 12288,
+                        "index": "126",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelPCHPMC": {
+                        "version": "2.0.1",
+                        "size": 24576,
+                        "index": "131",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IONDRVSupport": {
+                        "version": "569.4",
+                        "size": 57344,
+                        "index": "132",
+                        "refcount": "3"
+                    },
+                    "com.apple.driver.AppleGFXHDA": {
+                        "version": "100.1.424",
+                        "size": 487424,
+                        "index": "133",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleBridgeAudioController": {
+                        "version": "6.66",
+                        "size": 49152,
+                        "index": "134",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHIDALSService": {
+                        "version": "1",
+                        "size": 8192,
+                        "index": "135",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHIDKeyboard": {
+                        "version": "209",
+                        "size": 45056,
+                        "index": "136",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleMCCSControl": {
+                        "version": "1.13",
+                        "size": 61440,
+                        "index": "140",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleInputDeviceSupport": {
+                        "version": "3430.1",
+                        "size": 106496,
+                        "index": "141",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleMultitouchDriver": {
+                        "version": "3430.1",
+                        "size": 163840,
+                        "index": "142",
+                        "refcount": "2"
+                    },
+                    "com.apple.driver.AppleActuatorDriver": {
+                        "version": "3430.1",
+                        "size": 61440,
+                        "index": "143",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleAVEBridge": {
+                        "version": "6.1",
+                        "size": 20480,
+                        "index": "144",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.X86PlatformPlugin": {
+                        "version": "1.0.0",
+                        "size": 98304,
+                        "index": "146",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleHSBluetoothDriver": {
+                        "version": "3430.1",
+                        "size": 57344,
+                        "index": "149",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AppleTopCaseHIDEventDriver": {
+                        "version": "3430.1",
+                        "size": 40960,
+                        "index": "150",
+                        "refcount": "0"
+                    },
+                    "com.apple.AppleGPUWrangler": {
+                        "version": "4.7.2",
+                        "size": 45056,
+                        "index": "151",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMD9500Controller": {
+                        "version": "3.0.5",
+                        "size": 491520,
+                        "index": "152",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleThunderboltIP": {
+                        "version": "3.1.3",
+                        "size": 90112,
+                        "index": "155",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleBacklightExpert": {
+                        "version": "1.1.0",
+                        "size": 20480,
+                        "index": "156",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.BridgeAudioCommunication": {
+                        "version": "6.66",
+                        "size": 53248,
+                        "index": "158",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleIntelKBLGraphics": {
+                        "version": "14.0.4",
+                        "size": 995328,
+                        "index": "162",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AGDCBacklightControl": {
+                        "version": "4.7.2",
+                        "size": 20480,
+                        "index": "163",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.pmtelemetry": {
+                        "version": "1",
+                        "size": 90112,
+                        "index": "164",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleUpstreamUserClient": {
+                        "version": "3.6.8",
+                        "size": 20480,
+                        "index": "165",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.X86PlatformShim": {
+                        "version": "1.0.0",
+                        "size": 28672,
+                        "index": "166",
+                        "refcount": "1"
+                    },
+                    "com.apple.driver.AGPM": {
+                        "version": "111.4.2",
+                        "size": 135168,
+                        "index": "168",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleSSE": {
+                        "version": "1.0",
+                        "size": 45056,
+                        "index": "170",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOUserEthernet": {
+                        "version": "1.0.1",
+                        "size": 24576,
+                        "index": "171",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleHV": {
+                        "version": "1",
+                        "size": 40960,
+                        "index": "172",
+                        "refcount": "0"
+                    },
+                    "com.apple.iokit.IOAVBFamily": {
+                        "version": "800.17",
+                        "size": 139264,
+                        "index": "173",
+                        "refcount": "0"
+                    },
+                    "com.apple.AGDCPluginDisplayMetrics": {
+                        "version": "4.7.2",
+                        "size": 12288,
+                        "index": "174",
+                        "refcount": "0"
+                    },
+                    "com.avira.kext.FileAccessControl": {
+                        "version": "1.2.5",
+                        "size": 28672,
+                        "index": "175",
+                        "refcount": "0"
+                    },
+                    "com.apple.fileutil": {
+                        "version": "20.036.15",
+                        "size": 98304,
+                        "index": "176",
+                        "refcount": "0"
+                    },
+                    "com.apple.driver.AppleGraphicsDevicePolicy": {
+                        "version": "4.7.2",
+                        "size": 81920,
+                        "index": "177",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDRadeonServiceManager": {
+                        "version": "3.0.5",
+                        "size": 20480,
+                        "index": "178",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDRadeonX4000HWServices": {
+                        "version": "3.0.5",
+                        "size": 69632,
+                        "index": "179",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDRadeonX4000": {
+                        "version": "3.0.5",
+                        "size": 4485120,
+                        "index": "180",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDRadeonX4100HWLibs": {
+                        "version": "1.0",
+                        "size": 12910592,
+                        "index": "181",
+                        "refcount": "0"
+                    },
+                    "com.apple.kext.AMDFramebuffer": {
+                        "version": "3.0.5",
+                        "size": 176128,
+                        "index": "182",
+                        "refcount": "0"
+                    }
+                }
+            },
+            "os": "darwin",
+            "os_version": "19.3.0",
+            "platform": "mac_os_x",
+            "platform_version": "10.15.3",
+            "platform_build": "19D76",
+            "platform_family": "mac_os_x",
+            "memory": {
+                "total": "32768MB",
+                "active": "10979MB",
+                "inactive": "6399MB",
+                "free": "15389MB"
+            },
+            "dmi": {},
+            "hostname": "Beths-MacBook-Pro-2",
+            "machinename": "Beths-MacBook-Pro-2.local",
+            "fqdn": "localhost",
+            "domain": null,
+            "hardware": {
+                "activation_lock_status": "activation_lock_disabled",
+                "boot_rom_version": "1037.80.53.0.0 (iBridge: 17.16.13050.0.0,0)",
+                "cpu_type": "6-Core Intel Core i7",
+                "current_processor_speed": "2.2 GHz",
+                "l2_cache_core": "256 KB",
+                "l3_cache": "9 MB",
+                "machine_model": "MacBookPro15,1",
+                "machine_name": "MacBook Pro",
+                "number_processors": 6,
+                "packages": 1,
+                "physical_memory": "32 GB",
+                "platform_UUID": "5841B142-A40A-5E52-BB23-4B14D7EB3F58",
+                "platform_cpu_htt": "htt_enabled",
+                "serial_number": "C02YJ0PLJGH5",
+                "operating_system": "Mac OS X",
+                "operating_system_version": "10.15.3",
+                "build_version": "19D76",
+                "architecture": "x86_64",
+                "storage": [
+                    {
+                        "name": "Macintosh HD - Data",
+                        "bsd_name": "disk1s1",
+                        "capacity": 1000240963584
+                    },
+                    {
+                        "name": "Macintosh HD",
+                        "bsd_name": "disk1s5",
+                        "capacity": 1000240963584
+                    }
+                ],
+                "battery": {
+                    "current_capacity": 2584,
+                    "max_capacity": 6899,
+                    "fully_charged": false,
+                    "is_charging": false,
+                    "charge_cycle_count": 56,
+                    "health": "Good",
+                    "serial": "D869021A0LAJ65HA7",
+                    "remaining": 37
+                }
+            },
+            "virtualization": {
+                "systems": {}
+            },
+            "time": {
+                "timezone": "PDT"
+            },
+            "command": {
+                "ps": "ps -ef"
+            },
+            "root_group": "wheel",
+            "shard_seed": 44624043,
+            "keys": {
+                "ssh": {}
+            },
+            "shells": [
+                "/bin/bash",
+                "/bin/csh",
+                "/bin/dash",
+                "/bin/ksh",
+                "/bin/sh",
+                "/bin/tcsh",
+                "/bin/zsh"
+            ],
+            "ohai_time": 1586211649.75331,
+            "cpu": {
+                "cores": 6,
+                "total": 12,
+                "mhz": 2200,
+                "real": 1,
+                "vendor_id": "GenuineIntel",
+                "model_name": "Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz",
+                "family": 6,
+                "model": 158,
+                "stepping": 10,
+                "flags": [
+                    "fpu",
+                    "vme",
+                    "de",
+                    "pse",
+                    "tsc",
+                    "msr",
+                    "pae",
+                    "mce",
+                    "cx8",
+                    "apic",
+                    "sep",
+                    "mtrr",
+                    "pge",
+                    "mca",
+                    "cmov",
+                    "pat",
+                    "pse36",
+                    "clfsh",
+                    "ds",
+                    "acpi",
+                    "mmx",
+                    "fxsr",
+                    "sse",
+                    "sse2",
+                    "ss",
+                    "htt",
+                    "tm",
+                    "pbe",
+                    "sse3",
+                    "pclmulqdq",
+                    "dtes64",
+                    "mon",
+                    "dscpl",
+                    "vmx",
+                    "est",
+                    "tm2",
+                    "ssse3",
+                    "fma",
+                    "cx16",
+                    "tpr",
+                    "pdcm",
+                    "sse4.1",
+                    "sse4.2",
+                    "x2apic",
+                    "movbe",
+                    "popcnt",
+                    "aes",
+                    "pcid",
+                    "xsave",
+                    "osxsave",
+                    "seglim64",
+                    "tsctmr",
+                    "avx1.0",
+                    "rdrand",
+                    "f16c"
+                ]
+            },
+            "filesystem": {
+                "by_device": {
+                    "/dev/disk1s5": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "10719524",
+                        "kb_available": "895397524",
+                        "percent_used": "2%",
+                        "inodes_used": "484321",
+                        "inodes_available": "9767493839",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ],
+                        "mounts": [
+                            "/"
+                        ]
+                    },
+                    "devfs": {
+                        "block_size": 512,
+                        "kb_size": "190",
+                        "kb_used": "190",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "665",
+                        "inodes_available": "0",
+                        "total_inodes": "665",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/dev"
+                        ]
+                    },
+                    "/dev/disk1s1": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "68834748",
+                        "kb_available": "895397524",
+                        "percent_used": "8%",
+                        "inodes_used": "1008309",
+                        "inodes_available": "9766969851",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/System/Volumes/Data"
+                        ]
+                    },
+                    "/dev/disk1s4": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "1048596",
+                        "kb_available": "895397524",
+                        "percent_used": "1%",
+                        "inodes_used": "1",
+                        "inodes_available": "9767978159",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/private/var/vm"
+                        ]
+                    },
+                    "map auto_home": {
+                        "block_size": 512,
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ],
+                        "mounts": [
+                            "/System/Volumes/Data/home"
+                        ]
+                    }
+                },
+                "by_mountpoint": {
+                    "/": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "10719524",
+                        "kb_available": "895397524",
+                        "percent_used": "2%",
+                        "inodes_used": "484321",
+                        "inodes_available": "9767493839",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ],
+                        "devices": [
+                            "/dev/disk1s5"
+                        ]
+                    },
+                    "/dev": {
+                        "block_size": 512,
+                        "kb_size": "190",
+                        "kb_used": "190",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "665",
+                        "inodes_available": "0",
+                        "total_inodes": "665",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "devfs"
+                        ]
+                    },
+                    "/System/Volumes/Data": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "68834748",
+                        "kb_available": "895397524",
+                        "percent_used": "8%",
+                        "inodes_used": "1008309",
+                        "inodes_available": "9766969851",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "/dev/disk1s1"
+                        ]
+                    },
+                    "/private/var/vm": {
+                        "block_size": 512,
+                        "kb_size": "976797816",
+                        "kb_used": "1048596",
+                        "kb_available": "895397524",
+                        "percent_used": "1%",
+                        "inodes_used": "1",
+                        "inodes_available": "9767978159",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "/dev/disk1s4"
+                        ]
+                    },
+                    "/System/Volumes/Data/home": {
+                        "block_size": 512,
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ],
+                        "devices": [
+                            "map auto_home"
+                        ]
+                    }
+                },
+                "by_pair": {
+                    "/dev/disk1s5,/": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s5",
+                        "kb_size": "976797816",
+                        "kb_used": "10719524",
+                        "kb_available": "895397524",
+                        "percent_used": "2%",
+                        "inodes_used": "484321",
+                        "inodes_available": "9767493839",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "mount": "/",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "read-only",
+                            "journaled"
+                        ]
+                    },
+                    "devfs,/dev": {
+                        "block_size": 512,
+                        "device": "devfs",
+                        "kb_size": "190",
+                        "kb_used": "190",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "665",
+                        "inodes_available": "0",
+                        "total_inodes": "665",
+                        "inodes_percent_used": "100%",
+                        "mount": "/dev",
+                        "fs_type": "devfs",
+                        "mount_options": [
+                            "local",
+                            "nobrowse"
+                        ]
+                    },
+                    "/dev/disk1s1,/System/Volumes/Data": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s1",
+                        "kb_size": "976797816",
+                        "kb_used": "68834748",
+                        "kb_available": "895397524",
+                        "percent_used": "8%",
+                        "inodes_used": "1008309",
+                        "inodes_available": "9766969851",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "mount": "/System/Volumes/Data",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ]
+                    },
+                    "/dev/disk1s4,/private/var/vm": {
+                        "block_size": 512,
+                        "device": "/dev/disk1s4",
+                        "kb_size": "976797816",
+                        "kb_used": "1048596",
+                        "kb_available": "895397524",
+                        "percent_used": "1%",
+                        "inodes_used": "1",
+                        "inodes_available": "9767978159",
+                        "total_inodes": "9767978160",
+                        "inodes_percent_used": "0%",
+                        "mount": "/private/var/vm",
+                        "fs_type": "apfs",
+                        "mount_options": [
+                            "local",
+                            "journaled",
+                            "nobrowse"
+                        ]
+                    },
+                    "map auto_home,/System/Volumes/Data/home": {
+                        "block_size": 512,
+                        "device": "map auto_home",
+                        "kb_size": "0",
+                        "kb_used": "0",
+                        "kb_available": "0",
+                        "percent_used": "100%",
+                        "inodes_used": "0",
+                        "inodes_available": "0",
+                        "total_inodes": "0",
+                        "inodes_percent_used": "100%",
+                        "mount": "/System/Volumes/Data/home",
+                        "fs_type": "autofs",
+                        "mount_options": [
+                            "automounted",
+                            "nobrowse"
+                        ]
+                    }
+                }
+            },
+            "cloud": null,
+            "chef_guid": "fb180f13-9781-4b16-b41c-62577c2c722d",
+            "name": "C02YJ0PLJGH5",
+            "chef_environment": "_default",
+            "recipes": [
+                "cpe_init",
+                "cpe_init::default",
+                "cpe_init::mac_os_x_init",
+                "cpe_init::company_init",
+                "chefit-masterclient::default",
+                "cpe_bluetooth::default",
+                "cpe_chrome::default",
+                "cpe_chrome::mac_os_x_chrome",
+                "cpe_desktop::default",
+                "cpe_hosts::default",
+                "cpe_chef::default",
+                "cpe_pathsd::default",
+                "cpe_screensaver::default",
+                "cpe_spotlight::default",
+                "cpe_powermanagement::default",
+                "cpe_preferencepanes::default",
+                "cpe_munki::default",
+                "cpe_launchd::default",
+                "cpe_crypt::default",
+                "cpe_profiles::default",
+                "audit::default",
+                "audit::inspec",
+                "slack_handler::default",
+                "chef-client::delete_validation"
+            ],
+            "expanded_run_list": [
+                "cpe_init::default"
+            ],
+            "roles": [
+                "cpe_base"
+            ],
+            "cookbooks": {
+                "cpe_init": {
+                    "version": "0.1.105"
+                },
+                "cpe_utils": {
+                    "version": "0.1.0"
+                },
+                "audit": {
+                    "version": "7.4.1"
+                },
+                "chef-client": {
+                    "version": "11.0.3"
+                },
+                "cron": {
+                    "version": "5.1.0"
+                },
+                "logrotate": {
+                    "version": "2.1.0"
+                },
+                "compat_resource": {
+                    "version": "12.19.1"
+                },
+                "cpe_bluetooth": {
+                    "version": "0.1.0"
+                },
+                "cpe_profiles": {
+                    "version": "0.1.0"
+                },
+                "chefit-masterclient": {
+                    "version": "0.1.20"
+                },
+                "cpe_desktop": {
+                    "version": "0.1.0"
+                },
+                "cpe_chrome": {
+                    "version": "0.1.0"
+                },
+                "cpe_choco": {
+                    "version": "0.1.2"
+                },
+                "cpe_chef": {
+                    "version": "0.1.2"
+                },
+                "cpe_crypt": {
+                    "version": "0.1.0"
+                },
+                "cpe_launchd": {
+                    "version": "0.1.2"
+                },
+                "cpe_remote": {
+                    "version": "0.1.0"
+                },
+                "cpe_logger": {
+                    "version": "0.1.0"
+                },
+                "cpe_hosts": {
+                    "version": "0.2.0"
+                },
+                "cpe_macos_server": {
+                    "version": "0.1.0"
+                },
+                "cpe_munki": {
+                    "version": "0.3.0"
+                },
+                "cpe_nightly_reboot": {
+                    "version": "0.1.0"
+                },
+                "cpe_pathsd": {
+                    "version": "0.1.0"
+                },
+                "cpe_powermanagement": {
+                    "version": "0.1.0"
+                },
+                "cpe_preferencepanes": {
+                    "version": "0.1.0"
+                },
+                "cpe_prompt_user": {
+                    "version": "0.1.0"
+                },
+                "cpe_screensaver": {
+                    "version": "0.1.0"
+                },
+                "cpe_spotlight": {
+                    "version": "0.1.0"
+                },
+                "cpe_batterycheck": {
+                    "version": "0.1.0"
+                },
+                "cpe_botmanagement": {
+                    "version": "0.1.0"
+                },
+                "slack_handler": {
+                    "version": "1.0.0"
+                },
+                "windows_localadminaccount": {
+                    "version": "0.1.3"
+                },
+                "windows_screensaver": {
+                    "version": "0.1.11"
+                }
+            }
+        },
+        "normal": {
+            "tags": []
+        },
+        "chef_type": "node",
+        "default": {
+            "audit": {
+                "inspec_version": null,
+                "inspec_gem_source": null,
+                "inspec_backend_cache": true,
+                "reporter": "chef-automate",
+                "fetcher": "chef-automate",
+                "server": null,
+                "refresh_token": null,
+                "token": null,
+                "insecure": null,
+                "owner": null,
+                "raise_if_unreachable": true,
+                "fail_if_not_present": false,
+                "interval": {
+                    "enabled": false,
+                    "time": 1440
+                },
+                "quiet": true,
+                "overwrite": true,
+                "profiles": [
+                    {
+                        "name": "mac_os_x",
+                        "compliance": "jmccrae@chef.io/mac_os_x"
+                    }
+                ],
+                "attributes": {},
+                "chef_node_attribute_enabled": false,
+                "json_file": {
+                    "location": "/var/chef/cache/cookbooks/audit/inspec-20200406222052.json"
+                }
+            },
+            "cron": {
+                "package_name": [],
+                "service_name": "cron",
+                "emulate_cron.d": false
+            },
+            "logrotate": {
+                "package": {
+                    "name": "logrotate",
+                    "source": null,
+                    "version": null,
+                    "provider": null
+                },
+                "directory": "/etc/logrotate.d",
+                "cron": {
+                    "install": false,
+                    "name": "logrotate",
+                    "command": "/usr/sbin/logrotate /etc/logrotate.conf",
+                    "minute": 35,
+                    "hour": 2
+                },
+                "global": {
+                    "weekly": true,
+                    "rotate": 4,
+                    "create": "",
+                    "/var/log/wtmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0664 root utmp",
+                        "rotate": 1
+                    },
+                    "/var/log/btmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0660 root utmp",
+                        "rotate": 1
+                    }
+                }
+            },
+            "chef_client": {
+                "config": {
+                    "chef_server_url": "https://api.chef.io/organizations/chefitproduction",
+                    "validation_client_name": "chefitproduction-validator",
+                    "node_name": "C02YJ0PLJGH5",
+                    "verify_api_cert": true,
+                    "client_fork": true,
+                    "start_handlers": [],
+                    "report_handlers": [],
+                    "exception_handlers": []
+                },
+                "log_file": "client.log",
+                "interval": "1800",
+                "splay": "300",
+                "conf_dir": "/etc/chef",
+                "bin": "/usr/bin/chef-client",
+                "log_dir": "/Library/Logs/Chef",
+                "log_perm": "640",
+                "cron": {
+                    "minute": "0",
+                    "hour": "0,4,8,12,16,20",
+                    "weekday": "*",
+                    "path": null,
+                    "environment_variables": null,
+                    "log_file": "/dev/null",
+                    "append_log": false,
+                    "use_cron_d": false,
+                    "mailto": null
+                },
+                "systemd": {
+                    "timer": false,
+                    "timeout": false,
+                    "restart": "always"
+                },
+                "task": {
+                    "frequency": "minute",
+                    "frequency_modifier": 30,
+                    "user": "SYSTEM",
+                    "password": null,
+                    "start_time": null,
+                    "start_date": null,
+                    "name": "chef-client"
+                },
+                "load_gems": {},
+                "reload_config": true,
+                "daemon_options": [],
+                "logrotate": {
+                    "rotate": 12,
+                    "frequency": "weekly"
+                },
+                "init_style": "launchd",
+                "run_path": "/var/run/chef",
+                "cache_path": "/Library/Caches/Chef",
+                "backup_path": "/Library/Caches/Chef/Backup",
+                "launchd_mode": "interval",
+                "log_rotation": {
+                    "options": [
+                        "compress"
+                    ],
+                    "prerotate": null,
+                    "postrotate": "/etc/init.d/chef-client reload >/dev/null || :"
+                },
+                "handler": {
+                    "slack": {
+                        "team": null,
+                        "api_key": null,
+                        "channel": null,
+                        "webhooks": {
+                            "name": [
+                                "itchannel"
+                            ],
+                            "itchannel": {
+                                "url": "https://hooks.slack.com/services/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"
+                            }
+                        },
+                        "timeout": 15,
+                        "username": "Chef Run Bot",
+                        "icon_url": "https://avatars1.githubusercontent.com/u/29740",
+                        "icon_emoji": ":fork_and_knife:",
+                        "message_detail_level": "elapsed",
+                        "cookbook_detail_level": "all",
+                        "fail_only": true,
+                        "send_start_message": false,
+                        "send_environment": false,
+                        "send_organization": false
+                    }
+                }
+            },
+            "ohai": {
+                "disabled_plugins": [],
+                "plugin_path": null
+            },
+            "cpe_profiles": {
+                "prefix": "com.chef.chefit",
+                "com.chef.chefit.browsers.chrome": {
+                    "PayloadIdentifier": "com.chef.chefit.browsers.chrome",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "bf900530-2306-0131-32e2-000c2944c108",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Chrome",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.browsers.chrome",
+                            "PayloadUUID": "3377ead0-2310-0131-32ec-000c2944c108",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Chrome",
+                            "PayloadContent": {
+                                "com.google.Chrome": {
+                                    "Forced": [
+                                        {
+                                            "mcx_preference_settings": {
+                                                "ExtensionInstallForcelist": [],
+                                                "ExtensionInstallBlacklist": [],
+                                                "EnabledPlugins": [],
+                                                "DisabledPlugins": [],
+                                                "DefaultPluginsSetting": 1,
+                                                "ExtensionInstallSources": [],
+                                                "PluginsAllowedForUrls": []
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "com.chef.chefit.screensaver": {
+                    "PayloadIdentifier": "com.chef.chefit.screensaver",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "CEA1E58D-9D0F-453A-AA52-830986A8366C",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Screensaver",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.screensaver",
+                            "PayloadUUID": "3B2AD6A9-F99E-4813-980A-4147617B2E75",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "ScreenSaver",
+                            "PayloadContent": {
+                                "com.apple.screensaver": {
+                                    "Forced": [
+                                        {
+                                            "mcx_preference_settings": {
+                                                "idleTime": 1200,
+                                                "askForPassword": 1,
+                                                "askForPasswordDelay": 5
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "com.chef.chefit.munki": {
+                    "PayloadIdentifier": "com.chef.chefit.munki",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "a3f3dc40-1fde-0131-31d5-000c2944c108",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Munki",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "ManagedInstalls",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.munki",
+                            "PayloadUUID": "7059fe60-222f-0131-31db-000c2944c108",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Munki",
+                            "AppleSoftwareUpdatesOnly": false,
+                            "DaysBetweenNotifications": 1,
+                            "FollowHTTPRedirects": "none",
+                            "InstallAppleSoftwareUpdates": false,
+                            "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+                            "LoggingLevel": 1,
+                            "LogToSyslog": false,
+                            "PerformAuthRestarts": false,
+                            "SoftwareRepoURL": "https://munki.opscodecorp.com/munki_repo",
+                            "SuppressAutoInstall": false,
+                            "SuppressStopButtonOnInstall": false,
+                            "SuppressUserNotification": false,
+                            "UnattendedAppleUpdates": false,
+                            "UseClientCertificate": false
+                        }
+                    ]
+                },
+                "com.chef.chefit.crypt": {
+                    "PayloadIdentifier": "com.chef.chefit.crypt",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "28A33C8B-6808-4457-B6CC-F866AD3272C2",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Crypt",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.grahamgilbert.crypt",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.crypt",
+                            "PayloadUUID": "F9A5E8E1-3C08-4D32-94A5-325009F9C999",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Crypt",
+                            "ServerURL": "https://crypt.opscodecorp.com",
+                            "SkipUsers": [],
+                            "RemovePlist": true,
+                            "RotateUsedKey": false
+                        }
+                    ]
+                }
+            },
+            "cpe_bluetooth": {
+                "BluetoothAutoSeekKeyboard": null,
+                "BluetoothAutoSeekPointingDevice": null
+            },
+            "cpe_chef": {
+                "config": true,
+                "interval": 1800,
+                "knife": false
+            },
+            "cpe_choco": {
+                "bootstrap": {
+                    "installation_uri": "https://chocolatey.org/install.ps1",
+                    "upgrade_source": "https://chocolatey.org/api/v2",
+                    "version": "0.10.3",
+                    "choco_download_url": "https://chocolatey.org/api/v2/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion",
+                    "zip_location": "https://chocolatey.org/7za.exe",
+                    "use_windows_compression": "true"
+                },
+                "install": {},
+                "uninstall": {},
+                "source_blacklist": [],
+                "default_feed": "https://chocolatey.org/api/v2",
+                "sources": {
+                    "chocolatey": {
+                        "source": "https://chocolatey.org/api/v2"
+                    }
+                },
+                "config": {
+                    "cacheLocation": {
+                        "value": "",
+                        "description": "Cache location if not TEMP folder."
+                    },
+                    "commandExecutionTimeoutSeconds": {
+                        "value": 2700,
+                        "description": "Default timeout for command execution."
+                    },
+                    "webRequestTimeoutSeconds": {
+                        "value": 30,
+                        "description": "Default timeout for web requests. Available in 0.9.10+."
+                    },
+                    "containsLegacyPackageInstalls": {
+                        "value": true,
+                        "description": "Install has packages installed prior to 0.9.9 series."
+                    },
+                    "proxy": {
+                        "value": "",
+                        "description": "Explicit proxy location."
+                    },
+                    "proxyUser": {
+                        "value": "",
+                        "description": "Optional proxy user."
+                    },
+                    "proxyPassword": {
+                        "value": "",
+                        "description": "Optional proxy password. Encrypted."
+                    }
+                },
+                "features": {
+                    "checksumFiles": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Checksum files when pulled in from internet (based on package)."
+                    },
+                    "autoUninstaller": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Uninstall from programs and features without requiring an explicit uninstall script."
+                    },
+                    "allowGlobalConfirmation": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Prompt for confirmation in scripts or bypass."
+                    },
+                    "failOnAutoUninstaller": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Fail if automatic uninstaller fails."
+                    },
+                    "failOnStandardError": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Fail if install provider writes to stderr. Available in 0.9.10+."
+                    },
+                    "powershellHost": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Use Chocolatey's built-in PowerShell host. Available in 0.9.10+."
+                    },
+                    "logEnvironmentValues": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Log Environment Values - will log values of environment before and after install (could disclose sensitive data). Available in 0.9.10+."
+                    },
+                    "virusCheck": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Virus Check - perform virus checking on downloaded files. Available in 0.9.10+. Licensed versions only."
+                    },
+                    "failOnInvalidOrMissingLicense": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Fail On Invalid Or Missing License - allows knowing when a license is expired or not applied to a machine. Available in 0.9.10+."
+                    },
+                    "ignoreInvalidOptionsSwitches": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Ignore Invalid Options/Switches - If a switch or option is passed that is not recognized, should choco fail? Available in 0.9.10+."
+                    },
+                    "usePackageExitCodes": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+."
+                    },
+                    "useFipsCompliantChecksums": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Use FIPS Compliant Checksums - Ensure checksumming done by choco uses FIPS compliant algorithms. Not recommended unless required by FIPS Mode. Enabling on an existing installation could have unintended consequences related to upgrades/uninstalls. Available in 0.9.10+."
+                    },
+                    "allowEmptyChecksums": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Allow packages to have empty/missing checksums for downloaded resources from non-secure locations (HTTP, FTP). Enabling is not recommended if using sources that download resources from the internet. Available in 0.10.0+."
+                    },
+                    "allowEmptyChecksumsSecure": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Allow packages to have empty/missing checksums for downloaded resources from secure locations (HTTPS). Available in 0.10.0+."
+                    },
+                    "scriptsCheckLastExitCode": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Scripts Check $LastExitCode (external commands) - Leave this off unless you absolutely need it while you fix your package scripts  to use `throw 'error message'` or `Set-PowerShellExitCode #` instead of `exit #`. This behavior started in 0.9.10 and produced hard to find bugs. If the last external process exits successfully but with an exit code of not zero, this could cause hard to detect package failures. Available in 0.10.3+. Will be removed in 0.11.0."
+                    }
+                }
+            },
+            "cpe_chrome": {
+                "profile": {
+                    "ExtensionInstallForcelist": [],
+                    "ExtensionInstallBlacklist": [],
+                    "EnabledPlugins": [],
+                    "DisabledPlugins": [],
+                    "DefaultPluginsSetting": 1,
+                    "ExtensionInstallSources": [],
+                    "PluginsAllowedForUrls": []
+                },
+                "mp": {
+                    "UseMasterPreferencesFile": false,
+                    "FileContents": {}
+                }
+            },
+            "cpe_launchd": {
+                "prefix": "com.chef.chefit",
+                "com.chef.chefit.chef.interval": {
+                    "program_arguments": [
+                        "/opt/chef/bin/chef-client",
+                        "--log_level",
+                        "info",
+                        "--no-color"
+                    ],
+                    "run_at_load": true,
+                    "start_interval": 1800,
+                    "standard_out_path": "/var/log/chef-interval.log"
+                },
+                "com.chef.chefit.chef.gui": {
+                    "program_arguments": [
+                        "/bin/sh",
+                        "-c",
+                        "/bin/sleep 60; echo $USER"
+                    ],
+                    "limit_load_to_session_type": [
+                        "Aqua"
+                    ],
+                    "run_at_load": true,
+                    "type": "agent",
+                    "standard_out_path": "/Users/Shared/.com.chef.chefit.chef"
+                },
+                "com.chef.chefit.chef.login": {
+                    "program_arguments": [
+                        "/opt/chef/bin/chef-client",
+                        "--log_level",
+                        "info",
+                        "--no-color"
+                    ],
+                    "watch_paths": [
+                        "/Users/Shared/.com.chef.chefit.chef"
+                    ],
+                    "run_at_load": true,
+                    "standard_out_path": "/var/log/chef-login.log"
+                },
+                "com.grahamgilbert.crypt": {
+                    "program_arguments": [
+                        "/Library/Crypt/checkin"
+                    ],
+                    "disabled": false,
+                    "run_at_load": true,
+                    "start_interval": 120,
+                    "type": "daemon"
+                }
+            },
+            "cpe_remote": {
+                "base_url": "munki.opscodecorp.com/munki_repo/chef",
+                "server_accessible": true
+            },
+            "cpe_crypt": {
+                "install": true,
+                "uninstall": false,
+                "profile": true,
+                "manage_authdb": true,
+                "manage_ld": true,
+                "ld": {
+                    "program_arguments": [
+                        "/Library/Crypt/checkin"
+                    ],
+                    "disabled": false,
+                    "run_at_load": true,
+                    "start_interval": 120,
+                    "type": "daemon"
+                },
+                "prefs": {
+                    "ServerURL": "https://crypt.opscodecorp.com",
+                    "SkipUsers": [],
+                    "RemovePlist": true,
+                    "RotateUsedKey": false,
+                    "ValidateKey": null,
+                    "FDEAddUser": null,
+                    "OutputPath": null,
+                    "KeyEscrowInterval": null
+                },
+                "pkg": {
+                    "app": "crypt",
+                    "checksum": "5ec9624766de7394e32e8f2bfb5b56be38fc6d580e16734b748fff2e50dcfdf8",
+                    "receipt": "com.grahamgilbert.Crypt",
+                    "version": "3.2.1",
+                    "pkg_name": "Crypt-3.2.1.pkg",
+                    "pkg_url": "https://chefitpublic.file.core.windows.net/chefdeploy/Crypt-3.2.1.pkg?sv=2019-02-02&ss=f&srt=co&sp=rwdlc&se=2020-12-03T05:44:57Z&st=2019-12-02T21:44:57Z&spr=https&sig=GFxQyrLNGAEr4GXMiLM9htNUGg00sQC94InYs940IR4%3D"
+                }
+            },
+            "cpe_desktop": {
+                "override-picture-path": null
+            },
+            "cpe_hosts": {
+                "extra_entries": {
+                    "::1": [],
+                    "127.0.0.1": []
+                }
+            },
+            "cpe_macos_server": {
+                "setup": false,
+                "manage": false,
+                "services": {}
+            },
+            "cpe_munki": {
+                "install": true,
+                "configure": true,
+                "auto_remediate": null,
+                "local": {
+                    "managed_installs": [],
+                    "managed_uninstalls": []
+                },
+                "preferences": {
+                    "AppleSoftwareUpdatesOnly": false,
+                    "DaysBetweenNotifications": 1,
+                    "FollowHTTPRedirects": "none",
+                    "InstallAppleSoftwareUpdates": false,
+                    "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+                    "LoggingLevel": 1,
+                    "LogToSyslog": false,
+                    "PerformAuthRestarts": false,
+                    "RecoveryKeyFile": null,
+                    "SoftwareRepoURL": "https://munki.opscodecorp.com/munki_repo",
+                    "SuppressAutoInstall": false,
+                    "SuppressStopButtonOnInstall": false,
+                    "SuppressUserNotification": false,
+                    "UnattendedAppleUpdates": false,
+                    "UseClientCertificate": false,
+                    "UseNotificationCenterDays": null
+                },
+                "munki_version_to_install": {
+                    "launchd": {
+                        "version": "3.0.3265",
+                        "checksum": "06bab5876d3f13eb74256a6e3ad25b3e0ca299a74338d09ba0245f5a1635112d"
+                    },
+                    "admin": {
+                        "version": "3.6.2.3776",
+                        "checksum": "fa4b90d4ff91ae0aaa29909d3b34fa26ab5aebb76b9756bc544a3269684adb2b"
+                    },
+                    "app": {
+                        "version": "5.1.0.3774",
+                        "checksum": "6ce39ce5fdb6e6107f03d0d9ecfe728f5397c5d6aa206ab3911083a3e1b2f30e"
+                    },
+                    "app_usage": {
+                        "version": "3.6.2.3776",
+                        "checksum": "52abd84b39cce2eccff94c69261f9e02738805b40b82c8d1c26b472b33b50c73"
+                    },
+                    "core": {
+                        "version": "3.6.2.3776",
+                        "checksum": "4c834d0506c72dd88a92d506b528ea8f23622223b010174c294241b1669e43d6"
+                    }
+                },
+                "2.8.0.2810": {
+                    "munki_core_version": "2.8.0.2810",
+                    "munki_core_folders": [
+                        "Library/Managed Installs",
+                        "Library/Managed Installs/Cache",
+                        "Library/Managed Installs/catalogs",
+                        "Library/Managed Installs/manifests",
+                        "private/etc/paths.d",
+                        "usr/local/munki",
+                        "usr/local/munki/munkilib"
+                    ],
+                    "munki_core_files": [
+                        "private/etc/paths.d/munki",
+                        "usr/local/munki/launchapp",
+                        "usr/local/munki/logouthelper",
+                        "usr/local/munki/managedsoftwareupdate",
+                        "usr/local/munki/ptyexec",
+                        "usr/local/munki/supervisor",
+                        "usr/local/munki/munkilib/__init__.py",
+                        "usr/local/munki/munkilib/adobeutils.py",
+                        "usr/local/munki/munkilib/appleupdates.py",
+                        "usr/local/munki/munkilib/fetch.py",
+                        "usr/local/munki/munkilib/FoundationPlist.py",
+                        "usr/local/munki/munkilib/gurl.py",
+                        "usr/local/munki/munkilib/iconutils.py",
+                        "usr/local/munki/munkilib/installer.py",
+                        "usr/local/munki/munkilib/keychain.py",
+                        "usr/local/munki/munkilib/launchd.py",
+                        "usr/local/munki/munkilib/munkicommon.py",
+                        "usr/local/munki/munkilib/munkistatus.py",
+                        "usr/local/munki/munkilib/powermgr.py",
+                        "usr/local/munki/munkilib/profiles.py",
+                        "usr/local/munki/munkilib/removepackages.py",
+                        "usr/local/munki/munkilib/updatecheck.py",
+                        "usr/local/munki/munkilib/utils.py",
+                        "usr/local/munki/munkilib/version.plist"
+                    ],
+                    "munki_admin_version": "2.8.0.2810",
+                    "munki_admin_folders": [
+                        "private/etc/paths.d",
+                        "usr/local/munki"
+                    ],
+                    "munki_admin_files": [
+                        "private/etc/paths.d/munki",
+                        "usr/local/munki/iconimporter",
+                        "usr/local/munki/makecatalogs",
+                        "usr/local/munki/makepkginfo",
+                        "usr/local/munki/manifestutil",
+                        "usr/local/munki/munkiimport"
+                    ],
+                    "munki_launchd_version": "2.0.0.1969",
+                    "munki_launchd_folders": [
+                        "Library/LaunchAgents",
+                        "Library/LaunchDaemons"
+                    ],
+                    "munki_launcha_files": [
+                        "com.googlecode.munki.ManagedSoftwareCenter.plist",
+                        "com.googlecode.munki.managedsoftwareupdate-loginwindow.plist",
+                        "com.googlecode.munki.MunkiStatus.plist"
+                    ],
+                    "munki_ld_files": [
+                        "com.googlecode.munki.logouthelper.plist",
+                        "com.googlecode.munki.managedsoftwareupdate-check.plist",
+                        "com.googlecode.munki.managedsoftwareupdate-install.plist",
+                        "com.googlecode.munki.managedsoftwareupdate-manualcheck.plist"
+                    ],
+                    "munki_app_version": "4.2.2759",
+                    "munki_app_checksum": "0feb9567930ce815cb4785e4b3ad1a7aa7a47eee2a2657a41f2acc9cef72c209"
+                }
+            },
+            "cpe_nightly_reboot": {
+                "script": "/opt/chef/scripts/logout_bootstrap.py",
+                "restart": {
+                    "Month": null,
+                    "Day": null,
+                    "Weekday": null,
+                    "Hour": null,
+                    "Minute": null
+                },
+                "logout": {
+                    "Month": null,
+                    "Day": null,
+                    "Weekday": null,
+                    "Hour": null,
+                    "Minute": null
+                }
+            },
+            "cpe_pathsd": [],
+            "cpe_powermanagement": {
+                "ACPower": {
+                    "Automatic Restart On Power Loss": null,
+                    "Disk Sleep Timer": null,
+                    "Display Sleep Timer": null,
+                    "Sleep On Power Button": null,
+                    "System Sleep Timer": null,
+                    "Wake On LAN": null,
+                    "RestartAfterKernelPanic": null
+                },
+                "Battery": {
+                    "Automatic Restart On Power Loss": null,
+                    "Disk Sleep Timer": null,
+                    "Display Sleep Timer": null,
+                    "Sleep On Power Button": null,
+                    "System Sleep Timer": null,
+                    "Wake On LAN": null,
+                    "RestartAfterKernelPanic": null
+                }
+            },
+            "cpe_preferencepanes": {
+                "DisabledPreferencePanes": null,
+                "HiddenPreferencePanes": null
+            },
+            "cpe_prompt_user": {
+                "CocoaDialog": "/Applications/CocoaDialog.app/Contents/MacOS/CocoaDialog",
+                "icon": null,
+                "prompts": {}
+            },
+            "cpe_screensaver": {
+                "idleTime": 1200,
+                "askForPassword": 1,
+                "askForPasswordDelay": 5
+            },
+            "cpe_spotlight": {
+                "exclusions": []
+            },
+            "cpe_user": {
+                "boiardie": {
+                    "comment": "Chef Boiardie",
+                    "uid": "499",
+                    "home": "/var/boiardie",
+                    "password": "0psCode!!",
+                    "iterations": 27964,
+                    "manage_home": true,
+                    "admin": 1,
+                    "hidden": 1
+                }
+            },
+            "organization": "chef"
+        },
+        "override": {},
+        "run_list": [
+            "role[cpe_base]"
+        ]
+    },
+    "node_name": "C02YJ0PLJGH5",
+    "organization_name": "chefitproduction",
+    "resources": [
+        {
+            "type": "inspec_gem",
+            "name": "inspec",
+            "id": "inspec",
+            "after": {
+                "version": null,
+                "source": null
+            },
+            "before": {},
+            "duration": "90",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "audit",
+            "cookbook_version": "7.4.1",
+            "recipe_name": "inspec"
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/var/chef/cache/slack_handler_util.rb",
+            "id": "/var/chef/cache/slack_handler_util.rb",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_util.rb",
+                "verifications": [],
+                "source": "slack_handler_util.rb"
+            },
+            "before": {
+                "checksum": "1d96a6d2d30f80a8499190df8220ad532966fe18e57a87359b9a60623bfecff7",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_util.rb"
+            },
+            "duration": "9",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/var/chef/cache/slack_handler_webhook.rb",
+            "id": "/var/chef/cache/slack_handler_webhook.rb",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_webhook.rb",
+                "verifications": [],
+                "source": "slack_handler_webhook.rb"
+            },
+            "before": {
+                "checksum": "8a9338f1c88e1a5ecdac3f86747e9acb55ebc585ccbdf3de31b29d77c8512bec",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_webhook.rb"
+            },
+            "duration": "11",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "chef_handler",
+            "name": "Chef::Handler::Slack",
+            "id": "Chef::Handler::Slack",
+            "after": {
+                "class_name": "Chef::Handler::Slack",
+                "source": "/var/chef/cache/slack_handler_webhook.rb",
+                "arguments": [
+                    {
+                        "team": null,
+                        "api_key": null,
+                        "channel": null,
+                        "webhooks": {
+                            "name": [
+                                "itchannel"
+                            ],
+                            "itchannel": {
+                                "url": "https://hooks.slack.com/services/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"
+                            }
+                        },
+                        "timeout": 15,
+                        "username": "Chef Run Bot",
+                        "icon_url": "https://avatars1.githubusercontent.com/u/29740",
+                        "icon_emoji": ":fork_and_knife:",
+                        "message_detail_level": "elapsed",
+                        "cookbook_detail_level": "all",
+                        "fail_only": true,
+                        "send_start_message": false,
+                        "send_environment": false,
+                        "send_organization": false
+                    }
+                ],
+                "type": {
+                    "start": true,
+                    "report": true,
+                    "exception": true
+                }
+            },
+            "before": {},
+            "duration": "6",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "ruby_block",
+            "name": "trigger_start_handlers",
+            "id": "trigger_start_handlers",
+            "after": {
+                "block_name": "trigger_start_handlers"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "directory",
+            "name": "/etc/chef",
+            "id": "/etc/chef",
+            "after": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/etc/chef"
+            },
+            "before": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/etc/chef"
+            },
+            "duration": "2",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "chefit-masterclient",
+            "cookbook_version": "0.1.20",
+            "recipe_name": "default"
+        },
+        {
+            "type": "template",
+            "name": "/templates/default/client.rb",
+            "id": "/etc/chef/client.rb",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/chef/client.rb",
+                "verifications": [],
+                "variables": {
+                    "erb_token": "tNU9pwnSHSZXjAEkNGHpZeLFCMg=",
+                    "erb_server_url": "https://chefit.automate.chef.io/data-collector/v0"
+                },
+                "checksum": "40ec79fa042be1c3918236b160968c3074561a4cb198ffee75ea3891111ab08d"
+            },
+            "before": {
+                "checksum": "4cd8de5cdf6409e06d7013d4e00811c421e1e9ec65fbc423e3dbf5c5553b6b4b",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/chef/client.rb"
+            },
+            "duration": "15",
+            "delta": "--- /etc/chef/client.rb\t2020-04-06 15:20:27.141915817 -0700\\n+++ /etc/chef/.chef-client20200406-2787-1b8mjen.rb\t2020-04-06 15:20:55.736873337 -0700\\n@@ -10,7 +10,6 @@\\n http_retry_count       3\\n \\n node_name \"C02YJ0PLJGH5\"\\n-Chef::Config[:data_collector][:output_locations] = { files:  [ \"/Users/beth_hall/data_collector.out\" ] }\\n data_collector.server_url \"https://chefit.automate.chef.io/data-collector/v0\"\\n data_collector.token \"tNU9pwnSHSZXjAEkNGHpZeLFCMg=\"\\n slack_webhook_url \"\"",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "chefit-masterclient",
+            "cookbook_version": "0.1.20",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_bluetooth",
+            "name": "Configure Bluetooth Profile",
+            "id": "Configure Bluetooth Profile",
+            "after": {},
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_bluetooth",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_chrome",
+            "name": "Configure Google Chrome",
+            "id": "Configure Google Chrome",
+            "after": {},
+            "before": {},
+            "duration": "96",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_chrome",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "mac_os_x_chrome"
+        },
+        {
+            "type": "cpe_desktop",
+            "name": "Apply Preference Desktop Wallpaper",
+            "id": "Apply Preference Desktop Wallpaper",
+            "after": {},
+            "before": {},
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_desktop",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "file",
+            "name": "/etc/hosts",
+            "id": "/etc/hosts",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/hosts",
+                "verifications": []
+            },
+            "before": {
+                "checksum": "64bb70bd267972ff4814b832712c72df883f554e6e70a0074b9ce550306c83f4",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/hosts"
+            },
+            "duration": "14",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_hosts",
+            "cookbook_version": "0.2.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_hosts",
+            "name": "Managing hosts file",
+            "id": "Managing hosts file",
+            "after": {},
+            "before": {},
+            "duration": "17",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_hosts",
+            "cookbook_version": "0.2.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "file",
+            "name": "/Users/Shared/.com.chef.chefit.chef",
+            "id": "/Users/Shared/.com.chef.chefit.chef",
+            "after": {
+                "owner": "root",
+                "group": "staff",
+                "mode": "0666",
+                "path": "/Users/Shared/.com.chef.chefit.chef"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "staff",
+                "mode": "0666",
+                "path": "/Users/Shared/.com.chef.chefit.chef"
+            },
+            "duration": "8",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_chef",
+            "cookbook_version": "0.1.2",
+            "recipe_name": null
+        },
+        {
+            "type": "directory",
+            "name": "/Users/beth_hall/.chef",
+            "id": "/Users/beth_hall/.chef",
+            "after": {
+                "group": "staff",
+                "mode": "0700",
+                "owner": "beth_hall",
+                "path": "/Users/beth_hall/.chef"
+            },
+            "before": {
+                "group": "staff",
+                "mode": "0700",
+                "owner": "beth_hall",
+                "path": "/Users/beth_hall/.chef"
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_chef",
+            "cookbook_version": "0.1.2",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_chef",
+            "name": "Managing chef daemon",
+            "id": "Managing chef daemon",
+            "after": {},
+            "before": {},
+            "duration": "38",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_chef",
+            "cookbook_version": "0.1.2",
+            "recipe_name": "default"
+        },
+        {
+            "type": "directory",
+            "name": "/etc/paths.d/",
+            "id": "/etc/paths.d/",
+            "after": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/etc/paths.d/"
+            },
+            "before": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/etc/paths.d/"
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_pathsd",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "template",
+            "name": "/etc/paths.d/cpe_pathsd",
+            "id": "/etc/paths.d/cpe_pathsd",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/paths.d/cpe_pathsd",
+                "verifications": [],
+                "variables": {}
+            },
+            "before": {
+                "checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/etc/paths.d/cpe_pathsd"
+            },
+            "duration": "7",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_pathsd",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_screensaver",
+            "name": "Configure Screen Saver Profile",
+            "id": "Configure Screen Saver Profile",
+            "after": {},
+            "before": {},
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_screensaver",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "directory",
+            "name": "/private/var/chef",
+            "id": "/private/var/chef",
+            "after": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/private/var/chef"
+            },
+            "before": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/private/var/chef"
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_spotlight",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_spotlight",
+            "name": "Manage Spotlight exclusions",
+            "id": "Manage Spotlight exclusions",
+            "after": {},
+            "before": {},
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_spotlight",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_spotlight",
+            "name": "Clean up removed Spotlight exclusions",
+            "id": "Clean up removed Spotlight exclusions",
+            "after": {},
+            "before": {},
+            "duration": "1247",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "clean_up",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_spotlight",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_powermanagement",
+            "name": "Configure Power Management Profile",
+            "id": "Configure Power Management Profile",
+            "after": {},
+            "before": {},
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_powermanagement",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_preferencepanes",
+            "name": "Configure PreferencePanes Profile",
+            "id": "Configure PreferencePanes Profile",
+            "after": {},
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_preferencepanes",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "munkitools_launchd",
+            "id": "munkitools_launchd",
+            "after": {
+                "app": "munkitools",
+                "checksum": "06bab5876d3f13eb74256a6e3ad25b3e0ca299a74338d09ba0245f5a1635112d",
+                "pkg_name": "munkitools_launchd-3.0.3265",
+                "version": "3.0.3265"
+            },
+            "before": {
+                "app": "munkitools",
+                "version": "3.0.3265"
+            },
+            "duration": "101",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "munkitools_admin",
+            "id": "munkitools_admin",
+            "after": {
+                "app": "munkitools",
+                "checksum": "fa4b90d4ff91ae0aaa29909d3b34fa26ab5aebb76b9756bc544a3269684adb2b",
+                "pkg_name": "munkitools_admin-3.6.2.3776",
+                "version": "3.6.2.3776"
+            },
+            "before": {
+                "app": "munkitools",
+                "version": "3.6.2.3776"
+            },
+            "duration": "103",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "munkitools_app",
+            "id": "munkitools_app",
+            "after": {
+                "app": "munkitools",
+                "checksum": "6ce39ce5fdb6e6107f03d0d9ecfe728f5397c5d6aa206ab3911083a3e1b2f30e",
+                "pkg_name": "munkitools_app-5.1.0.3774",
+                "version": "5.1.0.3774"
+            },
+            "before": {
+                "app": "munkitools",
+                "version": "5.1.0.3774"
+            },
+            "duration": "96",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "munkitools_app_usage",
+            "id": "munkitools_app_usage",
+            "after": {
+                "app": "munkitools",
+                "checksum": "52abd84b39cce2eccff94c69261f9e02738805b40b82c8d1c26b472b33b50c73",
+                "pkg_name": "munkitools_app_usage-3.6.2.3776",
+                "version": "3.6.2.3776"
+            },
+            "before": {
+                "app": "munkitools",
+                "version": "3.6.2.3776"
+            },
+            "duration": "99",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "munkitools_core",
+            "id": "munkitools_core",
+            "after": {
+                "app": "munkitools",
+                "checksum": "4c834d0506c72dd88a92d506b528ea8f23622223b010174c294241b1669e43d6",
+                "pkg_name": "munkitools_core-3.6.2.3776",
+                "version": "3.6.2.3776"
+            },
+            "before": {
+                "app": "munkitools",
+                "version": "3.6.2.3776"
+            },
+            "duration": "95",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist",
+            "id": "/Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist"
+            },
+            "duration": "6",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.logouthelper",
+            "id": "com.googlecode.munki.logouthelper",
+            "after": {
+                "service_name": "com.googlecode.munki.logouthelper",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.googlecode.munki.logouthelper.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.logouthelper",
+                "enabled": true
+            },
+            "duration": "61",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.logouthelper",
+            "id": "com.googlecode.munki.logouthelper",
+            "after": {
+                "label": "com.googlecode.munki.logouthelper",
+                "type": "daemon"
+            },
+            "before": {},
+            "duration": "70",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist",
+            "id": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist"
+            },
+            "duration": "6",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.managedsoftwareupdate-check",
+            "id": "com.googlecode.munki.managedsoftwareupdate-check",
+            "after": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-check",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-check.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-check",
+                "enabled": true
+            },
+            "duration": "62",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.managedsoftwareupdate-check",
+            "id": "com.googlecode.munki.managedsoftwareupdate-check",
+            "after": {
+                "label": "com.googlecode.munki.managedsoftwareupdate-check",
+                "type": "daemon"
+            },
+            "before": {},
+            "duration": "69",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist",
+            "id": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist"
+            },
+            "duration": "7",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+            "id": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+            "after": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-manualcheck.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+                "enabled": true
+            },
+            "duration": "90",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+            "id": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+            "after": {
+                "label": "com.googlecode.munki.managedsoftwareupdate-manualcheck",
+                "type": "daemon"
+            },
+            "before": {},
+            "duration": "99",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.googlecode.munki.authrestartd.plist",
+            "id": "/Library/LaunchDaemons/com.googlecode.munki.authrestartd.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.authrestartd.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.authrestartd.plist"
+            },
+            "duration": "6",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.authrestartd",
+            "id": "com.googlecode.munki.authrestartd",
+            "after": {
+                "service_name": "com.googlecode.munki.authrestartd",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.googlecode.munki.authrestartd.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.authrestartd",
+                "enabled": true
+            },
+            "duration": "70",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.authrestartd",
+            "id": "com.googlecode.munki.authrestartd",
+            "after": {
+                "label": "com.googlecode.munki.authrestartd",
+                "type": "daemon"
+            },
+            "before": {},
+            "duration": "79",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist",
+            "id": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist"
+            },
+            "duration": "8",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.managedsoftwareupdate-install",
+            "id": "com.googlecode.munki.managedsoftwareupdate-install",
+            "after": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-install",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.googlecode.munki.managedsoftwareupdate-install.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.managedsoftwareupdate-install",
+                "enabled": true
+            },
+            "duration": "66",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.managedsoftwareupdate-install",
+            "id": "com.googlecode.munki.managedsoftwareupdate-install",
+            "after": {
+                "label": "com.googlecode.munki.managedsoftwareupdate-install",
+                "type": "daemon"
+            },
+            "before": {},
+            "duration": "76",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.app_usage_monitor",
+            "id": "com.googlecode.munki.app_usage_monitor",
+            "after": {
+                "label": "com.googlecode.munki.app_usage_monitor"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "skipped",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null,
+            "conditional": "only_if { #code block }"
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist",
+            "id": "/Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist"
+            },
+            "duration": "7",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.munki-notifier",
+            "id": "com.googlecode.munki.munki-notifier",
+            "after": {
+                "service_name": "com.googlecode.munki.munki-notifier",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.munki-notifier",
+                "enabled": true
+            },
+            "duration": "125",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.munki-notifier",
+            "id": "com.googlecode.munki.munki-notifier",
+            "after": {
+                "label": "com.googlecode.munki.munki-notifier",
+                "type": "agent"
+            },
+            "before": {},
+            "duration": "135",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist",
+            "id": "/Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist"
+            },
+            "duration": "5",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.googlecode.munki.ManagedSoftwareCenter",
+            "id": "com.googlecode.munki.ManagedSoftwareCenter",
+            "after": {
+                "service_name": "com.googlecode.munki.ManagedSoftwareCenter",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist"
+            },
+            "before": {
+                "service_name": "com.googlecode.munki.ManagedSoftwareCenter",
+                "enabled": true
+            },
+            "duration": "132",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.googlecode.munki.ManagedSoftwareCenter",
+            "id": "com.googlecode.munki.ManagedSoftwareCenter",
+            "after": {
+                "label": "com.googlecode.munki.ManagedSoftwareCenter",
+                "type": "agent"
+            },
+            "before": {},
+            "duration": "139",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_munki_install",
+            "name": "Install Munki",
+            "id": "Install Munki",
+            "after": {},
+            "before": {},
+            "duration": "1172",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_munki_local",
+            "name": "Manage Local Munki Manifest",
+            "id": "Manage Local Munki Manifest",
+            "after": {},
+            "before": {},
+            "duration": "2",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_munki_config",
+            "name": "Manage Munki Settings",
+            "id": "Manage Munki Settings",
+            "after": {},
+            "before": {},
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_munki",
+            "cookbook_version": "0.3.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.chef.chefit.chef.interval.plist",
+            "id": "/Library/LaunchDaemons/com.chef.chefit.chef.interval.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.chef.chefit.chef.interval.plist",
+                "verifications": []
+            },
+            "before": {
+                "checksum": "d813ec48e4e7b40a4d8f07a642775c45f31daaff246fce41f7c0e6b680afe310",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.chef.chefit.chef.interval.plist"
+            },
+            "duration": "9",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.chef.chefit.chef.interval",
+            "id": "com.chef.chefit.chef.interval",
+            "after": {
+                "service_name": "com.chef.chefit.chef.interval",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.chef.chefit.chef.interval.plist"
+            },
+            "before": {
+                "service_name": "com.chef.chefit.chef.interval",
+                "enabled": true
+            },
+            "duration": "63",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.chef.chefit.chef.interval",
+            "id": "com.chef.chefit.chef.interval",
+            "after": {
+                "label": "com.chef.chefit.chef.interval",
+                "type": "daemon",
+                "program_arguments": [
+                    "/opt/chef/bin/chef-client",
+                    "--log_level",
+                    "info",
+                    "--no-color"
+                ],
+                "run_at_load": true,
+                "standard_out_path": "/var/log/chef-interval.log",
+                "start_interval": 1800
+            },
+            "before": {},
+            "duration": "76",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchAgents/com.chef.chefit.chef.gui.plist",
+            "id": "/Library/LaunchAgents/com.chef.chefit.chef.gui.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.chef.chefit.chef.gui.plist",
+                "verifications": []
+            },
+            "before": {
+                "checksum": "e95f9a65ae5681b654be5f134a94d3ea2ac02a24b0f35cbb6ec28a5ca212661c",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchAgents/com.chef.chefit.chef.gui.plist"
+            },
+            "duration": "11",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.chef.chefit.chef.gui",
+            "id": "com.chef.chefit.chef.gui",
+            "after": {
+                "service_name": "com.chef.chefit.chef.gui",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchAgents/com.chef.chefit.chef.gui.plist"
+            },
+            "before": {
+                "service_name": "com.chef.chefit.chef.gui",
+                "enabled": true
+            },
+            "duration": "122",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.chef.chefit.chef.gui",
+            "id": "com.chef.chefit.chef.gui",
+            "after": {
+                "label": "com.chef.chefit.chef.gui",
+                "type": "agent",
+                "limit_load_to_session_type": [
+                    "Aqua"
+                ],
+                "program_arguments": [
+                    "/bin/sh",
+                    "-c",
+                    "/bin/sleep 60; echo $USER"
+                ],
+                "run_at_load": true,
+                "standard_out_path": "/Users/Shared/.com.chef.chefit.chef"
+            },
+            "before": {},
+            "duration": "140",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "file",
+            "name": "/Library/LaunchDaemons/com.chef.chefit.chef.login.plist",
+            "id": "/Library/LaunchDaemons/com.chef.chefit.chef.login.plist",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.chef.chefit.chef.login.plist",
+                "verifications": []
+            },
+            "before": {
+                "checksum": "7b371f11268d034e72ece55f9f0ed15961fcd88c670af6e6852bcf2e394326c1",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/LaunchDaemons/com.chef.chefit.chef.login.plist"
+            },
+            "duration": "8",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date"
+        },
+        {
+            "type": "macosx_service",
+            "name": "com.chef.chefit.chef.login",
+            "id": "com.chef.chefit.chef.login",
+            "after": {
+                "service_name": "com.chef.chefit.chef.login",
+                "enabled": true,
+                "running": null,
+                "masked": null,
+                "plist": "/Library/LaunchDaemons/com.chef.chefit.chef.login.plist"
+            },
+            "before": {
+                "service_name": "com.chef.chefit.chef.login",
+                "enabled": true
+            },
+            "duration": "81",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "launchd",
+            "name": "com.chef.chefit.chef.login",
+            "id": "com.chef.chefit.chef.login",
+            "after": {
+                "label": "com.chef.chefit.chef.login",
+                "type": "daemon",
+                "program_arguments": [
+                    "/opt/chef/bin/chef-client",
+                    "--log_level",
+                    "info",
+                    "--no-color"
+                ],
+                "run_at_load": true,
+                "standard_out_path": "/var/log/chef-login.log",
+                "watch_paths": [
+                    "/Users/Shared/.com.chef.chefit.chef"
+                ]
+            },
+            "before": {},
+            "duration": "93",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "enable",
+            "status": "up-to-date"
+        },
+        {
+            "type": "cpe_launchd",
+            "name": "Managing all of launchd",
+            "id": "Managing all of launchd",
+            "after": {},
+            "before": {},
+            "duration": "313",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_launchd",
+            "cookbook_version": "0.1.2",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_launchd",
+            "name": "Cleaning up un-needed launch daemons",
+            "id": "Cleaning up un-needed launch daemons",
+            "after": {},
+            "before": {},
+            "duration": "2",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "clean_up",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_launchd",
+            "cookbook_version": "0.1.2",
+            "recipe_name": "default"
+        },
+        {
+            "type": "link",
+            "name": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "target_file": "/var/chef/cache/Crypt-3.2.1.pkg.pkg"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "skipped",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null,
+            "conditional": "only_if { #code block }"
+        },
+        {
+            "type": "remote_file",
+            "name": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "checksum": "5ec9624766de7394e32e8f2bfb5b56be38fc6d580e16734b748fff2e50dcfdf8",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+                "verifications": [],
+                "headers": {},
+                "remote_user": null,
+                "remote_domain": null
+            },
+            "before": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg"
+            },
+            "duration": "2823",
+            "delta": null,
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_file",
+            "name": "Crypt-3.2.1.pkg.pkg",
+            "id": "Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "folder_name": "crypt",
+                "checksum": "5ec9624766de7394e32e8f2bfb5b56be38fc6d580e16734b748fff2e50dcfdf8",
+                "mode": "644"
+            },
+            "before": {
+                "folder_name": "crypt",
+                "mode": "644"
+            },
+            "duration": "2826",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "execute",
+            "name": "Unzipping /var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "cd /var/chef/cache && /usr/bin/unzip -o '/var/chef/cache/Crypt-3.2.1.pkg.pkg'",
+            "after": {
+                "command": "cd /var/chef/cache && /usr/bin/unzip -o '/var/chef/cache/Crypt-3.2.1.pkg.pkg'",
+                "user": null,
+                "domain": null
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "skipped",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null,
+            "conditional": "only_if { #code block }"
+        },
+        {
+            "type": "execute",
+            "name": "Installing Crypt-3.2.1.pkg.pkg",
+            "id": "/usr/sbin/installer -pkg '/var/chef/cache/Crypt-3.2.1.pkg.pkg' -target /",
+            "after": {
+                "command": "/usr/sbin/installer -pkg '/var/chef/cache/Crypt-3.2.1.pkg.pkg' -target /",
+                "user": null,
+                "domain": null
+            },
+            "before": {},
+            "duration": "2838",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "skipped",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null,
+            "conditional": "only_if { #code block }"
+        },
+        {
+            "type": "directory",
+            "name": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "group": null,
+                "mode": null,
+                "owner": null,
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+                "recursive": true
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "skipped",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null,
+            "conditional": "only_if { #code block }"
+        },
+        {
+            "type": "file",
+            "name": "delete-/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "id": "/var/chef/cache/Crypt-3.2.1.pkg.pkg",
+            "after": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/var/chef/cache/Crypt-3.2.1.pkg.pkg"
+            },
+            "duration": "6",
+            "delta": null,
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_remote_pkg",
+            "name": "crypt",
+            "id": "crypt",
+            "after": {
+                "app": "crypt",
+                "checksum": "5ec9624766de7394e32e8f2bfb5b56be38fc6d580e16734b748fff2e50dcfdf8",
+                "pkg_name": "Crypt-3.2.1.pkg",
+                "pkg_url": "https://chefitpublic.file.core.windows.net/chefdeploy/Crypt-3.2.1.pkg?sv=2019-02-02&ss=f&srt=co&sp=rwdlc&se=2020-12-03T05:44:57Z&st=2019-12-02T21:44:57Z&spr=https&sig=GFxQyrLNGAEr4GXMiLM9htNUGg00sQC94InYs940IR4%3D",
+                "version": "3.2.1"
+            },
+            "before": {
+                "version": "3.2.1.168"
+            },
+            "duration": "6129",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_crypt_install",
+            "name": "Install Crypt package",
+            "id": "Install Crypt package",
+            "after": {},
+            "before": {},
+            "duration": "6131",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "manage",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_crypt_profile",
+            "name": "Apply Crypt profile",
+            "id": "Apply Crypt profile",
+            "after": {},
+            "before": {},
+            "duration": "2",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "config",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_crypt_authdb",
+            "name": "Manage Crypt authorization db settings",
+            "id": "Manage Crypt authorization db settings",
+            "after": {},
+            "before": {},
+            "duration": "54",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "manage",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/Library/Crypt/checkin",
+            "id": "/Library/Crypt/checkin",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0755",
+                "path": "/Library/Crypt/checkin",
+                "verifications": [],
+                "source": "crypt/checkin",
+                "checksum": "13f86ebcb1029040a2b193ef42f104d3b3035bdd5b8d92b53cfdf02fdc39982c"
+            },
+            "before": {
+                "checksum": "b5dc74ae2a451377cff31faafbf0d7ccdf44b8b852c70862d94a857db0bf4bb3",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0755",
+                "path": "/Library/Crypt/checkin"
+            },
+            "duration": "31",
+            "delta": "--- /Library/Crypt/checkin\t2018-08-20 19:11:31.000000000 -0700\\n+++ /Library/Crypt/.chef-checkin20200406-2787-123r54s\t2020-04-06 15:21:04.863597093 -0700\\n@@ -8,7 +8,6 @@\\n import datetime\\n import syslog\\n import platform\\n-import json\\n from distutils.version import LooseVersion\\n \\n import FoundationPlist\\n@@ -33,13 +32,11 @@\\n stdout_logging.setFormatter(logging.Formatter())\\n logging.getLogger().addHandler(stdout_logging)\\n \\n-\\n def get_console_user():\\n     \"\"\"returns the current console user via PyObjc\"\"\"\\n     cfuser = SCDynamicStoreCopyConsoleUser(None, None, None)\\n     return cfuser[0]\\n \\n-\\n def get_os_version(only_major_minor=True, as_tuple=False):\\n     \"\"\"Returns an OS version.\\n     Args:\\n@@ -55,7 +52,6 @@\\n     else:\\n         return '.'.join(os_version_tuple)\\n \\n-\\n def set_pref(pref_name, pref_value):\\n     \"\"\"Sets a preference, writing it to\\n         /Library/Preferences/com.grahamgilbert.crypt.plist.\\n@@ -134,42 +130,13 @@\\n     task = subprocess.Popen(cmd, stdout=subprocess.PIPE,\\n                             stderr=subprocess.PIPE)\\n     (output, error) = task.communicate()\\n-\\n     if task.returncode == 0:\\n         logging.info('Key escrow successful.')\\n-        server_initiated_rotation(output)\\n         return True\\n     else:\\n         logging.error('Key escrow unsuccessful.')\\n         return False\\n \\n-\\n-def server_initiated_rotation(output):\\n-    \"\"\"\\n-    Rotate the key if the server tells us to.\\n-    We need the old key to be present on disk and RotateUsedKey to be True\\n-    \"\"\"\\n-    try:\\n-        json_output = json.loads(output)\\n-    except ValueError:\\n-        return ''\\n-\\n-    if not pref('RotateUsedKey') or pref('RemovePlist'):\\n-        # Don't do anything if we don't care about the good stuff\\n-        return ''\\n-\\n-    output_plist = pref('OutputPath')\\n-    if not os.path.isfile(output_plist):\\n-        # Need this to be here too (which it should, but you never know..)\\n-        return ''\\n-\\n-    if json_output.get('rotation_required', False):\\n-        logging.info('Removing output plist for rotation at next login.')\\n-        os.remove(output_plist)\\n-\\n-    post_run_command()\\n-\\n-\\n def using_recovery_key():\\n     \"\"\"Check if FileVault is currently unlocked using\\n     the recovery key.\\n@@ -187,18 +154,6 @@\\n         return False\\n \\n \\n-def post_run_command():\\n-    run_command = pref('PostRunCommand')\\n-    output_plist = pref('OutputPath')\\n-    if run_command and not os.path.isfile(output_plist):\\n-        logging.info('Running {}'.format(run_command))\\n-        try:\\n-            output = subprocess.check_output(run_command)\\n-            logging.info(output)\\n-        except subprocess.CalledProcessError as e:\\n-            logging.error('Failed to run PostRunCommand: {}'.format(e))\\n-\\n-\\n def get_recovery_key(key_location):\\n     \"\"\"Returns recovery key as a string... If we failed\\n     to get the proper information, returns an empty string\"\"\"\\n@@ -216,7 +171,6 @@\\n             'Problem with Key: \"RecoveryKey\" in {0}...'.format(key_location))\\n         return False\\n \\n-\\n def rotate_invalid_key(plist_path):\\n     \"\"\"\\n     Will send the key (if present) for validation. If validation fails,\\n@@ -224,10 +178,6 @@\\n     Due to the bug that restricts the number of validations before reboot\\n     in versions of macOS prior to 10.12.5, this will only run there.\\n     \"\"\"\\n-    # a work aroud for https://github.com/grahamgilbert/crypt/issues/68\\n-    if not get_console_user():\\n-        logging.info('Skipping Validation, no user is logged in.')\\n-        return True\\n \\n     macos_version = get_os_version(only_major_minor=False, as_tuple=False)\\n \\n@@ -235,7 +185,7 @@\\n         logging.warning('macOS version is too old to run reliably')\\n         return False\\n \\n-    if os.path.isfile(plist_path):\\n+    if os.path.exists(plist_path):\\n         recovery_key = get_recovery_key(plist_path)\\n     else:\\n         logging.warning('Recovery key is not present on disk')\\n@@ -255,11 +205,9 @@\\n     logging.info('Stored recovery key is valid.')\\n     return True\\n \\n-\\n def validate_key(current_key):\\n     \"\"\"Validates the given recovery key against FileVault, returns True\\n     or False accordingly\"\"\"\\n-\\n     key = {'Password': current_key}\\n     input_plist = FoundationPlist.writePlistToString(key)\\n     cmd = subprocess.Popen(['/usr/bin/fdesetup', 'validaterecovery',\\n@@ -272,9 +220,8 @@\\n     if stdout_data.strip() == 'true':\\n         return True\\n     else:\\n-        logging.error('Recovery Key could not be validated.')\\n-        logging.error('Failed with Error: {}'.format(stdout_data))\\n         return False\\n+        logging.info('Recovery Key could not be validated.')\\n \\n \\n def rotate_key(current_key, plist):\\n@@ -313,7 +260,6 @@\\n             break\\n     return cryptuser\\n \\n-\\n def rotate_if_used(key_path):\\n     \"\"\"Checks to see if the recovery key was used to unlock the machine\\n     if it was then use our current key to rotate it\"\"\"\\n@@ -340,7 +286,6 @@\\n     if pref('RotateUsedKey') and pref('ValidateKey') and \\\\n     not pref('RemovePlist'):\\n         rotate_invalid_key(plist_path)\\n-        post_run_command()\\n \\n     if os.path.isfile(plist_path):\\n         plist = FoundationPlist.readPlist(plist_path)\\n@@ -368,7 +313,7 @@\\n                         escrow_interval))\\n                 sys.exit(0)\\n         escrow_result = escrow_key(plist=plist)\\n-        if escrow_result and os.path.isfile(plist_path):\\n+        if escrow_result:\\n             remove_plist = pref('RemovePlist')\\n             plist['escrow_success'] = True\\n             plist['last_run'] = datetime.datetime.now()\\n@@ -376,10 +321,6 @@\\n             if remove_plist is True:\\n                 os.remove(plist_path)\\n                 logging.info('Removing plist due to configuration.')\\n-            else:\\n-                os.chmod(plist_path, 0600)\\n-                logging.info('Ensuring permissions on plist.')\\n-\\n \\n if __name__ == '__main__':\\n     main()",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/Library/Crypt/FoundationPlist.py",
+            "id": "/Library/Crypt/FoundationPlist.py",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0755",
+                "path": "/Library/Crypt/FoundationPlist.py",
+                "verifications": [],
+                "source": "crypt/FoundationPlist.py"
+            },
+            "before": {
+                "checksum": "1fcc0257b23fbfb35f0759ad57413ade2a3bf6b6614aa53b418948a3042e885d",
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/Crypt/FoundationPlist.py"
+            },
+            "duration": "13",
+            "delta": null,
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "file",
+            "name": "/Library/Crypt/FoundationPlist.pyc",
+            "id": "/Library/Crypt/FoundationPlist.pyc",
+            "after": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/Library/Crypt/FoundationPlist.pyc"
+            },
+            "before": {
+                "checksum": null,
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0644",
+                "path": "/Library/Crypt/FoundationPlist.pyc"
+            },
+            "duration": "10",
+            "delta": null,
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "updated"
+        },
+        {
+            "type": "remote_directory",
+            "name": "/Library/Crypt",
+            "id": "/Library/Crypt",
+            "after": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/Library/Crypt",
+                "files_mode": "0755"
+            },
+            "before": {
+                "group": "wheel",
+                "mode": "0755",
+                "owner": "root",
+                "path": "/Library/Crypt"
+            },
+            "duration": "61",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": null
+        },
+        {
+            "type": "cpe_crypt_ld",
+            "name": "Manage Crypt LaunchDaemon",
+            "id": "Manage Crypt LaunchDaemon",
+            "after": {},
+            "before": {},
+            "duration": "63",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "manage",
+            "status": "updated",
+            "cookbook_name": "cpe_crypt",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "osx_profile",
+            "name": "com.chef.chefit.browsers.chrome",
+            "id": "com.chef.chefit.browsers.chrome",
+            "after": {
+                "profile_name": "com.chef.chefit.browsers.chrome",
+                "profile": {
+                    "PayloadIdentifier": "com.chef.chefit.browsers.chrome",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "b2aeace0-7485-5315-9297-ed3a5e4451e1",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Chrome",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.browsers.chrome",
+                            "PayloadUUID": "3377ead0-2310-0131-32ec-000c2944c108",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Chrome",
+                            "PayloadContent": {
+                                "com.google.Chrome": {
+                                    "Forced": [
+                                        {
+                                            "mcx_preference_settings": {
+                                                "ExtensionInstallForcelist": [],
+                                                "ExtensionInstallBlacklist": [],
+                                                "EnabledPlugins": [],
+                                                "DisabledPlugins": [],
+                                                "DefaultPluginsSetting": 1,
+                                                "ExtensionInstallSources": [],
+                                                "PluginsAllowedForUrls": []
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "before": {
+                "profile_name": "com.chef.chefit.browsers.chrome",
+                "profile": {
+                    "ProfileDisplayName": "Chrome",
+                    "ProfileIdentifier": "com.chef.chefit.browsers.chrome",
+                    "ProfileInstallDate": "2019-11-15 23:29:42 +0000",
+                    "ProfileItems": [
+                        {
+                            "PayloadContent": {
+                                "PayloadContentManagedPreferences": {
+                                    "com.google.Chrome": {
+                                        "Forced": [
+                                            {
+                                                "mcx_preference_settings": {
+                                                    "DefaultPluginsSetting": 1,
+                                                    "DisabledPlugins": [],
+                                                    "EnabledPlugins": [],
+                                                    "ExtensionInstallBlacklist": [],
+                                                    "ExtensionInstallForcelist": [],
+                                                    "ExtensionInstallSources": [],
+                                                    "PluginsAllowedForUrls": []
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "PayloadDisplayName": "Chrome",
+                            "PayloadIdentifier": "com.chef.chefit.browsers.chrome",
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadUUID": "3377ead0-2310-0131-32ec-000c2944c108",
+                            "PayloadVersion": 1
+                        }
+                    ],
+                    "ProfileOrganization": "chef",
+                    "ProfileRemovalDisallowed": "true",
+                    "ProfileType": "Configuration",
+                    "ProfileUUID": "b2aeace0-7485-5315-9297-ed3a5e4451e1",
+                    "ProfileVersion": 1
+                }
+            },
+            "duration": "145",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date"
+        },
+        {
+            "type": "osx_profile",
+            "name": "com.chef.chefit.screensaver",
+            "id": "com.chef.chefit.screensaver",
+            "after": {
+                "profile_name": "com.chef.chefit.screensaver",
+                "profile": {
+                    "PayloadIdentifier": "com.chef.chefit.screensaver",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "13cbb1f1-5def-5dab-83f7-821a9131104b",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Screensaver",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.screensaver",
+                            "PayloadUUID": "3B2AD6A9-F99E-4813-980A-4147617B2E75",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "ScreenSaver",
+                            "PayloadContent": {
+                                "com.apple.screensaver": {
+                                    "Forced": [
+                                        {
+                                            "mcx_preference_settings": {
+                                                "idleTime": 1200,
+                                                "askForPassword": 1,
+                                                "askForPasswordDelay": 5
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "before": {
+                "profile_name": "com.chef.chefit.screensaver",
+                "profile": {
+                    "ProfileDisplayName": "Screensaver",
+                    "ProfileIdentifier": "com.chef.chefit.screensaver",
+                    "ProfileInstallDate": "2019-05-06 16:42:28 +0000",
+                    "ProfileItems": [
+                        {
+                            "PayloadContent": {
+                                "PayloadContentManagedPreferences": {
+                                    "com.apple.screensaver": {
+                                        "Forced": [
+                                            {
+                                                "mcx_preference_settings": {
+                                                    "askForPassword": 1,
+                                                    "askForPasswordDelay": 5,
+                                                    "idleTime": 1200
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "PayloadDisplayName": "ScreenSaver",
+                            "PayloadIdentifier": "com.chef.chefit.screensaver",
+                            "PayloadType": "com.apple.ManagedClient.preferences",
+                            "PayloadUUID": "3B2AD6A9-F99E-4813-980A-4147617B2E75",
+                            "PayloadVersion": 1
+                        }
+                    ],
+                    "ProfileOrganization": "chef",
+                    "ProfileRemovalDisallowed": "true",
+                    "ProfileType": "Configuration",
+                    "ProfileUUID": "13cbb1f1-5def-5dab-83f7-821a9131104b",
+                    "ProfileVersion": 1
+                }
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date"
+        },
+        {
+            "type": "osx_profile",
+            "name": "com.chef.chefit.munki",
+            "id": "com.chef.chefit.munki",
+            "after": {
+                "profile_name": "com.chef.chefit.munki",
+                "profile": {
+                    "PayloadIdentifier": "com.chef.chefit.munki",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "c9e1eb6d-e906-5a38-b689-32a047407c75",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Munki",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "ManagedInstalls",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.munki",
+                            "PayloadUUID": "7059fe60-222f-0131-31db-000c2944c108",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Munki",
+                            "AppleSoftwareUpdatesOnly": false,
+                            "DaysBetweenNotifications": 1,
+                            "FollowHTTPRedirects": "none",
+                            "InstallAppleSoftwareUpdates": false,
+                            "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+                            "LoggingLevel": 1,
+                            "LogToSyslog": false,
+                            "PerformAuthRestarts": false,
+                            "SoftwareRepoURL": "https://munki.opscodecorp.com/munki_repo",
+                            "SuppressAutoInstall": false,
+                            "SuppressStopButtonOnInstall": false,
+                            "SuppressUserNotification": false,
+                            "UnattendedAppleUpdates": false,
+                            "UseClientCertificate": false
+                        }
+                    ]
+                }
+            },
+            "before": {
+                "profile_name": "com.chef.chefit.munki",
+                "profile": {
+                    "ProfileDisplayName": "Munki",
+                    "ProfileIdentifier": "com.chef.chefit.munki",
+                    "ProfileInstallDate": "2019-07-08 22:59:49 +0000",
+                    "ProfileItems": [
+                        {
+                            "PayloadContent": {
+                                "AppleSoftwareUpdatesOnly": false,
+                                "DaysBetweenNotifications": 1,
+                                "FollowHTTPRedirects": "none",
+                                "InstallAppleSoftwareUpdates": false,
+                                "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+                                "LogToSyslog": false,
+                                "LoggingLevel": 1,
+                                "PerformAuthRestarts": false,
+                                "SoftwareRepoURL": "https://munki.opscodecorp.com/munki_repo",
+                                "SuppressAutoInstall": false,
+                                "SuppressStopButtonOnInstall": false,
+                                "SuppressUserNotification": false,
+                                "UnattendedAppleUpdates": false,
+                                "UseClientCertificate": false
+                            },
+                            "PayloadDisplayName": "Munki",
+                            "PayloadIdentifier": "com.chef.chefit.munki",
+                            "PayloadType": "ManagedInstalls",
+                            "PayloadUUID": "7059fe60-222f-0131-31db-000c2944c108",
+                            "PayloadVersion": 1
+                        }
+                    ],
+                    "ProfileOrganization": "chef",
+                    "ProfileRemovalDisallowed": "true",
+                    "ProfileType": "Configuration",
+                    "ProfileUUID": "c9e1eb6d-e906-5a38-b689-32a047407c75",
+                    "ProfileVersion": 1
+                }
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date"
+        },
+        {
+            "type": "osx_profile",
+            "name": "com.chef.chefit.crypt",
+            "id": "com.chef.chefit.crypt",
+            "after": {
+                "profile_name": "com.chef.chefit.crypt",
+                "profile": {
+                    "PayloadIdentifier": "com.chef.chefit.crypt",
+                    "PayloadRemovalDisallowed": true,
+                    "PayloadScope": "System",
+                    "PayloadType": "Configuration",
+                    "PayloadUUID": "cd05a122-e566-5eff-91e0-408097803a1a",
+                    "PayloadOrganization": "chef",
+                    "PayloadVersion": 1,
+                    "PayloadDisplayName": "Crypt",
+                    "PayloadContent": [
+                        {
+                            "PayloadType": "com.grahamgilbert.crypt",
+                            "PayloadVersion": 1,
+                            "PayloadIdentifier": "com.chef.chefit.crypt",
+                            "PayloadUUID": "F9A5E8E1-3C08-4D32-94A5-325009F9C999",
+                            "PayloadEnabled": true,
+                            "PayloadDisplayName": "Crypt",
+                            "ServerURL": "https://crypt.opscodecorp.com",
+                            "SkipUsers": [],
+                            "RemovePlist": true,
+                            "RotateUsedKey": false
+                        }
+                    ]
+                }
+            },
+            "before": {
+                "profile_name": "com.chef.chefit.crypt",
+                "profile": {
+                    "ProfileDisplayName": "Crypt",
+                    "ProfileIdentifier": "com.chef.chefit.crypt",
+                    "ProfileInstallDate": "2019-05-06 16:42:29 +0000",
+                    "ProfileItems": [
+                        {
+                            "PayloadContent": {
+                                "RemovePlist": true,
+                                "RotateUsedKey": false,
+                                "ServerURL": "https://crypt.opscodecorp.com",
+                                "SkipUsers": []
+                            },
+                            "PayloadDisplayName": "Crypt",
+                            "PayloadIdentifier": "com.chef.chefit.crypt",
+                            "PayloadType": "com.grahamgilbert.crypt",
+                            "PayloadUUID": "F9A5E8E1-3C08-4D32-94A5-325009F9C999",
+                            "PayloadVersion": 1
+                        }
+                    ],
+                    "ProfileOrganization": "chef",
+                    "ProfileRemovalDisallowed": "true",
+                    "ProfileType": "Configuration",
+                    "ProfileUUID": "cd05a122-e566-5eff-91e0-408097803a1a",
+                    "ProfileVersion": 1
+                }
+            },
+            "duration": "1",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date"
+        },
+        {
+            "type": "cpe_profiles",
+            "name": "Managing all of Configuration Profiles",
+            "id": "Managing all of Configuration Profiles",
+            "after": {},
+            "before": {},
+            "duration": "154",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_profiles",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "cpe_profiles",
+            "name": "Cleaning up un-needed Configuration Profiles",
+            "id": "Cleaning up un-needed Configuration Profiles",
+            "after": {},
+            "before": {},
+            "duration": "95",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "clean_up",
+            "status": "up-to-date",
+            "cookbook_name": "cpe_profiles",
+            "cookbook_version": "0.1.0",
+            "recipe_name": "default"
+        },
+        {
+            "type": "inspec_gem",
+            "name": "inspec",
+            "id": "inspec",
+            "after": {
+                "version": null,
+                "source": null
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "audit",
+            "cookbook_version": "7.4.1",
+            "recipe_name": "inspec",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/var/chef/cache/slack_handler_util.rb",
+            "id": "/var/chef/cache/slack_handler_util.rb",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_util.rb",
+                "verifications": [],
+                "source": "slack_handler_util.rb"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "cookbook_file",
+            "name": "/var/chef/cache/slack_handler_webhook.rb",
+            "id": "/var/chef/cache/slack_handler_webhook.rb",
+            "after": {
+                "owner": "root",
+                "group": "wheel",
+                "mode": "0600",
+                "path": "/var/chef/cache/slack_handler_webhook.rb",
+                "verifications": [],
+                "source": "slack_handler_webhook.rb"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "chef_handler",
+            "name": "Chef::Handler::Slack",
+            "id": "Chef::Handler::Slack",
+            "after": {
+                "class_name": "Chef::Handler::Slack",
+                "source": "/var/chef/cache/slack_handler_webhook.rb",
+                "arguments": [
+                    {
+                        "team": null,
+                        "api_key": null,
+                        "channel": null,
+                        "webhooks": {
+                            "name": [
+                                "itchannel"
+                            ],
+                            "itchannel": {
+                                "url": "https://hooks.slack.com/services/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"
+                            }
+                        },
+                        "timeout": 15,
+                        "username": "Chef Run Bot",
+                        "icon_url": "https://avatars1.githubusercontent.com/u/29740",
+                        "icon_emoji": ":fork_and_knife:",
+                        "message_detail_level": "elapsed",
+                        "cookbook_detail_level": "all",
+                        "fail_only": true,
+                        "send_start_message": false,
+                        "send_environment": false,
+                        "send_organization": false
+                    }
+                ],
+                "type": {
+                    "start": true,
+                    "report": true,
+                    "exception": true
+                }
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "ruby_block",
+            "name": "trigger_start_handlers",
+            "id": "trigger_start_handlers",
+            "after": {
+                "block_name": "trigger_start_handlers"
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "slack_handler",
+            "cookbook_version": "1.0.0",
+            "recipe_name": "default",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "file",
+            "name": "/etc/chef/validation.pem",
+            "id": "/etc/chef/validation.pem",
+            "after": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/etc/chef/validation.pem"
+            },
+            "before": {
+                "owner": null,
+                "group": null,
+                "mode": null,
+                "path": "/etc/chef/validation.pem"
+            },
+            "duration": "8",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "delete",
+            "status": "up-to-date",
+            "cookbook_name": "chef-client",
+            "cookbook_version": "11.0.3",
+            "recipe_name": "delete_validation"
+        }
+    ],
+    "run_id": "92c65967-db70-4852-b587-e67225a0bad0",
+    "run_list": [
+        "role[cpe_base]"
+    ],
+    "cookbooks": {
+        "cpe_init": {
+            "version": "0.1.105"
+        },
+        "cpe_utils": {
+            "version": "0.1.0"
+        },
+        "audit": {
+            "version": "7.4.1"
+        },
+        "chef-client": {
+            "version": "11.0.3"
+        },
+        "cron": {
+            "version": "5.1.0"
+        },
+        "logrotate": {
+            "version": "2.1.0"
+        },
+        "compat_resource": {
+            "version": "12.19.1"
+        },
+        "cpe_bluetooth": {
+            "version": "0.1.0"
+        },
+        "cpe_profiles": {
+            "version": "0.1.0"
+        },
+        "chefit-masterclient": {
+            "version": "0.1.20"
+        },
+        "cpe_desktop": {
+            "version": "0.1.0"
+        },
+        "cpe_chrome": {
+            "version": "0.1.0"
+        },
+        "cpe_choco": {
+            "version": "0.1.2"
+        },
+        "cpe_chef": {
+            "version": "0.1.2"
+        },
+        "cpe_crypt": {
+            "version": "0.1.0"
+        },
+        "cpe_launchd": {
+            "version": "0.1.2"
+        },
+        "cpe_remote": {
+            "version": "0.1.0"
+        },
+        "cpe_logger": {
+            "version": "0.1.0"
+        },
+        "cpe_hosts": {
+            "version": "0.2.0"
+        },
+        "cpe_macos_server": {
+            "version": "0.1.0"
+        },
+        "cpe_munki": {
+            "version": "0.3.0"
+        },
+        "cpe_nightly_reboot": {
+            "version": "0.1.0"
+        },
+        "cpe_pathsd": {
+            "version": "0.1.0"
+        },
+        "cpe_powermanagement": {
+            "version": "0.1.0"
+        },
+        "cpe_preferencepanes": {
+            "version": "0.1.0"
+        },
+        "cpe_prompt_user": {
+            "version": "0.1.0"
+        },
+        "cpe_screensaver": {
+            "version": "0.1.0"
+        },
+        "cpe_spotlight": {
+            "version": "0.1.0"
+        },
+        "cpe_batterycheck": {
+            "version": "0.1.0"
+        },
+        "cpe_botmanagement": {
+            "version": "0.1.0"
+        },
+        "slack_handler": {
+            "version": "1.0.0"
+        },
+        "windows_localadminaccount": {
+            "version": "0.1.3"
+        },
+        "windows_screensaver": {
+            "version": "0.1.11"
+        }
+    },
+    "policy_name": null,
+    "policy_group": null,
+    "start_time": "2020-04-06T22:20:50Z",
+    "end_time": "2020-04-06T22:21:06Z",
+    "source": "chef_client",
+    "status": "success",
+    "total_resource_count": 93,
+    "updated_resource_count": 13,
+    "deprecations": []
+}

--- a/dev-docs/adding-data/sample-reports/desktop-report-2.json
+++ b/dev-docs/adding-data/sample-reports/desktop-report-2.json
@@ -2878,7 +2878,7 @@
                                 "itchannel"
                             ],
                             "itchannel": {
-                                "url": "https://hooks.slack.com/services/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"
+                                "url": "https://some-url"
                             }
                         },
                         "timeout": 15,
@@ -3566,7 +3566,7 @@
                                 "itchannel"
                             ],
                             "itchannel": {
-                                "url": "https://hooks.slack.com/services/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"
+                                "url": "https://some-url"
                             }
                         },
                         "timeout": 15,
@@ -5632,7 +5632,7 @@
                                 "itchannel"
                             ],
                             "itchannel": {
-                                "url": "https://hooks.slack.com/services/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"
+                                "url": "https://some-url"
                             }
                         },
                         "timeout": 15,

--- a/dev-docs/adding-data/sample-reports/desktop-report-3.json
+++ b/dev-docs/adding-data/sample-reports/desktop-report-3.json
@@ -2119,7 +2119,7 @@
                                 "itchannel"
                             ],
                             "itchannel": {
-                                "url": "https://hooks.slack.com/services/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"
+                                "url": "https://some-url"
                             }
                         },
                         "timeout": 15,

--- a/dev-docs/adding-data/sample-reports/desktop-report-3.json
+++ b/dev-docs/adding-data/sample-reports/desktop-report-3.json
@@ -1,0 +1,2997 @@
+{
+    "chef_server_fqdn": "api.chef.io",
+    "entity_uuid": "9d049b11-1107-4324-ac40-3909f5694726",
+    "expanded_run_list": {
+        "id": "_default",
+        "run_list": [
+            {
+                "type": "role",
+                "name": "cpe_base",
+                "children": [
+                    {
+                        "type": "recipe",
+                        "name": "cpe_init",
+                        "version": null,
+                        "skipped": false
+                    }
+                ],
+                "missing": null,
+                "error": null,
+                "skipped": null
+            }
+        ]
+    },
+    "id": "8e2886dd-58f5-4db0-b0d1-70e1f1af5466",
+    "message_version": "1.1.0",
+    "message_type": "run_converge",
+    "node": {
+        "name": "LAPTOP-03J74NE1",
+        "chef_environment": "_default",
+        "json_class": "Chef::Node",
+        "automatic": {
+            "kernel": {
+                "os_info": {
+                    "boot_device": "\\Device\\HarddiskVolume1",
+                    "build_number": "18363",
+                    "build_type": "Multiprocessor Free",
+                    "caption": "Microsoft Windows 10 Enterprise",
+                    "code_set": "1252",
+                    "country_code": "1",
+                    "csd_version": null,
+                    "cs_name": "LAPTOP-03J74NE1",
+                    "current_time_zone": -420,
+                    "data_execution_prevention_32_bit_applications": true,
+                    "data_execution_prevention_available": true,
+                    "data_execution_prevention_drivers": true,
+                    "data_execution_prevention_support_policy": 2,
+                    "debug": false,
+                    "description": "",
+                    "distributed": false,
+                    "encryption_level": 256,
+                    "foreground_application_boost": 2,
+                    "install_date": "20200314073623.000000-420",
+                    "large_system_cache": null,
+                    "last_boot_up_time": "20200329233853.323650-420",
+                    "local_date_time": "20200406134519.257000-420",
+                    "locale": "0409",
+                    "manufacturer": "Microsoft Corporation",
+                    "max_number_of_processes": -1,
+                    "max_process_memory_size": "137438953344",
+                    "mui_languages": [
+                        "en-US",
+                        "en-GB"
+                    ],
+                    "name": "Microsoft Windows 10 Enterprise|C:\\WINDOWS|\\Device\\Harddisk0\\Partition3",
+                    "number_of_licensed_users": 0,
+                    "number_of_processes": 324,
+                    "number_of_users": 2,
+                    "operating_system_sku": 4,
+                    "organization": "",
+                    "os_architecture": "64-bit",
+                    "os_language": 1033,
+                    "os_product_suite": 256,
+                    "os_type": 18,
+                    "other_type_description": null,
+                    "pae_enabled": null,
+                    "plus_product_id": null,
+                    "plus_version_number": null,
+                    "portable_operating_system": false,
+                    "primary": true,
+                    "product_type": 1,
+                    "registered_user": "Windows User",
+                    "serial_number": "00330-80000-00000-AA524",
+                    "service_pack_major_version": 0,
+                    "service_pack_minor_version": 0,
+                    "size_stored_in_paging_files": "4980736",
+                    "status": "OK",
+                    "suite_mask": 272,
+                    "system_device": "\\Device\\HarddiskVolume3",
+                    "system_directory": "C:\\WINDOWS\\system32",
+                    "system_drive": "C:",
+                    "total_visible_memory_size": "33120380",
+                    "version": "10.0.18363",
+                    "windows_directory": "C:\\WINDOWS"
+                },
+                "name": "Microsoft Windows 10 Enterprise",
+                "release": "10.0.18363",
+                "version": "10.0.18363  Build 18363",
+                "os": "WINNT",
+                "product_type": "Workstation",
+                "server_core": false,
+                "cs_info": {
+                    "admin_password_status": 0,
+                    "automatic_managed_pagefile": true,
+                    "automatic_reset_boot_option": true,
+                    "automatic_reset_capability": true,
+                    "boot_option_on_limit": null,
+                    "boot_option_on_watch_dog": null,
+                    "boot_rom_supported": true,
+                    "boot_status": null,
+                    "bootup_state": "Normal boot",
+                    "caption": "LAPTOP-03J74NE1",
+                    "chassis_bootup_state": 2,
+                    "chassis_sku_number": null,
+                    "current_time_zone": -420,
+                    "daylight_in_effect": true,
+                    "description": "AT/AT COMPATIBLE",
+                    "dns_host_name": "LAPTOP-03J74NE1",
+                    "domain": "WORKGROUP",
+                    "domain_role": 0,
+                    "enable_daylight_savings_time": true,
+                    "front_panel_reset_status": 2,
+                    "hypervisor_present": false,
+                    "infrared_supported": false,
+                    "initial_load_info": null,
+                    "install_date": null,
+                    "keyboard_password_status": 2,
+                    "last_load_info": null,
+                    "manufacturer": "LENOVO",
+                    "model": "20MD0026US",
+                    "name": "LAPTOP-03J74NE1",
+                    "name_format": null,
+                    "network_server_mode_enabled": true,
+                    "number_of_logical_processors": 12,
+                    "number_of_processors": 1,
+                    "oem_string_array": null,
+                    "part_of_domain": false,
+                    "pause_after_reset": "-1",
+                    "pc_system_type": 2,
+                    "pc_system_type_ex": 2,
+                    "power_management_capabilities": null,
+                    "power_management_supported": null,
+                    "power_on_password_status": 0,
+                    "power_state": 0,
+                    "power_supply_state": 2,
+                    "primary_owner_contact": null,
+                    "primary_owner_name": "Windows User",
+                    "reset_capability": 1,
+                    "reset_count": -1,
+                    "reset_limit": -1,
+                    "roles": [
+                        "LM_Workstation",
+                        "LM_Server",
+                        "NT"
+                    ],
+                    "status": "OK",
+                    "support_contact_description": null,
+                    "system_family": "ThinkPad P1",
+                    "system_sku_number": "LENOVO_MT_20MD_BU_Think_FM_ThinkPad P1",
+                    "system_startup_delay": null,
+                    "system_startup_options": null,
+                    "system_startup_setting": null,
+                    "system_type": "x64-based PC",
+                    "thermal_state": 2,
+                    "total_physical_memory": "33915269120",
+                    "user_name": "OPSCODECORP\\jmccrae",
+                    "wake_up_type": 6,
+                    "workgroup": "WORKGROUP"
+                },
+                "machine": "x86_64",
+                "system_type": "Mobile"
+            },
+            "memory": {
+                "swap": {
+                    "total": "4980736kB",
+                    "free": "4923128kB"
+                },
+                "total": "33120380kB",
+                "free": "21884808kB"
+            },
+            "network": {
+                "interfaces": {
+                    "0x8": {
+                        "configuration": {
+                            "ip_address": [
+                                "192.168.1.54",
+                                "fe80::7809:a598:40be:f1b7"
+                            ],
+                            "arp_always_source_route": null,
+                            "arp_use_ether_snap": null,
+                            "caption": "[00000002] Intel(R) Wireless-AC 9560 160MHz",
+                            "database_path": "%SystemRoot%\\System32\\drivers\\etc",
+                            "dead_gw_detect_enabled": null,
+                            "default_ip_gateway": [
+                                "192.168.1.1"
+                            ],
+                            "default_tos": null,
+                            "default_ttl": null,
+                            "description": "Intel(R) Wireless-AC 9560 160MHz",
+                            "dhcp_enabled": true,
+                            "dhcp_lease_expires": "20200407133415.000000-420",
+                            "dhcp_lease_obtained": "20200406133415.000000-420",
+                            "dhcp_server": "192.168.1.1",
+                            "dns_domain": null,
+                            "dns_domain_suffix_search_order": [],
+                            "dns_enabled_for_wins_resolution": false,
+                            "dns_host_name": "LAPTOP-03J74NE1",
+                            "dns_server_search_order": [
+                                "192.168.1.1"
+                            ],
+                            "domain_dns_registration_enabled": false,
+                            "forward_buffer_memory": null,
+                            "full_dns_registration_enabled": true,
+                            "gateway_cost_metric": [
+                                0
+                            ],
+                            "igmp_level": null,
+                            "index": 2,
+                            "interface_index": 8,
+                            "ip_connection_metric": 35,
+                            "ip_enabled": true,
+                            "ip_filter_security_enabled": false,
+                            "ip_port_security_enabled": null,
+                            "ip_sec_permit_ip_protocols": [],
+                            "ip_sec_permit_tcp_ports": [],
+                            "ip_sec_permit_udp_ports": [],
+                            "ip_subnet": [
+                                "255.255.255.0",
+                                "64"
+                            ],
+                            "ip_use_zero_broadcast": null,
+                            "ipx_address": null,
+                            "ipx_enabled": null,
+                            "ipx_frame_type": null,
+                            "ipx_media_type": null,
+                            "ipx_network_number": null,
+                            "ipx_virtual_net_number": null,
+                            "keep_alive_interval": null,
+                            "keep_alive_time": null,
+                            "mac_address": "48:F1:7F:90:BC:3A",
+                            "mtu": null,
+                            "num_forward_packets": null,
+                            "pmtubh_detect_enabled": null,
+                            "pmtu_discovery_enabled": null,
+                            "service_name": "Netwtw08",
+                            "setting_id": "{4957E994-91D6-4005-B0F4-20FFBFA02254}",
+                            "tcpip_netbios_options": 0,
+                            "tcp_max_connect_retransmissions": null,
+                            "tcp_max_data_retransmissions": null,
+                            "tcp_num_connections": null,
+                            "tcp_use_rfc1122_urgent_pointer": null,
+                            "tcp_window_size": null,
+                            "wins_enable_lm_hosts_lookup": true,
+                            "wins_host_lookup_file": null,
+                            "wins_primary_server": null,
+                            "wins_scope_id": "",
+                            "wins_secondary_server": null
+                        },
+                        "instance": {
+                            "adapter_type": "Ethernet 802.3",
+                            "adapter_type_id": 0,
+                            "auto_sense": null,
+                            "availability": 3,
+                            "caption": "[00000002] Intel(R) Wireless-AC 9560 160MHz",
+                            "config_manager_error_code": 0,
+                            "config_manager_user_config": false,
+                            "description": "Intel(R) Wireless-AC 9560 160MHz",
+                            "device_id": "2",
+                            "error_cleared": null,
+                            "error_description": null,
+                            "guid": "{4957E994-91D6-4005-B0F4-20FFBFA02254}",
+                            "index": 2,
+                            "install_date": null,
+                            "installed": true,
+                            "interface_index": 8,
+                            "last_error_code": null,
+                            "mac_address": "48:F1:7F:90:BC:3A",
+                            "manufacturer": "Intel Corporation",
+                            "max_number_controlled": 0,
+                            "max_speed": null,
+                            "name": "Intel(R) Wireless-AC 9560 160MHz",
+                            "net_connection_id": "Wi-Fi",
+                            "net_connection_status": 2,
+                            "net_enabled": true,
+                            "network_addresses": null,
+                            "permanent_address": null,
+                            "physical_adapter": true,
+                            "pnp_device_id": "PCI\\VEN_8086&DEV_A370&SUBSYS_00308086&REV_10\\3&11583659&1&A3",
+                            "power_management_capabilities": null,
+                            "power_management_supported": false,
+                            "product_name": "Intel(R) Wireless-AC 9560 160MHz",
+                            "service_name": "Netwtw08",
+                            "speed": "400000000",
+                            "status": null,
+                            "status_info": null,
+                            "system_name": "LAPTOP-03J74NE1",
+                            "time_of_last_reset": "20200329233853.323650-420"
+                        },
+                        "counters": {},
+                        "addresses": {
+                            "192.168.1.54": {
+                                "prefixlen": "24",
+                                "netmask": "255.255.255.0",
+                                "broadcast": "192.168.1.255",
+                                "family": "inet"
+                            },
+                            "fe80::7809:a598:40be:f1b7": {
+                                "prefixlen": "64",
+                                "family": "inet6",
+                                "scope": "Link"
+                            },
+                            "48:F1:7F:90:BC:3A": {
+                                "family": "lladdr"
+                            }
+                        },
+                        "mtu": null,
+                        "type": "Ethernet 802.3",
+                        "arp": {
+                            "192.168.1.1": "18:e8:29:45:19:0a",
+                            "192.168.1.45": "dc:3a:5e:96:07:46",
+                            "192.168.1.51": "5c:41:5a:a9:cb:17",
+                            "192.168.1.255": "ff:ff:ff:ff:ff:ff",
+                            "224.0.0.22": "01:00:5e:00:00:16",
+                            "224.0.0.251": "01:00:5e:00:00:fb",
+                            "224.0.0.252": "01:00:5e:00:00:fc",
+                            "239.255.255.250": "01:00:5e:7f:ff:fa",
+                            "255.255.255.255": "ff:ff:ff:ff:ff:ff"
+                        },
+                        "encapsulation": "Ethernet"
+                    }
+                },
+                "default_gateway": "192.168.1.1",
+                "default_interface": "0x8"
+            },
+            "counters": {
+                "network": {}
+            },
+            "ipaddress": "192.168.1.54",
+            "macaddress": "48:F1:7F:90:BC:3A",
+            "ip6address": "fe80::7809:a598:40be:f1b7",
+            "os": "windows",
+            "os_version": "10.0.18363",
+            "platform": "windows",
+            "platform_version": "10.0.18363",
+            "platform_family": "windows",
+            "uptime_seconds": 655586,
+            "uptime": "7 days 14 hours 06 minutes 26 seconds",
+            "dmi": {},
+            "virtualization": {
+                "systems": {}
+            },
+            "languages": {
+                "perl": {
+                    "version": "5.8.8",
+                    "archname": "msys-64int"
+                },
+                "powershell": {
+                    "version": "5.1.18362.752",
+                    "ws_man_stack_version": "3.0",
+                    "serialization_version": "1.1.0.1",
+                    "clr_version": "4.0.30319.42000",
+                    "build_version": "10.0.18362.752",
+                    "compatible_versions": [
+                        "1.0",
+                        "2.0",
+                        "3.0",
+                        "4.0",
+                        "5.0",
+                        "5.1.18362.752"
+                    ],
+                    "remoting_protocol_version": "2.3"
+                },
+                "python": {
+                    "version": "3.7.7",
+                    "builddate": "Mar 10 2020, 10:41:24"
+                },
+                "ruby": {
+                    "platform": "x64-mingw32",
+                    "version": "2.6.5",
+                    "release_date": "2019-10-01",
+                    "target": "x86_64-w64-mingw32",
+                    "target_cpu": "x64",
+                    "target_vendor": "w64",
+                    "target_os": "mingw32",
+                    "host": "x86_64-w64-mingw32",
+                    "host_cpu": "x86_64",
+                    "host_os": "mingw32",
+                    "host_vendor": "w64",
+                    "bin_dir": "C:/opscode/chef-workstation/embedded/bin",
+                    "ruby_bin": "C:/opscode/chef-workstation/embedded/bin/ruby",
+                    "gems_dir": "C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0",
+                    "gem_bin": "C:/opscode/chef-workstation/embedded/bin/gem"
+                }
+            },
+            "chef_packages": {
+                "chef": {
+                    "version": "15.8.23",
+                    "chef_root": "C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/chef-15.8.23-universal-mingw32/lib"
+                },
+                "ohai": {
+                    "version": "15.7.4",
+                    "ohai_root": "C:/opscode/chef-workstation/embedded/lib/ruby/gems/2.6.0/gems/ohai-15.7.4/lib/ohai"
+                }
+            },
+            "cloud": null,
+            "command": {},
+            "cpu": {
+                "0": {
+                    "cores": 6,
+                    "vendor_id": "GenuineIntel",
+                    "family": "198",
+                    "model": "",
+                    "stepping": "10",
+                    "physical_id": "CPU0",
+                    "model_name": "Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz",
+                    "description": "Intel64 Family 6 Model 158 Stepping 10",
+                    "mhz": "2592",
+                    "cache_size": "1536 KB"
+                },
+                "total": 12,
+                "cores": 6,
+                "real": 1
+            },
+            "filesystem": {
+                "C:": {
+                    "kb_size": 1022869106,
+                    "kb_available": 911805657,
+                    "kb_used": 111063449,
+                    "percent_used": 10,
+                    "fs_type": "ntfs",
+                    "drive_type": 3,
+                    "drive_type_string": "local",
+                    "drive_type_human": "Local Fixed Disk",
+                    "volume_name": "Windows",
+                    "encryption_status": "FullyEncrypted"
+                }
+            },
+            "filesystem2": {
+                "by_device": {
+                    "windows": {
+                        "kb_size": 1022869106,
+                        "kb_available": 911805657,
+                        "kb_used": 111063449,
+                        "percent_used": 10,
+                        "fs_type": "ntfs",
+                        "drive_type": 3,
+                        "drive_type_string": "local",
+                        "drive_type_human": "Local Fixed Disk",
+                        "volume_name": "Windows",
+                        "encryption_status": "FullyEncrypted",
+                        "mounts": [
+                            "C:"
+                        ]
+                    }
+                },
+                "by_mountpoint": {
+                    "C:": {
+                        "kb_size": 1022869106,
+                        "kb_available": 911805657,
+                        "kb_used": 111063449,
+                        "percent_used": 10,
+                        "fs_type": "ntfs",
+                        "drive_type": 3,
+                        "drive_type_string": "local",
+                        "drive_type_human": "Local Fixed Disk",
+                        "volume_name": "Windows",
+                        "encryption_status": "FullyEncrypted",
+                        "devices": [
+                            "windows"
+                        ]
+                    }
+                },
+                "by_pair": {
+                    "windows,C:": {
+                        "kb_size": 1022869106,
+                        "kb_available": 911805657,
+                        "kb_used": 111063449,
+                        "percent_used": 10,
+                        "mount": "C:",
+                        "fs_type": "ntfs",
+                        "drive_type": 3,
+                        "drive_type_string": "local",
+                        "drive_type_human": "Local Fixed Disk",
+                        "volume_name": "Windows",
+                        "device": "windows",
+                        "encryption_status": "FullyEncrypted"
+                    }
+                }
+            },
+            "hostname": "LAPTOP-03J74NE1",
+            "machinename": "LAPTOP-03J74NE1",
+            "fqdn": "LAPTOP-03J74NE1",
+            "domain": null,
+            "keys": {
+                "ssh": {}
+            },
+            "fips": {
+                "kernel": {
+                    "enabled": false
+                }
+            },
+            "ohai_time": 1586205923.3443272,
+            "packages": {
+                "7-Zip 19.00 (x64)": {
+                    "version": "19.00",
+                    "publisher": "Igor Pavlov"
+                },
+                "Beyond Compare 4.3.4": {
+                    "version": "4.3.4.24657",
+                    "publisher": "Scooter Software",
+                    "installdate": "20200327"
+                },
+                "Git version 2.25.1": {
+                    "version": "2.25.1",
+                    "publisher": "The Git Development Community",
+                    "installdate": "20200314"
+                },
+                "Microsoft Azure Compute Emulator - v2.9.6": {
+                    "version": "2.9.8899.26",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Mouse and Keyboard Center": {
+                    "version": "12.181.137.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200317"
+                },
+                "Microsoft Visual Studio 2010 Tools for Office Runtime (x64)": {
+                    "version": "10.0.50908",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Office 365 ProPlus - en-us": {
+                    "version": "16.0.12527.20278",
+                    "publisher": "Microsoft Corporation"
+                },
+                "UNO": {
+                    "publisher": "Ubisoft Entertainment"
+                },
+                "Microsoft ASP.NET Core 3.1.2 Shared Framework (x64)": {
+                    "version": "3.1.2.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Intel® PROSet/Wireless WiFi Software": {
+                    "version": "21.10.1.3139",
+                    "publisher": "Intel Corporation",
+                    "installdate": "20200314"
+                },
+                "IIS Express Application Compatibility Database for x64": {},
+                "Microsoft .NET Core AppHost Pack - 3.1.2 (x64_x86)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "ConEmu 191012.x64": {
+                    "version": "11.191.0120",
+                    "publisher": "ConEmu-Maximus5",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.1 (x64_arm)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Application Verifier x64 External Package": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Toolset 3.1.102 (x64)": {
+                    "version": "12.16.47641",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft ASP.NET Core 3.1.1 Shared Framework (x64)": {
+                    "version": "3.1.1.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "IntelliTraceProfilerProxy": {
+                    "version": "15.0.18198.01",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "DiagnosticsHub_CollectionService": {
+                    "version": "16.1.28901",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows App Certification Kit Native Components": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Core 2.1.15 Shared Framework (x64)": {
+                    "version": "2.1.15.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Runtime - 2.1.15 (x64)": {
+                    "version": "16.124.28327",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Chef Infra Client v15.8.23": {
+                    "version": "15.8.23.1",
+                    "publisher": "Chef Software, Inc.",
+                    "installdate": "20200314"
+                },
+                "Microsoft .NET Core Targeting Pack - 3.1.0 (x64)": {
+                    "version": "24.64.28315",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Typora version 0.9.86": {
+                    "version": "0.9.86",
+                    "publisher": "typora.io",
+                    "installdate": "20200318"
+                },
+                "Microsoft Visual C++ 2012 x64 Additional Runtime - 11.0.61030": {
+                    "version": "11.0.61030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200323"
+                },
+                "Python 3.7.7 Utility Scripts (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Azure PowerShell - April 2018": {
+                    "version": "5.7.0.18831",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "icecap_collection_x64": {
+                    "version": "16.4.29904",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Test Suite (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "VS JIT Debugger": {
+                    "version": "16.0.98.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Command Line Utilities 15 for SQL Server": {
+                    "version": "15.0.1300.359",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Host FX Resolver - 3.1.2 (x64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.1 (x64_x86)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core 3.1 Templates 3.1.101 (x64)": {
+                    "version": "3.1.1.014848",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Workflow Diagnostic Pack for x64": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Universal CRT Tools x64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Toolset 3.1.101 (x64)": {
+                    "version": "12.16.31232",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Windows Desktop Runtime - 3.1.1 (x64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Standard Library (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Executables (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Intel(R) Chipset Device Software": {
+                    "version": "10.1.17695.8086",
+                    "publisher": "Intel(R) Corporation"
+                },
+                "IIS 10.0 Express": {
+                    "version": "10.0.03203",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Workflow Manager Client 1.0": {
+                    "version": "2.1.10525.2",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Active Directory Authentication Library for SQL Server": {
+                    "version": "15.0.1300.359",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Workflow Debugger v1.0 for amd64": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Windows SDK DirectX x64 Remote": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual Studio Installer": {
+                    "version": "2.4.1083.303",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Host FX Resolver - 3.1.1 (x64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Windows Desktop Targeting Pack - 3.1.0 (x64)": {
+                    "version": "24.64.28315",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2019 X64 Additional Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.2 (x64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.1 (x64_arm64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft System CLR Types for SQL Server 2019 CTP2.2": {
+                    "version": "15.0.1200.24",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ODBC Driver 17 for SQL Server": {
+                    "version": "17.2.0.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Office 16 Click-to-Run Licensing Component": {
+                    "version": "16.0.12527.20242",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Office 16 Click-to-Run Extensibility Component": {
+                    "version": "16.0.12527.20278",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200326"
+                },
+                "Office 16 Click-to-Run Localization Component": {
+                    "version": "16.0.12527.20278",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200326"
+                },
+                "Microsoft SQL Server 2016 LocalDB ": {
+                    "version": "13.1.4001.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Chef Workstation v0.17.5": {
+                    "version": "0.17.5.1",
+                    "publisher": "\"Chef Software, Inc. <maintainers@chef.io>\"",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.21005": {
+                    "version": "12.0.21005",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20190224"
+                },
+                "Python 3.7.7 Development Libraries (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Runtime - 3.1.2 (x64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft .NET Core SDK 3.1.101 (x64) from Visual Studio": {
+                    "version": "3.1.101.014848",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Core Interpreter (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Documentation (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Standard Targeting Pack - 2.1.0 (x64)": {
+                    "version": "24.0.28113",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.21005": {
+                    "version": "12.0.21005",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20190224"
+                },
+                "vs_Graphics_Singletonx64": {
+                    "version": "16.4.29411",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "IIS Express Application Compatibility Database for x86": {},
+                "Microsoft .NET Core Host - 3.1.1 (x64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "NVIDIA Ansel": {
+                    "version": "7.0.506.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20200314"
+                },
+                "NVIDIA Control Panel 416.16": {
+                    "version": "416.16",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Graphics Driver 431.94": {
+                    "version": "431.94",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20200314"
+                },
+                "NVIDIA 3D Vision Controller Driver 390.41": {
+                    "version": "390.41",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA WMI 2.33.0": {
+                    "version": "2.33.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Optimus Update 33.2.0.0": {
+                    "version": "33.2.0.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Update 33.2.0.0": {
+                    "version": "33.2.0.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Install Application": {
+                    "version": "2.1002.324.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20200314"
+                },
+                "NVIDIA Display Container": {
+                    "version": "1.11",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Display Container LS": {
+                    "version": "1.11",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Display Watchdog Plugin": {
+                    "version": "1.11",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Display Session Container": {
+                    "version": "1.11",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Telemetry Client": {
+                    "version": "13.2.22.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Telemetry Container": {
+                    "version": "13.2.22.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "NVIDIA Update Core": {
+                    "version": "33.2.0.0",
+                    "publisher": "NVIDIA Corporation",
+                    "installdate": "20190224"
+                },
+                "PowerShell 7-x64": {
+                    "version": "7.0.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Windows Desktop Runtime - 3.1.2 (x64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft Web Deploy 4.0": {
+                    "version": "10.0.2606",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Core Module V2 for IIS Express": {
+                    "version": "13.0.19213.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Host - 3.1.2 (x64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Workflow Manager Tools 1.0 for Visual Studio": {
+                    "version": "2.1.30411.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Azure Libraries for .NET – v2.9": {
+                    "version": "3.0.0127.060",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 Add to Path (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "VS WCF Debugging": {
+                    "version": "16.0.98.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core 3.1 Templates 3.1.102 (x64)": {
+                    "version": "3.1.3.014873",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft Visual C++ 2012 x64 Minimum Runtime - 11.0.61030": {
+                    "version": "11.0.61030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200323"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.2 (x64_arm64)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft ASP.NET Core 3.1.0 Targeting Pack (x64)": {
+                    "version": "3.1.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "VS Script Debugging Common": {
+                    "version": "16.0.98.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python 3.7.7 pip Bootstrap (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core 2.1 Templates 3.1.101 (x64)": {
+                    "version": "2.1.14.014848",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Core 3.1.2 Targeting Pack (x64)": {
+                    "version": "3.1.2.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Microsoft .NET Core Runtime - 3.1.1 (x64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Azure Authoring Tools - v2.9.6": {
+                    "version": "2.9.8899.26",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.2 (x64_arm)": {
+                    "version": "24.72.28517",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "Python 3.7.7 Tcl/Tk Support (64-bit)": {
+                    "version": "3.7.7150.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core AppHost Pack - 3.1.1 (x64)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Identity Extensions": {
+                    "version": "2.0.1459.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2019 X64 Debug Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Core Module for IIS Express": {
+                    "version": "12.2.18292.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Visual Studio Enterprise 2019": {
+                    "version": "16.4.29905.134",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Google Chrome": {
+                    "version": "80.0.3987.163",
+                    "publisher": "Google LLC",
+                    "installdate": "20200406"
+                },
+                "Microsoft Azure Storage Emulator - v5.10": {
+                    "version": "5.10.19227.2113",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Edge": {
+                    "version": "80.0.361.109",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200401"
+                },
+                "Microsoft Edge Update": {
+                    "version": "1.3.121.21"
+                },
+                "Steam": {
+                    "version": "2.10.91.91",
+                    "publisher": "Valve Corporation"
+                },
+                "Uplay": {
+                    "version": "104.0",
+                    "publisher": "Ubisoft"
+                },
+                "Microsoft Workflow Debugger v1.0 for x86": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Universal CRT Redistributable": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.30501": {
+                    "version": "12.0.30501.0",
+                    "publisher": "Microsoft Corporation"
+                },
+                "vs_loadtestexceladdinmsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Python Launcher": {
+                    "version": "3.7.7008.0",
+                    "publisher": "Python Software Foundation",
+                    "installdate": "20200315"
+                },
+                "Windows Simulator - ENU": {
+                    "version": "16.0.28522",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Web Tools Packages 16.0 - ENU": {
+                    "version": "1.0.20910.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft UniversalWindowsPlatform SDK": {
+                    "version": "15.9.11",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Windows Software Development Kit - Windows 10.0.18362.1": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation"
+                },
+                "Microsoft .NET CoreRuntime SDK": {
+                    "version": "1.1.27004.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Universal CRT Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.21005": {
+                    "version": "12.0.21005",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20190224"
+                },
+                "Windows Mobile Extension SDK Contracts": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows App Certification Kit x64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Libs arm64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.7.2 Targeting Pack": {
+                    "version": "4.7.03062",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Diagnostic Pack for Visual Studio": {
+                    "version": "16.4.462.24200",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Visual C++ Library CRT Desktop Appx Package": {
+                    "version": "14.24.28314",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.5.2 Multi-Targeting Pack": {
+                    "version": "4.5.51651",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Thunderbolt™ Software": {
+                    "version": "17.4.80.550",
+                    "publisher": "Intel Corporation",
+                    "installdate": "20200316"
+                },
+                "Windows Phone SDK 8.0 Assemblies for Visual Studio 2019": {
+                    "version": "16.0.29430",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_webtestrecordermsi": {
+                    "version": "16.4.29430",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK ARM Desktop Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Modern Versioned Developer Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps Libs": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Libs x86": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Exchange Web Services Managed API 2.1": {
+                    "version": "15.0.847.30",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense UAP - Other Languages": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_clickoncebootstrappermsires": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_minshellinteropmsi": {
+                    "version": "16.2.28917",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.24.28127": {
+                    "version": "14.24.28127.4",
+                    "publisher": "Microsoft Corporation"
+                },
+                "Microsoft .NET Framework 4.6 Targeting Pack": {
+                    "version": "4.6.00081",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Tools arm64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Mobile Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_clickoncesigntoolmsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Windows Desktop Runtime - 3.1.1 (x86)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2012 Redistributable (x86) - 11.0.61030": {
+                    "version": "11.0.61030.0",
+                    "publisher": "Microsoft Corporation"
+                },
+                "Windows SDK Redistributables": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense IoT - en-us": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Visual C++ Library CRT Appx Package": {
+                    "version": "14.24.28314",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Desktop Extension SDK Contracts": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows IoT Extension SDK Contracts": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "sptools_Microsoft.VisualStudio.Vsto.Msi.Resources": {
+                    "version": "16.0.28030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Headers arm": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Open XML SDK 2.5 for Microsoft Office": {
+                    "version": "2.5.5631",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Chocolatey GUI": {
+                    "version": "0.17.0.0",
+                    "publisher": "Chocolatey",
+                    "installdate": "20200331"
+                },
+                "Windows SDK Desktop Headers arm64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_minshellmsi": {
+                    "version": "16.4.29709",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET CoreRuntime For CoreCon": {
+                    "version": "1.0.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_networkemulationmsi_x64": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Signing Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "TypeScript SDK": {
+                    "version": "3.7.4.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK DirectX x86 Remote": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Tools x86": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Libs x64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Host FX Resolver - 3.1.1 (x86)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.5 Multi-Targeting Pack": {
+                    "version": "4.5.50710",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_cuitextensionmsi16": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_communitymsi": {
+                    "version": "16.4.29709",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows App Certification Kit SupportedApiList x86": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Team Extension SDK Contracts": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Core Runtime - 3.1.1 (x86)": {
+                    "version": "24.68.28408",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK EULA": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporations",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps Metadata": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "ClickOnce Bootstrapper Package for Microsoft .NET Framework": {
+                    "version": "4.8.03928",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Google Update Helper": {
+                    "version": "1.3.35.451",
+                    "publisher": "Google LLC",
+                    "installdate": "20200321"
+                },
+                "Microsoft .NET Core SDK 3.1.102 (x64)": {
+                    "version": "3.1.102.14873",
+                    "publisher": "Microsoft Corporation"
+                },
+                "Kits Configuration Installer": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps Headers": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense PPI - en-us": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "SDK ARM Redistributables": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_FileTracker_Singleton": {
+                    "version": "16.3.29209",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.5.1 Multi-Targeting Pack": {
+                    "version": "4.5.50932",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_webtestrecordermsi_x64": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Headers x64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense IoT - Other Languages": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense UAP - en-us": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_filehandler_x86": {
+                    "version": "16.4.29709",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Team Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Universal General MIDI DLS Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_filehandler_amd64": {
+                    "version": "16.4.29709",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "sptools_Microsoft.VisualStudio.OfficeDeveloperTools.Msi": {
+                    "version": "15.0.26501",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Teams Machine-Wide Installer": {
+                    "version": "1.3.0.362",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200314"
+                },
+                "SDK ARM Additions": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft NetStandard SDK": {
+                    "version": "15.0.51105",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Universal CRT Headers Libraries and Sources": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "VS Immersive Activate Helper": {
+                    "version": "16.0.98.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Tools x64": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Entity Framework 6.2.0 Tools  for Visual Studio 2019": {
+                    "version": "6.2.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "icecap_collection_neutral": {
+                    "version": "16.4.29904",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Visual C++ Library CRT ARM64 Appx Package": {
+                    "version": "14.24.28314",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense Desktop - Other Languages": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Headers x86": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Azure Storage Tools - v6.2.0": {
+                    "version": "6.2.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.6.1 Targeting Pack": {
+                    "version": "4.6.01055",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft TestPlatform SDK Local Feed": {
+                    "version": "16.0.0.3069091",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                },
+                "WinAppDeploy": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps DirectX x86 Remote": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense Mobile - en-us": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Intel® PROSet/Wireless Software": {
+                    "version": "21.10.1.0u",
+                    "publisher": "Intel Corporation"
+                },
+                "vs_SQLClickOnceBootstrappermsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_codeduitestframeworkmsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.8 SDK": {
+                    "version": "4.8.03928",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_communitymsires": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Desktop Libs arm": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense PPI - Other Languages": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows IoT Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "icecap_collectionresources": {
+                    "version": "16.4.29430",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Universal CRT Tools x86": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_cuitcommoncoremsi16": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Apps Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Facade Windows WinMD Versioned": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vcpp_crt.redist.clickonce": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_devenvmsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2012 x86 Additional Runtime - 11.0.61030": {
+                    "version": "11.0.61030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200323"
+                },
+                "windows_toolscorepkg": {
+                    "version": "16.2.29006",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Desktop Extension SDK": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4.7.2 Targeting Pack (ENU)": {
+                    "version": "4.7.03062",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_BlendMsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_clickoncebootstrappermsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2012 x86 Minimum Runtime - 11.0.61030": {
+                    "version": "11.0.61030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200323"
+                },
+                "Microsoft Intune Management Extension": {
+                    "version": "1.29.201.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200318"
+                },
+                "Windows SDK for Windows Store Apps Contracts": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework Cumulative Intellisense Pack for Visual Studio (ENU)": {
+                    "version": "4.8.03761",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft ASP.NET Core 3.1.1 Shared Framework (x86)": {
+                    "version": "3.1.1.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030": {
+                    "version": "11.0.61030.0",
+                    "publisher": "Microsoft Corporation"
+                },
+                "vs_codecoveragemsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK for Windows Store Managed Apps Libs": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Framework 4 Multi-Targeting Pack": {
+                    "version": "4.0.30319",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Update for  (KB2504637)": {
+                    "version": "1",
+                    "publisher": "Microsoft Corporation"
+                },
+                "sptools_Microsoft.VisualStudio.Vsto.Msi.x64": {
+                    "version": "16.0.28030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "MSI Development Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK Modern Non-Versioned Developer Tools": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_tipsmsi": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.24.28127": {
+                    "version": "14.24.28127.4",
+                    "publisher": "Microsoft Corporation"
+                },
+                "vs_Graphics_Singletonx86": {
+                    "version": "16.4.29411",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "WinRT Intellisense Desktop - en-us": {
+                    "version": "10.1.18362.1",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows SDK AddOn": {
+                    "version": "10.1.0.0",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Windows Simulator": {
+                    "version": "16.0.28522",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2019 X86 Additional Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_minshellmsires": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "vs_cuitextensionmsi16_x64": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual Studio Setup Configuration": {
+                    "version": "2.3.2200.14893",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft .NET Native SDK": {
+                    "version": "15.0.24211.07",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Intel(R) Processor Graphics": {
+                    "version": "24.20.100.6346",
+                    "publisher": "Intel Corporation"
+                },
+                "Visual C++ Library CRT Appx Resource Package": {
+                    "version": "14.24.28314",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "icecap_collectionresourcesx64": {
+                    "version": "16.4.29411",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.30501": {
+                    "version": "12.0.30501.0",
+                    "publisher": "Microsoft Corporation"
+                },
+                "Microsoft Visual C++ 2019 X86 Debug Runtime - 14.24.28127": {
+                    "version": "14.24.28127",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "sptools_Microsoft.VisualStudio.Vsto.Msi": {
+                    "version": "16.0.28030",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20200315"
+                },
+                "Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.21005": {
+                    "version": "12.0.21005",
+                    "publisher": "Microsoft Corporation",
+                    "installdate": "20190224"
+                },
+                "Microsoft Windows Communication Foundation Diagnostic Pack for x86": {
+                    "version": "16.0.28329",
+                    "publisher": "Microsoft",
+                    "installdate": "20200315"
+                }
+            },
+            "root_group": "Administrators",
+            "shard_seed": 216945772,
+            "time": {
+                "timezone": "Pacific Daylight Time"
+            },
+            "system_enclosure": {
+                "manufacturer": "LENOVO",
+                "serialnumber": "R90T7HK1"
+            },
+            "chef_guid": "9d049b11-1107-4324-ac40-3909f5694726",
+            "name": "LAPTOP-03J74NE1",
+            "chef_environment": "_default",
+            "recipes": [
+                "cpe_init",
+                "cpe_init::default",
+                "cpe_init::windows_init",
+                "audit::default",
+                "audit::inspec",
+                "chefit-masterclient::default",
+                "windows_localadminaccount::default",
+                "windows_screensaver::default",
+                "cpe_init::company_init"
+            ],
+            "expanded_run_list": [
+                "cpe_init::default"
+            ],
+            "roles": [
+                "cpe_base"
+            ],
+            "cookbooks": {
+                "cpe_init": {
+                    "version": "0.1.105"
+                },
+                "cpe_utils": {
+                    "version": "0.1.0"
+                },
+                "audit": {
+                    "version": "7.4.1"
+                },
+                "chef-client": {
+                    "version": "11.0.3"
+                },
+                "cron": {
+                    "version": "5.1.0"
+                },
+                "logrotate": {
+                    "version": "2.1.0"
+                },
+                "compat_resource": {
+                    "version": "12.19.1"
+                },
+                "cpe_bluetooth": {
+                    "version": "0.1.0"
+                },
+                "cpe_profiles": {
+                    "version": "0.1.0"
+                },
+                "chefit-masterclient": {
+                    "version": "0.1.20"
+                },
+                "cpe_desktop": {
+                    "version": "0.1.0"
+                },
+                "cpe_chrome": {
+                    "version": "0.1.0"
+                },
+                "cpe_choco": {
+                    "version": "0.1.2"
+                },
+                "cpe_chef": {
+                    "version": "0.1.2"
+                },
+                "cpe_crypt": {
+                    "version": "0.1.0"
+                },
+                "cpe_launchd": {
+                    "version": "0.1.2"
+                },
+                "cpe_remote": {
+                    "version": "0.1.0"
+                },
+                "cpe_logger": {
+                    "version": "0.1.0"
+                },
+                "cpe_hosts": {
+                    "version": "0.2.0"
+                },
+                "cpe_macos_server": {
+                    "version": "0.1.0"
+                },
+                "cpe_munki": {
+                    "version": "0.3.0"
+                },
+                "cpe_nightly_reboot": {
+                    "version": "0.1.0"
+                },
+                "cpe_pathsd": {
+                    "version": "0.1.0"
+                },
+                "cpe_powermanagement": {
+                    "version": "0.1.0"
+                },
+                "cpe_preferencepanes": {
+                    "version": "0.1.0"
+                },
+                "cpe_prompt_user": {
+                    "version": "0.1.0"
+                },
+                "cpe_screensaver": {
+                    "version": "0.1.0"
+                },
+                "cpe_spotlight": {
+                    "version": "0.1.0"
+                },
+                "cpe_batterycheck": {
+                    "version": "0.1.0"
+                },
+                "cpe_botmanagement": {
+                    "version": "0.1.0"
+                },
+                "slack_handler": {
+                    "version": "1.0.0"
+                },
+                "windows_localadminaccount": {
+                    "version": "0.1.3"
+                },
+                "windows_screensaver": {
+                    "version": "0.1.11"
+                }
+            }
+        },
+        "normal": {
+            "tags": []
+        },
+        "chef_type": "node",
+        "default": {
+            "audit": {
+                "inspec_version": null,
+                "inspec_gem_source": null,
+                "inspec_backend_cache": true,
+                "reporter": "chef-automate",
+                "fetcher": "chef-automate",
+                "server": null,
+                "refresh_token": null,
+                "token": null,
+                "insecure": null,
+                "owner": null,
+                "raise_if_unreachable": true,
+                "fail_if_not_present": false,
+                "interval": {
+                    "enabled": false,
+                    "time": 1440
+                },
+                "quiet": true,
+                "overwrite": true,
+                "profiles": [
+                    {
+                        "name": "mac_os_x",
+                        "compliance": "jmccrae@chef.io/mac_os_x"
+                    }
+                ],
+                "attributes": {},
+                "chef_node_attribute_enabled": false,
+                "json_file": {
+                    "location": "C:/chef/cache/cookbooks/audit/inspec-20200406204528.json"
+                }
+            },
+            "cron": {
+                "package_name": [],
+                "service_name": "cron",
+                "emulate_cron.d": false
+            },
+            "logrotate": {
+                "package": {
+                    "name": "logrotate",
+                    "source": null,
+                    "version": null,
+                    "provider": null
+                },
+                "directory": "/etc/logrotate.d",
+                "cron": {
+                    "install": false,
+                    "name": "logrotate",
+                    "command": "/usr/sbin/logrotate /etc/logrotate.conf",
+                    "minute": 35,
+                    "hour": 2
+                },
+                "global": {
+                    "weekly": true,
+                    "rotate": 4,
+                    "create": "",
+                    "/var/log/wtmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0664 root utmp",
+                        "rotate": 1
+                    },
+                    "/var/log/btmp": {
+                        "missingok": true,
+                        "monthly": true,
+                        "create": "0660 root utmp",
+                        "rotate": 1
+                    }
+                }
+            },
+            "chef_client": {
+                "config": {
+                    "chef_server_url": "https://api.chef.io/organizations/chefitproduction",
+                    "validation_client_name": "chefitproduction-validator",
+                    "node_name": "LAPTOP-03J74NE1",
+                    "verify_api_cert": true,
+                    "client_fork": true,
+                    "start_handlers": [],
+                    "report_handlers": [],
+                    "exception_handlers": []
+                },
+                "log_file": "client.log",
+                "interval": "1800",
+                "splay": "300",
+                "conf_dir": "C:/chef",
+                "bin": "C:/opscode/chef/bin/chef-client",
+                "log_dir": "C:/chef/log",
+                "log_perm": "640",
+                "cron": {
+                    "minute": "0",
+                    "hour": "0,4,8,12,16,20",
+                    "weekday": "*",
+                    "path": null,
+                    "environment_variables": null,
+                    "log_file": "/dev/null",
+                    "append_log": false,
+                    "use_cron_d": false,
+                    "mailto": null
+                },
+                "systemd": {
+                    "timer": false,
+                    "timeout": false,
+                    "restart": "always"
+                },
+                "task": {
+                    "frequency": "minute",
+                    "frequency_modifier": 30,
+                    "user": "Boiardie",
+                    "password": "0psCode!!",
+                    "start_time": null,
+                    "start_date": null,
+                    "name": "chef-client"
+                },
+                "load_gems": {},
+                "reload_config": true,
+                "daemon_options": [],
+                "logrotate": {
+                    "rotate": 12,
+                    "frequency": "weekly"
+                },
+                "init_style": "windows",
+                "run_path": "C:/chef/run",
+                "cache_path": "C:/chef/cache",
+                "backup_path": "C:/chef/backup",
+                "log_rotation": {
+                    "options": [
+                        "compress"
+                    ],
+                    "prerotate": null,
+                    "postrotate": "/etc/init.d/chef-client reload >/dev/null || :"
+                },
+                "handler": {
+                    "slack": {
+                        "team": null,
+                        "api_key": null,
+                        "channel": null,
+                        "webhooks": {
+                            "name": [
+                                "itchannel"
+                            ],
+                            "itchannel": {
+                                "url": "https://hooks.slack.com/services/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"
+                            }
+                        },
+                        "timeout": 15,
+                        "username": "Chef Run Bot",
+                        "icon_url": "https://avatars1.githubusercontent.com/u/29740",
+                        "icon_emoji": ":fork_and_knife:",
+                        "message_detail_level": "elapsed",
+                        "cookbook_detail_level": "all",
+                        "fail_only": true,
+                        "send_start_message": false,
+                        "send_environment": false,
+                        "send_organization": false
+                    }
+                }
+            },
+            "ohai": {
+                "disabled_plugins": [],
+                "plugin_path": null
+            },
+            "cpe_profiles": {
+                "prefix": "com.chef.chefit"
+            },
+            "cpe_bluetooth": {
+                "BluetoothAutoSeekKeyboard": null,
+                "BluetoothAutoSeekPointingDevice": null
+            },
+            "cpe_chef": {
+                "config": true,
+                "interval": 1800,
+                "knife": false
+            },
+            "cpe_choco": {
+                "bootstrap": {
+                    "installation_uri": "https://chocolatey.org/install.ps1",
+                    "upgrade_source": "https://chocolatey.org/api/v2",
+                    "version": "0.10.3",
+                    "choco_download_url": "https://chocolatey.org/api/v2/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion",
+                    "zip_location": "https://chocolatey.org/7za.exe",
+                    "use_windows_compression": "true"
+                },
+                "install": {},
+                "uninstall": {},
+                "source_blacklist": [],
+                "default_feed": "https://chocolatey.org/api/v2",
+                "sources": {
+                    "chocolatey": {
+                        "source": "https://chocolatey.org/api/v2"
+                    }
+                },
+                "config": {
+                    "cacheLocation": {
+                        "value": "",
+                        "description": "Cache location if not TEMP folder."
+                    },
+                    "commandExecutionTimeoutSeconds": {
+                        "value": 2700,
+                        "description": "Default timeout for command execution."
+                    },
+                    "webRequestTimeoutSeconds": {
+                        "value": 30,
+                        "description": "Default timeout for web requests. Available in 0.9.10+."
+                    },
+                    "containsLegacyPackageInstalls": {
+                        "value": true,
+                        "description": "Install has packages installed prior to 0.9.9 series."
+                    },
+                    "proxy": {
+                        "value": "",
+                        "description": "Explicit proxy location."
+                    },
+                    "proxyUser": {
+                        "value": "",
+                        "description": "Optional proxy user."
+                    },
+                    "proxyPassword": {
+                        "value": "",
+                        "description": "Optional proxy password. Encrypted."
+                    }
+                },
+                "features": {
+                    "checksumFiles": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Checksum files when pulled in from internet (based on package)."
+                    },
+                    "autoUninstaller": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Uninstall from programs and features without requiring an explicit uninstall script."
+                    },
+                    "allowGlobalConfirmation": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Prompt for confirmation in scripts or bypass."
+                    },
+                    "failOnAutoUninstaller": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Fail if automatic uninstaller fails."
+                    },
+                    "failOnStandardError": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Fail if install provider writes to stderr. Available in 0.9.10+."
+                    },
+                    "powershellHost": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Use Chocolatey's built-in PowerShell host. Available in 0.9.10+."
+                    },
+                    "logEnvironmentValues": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Log Environment Values - will log values of environment before and after install (could disclose sensitive data). Available in 0.9.10+."
+                    },
+                    "virusCheck": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Virus Check - perform virus checking on downloaded files. Available in 0.9.10+. Licensed versions only."
+                    },
+                    "failOnInvalidOrMissingLicense": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Fail On Invalid Or Missing License - allows knowing when a license is expired or not applied to a machine. Available in 0.9.10+."
+                    },
+                    "ignoreInvalidOptionsSwitches": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Ignore Invalid Options/Switches - If a switch or option is passed that is not recognized, should choco fail? Available in 0.9.10+."
+                    },
+                    "usePackageExitCodes": {
+                        "enabled": true,
+                        "setExplicitly": true,
+                        "description": "Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+."
+                    },
+                    "useFipsCompliantChecksums": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Use FIPS Compliant Checksums - Ensure checksumming done by choco uses FIPS compliant algorithms. Not recommended unless required by FIPS Mode. Enabling on an existing installation could have unintended consequences related to upgrades/uninstalls. Available in 0.9.10+."
+                    },
+                    "allowEmptyChecksums": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Allow packages to have empty/missing checksums for downloaded resources from non-secure locations (HTTP, FTP). Enabling is not recommended if using sources that download resources from the internet. Available in 0.10.0+."
+                    },
+                    "allowEmptyChecksumsSecure": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Allow packages to have empty/missing checksums for downloaded resources from secure locations (HTTPS). Available in 0.10.0+."
+                    },
+                    "scriptsCheckLastExitCode": {
+                        "enabled": false,
+                        "setExplicitly": true,
+                        "description": "Scripts Check $LastExitCode (external commands) - Leave this off unless you absolutely need it while you fix your package scripts  to use `throw 'error message'` or `Set-PowerShellExitCode #` instead of `exit #`. This behavior started in 0.9.10 and produced hard to find bugs. If the last external process exits successfully but with an exit code of not zero, this could cause hard to detect package failures. Available in 0.10.3+. Will be removed in 0.11.0."
+                    }
+                }
+            },
+            "cpe_chrome": {
+                "profile": {
+                    "ExtensionInstallForcelist": [],
+                    "ExtensionInstallBlacklist": [],
+                    "EnabledPlugins": [],
+                    "DisabledPlugins": [],
+                    "DefaultPluginsSetting": 1,
+                    "ExtensionInstallSources": [],
+                    "PluginsAllowedForUrls": []
+                },
+                "mp": {
+                    "UseMasterPreferencesFile": false,
+                    "FileContents": {}
+                }
+            },
+            "cpe_launchd": {
+                "prefix": "com.chef.chefit"
+            },
+            "cpe_remote": {
+                "base_url": "munki.opscodecorp.com/munki_repo/chef",
+                "server_accessible": true
+            },
+            "cpe_crypt": {
+                "install": false,
+                "uninstall": false,
+                "profile": true,
+                "manage_authdb": true,
+                "manage_ld": true,
+                "ld": {
+                    "program_arguments": [
+                        "/Library/Crypt/checkin"
+                    ],
+                    "disabled": false,
+                    "run_at_load": true,
+                    "start_interval": 120,
+                    "type": "daemon"
+                },
+                "prefs": {
+                    "ServerURL": null,
+                    "SkipUsers": null,
+                    "RemovePlist": null,
+                    "RotateUsedKey": null,
+                    "ValidateKey": null,
+                    "FDEAddUser": null,
+                    "OutputPath": null,
+                    "KeyEscrowInterval": null
+                },
+                "pkg": {
+                    "name": "crypt",
+                    "checksum": "1582e974820a5b27cfe462521cb0d4802319224753f3d6417ee23fff9333872a",
+                    "receipt": "com.grahamgilbert.Crypt",
+                    "version": "3.0.0.109",
+                    "pkg_name": null,
+                    "pkg_url": null
+                }
+            },
+            "cpe_desktop": {
+                "override-picture-path": null
+            },
+            "cpe_hosts": {
+                "extra_entries": {
+                    "::1": [],
+                    "127.0.0.1": []
+                }
+            },
+            "cpe_macos_server": {
+                "setup": false,
+                "manage": false,
+                "services": {}
+            },
+            "cpe_munki": {
+                "install": false,
+                "configure": false,
+                "auto_remediate": null,
+                "local": {
+                    "managed_installs": [],
+                    "managed_uninstalls": []
+                },
+                "preferences": {
+                    "AppleSoftwareUpdatesOnly": false,
+                    "DaysBetweenNotifications": 1,
+                    "FollowHTTPRedirects": "none",
+                    "InstallAppleSoftwareUpdates": false,
+                    "LogFile": "/Library/Managed Installs/Logs/ManagedSoftwareUpdate.log",
+                    "LoggingLevel": 1,
+                    "LogToSyslog": false,
+                    "PerformAuthRestarts": false,
+                    "RecoveryKeyFile": null,
+                    "SoftwareRepoURL": "https://munki/repo",
+                    "SuppressAutoInstall": false,
+                    "SuppressStopButtonOnInstall": false,
+                    "SuppressUserNotification": false,
+                    "UnattendedAppleUpdates": false,
+                    "UseClientCertificate": false,
+                    "UseNotificationCenterDays": null
+                },
+                "munki_version_to_install": {}
+            },
+            "cpe_nightly_reboot": {
+                "script": "/opt/chef/scripts/logout_bootstrap.py",
+                "restart": {
+                    "Month": null,
+                    "Day": null,
+                    "Weekday": null,
+                    "Hour": null,
+                    "Minute": null
+                },
+                "logout": {
+                    "Month": null,
+                    "Day": null,
+                    "Weekday": null,
+                    "Hour": null,
+                    "Minute": null
+                }
+            },
+            "cpe_pathsd": [],
+            "cpe_powermanagement": {
+                "ACPower": {
+                    "Automatic Restart On Power Loss": null,
+                    "Disk Sleep Timer": null,
+                    "Display Sleep Timer": null,
+                    "Sleep On Power Button": null,
+                    "System Sleep Timer": null,
+                    "Wake On LAN": null,
+                    "RestartAfterKernelPanic": null
+                },
+                "Battery": {
+                    "Automatic Restart On Power Loss": null,
+                    "Disk Sleep Timer": null,
+                    "Display Sleep Timer": null,
+                    "Sleep On Power Button": null,
+                    "System Sleep Timer": null,
+                    "Wake On LAN": null,
+                    "RestartAfterKernelPanic": null
+                }
+            },
+            "cpe_preferencepanes": {
+                "DisabledPreferencePanes": null,
+                "HiddenPreferencePanes": null
+            },
+            "cpe_prompt_user": {
+                "CocoaDialog": "/Applications/CocoaDialog.app/Contents/MacOS/CocoaDialog",
+                "icon": null,
+                "prompts": {}
+            },
+            "cpe_screensaver": {
+                "idleTime": null,
+                "askForPassword": null,
+                "askForPasswordDelay": null
+            },
+            "cpe_spotlight": {
+                "exclusions": []
+            },
+            "screensaver": {
+                "idle_time": 1200
+            },
+            "organization": "chef"
+        },
+        "override": {},
+        "run_list": [
+            "role[cpe_base]"
+        ]
+    },
+    "node_name": "LAPTOP-03J74NE1",
+    "organization_name": "chefitproduction",
+    "resources": [
+        {
+            "type": "inspec_gem",
+            "name": "inspec",
+            "id": "inspec",
+            "after": {
+                "version": null,
+                "source": null
+            },
+            "before": {},
+            "duration": "78",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "install",
+            "status": "up-to-date",
+            "cookbook_name": "audit",
+            "cookbook_version": "7.4.1",
+            "recipe_name": "inspec"
+        },
+        {
+            "type": "inspec_gem",
+            "name": "inspec",
+            "id": "inspec",
+            "after": {
+                "version": null,
+                "source": null
+            },
+            "before": {},
+            "duration": "0",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "nothing",
+            "status": "skipped",
+            "cookbook_name": "audit",
+            "cookbook_version": "7.4.1",
+            "recipe_name": "inspec",
+            "conditional": "not_if { action == :nothing }"
+        },
+        {
+            "type": "directory",
+            "name": "c:\\chef",
+            "id": "c:\\chef",
+            "after": {
+                "group": null,
+                "mode": null,
+                "owner": null,
+                "path": "c:\\chef"
+            },
+            "before": {
+                "group": null,
+                "mode": null,
+                "owner": null,
+                "path": "c:\\chef"
+            },
+            "duration": "2",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "up-to-date",
+            "cookbook_name": "chefit-masterclient",
+            "cookbook_version": "0.1.20",
+            "recipe_name": "default"
+        },
+        {
+            "type": "template",
+            "name": "/templates/default/windows.rb",
+            "id": "c:\\chef\\client.rb",
+            "after": {
+                "rights": null,
+                "deny_rights": null,
+                "path": "c:\\chef\\client.rb",
+                "verifications": [],
+                "variables": {
+                    "erb_token": "tNU9pwnSHSZXjAEkNGHpZeLFCMg=",
+                    "erb_server_url": "https://chefit.automate.chef.io/data-collector/v0"
+                },
+                "checksum": "73630fe0a50814fb5abba6815bf8bfa8eb6e146e07eab4e9b9f670c4e82b8449"
+            },
+            "before": {
+                "checksum": "efde2862d591b6e532abd6175c5ba2bf31ee689c6cb546eff677d3209ea9ec9f",
+                "rights": null,
+                "deny_rights": null,
+                "path": "c:\\chef\\client.rb"
+            },
+            "duration": "49",
+            "delta": "--- c:\\chef\\client.rb\t2020-04-06 13:44:59.621902000 -0700\\n+++ c:\\chef/chef-client20200406-3128-1c5dlwd.rb\t2020-04-06 13:45:31.455029100 -0700\\n@@ -3,17 +3,16 @@\\n validation_client_name 'chefitproduction-validator'\\n validation_key         File.expand_path('/chef/validation.pem')\\n chef_server_url        \"https://api.chef.io/organizations/chefitproduction\"\\n-#json_attribs           '/chef/run-list.json'\\n+json_attribs           '/chef/run-list.json'\\n ssl_verify_mode        :verify_peer\\n local_key_generation   true\\n rest_timeout           30\\n http_retry_count       3\\n \\n node_name \"LAPTOP-03J74NE1\"\\n-Chef::Config[:data_collector][:output_locations] = { files:  [ \"C:\\\\Users\\\\jmccrae\\\\data_collector.out\" ] }\\n data_collector.server_url \"https://chefit.automate.chef.io/data-collector/v0\"\\n data_collector.token \"tNU9pwnSHSZXjAEkNGHpZeLFCMg=\"\\n-slack_webhook_url \"\"\\n+slack_webhook_url \"\" \\n \\n ohai.directory = \"/chef/ohai_plugins\"\\n ohai.disabled_plugins = [:Passwd]",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "chefit-masterclient",
+            "cookbook_version": "0.1.20",
+            "recipe_name": "default"
+        },
+        {
+            "type": "powershell_script",
+            "name": "create_admin_user",
+            "id": "create_admin_user",
+            "after": {
+                "command": null,
+                "user": null,
+                "domain": null,
+                "code": "  $user = \"Boiardie\"\n  $pwd = \"0psCode!!\"\n  New-LocalUser -PasswordNeverExpires -Password (ConvertTo-SecureString -AsPlainText $pwd -Force) -Name $user\n",
+                "interpreter": "powershell.exe"
+            },
+            "before": {},
+            "duration": "775",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "run",
+            "status": "skipped",
+            "cookbook_name": "windows_localadminaccount",
+            "cookbook_version": "0.1.3",
+            "recipe_name": "default",
+            "conditional": "not_if \"Get-Localuser -Name Boiardie\""
+        },
+        {
+            "type": "group",
+            "name": "Administrators",
+            "id": "Administrators",
+            "after": {
+                "members": [
+                    "Boiardie"
+                ],
+                "group_name": "Administrators",
+                "excluded_members": [],
+                "append": true
+            },
+            "before": {
+                "members": [
+                    "S-1-5-21-4139225701-1809223480-1368843279-500",
+                    "S-1-12-1-610816556-1296309953-3772466358-3886913440",
+                    "S-1-12-1-601528976-1246840496-2885518471-1582481920",
+                    "S-1-12-1-4293681624-1320698286-1406452144-2493789976",
+                    "S-1-5-21-4139225701-1809223480-1368843279-1001"
+                ],
+                "group_name": "Administrators"
+            },
+            "duration": "10",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "modify",
+            "status": "up-to-date",
+            "cookbook_name": "windows_localadminaccount",
+            "cookbook_version": "0.1.3",
+            "recipe_name": "default"
+        },
+        {
+            "type": "registry_key",
+            "name": "Update or Set Screensaver",
+            "id": "HKEY_CURRENT_USER\\Control Panel\\Desktop",
+            "after": {
+                "values": [
+                    {
+                        "name": "ScreenSaveActive",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "ScreenSaverIsSecure",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "scrnsave.exe",
+                        "type": "string",
+                        "data": "c:\\windows\\system32\\mystify.scr"
+                    },
+                    {
+                        "name": "ScreenSaveTimeOut",
+                        "type": "string",
+                        "data": 1200
+                    }
+                ],
+                "key": "HKEY_CURRENT_USER\\Control Panel\\Desktop",
+                "recursive": true
+            },
+            "before": {
+                "values": [
+                    {
+                        "name": "ActiveWndTrackTimeout",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "BlockSendInputResets",
+                        "type": "string",
+                        "data": "0"
+                    },
+                    {
+                        "name": "CaretTimeout",
+                        "type": "dword",
+                        "data": "0f8eb4b72b6e0c9e88b388eb967b49e067ef1004bf07bffc22c3acb13b43580a"
+                    },
+                    {
+                        "name": "CaretWidth",
+                        "type": "dword",
+                        "data": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+                    },
+                    {
+                        "name": "ClickLockTime",
+                        "type": "dword",
+                        "data": "15197cf7214b58e67cae565e573ffd9aa44bcb81f8ee5d7185dfe8da0a16ef43"
+                    },
+                    {
+                        "name": "CoolSwitchColumns",
+                        "type": "string",
+                        "data": "7"
+                    },
+                    {
+                        "name": "CoolSwitchRows",
+                        "type": "string",
+                        "data": "3"
+                    },
+                    {
+                        "name": "CursorBlinkRate",
+                        "type": "string",
+                        "data": "530"
+                    },
+                    {
+                        "name": "DockMoving",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "DragFromMaximize",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "DragFullWindows",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "DragHeight",
+                        "type": "string",
+                        "data": "4"
+                    },
+                    {
+                        "name": "DragWidth",
+                        "type": "string",
+                        "data": "4"
+                    },
+                    {
+                        "name": "FocusBorderHeight",
+                        "type": "dword",
+                        "data": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+                    },
+                    {
+                        "name": "FocusBorderWidth",
+                        "type": "dword",
+                        "data": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+                    },
+                    {
+                        "name": "FontSmoothing",
+                        "type": "string",
+                        "data": "2"
+                    },
+                    {
+                        "name": "FontSmoothingGamma",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "FontSmoothingOrientation",
+                        "type": "dword",
+                        "data": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+                    },
+                    {
+                        "name": "FontSmoothingType",
+                        "type": "dword",
+                        "data": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+                    },
+                    {
+                        "name": "ForegroundFlashCount",
+                        "type": "dword",
+                        "data": "7902699be42c8a8e46fbbb4501726517e86b22c56a189f7625a6da49081b2451"
+                    },
+                    {
+                        "name": "ForegroundLockTimeout",
+                        "type": "dword",
+                        "data": "b552e632666bbf6125e3109e28a4fecc08340d017e44109dadbf497a280b8f82"
+                    },
+                    {
+                        "name": "LeftOverlapChars",
+                        "type": "string",
+                        "data": "3"
+                    },
+                    {
+                        "name": "MenuShowDelay",
+                        "type": "string",
+                        "data": "400"
+                    },
+                    {
+                        "name": "MouseWheelRouting",
+                        "type": "dword",
+                        "data": "d4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35"
+                    },
+                    {
+                        "name": "PaintDesktopVersion",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "Pattern",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "RightOverlapChars",
+                        "type": "string",
+                        "data": "3"
+                    },
+                    {
+                        "name": "ScreenSaveActive",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "SnapSizing",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "TileWallpaper",
+                        "type": "string",
+                        "data": "0"
+                    },
+                    {
+                        "name": "WallPaper",
+                        "type": "string",
+                        "data": "C:\\WINDOWS\\resources\\Themes\\W10_Dark_Graphite\\Wallpaper\\wall.jpg"
+                    },
+                    {
+                        "name": "WallpaperOriginX",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "WallpaperOriginY",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "WallpaperStyle",
+                        "type": "string",
+                        "data": "10"
+                    },
+                    {
+                        "name": "WheelScrollChars",
+                        "type": "string",
+                        "data": "3"
+                    },
+                    {
+                        "name": "WheelScrollLines",
+                        "type": "string",
+                        "data": "3"
+                    },
+                    {
+                        "name": "WindowArrangementActive",
+                        "type": "string",
+                        "data": "1"
+                    },
+                    {
+                        "name": "Win8DpiScaling",
+                        "type": "dword",
+                        "data": "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9"
+                    },
+                    {
+                        "name": "DpiScalingVer",
+                        "type": "dword",
+                        "data": "8b926d75599a618e21f1341318e66517be26e18cc7496783d2b59758c1333be8"
+                    },
+                    {
+                        "name": "UserPreferencesMask",
+                        "type": "binary",
+                        "data": "2d233bca82cd83699c9b0fc61e62acbfa2c7f9092084b792449993fe0c998d18"
+                    },
+                    {
+                        "name": "MaxVirtualDesktopDimension",
+                        "type": "dword",
+                        "data": "84b504f830bf8b6d2c233eead51d27a08d46a33ddf8225d90197e3f565f5d621"
+                    },
+                    {
+                        "name": "MaxMonitorDimension",
+                        "type": "dword",
+                        "data": "13105809c5b30ef11331cc0b62b71c70623c0353e7c32de4cf1d6d589bf3f286"
+                    },
+                    {
+                        "name": "TranscodedImageCount",
+                        "type": "dword",
+                        "data": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
+                    },
+                    {
+                        "name": "LastUpdated",
+                        "type": "dword",
+                        "data": "f807212b6748a8300fc3702322caa515edf0a6ed9bbc86e94c451e351b080c60"
+                    },
+                    {
+                        "name": "TranscodedImageCache",
+                        "type": "binary",
+                        "data": "eb9053233698dc8c9136e743d2c5c471f603a44191034960244da86161950e38"
+                    },
+                    {
+                        "name": "SCRNSAVE.EXE",
+                        "type": "string",
+                        "data": "c:\\windows\\system32\\mystify.scr"
+                    },
+                    {
+                        "name": "LockScreenAutoLockActive",
+                        "type": "string",
+                        "data": "0"
+                    },
+                    {
+                        "name": "ScreenSaveTimeOut",
+                        "type": "string",
+                        "data": "1200"
+                    },
+                    {
+                        "name": "ScreenSaverIsSecure",
+                        "type": "string",
+                        "data": "1"
+                    }
+                ],
+                "key": "HKEY_CURRENT_USER\\Control Panel\\Desktop",
+                "recursive": true,
+                "architecture": "machine"
+            },
+            "duration": "56",
+            "delta": "",
+            "ignore_failure": false,
+            "result": "create",
+            "status": "updated",
+            "cookbook_name": "windows_screensaver",
+            "cookbook_version": "0.1.11",
+            "recipe_name": "default"
+        }
+    ],
+    "run_id": "8e2886dd-58f5-4db0-b0d1-70e1f1af5466",
+    "run_list": [
+        "role[cpe_base]"
+    ],
+    "cookbooks": {
+        "cpe_init": {
+            "version": "0.1.105"
+        },
+        "cpe_utils": {
+            "version": "0.1.0"
+        },
+        "audit": {
+            "version": "7.4.1"
+        },
+        "chef-client": {
+            "version": "11.0.3"
+        },
+        "cron": {
+            "version": "5.1.0"
+        },
+        "logrotate": {
+            "version": "2.1.0"
+        },
+        "compat_resource": {
+            "version": "12.19.1"
+        },
+        "cpe_bluetooth": {
+            "version": "0.1.0"
+        },
+        "cpe_profiles": {
+            "version": "0.1.0"
+        },
+        "chefit-masterclient": {
+            "version": "0.1.20"
+        },
+        "cpe_desktop": {
+            "version": "0.1.0"
+        },
+        "cpe_chrome": {
+            "version": "0.1.0"
+        },
+        "cpe_choco": {
+            "version": "0.1.2"
+        },
+        "cpe_chef": {
+            "version": "0.1.2"
+        },
+        "cpe_crypt": {
+            "version": "0.1.0"
+        },
+        "cpe_launchd": {
+            "version": "0.1.2"
+        },
+        "cpe_remote": {
+            "version": "0.1.0"
+        },
+        "cpe_logger": {
+            "version": "0.1.0"
+        },
+        "cpe_hosts": {
+            "version": "0.2.0"
+        },
+        "cpe_macos_server": {
+            "version": "0.1.0"
+        },
+        "cpe_munki": {
+            "version": "0.3.0"
+        },
+        "cpe_nightly_reboot": {
+            "version": "0.1.0"
+        },
+        "cpe_pathsd": {
+            "version": "0.1.0"
+        },
+        "cpe_powermanagement": {
+            "version": "0.1.0"
+        },
+        "cpe_preferencepanes": {
+            "version": "0.1.0"
+        },
+        "cpe_prompt_user": {
+            "version": "0.1.0"
+        },
+        "cpe_screensaver": {
+            "version": "0.1.0"
+        },
+        "cpe_spotlight": {
+            "version": "0.1.0"
+        },
+        "cpe_batterycheck": {
+            "version": "0.1.0"
+        },
+        "cpe_botmanagement": {
+            "version": "0.1.0"
+        },
+        "slack_handler": {
+            "version": "1.0.0"
+        },
+        "windows_localadminaccount": {
+            "version": "0.1.3"
+        },
+        "windows_screensaver": {
+            "version": "0.1.11"
+        }
+    },
+    "policy_name": null,
+    "policy_group": null,
+    "start_time": "2020-04-06T20:45:25Z",
+    "end_time": "2020-04-06T20:45:33Z",
+    "source": "chef_client",
+    "status": "success",
+    "total_resource_count": 7,
+    "updated_resource_count": 2,
+    "deprecations": []
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
added command for all the desktop needs
- loads a few nodes then sets their last check in time to a long ago
- loads a few desktop reports, that should have all those special fields we need for the views
- loads some errored runs

### :athletic_shoe: How to Build and Test the Change
source .studio/ingest-service
load_desktop_reports
visit a2-url/desktop, see data

