### PR TITLE
fixed lock scrolling when page loading 

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -1,4 +1,4 @@
-<div class="content-container">
+<div class="content-container" [ngClass]="loading(loadedStatus$ | async) ? 'lock-scrolling' : ''">
   <div class="container">
 
     <div class="sticky-notifications">

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
@@ -121,3 +121,7 @@ app-client-runs-search-filters {
 #download-modal {
   text-align: center;
 }
+
+.lock-scrolling {
+  overflow: hidden;
+}


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
When on any page that has the loading overlay and enough content to allow scroll users are still able to scroll which makes the overlay look broken since it only stays in the top portion.

I have added changes to lock the screen when a page the loading.
### :chains: Related Resources
https://github.com/chef/automate/issues/2925
## Repro Steps
[Repro Image](https://images.zenhubusercontent.com/5d24fdf9dc67db59a676ebc6/cd57d5a4-0efd-4419-9450-1dea064824cf)

- Artificially slow down your connection, in Chrome... Dev Tools > Network > Change Online to Slow 3G
- Navigate to infrastructure/client-runs
- Scroll while the page is loading

### :+1: Definition of Done
Added changes to fix the spinner scrolling when a page data is loading.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![fixspinner](https://user-images.githubusercontent.com/12297653/82364949-9d362a80-9a2d-11ea-8424-77c18eeb98d5.png)

