### PR TITLE
Policy files list view tab on org details page

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -89,6 +89,7 @@ import { RoleRequests } from './entities/roles/role.requests';
 import { RuleRequests } from './entities/rules/rule.requests';
 import { ServerRequests } from './entities/servers/server.requests';
 import { OrgRequests } from './entities/orgs/org.requests';
+import { PolicyFileRequests } from './entities/policy-files/policy-file.requests';
 import { ServiceGroupsRequests } from './entities/service-groups/service-groups.requests';
 import { TeamRequests } from './entities/teams/team.requests';
 import { UserPermsRequests } from './entities/userperms/userperms.requests';
@@ -333,6 +334,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     RunHistoryStore,
     ServerRequests,
     OrgRequests,
+    PolicyFileRequests,
     ServiceGroupsRequests,
     SessionStorageService,
     TeamRequests,

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.action.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.action.ts
@@ -1,0 +1,33 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+import { PolicyFile } from './policy-file.model';
+
+export enum PolicyFileActionTypes {
+  GET_ALL = 'POLICYFILES::GET_ALL',
+  GET_ALL_SUCCESS = 'POLICYFILES::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'POLICYFILES::GET_ALL::FAILURE'
+}
+
+export interface PolicyFilesSuccessPayload {
+  policies: PolicyFile[];
+}
+
+export class GetPolicyFiles implements Action {
+  readonly type = PolicyFileActionTypes.GET_ALL;
+  constructor(public payload: { server_id: string, org_id: string }) { }
+}
+
+export class GetPolicyFilesSuccess implements Action {
+  readonly type = PolicyFileActionTypes.GET_ALL_SUCCESS;
+  constructor(public payload: PolicyFilesSuccessPayload) { }
+}
+
+export class GetPolicyFilesFailure implements Action {
+  readonly type = PolicyFileActionTypes.GET_ALL_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type PolicyFileActions =
+  | GetPolicyFiles
+  | GetPolicyFilesSuccess
+  | GetPolicyFilesFailure;

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetPolicyFiles,
+  GetPolicyFilesSuccess,
+  PolicyFilesSuccessPayload,
+  GetPolicyFilesFailure,
+  PolicyFileActionTypes
+} from './policy-file.action';
+
+import { PolicyFileRequests } from './policy-file.requests';
+
+@Injectable()
+export class PolicyFileEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: PolicyFileRequests
+  ) { }
+
+  @Effect()
+  getPolicyFiles$ = this.actions$.pipe(
+      ofType(PolicyFileActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id, org_id } }: GetPolicyFiles) =>
+        this.requests.getPolicyFiles(server_id, org_id).pipe(
+          map((resp: PolicyFilesSuccessPayload) => new GetPolicyFilesSuccess(resp)),
+          catchError((error: HttpErrorResponse) =>
+          observableOf(new GetPolicyFilesFailure(error))))));
+
+  @Effect()
+  getPolicyFilesFailure$ = this.actions$.pipe(
+      ofType(PolicyFileActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetPolicyFilesFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get policy files: ${msg || payload.error}`
+        });
+      }));
+
+}

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.model.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.model.ts
@@ -1,0 +1,5 @@
+export interface PolicyFile {
+  name: string;
+  revision_id: string;
+  policy_group: string;
+}

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
@@ -1,0 +1,46 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set, pipe } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { PolicyFileActionTypes, PolicyFileActions } from './policy-file.action';
+import { PolicyFile } from './policy-file.model';
+
+export interface PolicyFileEntityState extends EntityState<PolicyFile> {
+  getAllStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+
+export const policyFileEntityAdapter: EntityAdapter<PolicyFile> =
+  createEntityAdapter<PolicyFile>({
+  selectId: (policyFile: PolicyFile) => policyFile.revision_id
+});
+
+export const PolicyFileEntityInitialState: PolicyFileEntityState =
+  policyFileEntityAdapter.getInitialState(<PolicyFileEntityState>{
+  getAllStatus: EntityStatus.notLoaded
+});
+
+export function policyFileEntityReducer(
+  state: PolicyFileEntityState = PolicyFileEntityInitialState,
+  action: PolicyFileActions): PolicyFileEntityState {
+
+  switch (action.type) {
+    case PolicyFileActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, policyFileEntityAdapter.removeAll(state));
+
+    case PolicyFileActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (policyFileEntityAdapter.setAll(action.payload.policies, state)) as
+        PolicyFileEntityState;
+
+    case PolicyFileActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}
+
+export const getEntityById = (revision_id: string) =>
+  (state: PolicyFileEntityState) => state.entities[revision_id];

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
@@ -9,7 +9,6 @@ export class PolicyFileRequests {
 
   constructor(private http: HttpClient) { }
 
-  // tslint:disable-next-line: max-line-length
   public getPolicyFiles(server_id: string, org_id: string):
     Observable<PolicyFilesSuccessPayload> {
     return this.http.get<PolicyFilesSuccessPayload>(

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { PolicyFilesSuccessPayload } from './policy-file.action';
+
+@Injectable()
+export class PolicyFileRequests {
+
+  constructor(private http: HttpClient) { }
+
+  // tslint:disable-next-line: max-line-length
+  public getPolicyFiles(server_id: string, org_id: string):
+    Observable<PolicyFilesSuccessPayload> {
+    return this.http.get<PolicyFilesSuccessPayload>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/policyfiles`);
+  }
+}

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.selectors.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.selectors.ts
@@ -1,0 +1,21 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import { find } from 'lodash/fp';
+import { PolicyFileEntityState, policyFileEntityAdapter } from './policy-file.reducer';
+import { routeParams } from 'app/route.selectors';
+
+export const policyFileState = createFeatureSelector<PolicyFileEntityState>('policyFiles');
+export const {
+  selectAll: allPolicyFiles,
+  selectEntities: policyFileEntities
+} = policyFileEntityAdapter.getSelectors(policyFileState);
+
+export const getAllStatus = createSelector(
+  policyFileState,
+  (state) => state.getAllStatus
+);
+
+export const infraPolicyFileFromRoute = createSelector(
+  policyFileEntities,
+  routeParams,
+  (state, { revision_id }) => find({ revision_id }, state)
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -20,6 +20,7 @@ import { InfraRoleDetailsComponent } from './infra-role-details/infra-role-detai
 import { JsonTreeTableComponent } from './json-tree-table/json-tree-table.component';
 import { OrgDetailsComponent } from './org-details/org-details.component';
 import { OrgEditComponent } from './org-edit/org-edit.component';
+import { PolicyFilesComponent } from './policy-files/policy-files.component';
 import { TreeTableModule } from './tree-table/tree-table.module';
 
 @NgModule({
@@ -38,7 +39,8 @@ import { TreeTableModule } from './tree-table/tree-table.module';
     InfraRolesComponent,
     InfraRoleDetailsComponent,
     OrgDetailsComponent,
-    OrgEditComponent
+    OrgEditComponent,
+    PolicyFilesComponent
   ],
   imports: [
     CommonModule,

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -40,6 +40,9 @@
           <app-tab tabTitle="Clients" #clients_tab  [active]="clientsTab">
             <app-clients *ngIf="clients_tab.active" [serverId]="serverId" [orgId]="orgId"></app-clients>
           </app-tab>
+          <app-tab tabTitle="Policy Files" #policyFiles_tab  [active]="policyFilesTab">
+            <app-policy-files *ngIf="policyFiles_tab.active" [serverId]="serverId" [orgId]="orgId"></app-policy-files>
+          </app-tab>
           <app-tab tabTitle="Details" #details_tab [active]="false">
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
           </app-tab>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -114,7 +114,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         this.telemetryService.track('orgDetailsTab', 'policyFiles');
         break;
       case 6:
-        this.telemetryService.track('orgDetailsTab', 'org-edit');
+        this.telemetryService.track('orgDetailsTab', 'orgEdit');
         break;
     }
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -31,6 +31,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   public rolesTab = false;
   public dataBagsTab = false;
   public clientsTab = false;
+  public policyFilesTab = false;
   private isDestroyed = new Subject<boolean>();
 
   previousRoute$: Observable<RouterState>;
@@ -55,6 +56,13 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
           this.cookbooksTab = false;
           this.rolesTab = false;
           this.environmentsTab = true;
+        }
+
+        if ( params.path.includes('policyFiles') ) {
+          this.cookbooksTab = false;
+          this.rolesTab = false;
+          this.environmentsTab = false;
+          this.policyFilesTab = true;
         }
       });
     }
