### PR TITLE
Clients list view tab on org details page

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -69,6 +69,7 @@ import { AutomateSettingsRequests } from './entities/automate-settings/automate-
 import { CookbookRequests } from './entities/cookbooks/cookbook.requests';
 import { CookbookDetailsRequests } from './entities/cookbooks/cookbook-details.requests';
 import { CookbookVersionsRequests } from './entities/cookbooks/cookbook-versions.requests';
+import { ClientRequests } from './entities/clients/client.requests';
 import { ClientRunsRequests } from './entities/client-runs/client-runs.requests';
 import { CredentialRequests } from './entities/credentials/credential.requests';
 import { DataBagsRequests } from './entities/data-bags/data-bags.requests';
@@ -292,6 +293,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     CookbookDetailsRequests,
     CookbookRequests,
     CookbookVersionsRequests,
+    ClientRequests,
     CredentialRequests,
     DataBagsRequests,
     DesktopRequests,

--- a/components/automate-ui/src/app/entities/clients/client.action.ts
+++ b/components/automate-ui/src/app/entities/clients/client.action.ts
@@ -1,0 +1,33 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+import { Client } from './client.model';
+
+export enum ClientActionTypes {
+  GET_ALL = 'CLIENTS::GET_ALL',
+  GET_ALL_SUCCESS = 'CLIENTS::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'CLIENTS::GET_ALL::FAILURE'
+}
+
+export interface ClientsSuccessPayload {
+  clients: Client[];
+}
+
+export class GetClients implements Action {
+  readonly type = ClientActionTypes.GET_ALL;
+  constructor(public payload: { server_id: string, org_id: string }) { }
+}
+
+export class GetClientsSuccess implements Action {
+  readonly type = ClientActionTypes.GET_ALL_SUCCESS;
+  constructor(public payload: ClientsSuccessPayload) { }
+}
+
+export class GetClientsFailure implements Action {
+  readonly type = ClientActionTypes.GET_ALL_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type ClientActions =
+  | GetClients
+  | GetClientsSuccess
+  | GetClientsFailure;

--- a/components/automate-ui/src/app/entities/clients/client.effects.ts
+++ b/components/automate-ui/src/app/entities/clients/client.effects.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetClients,
+  GetClientsSuccess,
+  ClientsSuccessPayload,
+  GetClientsFailure,
+  ClientActionTypes
+} from './client.action';
+
+import { ClientRequests } from './client.requests';
+
+@Injectable()
+export class ClientEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: ClientRequests
+  ) { }
+
+  @Effect()
+  getClients$ = this.actions$.pipe(
+      ofType(ClientActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id, org_id } }: GetClients) =>
+        this.requests.getClients(server_id, org_id).pipe(
+          map((resp: ClientsSuccessPayload) => new GetClientsSuccess(resp)),
+          catchError((error: HttpErrorResponse) =>
+          observableOf(new GetClientsFailure(error))))));
+
+  @Effect()
+  getEnvironmentsFailure$ = this.actions$.pipe(
+      ofType(ClientActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetClientsFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get clients: ${msg || payload.error}`
+        });
+      }));
+
+}

--- a/components/automate-ui/src/app/entities/clients/client.model.ts
+++ b/components/automate-ui/src/app/entities/clients/client.model.ts
@@ -1,0 +1,3 @@
+export interface Client {
+  name: string;
+}

--- a/components/automate-ui/src/app/entities/clients/client.reducer.ts
+++ b/components/automate-ui/src/app/entities/clients/client.reducer.ts
@@ -1,0 +1,47 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set, pipe } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { ClientActionTypes, ClientActions } from './client.action';
+import { Client } from './client.model';
+
+export interface ClientEntityState extends EntityState<Client> {
+  clientsStatus: EntityStatus;
+  getAllStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+
+export const clientEntityAdapter: EntityAdapter<Client> =
+  createEntityAdapter<Client>({
+  selectId: (client: Client) => client.name
+});
+
+export const ClientEntityInitialState: ClientEntityState =
+  clientEntityAdapter.getInitialState(<ClientEntityState>{
+  getAllStatus: EntityStatus.notLoaded
+});
+
+export function clientEntityReducer(
+  state: ClientEntityState = ClientEntityInitialState,
+  action: ClientActions): ClientEntityState {
+
+  switch (action.type) {
+    case ClientActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, clientEntityAdapter.removeAll(state));
+
+    case ClientActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (clientEntityAdapter.setAll(action.payload.clients, state)) as
+        ClientEntityState;
+
+    case ClientActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}
+
+export const getEntityById = (id: string) =>
+  (state: ClientEntityState) => state.entities[id];

--- a/components/automate-ui/src/app/entities/clients/client.requests.ts
+++ b/components/automate-ui/src/app/entities/clients/client.requests.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { ClientsSuccessPayload } from './client.action';
+
+@Injectable()
+export class ClientRequests {
+
+  constructor(private http: HttpClient) { }
+
+  // tslint:disable-next-line: max-line-length
+  public getClients(server_id: string, org_id: string):
+    Observable<ClientsSuccessPayload> {
+    return this.http.get<ClientsSuccessPayload>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/clients`);
+  }
+}

