### PR TITLE
Desktop deployment UI

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -57,6 +57,7 @@ import {
 } from './services/node-details/node-noruns-details-resolver.service';
 import { NodeRunsService } from './services/node-details/node-runs.service';
 import { ProjectService } from './entities/projects/project.service';
+import { ProductDeployedService } from './services/product-deployed/product-deployed.service';
 import { ProjectsFilterService } from './services/projects-filter/projects-filter.service';
 import { RulesService } from './services/rules/rules.service';
 import { RunHistoryStore } from './services/run-history-store/run-history.store';
@@ -318,6 +319,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     NodeDetailsService,
     NodeRunsService,
     PolicyRequests,
+    ProductDeployedService,
     ProfileRequests,
     ProjectRequests,
     ProjectService,

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -12,10 +12,10 @@
         <div role="menuitem" class="nav-link"><a routerLink="/dashboards/event-feed" routerLinkActive="active" tabindex="0">Dashboards</a></div>
       </app-authorized>
 
-      <app-authorized [allOf]="[
+      <app-authorized *ngIf="isDesktopView" [allOf]="[
           ['/api/v0/cfgmgmt/nodes', 'get'],
           ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
-        <div *ngIf="isDesktopView" role="menuitem" class="nav-link"><a routerLink="/desktop" routerLinkActive="active" tabindex="0">Desktop</a></div>
+        <div role="menuitem" class="nav-link"><a routerLink="/desktop" routerLinkActive="active" tabindex="0">Desktop</a></div>
       </app-authorized>
 
       <app-authorized [allOf]="[

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -13,6 +13,12 @@
       </app-authorized>
 
       <app-authorized [allOf]="[
+          ['/api/v0/cfgmgmt/nodes', 'get'],
+          ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
+        <div *ngIf="isDesktopView()" role="menuitem" class="nav-link"><a routerLink="/desktop" routerLinkActive="active" tabindex="0">Desktop</a></div>
+      </app-authorized>
+
+      <app-authorized [allOf]="[
           ['/api/v0/applications/services', 'get'],
           ['/api/v0/applications/service-groups', 'get']]">
         <div role="menuitem" class="nav-link"><a routerLink="/applications/service-groups" routerLinkActive="active" tabindex="0">Applications</a></div>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -15,7 +15,7 @@
       <app-authorized [allOf]="[
           ['/api/v0/cfgmgmt/nodes', 'get'],
           ['/api/v0/cfgmgmt/stats/node_counts', 'get']]">
-        <div *ngIf="isDesktopView()" role="menuitem" class="nav-link"><a routerLink="/desktop" routerLinkActive="active" tabindex="0">Desktop</a></div>
+        <div *ngIf="isDesktopView" role="menuitem" class="nav-link"><a routerLink="/desktop" routerLinkActive="active" tabindex="0">Desktop</a></div>
       </app-authorized>
 
       <app-authorized [allOf]="[

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.spec.ts
@@ -10,67 +10,138 @@ import {
   PolicyEntityInitialState,
   policyEntityReducer
 } from 'app/entities/policies/policy.reducer';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
