### PR TITLE
Apps tab: Correctly support 64bit IDs in all the code

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -131,7 +131,7 @@ steps:
   - label: "applications-service"
     command:
       - . scripts/verify_setup.sh
-      - hab studio run "source scripts/verify_studio_init.sh && start_applications_service_deps && applications_integration"
+      - hab studio run "source scripts/verify_studio_init.sh && start_applications_service_deps && applications_set_service_seq_to_int_max && applications_integration"
     timeout_in_minutes: 20
     expeditor:
       executor:

--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -18,6 +18,16 @@ function start_applications_service_deps() {
   chef-automate dev remove-some "$(app_service_origin)/applications-service"
 }
 
+document "applications_set_service_seq_to_int_max" <<DOC
+  Set the service table's ID sequence to the max size for 32 bit integer.
+  Subsequent database operations expecting 32bit integers should fail, thus you
+  can test that all necessary code paths have been updated for the change from
+  32bit to 64bit.
+DOC
+function applications_set_service_seq_to_int_max() {
+  chef-automate dev psql chef_applications_service -- -c "SELECT setval('service_full_id_seq', 2147483647)"
+}
+
 
 document "applications_list_services" <<DOC
   List all the applications-service services

--- a/components/applications-service/pkg/storage/client.go
+++ b/components/applications-service/pkg/storage/client.go
@@ -87,7 +87,7 @@ func HabitatUpdateStrategyToStorageFormat(strategy habitat.UpdateStrategy) Updat
 }
 
 type Service struct {
-	ID                  int32
+	ID                  int64
 	SupMemberID         string
 	Origin              string
 	Name                string

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -16,7 +16,7 @@ import (
 // composedService is a more user friendly and clear representation of a service.
 // it is composed by values from other tables inside the database (JOINs)
 type composedService struct {
-	ID                  int32     `db:"id"`
+	ID                  int64     `db:"id"`
 	SupMemberID         string    `db:"sup_member_id"`
 	Origin              string    `db:"origin"`
 	Name                string    `db:"name"`


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In #3560 we fixed ingestion of services when the sequence generator for IDs had exceeded the max size of a 32 bit integer. There is some code used to generate the dashboard that's still expecting 32 bit integers for the IDs, it needs to be updated for 64 bit.
