### PR TITLE
Ensure sidebar entries receive icon rotation

### DIFF
--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.html
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.html
@@ -15,6 +15,7 @@
                 [id]="'entry' + groupIndex + '-' + itemIndex"
                 [route]="menuItem.route"
                 [icon]="menuItem.icon"
+                [iconRotation]="menuItem.iconRotation"
                 [customIcon]="menuItem.customIcon"
                 [openInNewPage]="menuItem.openInNewPage"
               >{{ menuItem.name }}</chef-sidebar-entry>
@@ -32,6 +33,7 @@
                   [id]="'entry' + groupIndex + '-' + itemIndex"
                   [route]="menuItem.route"
                   [icon]="menuItem.icon"
+                  [iconRotation]="menuItem.iconRotation"
                   [customIcon]="menuItem.customIcon"
                   [openInNewPage]="menuItem.openInNewPage"
                 >{{ menuItem.name }}</chef-sidebar-entry>


### PR DESCRIPTION
This commit fixes https://github.com/chef/automate/issues/3726. `chef-sidebar-entry` was setup to have its icon rotations configurable but this setting wasn't being utilized.

![](https://user-images.githubusercontent.com/479121/82263503-442ca080-9920-11ea-87ac-92894069fae3.png)
