### PR TITLE
Update chef-phat-radio to take optional canDeselect attribute

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -6,7 +6,7 @@
     </div>
     <app-chart-progress-bar size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>
   </div>
-  <chef-phat-radio [canDeselect]="true">
+  <chef-phat-radio deselectable>
     <chef-option value='unknown' tabindex="0">
       <div class="title">Unknown</div>
       <div class="total">{{ unknownCount }}</div>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -6,7 +6,7 @@
     </div>
     <app-chart-progress-bar size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>
   </div>
-  <chef-phat-radio>
+  <chef-phat-radio [canDeselect]="true">
     <chef-option value='unknown' tabindex="0">
       <div class="title">Unknown</div>
       <div class="total">{{ unknownCount }}</div>

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.e2e.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.e2e.tsx
@@ -123,7 +123,7 @@ describe('chef-phat-radio', () => {
     let html, page;
     beforeEach(async () => {
       html = `
-        <chef-phat-radio can-deselect="true">
+        <chef-phat-radio deselectable>
           <chef-option value='opt1'>Option 1</chef-option>
           <chef-option value='opt2'>Option 2</chef-option>
           <chef-option value='opt3'>Option 3</chef-option>

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.e2e.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.e2e.tsx
@@ -119,4 +119,40 @@ describe('chef-phat-radio', () => {
 
   });
 
+  describe('when group is deselectable by canDeselect prop', () => {
+    let html, page;
+    beforeEach(async () => {
+      html = `
+        <chef-phat-radio can-deselect="true">
+          <chef-option value='opt1'>Option 1</chef-option>
+          <chef-option value='opt2'>Option 2</chef-option>
+          <chef-option value='opt3'>Option 3</chef-option>
+        </chef-phat-radio
+      `;
+      page = await newE2EPage();
+      await page.setContent(html);
+    });
+
+    it('does not select any options by default', async () => {
+      const options = await page.findAll('chef-option');
+
+      expect(await options[0].getProperty('selected')).not.toBeTruthy();
+      expect(await options[1].getProperty('selected')).not.toBeTruthy();
+      expect(await options[2].getProperty('selected')).not.toBeTruthy();
+    });
+
+    it('marks only the selected option as selected', async () => {
+      const element = await page.find('chef-phat-radio');
+      element.setProperty('value', 'opt2');
+
+      await page.waitForChanges();
+
+      const options = await page.findAll('chef-option');
+
+      expect(await options[0].getProperty('selected')).not.toBeTruthy();
+      expect(await options[1].getProperty('selected')).toBeTruthy();
+      expect(await options[2].getProperty('selected')).not.toBeTruthy();
+    });
+  });
+
 });

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
@@ -59,9 +59,7 @@ export class ChefPhatRadio {
     this.selected = find(['value', this.value], options);
     // When option to deselect is true, we also do not want to make a default
     // selection upon load, so we return early unless a value has been explicity set by prop
-    if (!this.selected && this.deselectable) {
-      return;
-    } else if (!this.selected) {
+    if (!this.selected && !this.deselectable) {
       this.selected = this.el.querySelector('chef-option[selected]') || options[0];
       this.value = this.selected.value;
     }

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
@@ -22,6 +22,9 @@ export class ChefPhatRadio {
    * The value of the currently toggled option.
    */
   @Prop({ mutable: true }) value = '';
+  // canDeselect is an optional property that when true allows users
+  // to deselect all options by clicking on the currently selected option.
+  @Prop() canDeselect: boolean;
 
   @Element() el: HTMLElement;
 
@@ -32,17 +35,24 @@ export class ChefPhatRadio {
 
   @Listen('click') handleClick(event) {
     const option = event.target.closest('chef-option');
+    // If new click option is the same as current, we are deselecting
+    const isSameOption = this.value === option.value;
+
     if (option) {
-      this.value = option.value;
-      this.change.emit();
-      this.input.emit();
+    this.value = this.canDeselect && isSameOption ? '' : option.value;
+    this.change.emit();
+    this.input.emit();
     }
   }
 
   componentDidLoad() {
     const options = this.clearOptions();
     this.selected = find(['value', this.value], options);
-    if (!this.selected) {
+    // When option to deselect is true, we also do not want to make a default
+    // selection upon load, so we return early unless a value has been explicity set by prop
+    if (!this.selected && this.canDeselect) {
+      return;
+    } else if (!this.selected) {
       this.selected = this.el.querySelector('chef-option[selected]') || options[0];
       this.value = this.selected.value;
     }
@@ -51,6 +61,9 @@ export class ChefPhatRadio {
 
   componentDidUpdate() {
     this.clearOptions();
+    // Return early if the update is empty, because this means we are deselecting
+    if (this.canDeselect && this.value === '') { return; }
+
     this.selected = this.el.querySelector(`chef-option[value='${this.value}']`);
     this.selected.selected = true;
   }

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
@@ -11,6 +11,13 @@ import find from 'lodash/fp/find';
  *   <chef-option value='opt2'>Option 2</chef-option>
  *   <chef-option value='opt3'>Option 3</chef-option>
  * </chef-phat-radio>
+ *
+ * @example
+ * <chef-phat-radio deselectable value="opt2">
+ *   <chef-option value='opt1'>Option 1</chef-option>
+ *   <chef-option value='opt2'>Option 2</chef-option>
+ *   <chef-option value='opt3'>Option 3</chef-option>
+ * </chef-phat-radio>
  */
 @Component({
   tag: 'chef-phat-radio',
@@ -22,9 +29,11 @@ export class ChefPhatRadio {
    * The value of the currently toggled option.
    */
   @Prop({ mutable: true }) value = '';
-  // canDeselect is an optional property that when true allows users
-  // to deselect all options by clicking on the currently selected option.
-  @Prop() canDeselect: boolean;
+
+  /**
+   * An optional property that when true allows users to deselect an option by selecting a currently selected option
+   */
+  @Prop() deselectable = false;
 
   @Element() el: HTMLElement;
 
@@ -39,7 +48,7 @@ export class ChefPhatRadio {
     const isSameOption = this.value === option.value;
 
     if (option) {
-    this.value = this.canDeselect && isSameOption ? '' : option.value;
+    this.value = this.deselectable && isSameOption ? '' : option.value;
     this.change.emit();
     this.input.emit();
     }
@@ -50,7 +59,7 @@ export class ChefPhatRadio {
     this.selected = find(['value', this.value], options);
     // When option to deselect is true, we also do not want to make a default
     // selection upon load, so we return early unless a value has been explicity set by prop
-    if (!this.selected && this.canDeselect) {
+    if (!this.selected && this.deselectable) {
       return;
     } else if (!this.selected) {
       this.selected = this.el.querySelector('chef-option[selected]') || options[0];
@@ -62,7 +71,7 @@ export class ChefPhatRadio {
   componentDidUpdate() {
     this.clearOptions();
     // Return early if the update is empty, because this means we are deselecting
-    if (this.canDeselect && this.value === '') { return; }
+    if (this.deselectable && this.value === '') { return; }
 
     this.selected = this.el.querySelector(`chef-option[value='${this.value}']`);
     this.selected.selected = true;

--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
@@ -59,7 +59,9 @@ export class ChefPhatRadio {
     this.selected = find(['value', this.value], options);
     // When option to deselect is true, we also do not want to make a default
     // selection upon load, so we return early unless a value has been explicity set by prop
-    if (!this.selected && !this.deselectable) {
+    if (!this.selected && this.deselectable) { return; }
+
+    if (!this.selected) {
       this.selected = this.el.querySelector('chef-option[selected]') || options[0];
       this.value = this.selected.value;
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Our work on desktop required the ability to Deselect options in chef-phat-radio group.  The branch adds the ability to pass an optional `deselectable` prop to chef-phat-radio which causes two things to happen by default.
1. The user can deselect the group by clicking on the currently active option.
2. No Option is selected by default unless the option is specifically passed as a value prop.

### :chains: Related Resources

### :+1: Definition of Done
User can now deselect options in this group.
All other chef-phat-radio groups have no changes to their current behavior.  Currently these exist on:
https://a2-dev.test/desktop --> has option to deselect
https://a2-dev.test/compliance/reports/nodes
https://a2-dev.test/compliance/reports/nodes/{filtered-node}
https://a2-dev.test/compliance/reports/profiles
https://a2-dev.test/compliance/scan-jobs/nodes
https://a2-dev.test/settings/node-integrations/add

### :athletic_shoe: How to Build and Test the Change
in hab studio: `build components/automate-ui-devproxy && start_all_services`
in terminal: cd components/automate-ui
run `make update-ui-lib` to update chef-ui-library
run `make serve`

Visit https://a2-dev.test/desktop.  No default should be selected on page load.  User may select and deselect as they choose.

Visit the following list.  There should be no changes.
https://a2-dev.test/compliance/reports/nodes
https://a2-dev.test/compliance/reports/nodes/{filtered-node}
https://a2-dev.test/compliance/reports/profiles
https://a2-dev.test/compliance/scan-jobs/nodes
https://a2-dev.test/settings/node-integrations/add


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Chef Automate (7)](https://user-images.githubusercontent.com/16737484/82385885-f7140180-99e7-11ea-8924-81f025518c61.gif)