+
+class MockProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(_product: string): boolean {
+    return false;
+  }
+}
+
+class MockDesktopProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(product: string): boolean {
+    return product === 'desktop';
+  }
+}
 
 describe('NavbarComponent', () => {
   let element: HTMLElement;
   let fixture: ComponentFixture<NavbarComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        StoreModule.forRoot({
-          policies: policyEntityReducer
-        }, {
-          initialState: { policies: PolicyEntityInitialState },
-          runtimeChecks
-        })
-      ],
-      declarations: [
-        NavbarComponent,
-        MockComponent({ selector: 'app-profile' }),
-        MockComponent({ selector: 'app-projects-filter' }),
-        MockComponent({ selector: 'chef-icon' }),
-        MockComponent({ selector: 'chef-tooltip' }),
-        MockComponent({ selector: 'app-authorized',
-                        inputs: ['allOf', 'anyOf'],
-                        template: '<ng-content></ng-content>' })
-      ],
-      providers: [
-        FeatureFlagsService
-      ]
+  describe('non-desktop view', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          StoreModule.forRoot({
+            policies: policyEntityReducer
+          }, {
+            initialState: { policies: PolicyEntityInitialState },
+            runtimeChecks
+          })
+        ],
+        declarations: [
+          NavbarComponent,
+          MockComponent({ selector: 'app-profile' }),
+          MockComponent({ selector: 'app-projects-filter' }),
+          MockComponent({ selector: 'chef-icon' }),
+          MockComponent({ selector: 'chef-tooltip' }),
+          MockComponent({ selector: 'app-authorized',
+                          inputs: ['allOf', 'anyOf'],
+                          template: '<ng-content></ng-content>' })
+        ],
+        providers: [
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useClass: MockProductDeployedService }
+        ]
+      });
+
+      fixture = TestBed.createComponent(NavbarComponent);
+      fixture.detectChanges();
+      element = fixture.nativeElement;
     });
 
-    fixture = TestBed.createComponent(NavbarComponent);
-    fixture.detectChanges();
-    element = fixture.nativeElement;
-  });
+    it('displays the logo navigation link', () => {
+      const logo = element.querySelector('.logo');
+      expect(logo).not.toBeNull();
+      expect(logo.getAttribute('href')).toBe('/');
+    });
 
-  it('displays the logo navigation link', () => {
-    const logo = element.querySelector('.logo');
-    expect(logo).not.toBeNull();
-    expect(logo.getAttribute('href')).toBe('/');
-  });
+    using([
+      ['Dashboards',     '/dashboards/event-feed',         1],
+      ['Applications',   '/applications/service-groups',   2],
+      ['Infrastructure', '/infrastructure',                3],
+      ['Compliance',     '/compliance',                    4],
+      ['Settings',       '/settings',                      5]
+    ], function (label: string, path: string, position: number) {
+      it(`displays the ${label} navigation link`, () => {
+        const link = element.querySelector(`.navigation-menu > *:nth-child(${position}) a`);
+        expect(link.textContent).toBe(label);
+        expect(link.getAttribute('href')).toBe(path);
+      });
+    });
 
-  using([
-    ['Dashboards',     '/dashboards/event-feed',         1],
-    ['Applications',   '/applications/service-groups',   2],
-    ['Infrastructure', '/infrastructure',                3],
-    ['Compliance',     '/compliance',                    4],
-    ['Settings',       '/settings',                      5]
-  ], function (label: string, path: string, position: number) {
-    it(`displays the ${label} navigation link`, () => {
-      const link = element.querySelector(`.navigation-menu > *:nth-child(${position}) a`);
-      expect(link.textContent).toBe(label);
-      expect(link.getAttribute('href')).toBe(path);
+    it('displays the profile dropdown', () => {
+      expect(element.querySelector('app-profile')).not.toBeNull();
+    });
+
+    it('displays the projects filter', () => {
+      expect(element.querySelector('app-projects-filter')).not.toBeNull();
     });
   });
 
-  it('displays the profile dropdown', () => {
-    expect(element.querySelector('app-profile')).not.toBeNull();
-  });
+  describe('desktop view', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          StoreModule.forRoot({
+            policies: policyEntityReducer
+          }, {
+            initialState: { policies: PolicyEntityInitialState },
+            runtimeChecks
+          })
+        ],
+        declarations: [
+          NavbarComponent,
+          MockComponent({ selector: 'app-profile' }),
+          MockComponent({ selector: 'app-projects-filter' }),
+          MockComponent({ selector: 'chef-icon' }),
+          MockComponent({ selector: 'chef-tooltip' }),
+          MockComponent({ selector: 'app-authorized',
+                          inputs: ['allOf', 'anyOf'],
+                          template: '<ng-content></ng-content>' })
+        ],
+        providers: [
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useClass: MockDesktopProductDeployedService }
+        ]
+      });
 
