### PR TITLE
Fixing the deploy/dev pipeline

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -254,7 +254,7 @@ EOH
   berks upload -b /tmp/.Berksfile -c /tmp/.berks.config.json
 
   # add record to automate infra views to pre-populate deployed chef server.
-  configure_automate_infra_views
+  # configure_automate_infra_views
 
   if [[ "${enable_workflow}" == "true" ]]; then
     if ! chef-server-ctl user-list | grep delivery &> /dev/null; then


### PR DESCRIPTION
Commenting out the code that was added in this PR 4 hours ago
https://github.com/chef/automate/pull/3592.
This is getting the below error on each server.
```
data.template_file.install_chef_automate_cli: failed to render :
<template_file>:132,123-132: Unknown variable; There is no variable
named "server_id"., and 9 other diagnostic(s)
```

The problem is on this line https://github.com/chef/automate/blob/b508fa482a287056c177b8ff6eb92aceb7c84d8a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl#L132.

Below is a link to the failure in buildkite
https://buildkite.com/chef/chef-automate-master-deploy-dev/builds/1681#c27b949b-cbd5-4536-b262-124809eadb55