### PR TITLE
#3756 never skip the report if there is no infra data

### DIFF
--- a/components/data-feed-service/service/data-feed-aggregate-task.go
+++ b/components/data-feed-service/service/data-feed-aggregate-task.go
@@ -115,14 +115,12 @@ func (d *DataFeedAggregateTask) buildDatafeed(ctx context.Context, nodeIDs map[s
 
 		nodeData, err := d.getNodeClientData(ctx, ip, nodeID, updatedNodesOnly)
 		if err != nil {
-			log.Errorf("Error getting node data %v", err)
-			continue
+			log.Warnf("Error getting node data %v", err)
 		}
 
 		report, err := d.getNodeComplianceData(ctx, ip, nodeID, updatedNodesOnly)
 		if err != nil {
-			log.Errorf("Error getting compliance data %v", err)
-			continue
+			log.Warnf("Error getting compliance data %v", err)
 		}
 		// update the message with the full report
 		if report != nil {
@@ -155,7 +153,7 @@ func (d *DataFeedAggregateTask) getNodeClientData(ctx context.Context, ipaddress
 		filters := []string{"ipaddress:" + ipaddress}
 		_, macAddress, hostname, err := getNodeHostFields(ctx, d.cfgMgmt, filters)
 		if err != nil {
-			log.Errorf("Error getting node macaddress and hostname %v", err)
+			log.Warnf("Error getting node macaddress and hostname %v", err)
 		}
 		nodeDataContent := make(map[string]interface{})
 		nodeDataContent["macaddress"] = macAddress

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -277,7 +277,7 @@ func getNodeAttributes(ctx context.Context, client cfgmgmt.CfgMgmtClient, nodeId
 
 	nodeAttributes, err := client.GetAttributes(ctx, &cfgmgmtRequest.Node{NodeId: nodeId})
 	if err != nil {
-		log.Errorf("Error getting attributes %v", err)
+		log.Warnf("Error getting attributes %v", err)
 		return attributesJson, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Martin Scott <mscott@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Compliance reports for nodes without infra data in automate were being skipped when config setting update_nodes_only = false

Updated the code not to skip in this case.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
See issue #3756 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated? Manually tested all combinations of settings without and then with infra data
- [ ] Docs added/updated? NA
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
