### PR TITLE
automate-3081 ui flicker on applications tab

### DIFF
--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -69,7 +69,9 @@ export function serviceGroupsEntityReducer(
   switch (action.type) {
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS:
-      return set('status', EntityStatus.loading, state);
+      return pipe(
+        set('status', EntityStatus.loading),
+        set('list', {}))(state);
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_SUCCESS:
       return pipe(
@@ -108,7 +110,6 @@ export function serviceGroupsEntityReducer(
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP_SUCCESS:
       return pipe(
         set('selectedGroup.name', action.payload.group),
-        set('selectedGroup.services.status', EntityStatus.loadingSuccess),
         set('selectedGroup.services.healthSummary', action.payload.services_health_counts),
         set('selectedGroup.services.list', action.payload.services))(state);
 

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -105,7 +105,9 @@ export function serviceGroupsEntityReducer(
       return set('selectedGroup.services.filters', action.payload, state);
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP:
-      return set('selectedGroup.services.status', EntityStatus.loading, state);
+      return pipe(
+        set('selectedGroup.services.status', EntityStatus.loading),
+        set('selectedGroup.services.list', []))(state);
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP_SUCCESS:
       return pipe(

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -53,7 +53,7 @@
         </chef-option>
       </chef-status-filter-group>
     </div>
-    <ul>
+    <ul *ngIf="(services$ | async)?.length > 0">
       <li class="service-item" *ngFor="let service of services$ | async; let i = index">
         <div class="header">
           <div class ="fqdn-line"><chef-icon>storage</chef-icon> <p class="fqdn-data">{{ service.fqdn || "--"}}</p></div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -53,7 +53,7 @@
         </chef-option>
       </chef-status-filter-group>
     </div>
-    <ul *ngIf="(services$ | async)?.length > 0">
+    <ul>
       <li class="service-item" *ngFor="let service of services$ | async; let i = index">
         <div class="header">
           <div class ="fqdn-line"><chef-icon>storage</chef-icon> <p class="fqdn-data">{{ service.fqdn || "--"}}</p></div>

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.ts
@@ -246,22 +246,20 @@ export class ServiceGroupsComponent implements OnInit, OnDestroy {
     // are filtered out via those status filters we have a special state that
     // says, e.g., "none of the services returned warning" that we want to
     // show.
-    this.store.select(serviceGroupsStatus).subscribe((sgStatus) => {
-      if (sgStatus === 'loadingSuccess') {
-        this.store.select(selectedServiceGroupStatus).subscribe((sSgStatus) => {
-          if (sSgStatus === 'loadingSuccess') {
-            this.serviceGroupsList$.subscribe((serviceGroups) => {
-              if (serviceGroups.length > 0) {
-                this.store.select(selectedServiceGroupHealth).subscribe((sgHealth) => {
-                  if (sgHealth.total === 0) {
-                    this.onServiceGroupSelect(null, serviceGroups[0].id);
-                  }
-                });
-              }
-            });
-          }
-        });
-      }
+    this.store.select(selectedServiceGroupStatus).subscribe((sSgStatus) => {
+      this.store.select(serviceGroupsStatus).subscribe((sgStatus) => {
+        if (sgStatus === 'loadingSuccess' && sSgStatus === 'loadingSuccess') {
+          this.serviceGroupsList$.subscribe((serviceGroups) => {
+            if (serviceGroups.length > 0) {
+              this.store.select(selectedServiceGroupHealth).subscribe((sgHealth) => {
+                if (sgHealth.total === 0) {
+                  this.onServiceGroupSelect(null, serviceGroups[0].id);
+                }
+              });
+            }
+          });
+        }
+      });
     });
 
     this.selectedStatus$ = this.store.select(createSelector(serviceGroupsState,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When moving between "OK" and "Disconnected" nodes, the UI moves from the loading spinner, to the old data, to the new data, with a visible redraw when the new data is finally shown.

### :chains: Related Resources
fixes #3081

### :+1: Definition of Done
Smooth as butter, no flicker.

### :athletic_shoe: How to Build and Test the Change
hab studio enter
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
applications_populate_database

Steps to reproduce the behavior:
Go to Application Tab
Select "OK" filter
Select "Disconnected" filter.
Note I am very far from this A2 server, so high-network latency may help reproduce it.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-05-18 at 5 28 22 PM](https://user-images.githubusercontent.com/4108100/82265669-2c0f4e00-992d-11ea-8979-9ebae08ac239.png)
![Screen Shot 2020-05-18 at 5 28 45 PM](https://user-images.githubusercontent.com/4108100/82265672-2d407b00-992d-11ea-9284-7dd173d30e57.png)
![Screen Shot 2020-05-18 at 5 28 51 PM](https://user-images.githubusercontent.com/4108100/82265673-2dd91180-992d-11ea-8568-4995ca183179.png)
