### PR TITLE
Fixing a bug that the dev environment defaults to Desktop mode

### DIFF
--- a/dev/config.toml
+++ b/dev/config.toml
@@ -83,7 +83,6 @@ shared_buffers = "1GB"
     deployment_type = "local"
     manifest_cache_expiry = "0s"
     package_cleanup_mode = "disabled"
-    products = ["desktop"]
     [deployment.v1.svc.admin_user]
       # Default admin user settings
       username = "admin"


### PR DESCRIPTION
Fixing a bug that the dev environment defaults to Desktop mode. The dev/config.toml is the default configuration for developers. The `products = ["desktop"]` in the config.toml simulates an Automate Desktop install. This was accidentally checked in. 