-  it('displays the projects filter', () => {
-    expect(element.querySelector('app-projects-filter')).not.toBeNull();
+      fixture = TestBed.createComponent(NavbarComponent);
+      fixture.detectChanges();
+      element = fixture.nativeElement;
+    });
+
+    using([
+      ['Dashboards',     '/dashboards/event-feed',         1],
+      ['Desktop',        '/desktop',                       2],
+      ['Applications',   '/applications/service-groups',   3],
+      ['Infrastructure', '/infrastructure',                4],
+      ['Compliance',     '/compliance',                    5],
+      ['Settings',       '/settings',                      6]
+    ], function (label: string, path: string, position: number) {
+      it(`displays the ${label} navigation link`, () => {
+        const link = element.querySelector(`.navigation-menu > *:nth-child(${position}) a`);
+        expect(link.textContent).toBe(label);
+        expect(link.getAttribute('href')).toBe(path);
+      });
+    });
   });
 });

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
@@ -1,4 +1,6 @@
 import { Component, isDevMode } from '@angular/core';
+import { isProductDeployed } from 'app/staticConfig';
+
 @Component({
   selector: 'app-navbar',
   templateUrl: './navbar.component.html',
@@ -11,5 +13,9 @@ export class NavbarComponent {
 
   isDevMode() {
     return isDevMode();
+  }
+
+  isDesktopView(): boolean {
+    return isProductDeployed('desktop');
   }
 }

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.ts
@@ -1,5 +1,5 @@
-import { Component, isDevMode } from '@angular/core';
-import { isProductDeployed } from 'app/staticConfig';
+import { Component } from '@angular/core';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
 
 @Component({
   selector: 'app-navbar',
@@ -9,13 +9,9 @@ import { isProductDeployed } from 'app/staticConfig';
 
 export class NavbarComponent {
 
-  constructor() {}
+  public isDesktopView = false;
 
-  isDevMode() {
-    return isDevMode();
-  }
-
-  isDesktopView(): boolean {
-    return isProductDeployed('desktop');
+  constructor(private productDeployedService: ProductDeployedService) {
+    this.isDesktopView = this.productDeployedService.isProductDeployed('desktop');
   }
 }

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.spec.ts
@@ -5,34 +5,103 @@ import { MockComponent } from 'ng2-mock-component';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { TopNavLandingComponent } from './top-nav-landing.component';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
+
+class MockProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(_product: string): boolean {
+    return false;
+  }
+}
+
+class MockDesktopProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(product: string): boolean {
+    return product === 'desktop';
+  }
+}
 
 describe('TopNavLandingComponent', () => {
   let component: TopNavLandingComponent;
   let fixture: ComponentFixture<TopNavLandingComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      providers: [
-        FeatureFlagsService
-      ],
-       declarations: [
-        TopNavLandingComponent,
-        MockComponent({ selector: 'app-landing', inputs: ['routePerms', 'onNotFound'] })
-      ]
-    })
-    .compileComponents();
-  }));
+  describe('non Desktop view', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        providers: [
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useClass: MockProductDeployedService }
+        ],
+        declarations: [
+          TopNavLandingComponent,
+          MockComponent({ selector: 'app-landing', inputs: ['routePerms', 'onNotFound'] })
+        ]
+      })
+      .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(TopNavLandingComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TopNavLandingComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('order of start pages', () => {
+      expect(component.routeList[0].route).toEqual('/dashboards/event-feed');
+      expect(component.routeList[1].route).toEqual('/applications/service-groups');
+      expect(component.routeList[2].route).toEqual('/infrastructure');
+      expect(component.routeList[3].route).toEqual('/compliance');
+      expect(component.routeList[4].route).toEqual('/settings');
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('Desktop view', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        providers: [
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useClass: MockDesktopProductDeployedService }
+        ],
+        declarations: [
+          TopNavLandingComponent,
+          MockComponent({ selector: 'app-landing', inputs: ['routePerms', 'onNotFound'] })
+        ]
+      })
+      .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(TopNavLandingComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('order of start pages', () => {
+      expect(component.routeList[0].route).toEqual('/dashboards/event-feed');
+      expect(component.routeList[1].route).toEqual('/desktop');
+      expect(component.routeList[2].route).toEqual('/applications/service-groups');
+      expect(component.routeList[3].route).toEqual('/infrastructure');
+      expect(component.routeList[4].route).toEqual('/compliance');
+      expect(component.routeList[5].route).toEqual('/settings');
+    });
+
   });
 });

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -20,6 +20,12 @@ export class TopNavLandingComponent {
       ], route: '/dashboards/event-feed'
     },
     {
+      allOfCheck: [
+        ['/api/v0/cfgmgmt/nodes', 'get'],
+        ['/api/v0/cfgmgmt/stats/node_counts', 'get']
+      ], route: '/desktop'
+    },
+    {
       anyOfCheck: [
         ['/api/v0/applications/services', 'get'],
         ['/api/v0/applications/service-groups', 'get']

--- a/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
+++ b/components/automate-ui/src/app/pages/top-nav-landing/top-nav-landing.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RoutePerms } from 'app/components/landing/landing.component';
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
 
 @Component({
   selector: 'app-top-nav-landing',
@@ -18,12 +19,6 @@ export class TopNavLandingComponent {
         ['/api/v0/event_type_counts', 'get'],
         ['/api/v0/event_task_counts', 'get']
       ], route: '/dashboards/event-feed'
-    },
-    {
-      allOfCheck: [
-        ['/api/v0/cfgmgmt/nodes', 'get'],
-        ['/api/v0/cfgmgmt/stats/node_counts', 'get']
-      ], route: '/desktop'
     },
     {
       anyOfCheck: [
@@ -64,7 +59,19 @@ export class TopNavLandingComponent {
     }
   ];
 
-  constructor(public layoutFacade: LayoutFacadeService) { }
+  constructor(public layoutFacade: LayoutFacadeService,
+    productDeployed: ProductDeployedService) {
+    if ( productDeployed.isProductDeployed('desktop') ) {
+      this.routeList.splice(1, 0,
+        {
+          allOfCheck: [
+            ['/api/v0/cfgmgmt/nodes', 'get'],
+            ['/api/v0/cfgmgmt/stats/node_counts', 'get']
+          ], route: '/desktop'
+        }
+      );
+    }
+  }
 
   SetPageCoverage = () => this.layoutFacade.showFullPagePlusTopBar();
 }

--- a/components/automate-ui/src/app/services/product-deployed/product-deployed.service.ts
+++ b/components/automate-ui/src/app/services/product-deployed/product-deployed.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { isProductDeployed as staticIsProductDeployed } from 'app/staticConfig';
+
+@Injectable()
+export class ProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(product: string): boolean {
+    return staticIsProductDeployed( product );
+  }
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Display the Desktop nav on the top of the Automate page only when the Desktop in install. Added the desktop page to be the second page (after the event feed) to default to based on the user's permissions. 

### :chains: Related Resources
#3244 

### :athletic_shoe: How to Build and Test the Change
1. `start_all_services && start_automate_ui_background && ui_logs`
1. Open https://a2-dev.test/ and ensure the "Desktop" nav is not displayed. 
1. `enable_desktop` Wait about 10 seconds for it to apply
1. Open https://a2-dev.test/ and ensure the "Desktop" nav is displayed. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Below shows the "Desktop" nav link. 
![image](https://user-images.githubusercontent.com/1679247/82506371-766f0700-9ab4-11ea-9b19-f8595efe4c20.png)