### PR TITLE
Automate 3533/multiple dropdowns

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -49,7 +49,7 @@
             Also create owner, editor, and viewer policies for this project.
           </chef-checkbox>
         </div>
-        <div class="dropdown-margin" style="padding-left: 5em;" *ngIf="objectNoun === 'token'">
+        <div class="dropdown-margin" *ngIf="objectNoun === 'token'">
           <app-resource-dropdown
             [resources]="policies"
             [resourcesUpdated]="policiesUpdatedEvent"

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -49,7 +49,7 @@
             Also create owner, editor, and viewer policies for this project.
           </chef-checkbox>
         </div>
-        <div class="dropdown-margin" *ngIf="objectNoun === 'token'">
+        <div class="dropdown-margin" style="padding-left: 5em;" *ngIf="objectNoun === 'token'">
           <app-resource-dropdown
             [resources]="policies"
             [resourcesUpdated]="policiesUpdatedEvent"

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -1,7 +1,7 @@
 <label>{{ objectNounPlural | capitalize }}</label>
 <div class="dropdown-wrap">
   <button class="dropdown-button" attr.aria-label="Select {{ objectNounPlural }}"
-    (click)="toggleDropdown($event)"
+    (click)="toggleDropdown()"
     [ngClass]="{'active': active}"
     [disabled]="disabled"
     (keydown.arrowup)="moveFocus($event)"

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -2,7 +2,7 @@
 <div class="dropdown-wrap">
   <button class="dropdown-button" attr.aria-label="Select {{ objectNounPlural }}"
     (click)="toggleDropdown()"
-    [ngClass]="{'active': active}"
+    [ngClass]="{'active': dropdownState === 'open'}"
     [disabled]="disabled"
     (keydown.arrowup)="moveFocus($event)"
     (keydown.arrowdown)="moveFocus($event)">
@@ -11,7 +11,7 @@
     <chef-icon aria-hidden>keyboard_arrow_down</chef-icon>
   </button>
   <chef-click-outside (clickOutside)="handleClickOutside()">
-    <chef-dropdown [attr.visible]="active">
+    <chef-dropdown [attr.visible]="dropdownState === 'open'">
 
       <div id="filter-container">
         <input chefInput type="text" [(ngModel)]="filterValue" placeholder="Filter {{ objectNounPlural }}..."

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -10,7 +10,7 @@
     </div>
     <chef-icon aria-hidden>keyboard_arrow_down</chef-icon>
   </button>