--- a/components/automate-ui/src/app/entities/clients/client.selectors.ts
+++ b/components/automate-ui/src/app/entities/clients/client.selectors.ts
@@ -1,0 +1,18 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import { ClientEntityState, clientEntityAdapter } from './client.reducer';
+
+export const clientState = createFeatureSelector<ClientEntityState>('clients');
+export const {
+  selectAll: allClients,
+  selectEntities: clientEntities
+} = clientEntityAdapter.getSelectors(clientState);
+
+export const clientStatus = createSelector(
+  clientState,
+  (state) => state.clientsStatus
+);
+
+export const getAllStatus = createSelector(
+  clientState,
+  (state) => state.getAllStatus
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.html
@@ -1,0 +1,17 @@
+<section class="clients">
+  <chef-loading-spinner *ngIf="clientsListLoading" size="50"></chef-loading-spinner>
+  <ng-container *ngIf="!clientsListLoading">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-th>Clients Name</chef-th>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let client of clients">
+          <chef-td>{{ client.name }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.scss
@@ -1,0 +1,35 @@
+@import "~styles/variables";
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.spec.ts
@@ -1,0 +1,62 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClientsComponent } from './clients.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+
+describe('EnvironmentsComponent', () => {
+  let component: ClientsComponent;
+  let fixture: ComponentFixture<ClientsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
+        ClientsComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClientsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { GetClients } from 'app/entities/clients/client.action';
+import { Client } from 'app/entities/clients/client.model';
+import {
+  allClients,
+  getAllStatus as getAllClientsForOrgStatus
+} from 'app/entities/clients/client.selectors';
+
+
+@Component({
+  selector: 'app-clients',
+  templateUrl: './clients.component.html',
+  styleUrls: ['./clients.component.scss']
+})
+
+export class ClientsComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public clients: Client[] = [];
+  public clientsListLoading = true;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetClients({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllClientsForOrgStatus),
+      this.store.select(allClients)
+    ]).pipe(
+      filter(([getClientsSt, _allClientsState]) =>
+      getClientsSt === EntityStatus.loadingSuccess && !isNil(_allClientsState))
+    ).subscribe(([ _getClientsSt, allClientsState]) => {
+      this.clients = allClientsState;
+      this.clientsListLoading = false;
+    });
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -7,6 +7,7 @@ import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
 import { ChefComponentsModule } from 'app/components/chef-components.module';
 import { ChefServerDetailsComponent } from './chef-server-details/chef-server-details.component';
 import { ChefServersListComponent } from './chef-servers-list/chef-servers-list.component';
+import { ClientsComponent } from './clients/clients.component';
 import { CookbooksComponent } from './cookbooks/cookbooks.component';
 import { CookbookDetailsComponent } from './cookbook-details/cookbook-details.component';
 import { CreateChefServerModalComponent } from './create-chef-server-modal/create-chef-server-modal.component';
@@ -24,6 +25,7 @@ import { TreeTableModule } from './tree-table/tree-table.module';
   declarations: [
     ChefServersListComponent,
     ChefServerDetailsComponent,
+    ClientsComponent,
     CookbooksComponent,
     CookbookDetailsComponent,
     CreateChefServerModalComponent,

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -37,6 +37,9 @@
           <app-tab tabTitle="Data Bags" #data_bags_tab  [active]="dataBagsTab">
             <app-data-bags-list *ngIf="data_bags_tab.active" [serverId]="serverId" [orgId]="orgId"></app-data-bags-list>
           </app-tab>
+          <app-tab tabTitle="Clients" #clients_tab  [active]="clientsTab">
+            <app-clients *ngIf="clients_tab.active" [serverId]="serverId" [orgId]="orgId"></app-clients>
+          </app-tab>
           <app-tab tabTitle="Details" #details_tab [active]="false">
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
           </app-tab>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -30,6 +30,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   public environmentsTab = false;
   public rolesTab = false;
   public dataBagsTab = false;
+  public clientsTab = false;
   private isDestroyed = new Subject<boolean>();
 
   previousRoute$: Observable<RouterState>;
@@ -99,6 +100,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         this.telemetryService.track('orgDetailsTab', 'dataBags');
         break;
       case 4:
+        this.telemetryService.track('orgDetailsTab', 'clients');
+        break;
+      case 5:
         this.telemetryService.track('orgDetailsTab', 'org-edit');
         break;
     }

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -7,6 +7,7 @@ import { ClientRunsEffects } from './entities/client-runs/client-runs.effects';
 import { CookbookEffects } from './entities/cookbooks/cookbook.effects';
 import { CookbookDetailsEffects } from './entities/cookbooks/cookbook-details.effects';
 import { CookbookVersionsEffects } from './entities/cookbooks/cookbook-versions.effects';
+import { ClientEffects } from './entities/clients/client.effects';
 import { CredentialsEffects } from './pages/+compliance/+credentials/credentials.state';
 // CredentialEffect is for the credential entities. Don't confuse it with CredentialsEffects.
 // CredentialsEffects will be removed when the credentials page is refactored.
@@ -45,6 +46,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       CookbookEffects,
       CookbookDetailsEffects,
       CookbookVersionsEffects,
+      ClientEffects,
       CredentialsEffects,
       CredentialEffects,
       DataBagsEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -8,6 +8,7 @@ import * as eventFeed from './services/event-feed/event-feed.reducer';
 import * as projectsFilter from './services/projects-filter/projects-filter.reducer';
 import * as apiToken from './entities/api-tokens/api-token.reducer';
 import * as automateSettings from './entities/automate-settings/automate-settings.reducer';
+import * as clientEntity from './entities/clients/client.reducer';
 import * as clientRuns from './entities/client-runs/client-runs.reducer';
 import * as cookbookEntity from './entities/cookbooks/cookbook.reducer';
 import * as cookbookDetailsEntity from './entities/cookbooks/cookbook-details.reducer';
@@ -66,6 +67,7 @@ export interface NgrxStateAtom {
   automateSettings: automateSettings.AutomateSettingsEntityState;
   clientRunsEntity: clientRuns.ClientRunsEntityState;
   cookbooks: cookbookEntity.CookbookEntityState;
+  clients: clientEntity.ClientEntityState;
   cookbookDetails: cookbookDetailsEntity.CookbookDetailsEntityState;
   cookbookVersions: cookbookVersionsEntity.CookbookVersionsEntityState;
   dataBags: dataBagsEntity.DataBagsEntityState;
@@ -180,6 +182,7 @@ export const defaultInitialState = {
   // Entities
   apiTokens: apiToken.ApiTokenEntityInitialState,
   automateSettings: automateSettings.AutomateSettingsEntityInitialState,
+  clients: clientEntity.ClientEntityInitialState,
   clientRunsEntity: clientRuns.ClientRunsEntityInitialState,
   cookbooks: cookbookEntity.CookbookEntityInitialState,
   cookbookDetails: cookbookDetailsEntity.CookbookDetailsEntityInitialState,
@@ -229,6 +232,7 @@ export const ngrxReducers = {
   // Entities
   apiTokens: apiToken.apiTokenEntityReducer,
   automateSettings: automateSettings.automateSettingsEntityReducer,
+  clients: clientEntity.clientEntityReducer,
   clientRunsEntity: clientRuns.clientRunsEntityReducer,
   cookbooks: cookbookEntity.cookbookEntityReducer,
   cookbookDetails: cookbookDetailsEntity.cookbookDetailsEntityReducer,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added Infra proxy clients list view tab on the org details page.
### :chains: Related Resources
https://github.com/chef/automate/issues/3463
### :+1: Definition of Done
Added clients tab after the data bags tab on the org details page where we are displaying the client's lists.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![clients](https://user-images.githubusercontent.com/12297653/82194584-ab445800-9914-11ea-883a-bcc787ee242e.png)
