### PR TITLE
compliance profiles: accept application/json+lax header

### DIFF
--- a/components/automate-gateway/gateway/services.go
+++ b/components/automate-gateway/gateway/services.go
@@ -427,7 +427,7 @@ func (s *Server) ProfileCreateHandler(w http.ResponseWriter, r *http.Request) {
 	var cType, profileName, profileVersion string
 	contentTypeString := strings.Split(r.Header.Get("Content-type"), ";")
 	switch contentTypeString[0] {
-	case "application/json":
+	case "application/json", "application/json+lax":
 		cType = r.Header.Get("Content-type")
 		decoder := json.NewDecoder(r.Body)
 		var t ProfileRequest

--- a/components/compliance-service/api/profiles/server/pgserver.go
+++ b/components/compliance-service/api/profiles/server/pgserver.go
@@ -150,7 +150,7 @@ func (srv *PGProfileServer) Create(stream profiles.ProfilesService_CreateServer)
 	// verify that we accept the content
 	logrus.Debugf("Content Type %s", in.GetMeta().ContentType)
 	var reader io.ReadCloser
-	if in.GetMeta().ContentType == "application/json" {
+	if in.GetMeta().ContentType == "application/json" || in.GetMeta().ContentType == "application/json+lax" {
 		namespace := in.Owner
 		name := in.GetMeta().Name
 		version := in.GetMeta().Version


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

with the changes introduced in https://github.com/chef/automate/pull/3690, we now use the lax header on the endpoint for profile create - meaning we needed to update the code that looks at the header to accept the new "application/json+lax"

### :+1: Definition of Done
can install a profile by clicking "get" on an "available" profile

### :athletic_shoe: How to Build and Test the Change
rebuild compliance and gateway
install profile from "available" tab

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