@@ -103,6 +111,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         this.telemetryService.track('orgDetailsTab', 'clients');
         break;
       case 5:
+        this.telemetryService.track('orgDetailsTab', 'policyFiles');
+        break;
+      case 6:
         this.telemetryService.track('orgDetailsTab', 'org-edit');
         break;
     }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
@@ -1,0 +1,19 @@
+<section class="policy-files">
+  <chef-loading-spinner *ngIf="policyFilesListLoading" size="50"></chef-loading-spinner>
+  <ng-container *ngIf="!policyFilesListLoading">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-th>Policy Name</chef-th>
+          <chef-th>Policy Group</chef-th>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let policyFile of policyFiles">
+          <chef-td>{{ policyFile.name }}</chef-td>
+          <chef-td>{{ policyFile.policy_group }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
@@ -1,0 +1,35 @@
+@import "~styles/variables";
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
@@ -1,0 +1,64 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PolicyFilesComponent } from './policy-files.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+
+describe('PolicyFilesComponent', () => {
+  let component: PolicyFilesComponent;
+  let fixture: ComponentFixture<PolicyFilesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'chef-error' }),
+        MockComponent({ selector: 'chef-form-field' }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        PolicyFilesComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PolicyFilesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest } from 'rxjs';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { filter } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+import { EntityStatus } from 'app/entities/entities';
+import { GetPolicyFiles } from 'app/entities/policy-files/policy-file.action';
+import { PolicyFile } from 'app/entities/policy-files/policy-file.model';
+import {
+  allPolicyFiles,
+  getAllStatus as getAllPolicyFilesForOrgStatus
+} from 'app/entities/policy-files/policy-file.selectors';
+
+
+@Component({
+  selector: 'app-policy-files',
+  templateUrl: './policy-files.component.html',
+  styleUrls: ['./policy-files.component.scss']
+})
+
+export class PolicyFilesComponent implements OnInit {
+  @Input() serverId: string;
+  @Input() orgId: string;
+
+  public policyFiles: PolicyFile[] = [];
+  public policyFilesListLoading = true;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetPolicyFiles({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllPolicyFilesForOrgStatus),
+      this.store.select(allPolicyFiles)
+    ]).pipe(
+      filter(([getPolicyFilesSt, _allPolicyFilesState]) =>
+      getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(_allPolicyFilesState))
+    ).subscribe(([ _getPolicyFilesSt, allPolicyFilesState]) => {
+      this.policyFiles = allPolicyFilesState;
+      this.policyFilesListLoading = false;
+    });
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -43,8 +43,8 @@ export class PolicyFilesComponent implements OnInit {
       this.store.select(getAllPolicyFilesForOrgStatus),
       this.store.select(allPolicyFiles)
     ]).pipe(
-      filter(([getPolicyFilesSt, _allPolicyFilesState]) =>
-      getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(_allPolicyFilesState))
+      filter(([getPolicyFilesSt, allPolicyFilesState]) =>
+      getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState))
     ).subscribe(([ _getPolicyFilesSt, allPolicyFilesState]) => {
       this.policyFiles = allPolicyFilesState;
       this.policyFilesListLoading = false;

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -24,6 +24,7 @@ import { ManagerEffects } from './entities/managers/manager.effects';
 import { NodesEffects } from './entities/nodes/nodes.effects';
 import { OrgEffects } from './entities/orgs/org.effects';
 import { PolicyEffects } from './entities/policies/policy.effects';
+import { PolicyFileEffects } from './entities/policy-files/policy-file.effects';
 import { ProfileEffects } from './entities/profiles/profile.effects';
 import { ProjectEffects } from './entities/projects/project.effects';
 import { ProjectsFilterEffects } from './services/projects-filter/projects-filter.effects';
@@ -61,6 +62,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       NodesEffects,
       OrgEffects,
       PolicyEffects,
+      PolicyFileEffects,
       ProfileEffects,
       ProjectEffects,
       ProjectsFilterEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -33,6 +33,7 @@ import * as jobList from './pages/job-list/job-list.reducer';
 import * as manager from './entities/managers/manager.reducer';
 import * as permEntity from './entities/userperms/userperms.reducer';
 import * as policyEntity from './entities/policies/policy.reducer';
+import * as policyFileEntity from './entities/policy-files/policy-file.reducer';
 import * as profileEntity from './entities/profiles/profile.reducer';
 import * as projectEntity from './entities/projects/project.reducer';
 import * as roleEntity from './entities/roles/role.reducer';
@@ -83,6 +84,7 @@ export interface NgrxStateAtom {
   nodes: nodesEntity.NodesEntityState;
   notifications: notificationEntity.NotificationEntityState;
   policies: policyEntity.PolicyEntityState;
+  policyFiles: policyFileEntity.PolicyFileEntityState;
   profiles: profileEntity.ProfileEntityState;
   projects: projectEntity.ProjectEntityState;
   roles: roleEntity.RoleEntityState;
@@ -201,6 +203,7 @@ export const defaultInitialState = {
   nodes: nodesEntity.NodesEntityInitialState,
   notifications: notificationEntity.InitialState,
   policies: policyEntity.PolicyEntityInitialState,
+  policyFiles: policyFileEntity.PolicyFileEntityInitialState,
   profiles: profileEntity.ProfileEntityInitialState,
   projects: projectEntity.ProjectEntityInitialState,
   roles: roleEntity.RoleEntityInitialState,
@@ -253,6 +256,7 @@ export const ngrxReducers = {
   licenseStatus: license.licenseStatusEntityReducer,
   notifications: notificationEntity.notificationEntityReducer,
   policies: policyEntity.policyEntityReducer,
+  policyFiles: policyFileEntity.policyFileEntityReducer,
   profiles: profileEntity.profileEntityReducer,
   projects: projectEntity.projectEntityReducer,
   roles: roleEntity.roleEntityReducer,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added Infra Policy file tab on the org details page.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/3406
### :+1: Definition of Done
Added Policy file tab on the org details page where we are displaying the  Policy file lists.

-  When User clicks on the Policy file tab it will show the list of policy files that have Policy Name, Policy Group as it's headings.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```

1. git fetch origin Amol/policy_files_list
2. build components/automate-ui [Above steps for reference.]
3. To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
4. Go to Infrastructure tab >> Chef Servers its under Chef-Server feature flag.
5. Click on `Server list` >> `Organisation list` >> `Policy files` Tab.
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![policylist](https://user-images.githubusercontent.com/10369422/82992314-9b1b2f80-a01c-11ea-9d6a-2757d4c8d827.png)