-  <chef-click-outside (clickOutside)="closeDropdown()">
+  <chef-click-outside (clickOutside)="handleClickOutside()">
     <chef-dropdown [attr.visible]="active">
 
       <div id="filter-container">

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
@@ -1,9 +1,10 @@
-import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter, SimpleChange } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
+import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { ResourceDropdownComponent } from './resource-dropdown.component';
+import { ResourceDropdownComponent, ResourceChecked } from './resource-dropdown.component';
 
 describe('ResourceDropdownComponent', () => {
   let component: ResourceDropdownComponent;
@@ -11,11 +12,11 @@ describe('ResourceDropdownComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ResourceDropdownComponent ],
-      imports: [ ChefPipesModule, FormsModule ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      declarations: [ResourceDropdownComponent],
+      imports: [ChefPipesModule, FormsModule],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -48,15 +49,119 @@ describe('ResourceDropdownComponent', () => {
     });
 
     it('displays a list of checkbox options', () => {
-      const options = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
+      const options: HTMLInputElement[] = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
       expect(options.length).toEqual(component.filteredResources.length);
-      options.forEach((option: HTMLInputElement, index: number) => {
+      options.forEach((option, index) => {
         const { name, checked } = component.filteredResources[index];
         expect(option.textContent).toEqual(name);
         expect(option.checked).toEqual(checked);
       });
     });
 
+    it('allows customizing "none" designator', () => {
+      component.noneSelectedLabel = 'zilch';
+      component.ngOnChanges(
+        { resources: new SimpleChange([], [], true) });
+      expect(component.label).toEqual('zilch');
+    });
+
+    using([
+      ['single unchecked resource',
+        [
+          genResource('name1', false)
+        ]],
+      ['two resources but none checked',
+        [
+          genResource('name1', false),
+          genResource('name2', false)
+        ]]
+    ], function (description: string, resources: ResourceChecked[]) {
+      it(`displays 'none' designator for ${description}`, () => {
+        component.resources = resources;
+        component.ngOnChanges(
+          { resources: new SimpleChange([], resources, true) });
+        expect(component.label).toEqual('None');
+      });
+    });
+
+    using([
+      ['single checked resource',
+        [
+          genResource('target resource', true)
+        ]],
+      ['two resources but just one checked',
+        [
+          genResource('other resource2', false),
+          genResource('target resource', true)
+        ]],
+      ['multiple resources but just one checked in the middle',
+        [
+          genResource('other resource1', false),
+          genResource('other resource2', false),
+          genResource('target resource', true),
+          genResource('other resource3', false)
+        ]],
+      ['multiple resources but just one checked at the top',
+        [
+          genResource('target resource', true),
+          genResource('other resource1', false),
+          genResource('other resource2', false),
+          genResource('other resource3', false),
+          genResource('other resource4', false)
+        ]],
+      ['multiple resources but just one checked at the bottom',
+        [
+          genResource('other resource1', false),
+          genResource('other resource2', false),
+          genResource('target resource', true)
+        ]]
+    ], function (description: string, resources: ResourceChecked[]) {
+      it(`displays resource name for ${description}`, () => {
+        component.resources = resources;
+        component.ngOnChanges(
+          { resources: new SimpleChange([], resources, true) });
+        expect(component.label).toEqual('target resource');
+      });
+    });
+
+    using([
+      ['some checked and some not checked', 3,
+        [
+          genResource('name1', true),
+          genResource('name2', false),
+          genResource('name3', true),
+          genResource('name4', true),
+          genResource('name5', false)
+        ]],
+      ['all checked', 4,
+        [
+          genResource('name1', true),
+          genResource('name2', true),
+          genResource('name3', true),
+          genResource('name4', true)
+        ]],
+      ['just two and both checked', 2,
+        [
+          genResource('name1', true),
+          genResource('name2', true)
+        ]]
+    ], function (description: string, count: number, resources: ResourceChecked[]) {
+      it(`displays resource designator with count for multiple resources with ${description}`,
+        () => {
+          component.resources = resources;
+          component.objectNounPlural = 'lemurs';
+          component.ngOnChanges(
+            { resources: new SimpleChange([], resources, true) });
+          expect(component.label).toEqual(`${count} lemurs`);
+        });
+    });
   });
 
+  function genResource(name: string, checked: boolean): ResourceChecked {
+    return {
+      id: name.replace(' ', '-'),
+      name,
+      checked
+    };
+  }
 });

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
@@ -31,7 +31,7 @@ describe('ResourceDropdownComponent', () => {
 
   describe('dropdown', () => {
     beforeEach(() => {
-      component.active = true;
+      component.dropdownState = 'open';
       component.filteredResources = [
         {
           name: 'Project 1',

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -41,8 +41,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   // filteredResources is merely a container to hold the resources
   // that can be altered
   public filteredResources: ResourceChecked[] = [];
-  public active = false;
-  private activating = false;
+  public dropdownState: 'closed' | 'opening' | 'open' = 'closed';
   public label = this.noneSelectedLabel;
   public filterValue = '';
 
@@ -71,10 +70,12 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     if (this.disabled) {
       return;
     }
-    if (!this.active) { // opening
+    if (this.dropdownState === 'closed') { // opening
       this.filterValue = '';
       this.filteredResources = this.resourcesInOrder;
-      this.activating = true;
+      // we cannot go directly to 'open' because handleClickOutside,
+      // firing next on the same event that arrived here, would then immediately close it.
+      this.dropdownState = 'opening';
     } else { // closing
       this.closeDropdown();
     }
@@ -86,17 +87,19 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   }
 
   handleClickOutside(): void {
-    if (this.active) {
+    // Arriving here, the main goal is to close this dropdown if it is open.
+    if (this.dropdownState === 'open') {
       this.closeDropdown();
     }
-    if (this.activating) {
-      this.active = true;
-      this.activating = false;
+    // Now that we have checked the above,
+    // it is safe to complete opening if the click occurred when the dropdown was closed.
+    if (this.dropdownState === 'opening') {
+      this.dropdownState = 'open';
     }
   }
 
   closeDropdown(): void {
-    this.active = false;
+    this.dropdownState = 'closed';
     this.onDropdownClosing.emit(
       this.resources.filter(r => r.checked).map(r => r.id));
   }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -66,8 +66,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     return ChefSorters.naturalSort(this.resources, 'name');
   }
 
-  toggleDropdown(event: MouseEvent): void {
-    event.stopPropagation();
+  toggleDropdown(): void {
     if (this.disabled) {
       return;
     }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -42,6 +42,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   // that can be altered
   public filteredResources: ResourceChecked[] = [];
   public active = false;
+  private activating = false;
   public label = this.noneSelectedLabel;
   public filterValue = '';
 
@@ -73,7 +74,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     if (!this.active) { // opening
       this.filterValue = '';
       this.filteredResources = this.resourcesInOrder;
-      this.active = true;
+      this.activating = true;
     } else { // closing
       this.closeDropdown();
     }
@@ -87,6 +88,10 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   handleClickOutside(): void {
     if (this.active) {
       this.closeDropdown();
+    }
+    if (this.activating) {
+      this.active = true;
+      this.activating = false;
     }
   }
 

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -85,12 +85,16 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     this.updateLabel();
   }
 
-  closeDropdown(): void {
+  handleClickOutside(): void {
     if (this.active) {
-      this.active = false;
-      this.onDropdownClosing.emit(
-        this.resources.filter(r => r.checked).map(r => r.id));
+      this.closeDropdown();
     }
+  }
+
+  closeDropdown(): void {
+    this.active = false;
+    this.onDropdownClosing.emit(
+      this.resources.filter(r => r.checked).map(r => r.id));
   }
 
   handleFilterKeyUp(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The mechanism for auto-closing a dropdown when the user clicked anywhere outside its boundaries proved insufficient when putting two dropdowns in the same view.
This PR adds the necessary support.

#### Problem Exposition
The issue was exposed in the CreateObjectModalComponent when used for creating a token specifically, as that is where two dropdowns appear (one for policies, one for projects).

Those two dropdowns _almost_ co-existed peacefully. 
✅ If you opened either one, interacted with it, and closed it that worked.
✅ If you opened either one, and clicked elsewhere on static space in the modal, the dropdown closed.
✅ If you opened either one, and clicked even in an active input field, the dropdown closed.
❌ If however, you opened projects (1), then opened policies (2), it failed to close the projects dropdown and (rather awkwardly) put the freshly opened policies dropdown behind the projects dropdown!
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/6817500/82164857-92319d80-9867-11ea-9d23-b2f39e7ef574.png">


#### Problem Description
The capability that provides the elegant close-me-if-you-click-outside is at the heart of the problem. When you click anywhere, it triggers the "check-if-outside" handler action. _This is true even if you are clicking on the dropdown itself._ 

If you actually are clicking outside the dropdown, the "check-if-outside" handler does what it should.
But if you are clicking the dropdown itself to close it, that click emits an event that first triggers a toggle handler to close the dropdown, and then triggers the "check-if-outside" handler action. The toggle handler in its original rendition knew that, if reached, we were not actually outside. It therefore suppressed that event propagation so it never went to the check-outside handler: 
https://github.com/chef/automate/blob/0278ed975f8029ad65351a12a89284b3123dfd4c/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts#L69-L70 

Neat and simple. But that no longer works with multiple dropdowns. Suppressing the event propagation left the dropdown open--_you could not close it!_

#### Problem Resolution
I first realized that I had to allow the event propagation to proceed in order for things to work.
But that created its own problem--now, _you could not open it!_
(Why? The toggle handler toggled it open, then the "check-if-outside" handler immediately closed it. 🤷 )
The solution was that the "check-if-outside" handler had to be able to distinguish not just open and closed but also an intermediate state--opening.
That allowed opening and closing the modal to work, and open and closing _other_ modals to work.

### :chains: Related Resources
NA

### :+1: Definition of Done
Clicking outside any open dropdown closes that dropdown.

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui.
Create at least one project (Settings >> Projects >> Create Project).
Navigate to Settings >> Tokens >> Create Token.
Open the projects dropdown by clicking on it.
Now open the policies dropdown; this should simultaneously close the projects dropdown:
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/6817500/82164880-b4c3b680-9867-11ea-8d50-b0274ee5d721.png">

That seems to have worked--but did it really close the projects dropdown--or just open the policies dropdown in front of it?
To prove it really closed the projects dropdown, run `git revert -n 8e73ce4`, rebuild and try again. (The only change was shifting the policy dropdown so the project dropdown remains visible.)
Refresh the page and run the trial again and you will see indeed that the other dropdown has closed:
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/6817500/82164915-db81ed00-9867-11ea-84c3-c19bd3fbd4ff.png">

Also, now you can try them in the other order, too, i.e., click (2) then click (1).

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).