### PR TITLE
[automate-1882] Optionally add project teams if checkbox selected

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -45,8 +45,11 @@
           </chef-toolbar>
         </div>
         <div class="checkbox-margin" *ngIf="createProjectModal">
-          <chef-checkbox (change)="updatePolicyCheckbox($event.detail)" [checked]="addPolicies">
-            Also create owner, editor, and viewer policies for this project.
+          <chef-checkbox id="add-policy-checkbox" (change)="updatePolicyCheckbox($event.detail)" [checked]="addPolicies">
+            Also create owner, editor, and viewer <b>policies</b> for this project.
+          </chef-checkbox>
+          <chef-checkbox (change)="updateTeamCheckbox($event.detail)" [checked]="addTeams">
+            Also create owner, editor, and viewer <b>teams</b> for this project.
           </chef-checkbox>
         </div>
         <div class="dropdown-margin" *ngIf="objectNoun === 'token'">

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.scss
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.scss
@@ -27,6 +27,10 @@ chef-modal {
 
       .checkbox-margin {
         margin-bottom: 30px;
+
+        #add-policy-checkbox {
+          margin-bottom: 30px;
+        }
       }
 
       .dropdown-margin {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -112,7 +112,7 @@ describe('CreateObjectModalComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new GetPolicies());
   });
 
-  it('upon opening, "also create" checkboxs are checked', () => {
+  it('upon opening, "also create" checkboxes are checked', () => {
     component.createForm = new FormBuilder().group({
       name: '',
       addPolicies: '',

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -112,18 +112,24 @@ describe('CreateObjectModalComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new GetPolicies());
   });
 
-  it('upon opening, "also create policies" checkbox is checked', () => {
+  it('upon opening, "also create" checkboxs are checked', () => {
     component.createForm = new FormBuilder().group({
       name: '',
-      addPolicies: ''
+      addPolicies: '',
+      addTeams: ''
     });
-    component.createForm.controls.addPolicies.setValue(false); // force it to start at false
+
+    // force them to start at false
+    component.createForm.controls.addPolicies.setValue(false);
+    component.createForm.controls.addTeams.setValue(false);
+
     component.createProjectModal = true;
 
     component.ngOnChanges(
       { visible: new SimpleChange(false, true, true) });
 
     expect(component.createForm.controls.addPolicies.value).toEqual(true);
+    expect(component.createForm.controls.addTeams.value).toEqual(true);
   });
 
 });

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -37,6 +37,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   public modifyID = false; // Whether the edit ID form is open or not.
   public conflictError = false;
   public addPolicies = true;
+  public addTeams = true;
   public projectsUpdatedEvent = new EventEmitter();
   public policiesUpdatedEvent = new EventEmitter();
   public UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
@@ -76,7 +77,9 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       this.policiesUpdatedEvent.emit();
 
       if (this.createProjectModal) {
-        this.updatePolicyCheckbox(true); // default to checked upon opening
+         // default to checked upon opening
+        this.updatePolicyCheckbox(true);
+        this.updateTeamCheckbox(true);
       }
     }
   }
@@ -92,6 +95,11 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   updatePolicyCheckbox(event: boolean): void {
     this.addPolicies = event;
     this.createForm.controls.addPolicies.setValue(this.addPolicies);
+  }
+
+  updateTeamCheckbox(event: boolean): void {
+    this.addTeams = event;
+    this.createForm.controls.addTeams.setValue(this.addTeams);
   }
 
   handleNameInput(event: KeyboardEvent): void {

--- a/components/automate-ui/src/app/entities/teams/team.effects.ts
+++ b/components/automate-ui/src/app/entities/teams/team.effects.ts
@@ -113,10 +113,12 @@ export class TeamEffects {
   @Effect()
   createTeamSuccess$ = this.actions$.pipe(
     ofType<CreateTeamSuccess>(TeamActionTypes.CREATE_SUCCESS),
-    map(() => new CreateNotification({
+    map(( { payload: resp }: CreateTeamSuccess) =>
+    new CreateNotification({
       type: Type.info,
-      message: 'Created a new team.'
-    })));
+      message: `Created team ${resp.id}.`
+    })
+  ));
 
   @Effect()
   createTeamFailure$ = this.actions$.pipe(

--- a/components/automate-ui/src/app/entities/users/user.effects.ts
+++ b/components/automate-ui/src/app/entities/users/user.effects.ts
@@ -154,7 +154,7 @@ export class UserEffects {
     map(( { payload: user }: CreateUserSuccess)  =>
       new CreateNotification({
         type: Type.info,
-        message: `Created user: ${user.id}.`
+        message: `Created user ${user.id}.`
       })
     ));
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -85,9 +85,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     this.store.pipe(
       select(createStatus),
       takeUntil(this.isDestroyed),
-      filter(state => {
-        return this.creatingProject && state === EntityStatus.loadingSuccess;
-      }))
+      filter(state => this.creatingProject && state === EntityStatus.loadingSuccess))
       .subscribe(() => {
         this.creatingProject = false;
 

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -18,6 +18,7 @@ import {
   allProjects, getAllStatus, createStatus, createError
 } from 'app/entities/projects/project.selectors';
 import { GetProjects, CreateProject, DeleteProject, ProjectPayload  } from 'app/entities/projects/project.actions';
+import { CreateTeam } from 'app/entities/teams/team.actions';
 import { Project } from 'app/entities/projects/project.model';
 import { LoadOptions } from 'app/services/projects-filter/projects-filter.actions';
 
@@ -44,6 +45,12 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       'RULES_APPLIED': 'Applied'
   };
 
+  readonly teamsToCreate = {
+    'project-owners': 'Project Owners',
+    'editors': 'Editors',
+    'viewers': 'Viewers'
+  };
+
   constructor(
     private layoutFacade: LayoutFacadeService,
     private store: Store<NgrxStateAtom>,
@@ -55,7 +62,8 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       name: ['', Validators.required],
       id: ['',
         [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(48)]],
-      addPolicies: [true]
+      addPolicies: [true],
+      addTeams: [true]
     });
   }
 
@@ -82,11 +90,26 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       }))
       .subscribe(() => {
         this.creatingProject = false;
+
+        const createTeamsWasChecked = this.createProjectForm.controls['addTeams'].value;
+        const projectID = this.createProjectForm.controls['id'].value;
+        const projectName = this.createProjectForm.controls['name'].value;
+
         this.closeCreateModal();
 
         // This is issued periodically from projects-filter.effects.ts; we do it now
         // so the user doesn't have to wait.
         this.store.dispatch(new LoadOptions());
+
+        if (createTeamsWasChecked) {
+          for (const [teamID, teamName] of Object.entries(this.teamsToCreate)) {
+            this.store.dispatch(new CreateTeam({
+              id: `${projectID}-${teamID}`,
+              name: `${projectName} ${teamName}`,
+              projects: [projectID]
+            }));
+          }
+        }
       });
 
     combineLatest([

--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -11,6 +11,7 @@ describe('project management', () => {
   const customWithoutPolsProjectID = `${cypressPrefix}-custom1-${now}`;
   const customWithPolsProjectID = `${cypressPrefix}-custom2-${now}`;
   const associatedPolicies = ['project-editors', 'project-viewers', 'project-owners'];
+  const associatedTeams = ['project-owners', 'editors', 'viewers'];
 
   before(() => {
     cy.adminLogin('/settings/projects').then(() => {
@@ -72,8 +73,8 @@ describe('project management', () => {
     cy.get('app-create-object-modal chef-checkbox')
       .should('have.attr', 'aria-checked', 'true');
 
-    // don't create associated project policies
-    cy.get('app-create-object-modal chef-checkbox').click();
+    // don't create associated project policies or teams
+    cy.get('app-create-object-modal chef-checkbox').click({ multiple: true });
 
     cy.get('[data-cy=save-button]').click();
     cy.get('app-project-list chef-modal').should('not.be.visible');
@@ -99,8 +100,8 @@ describe('project management', () => {
     cy.get('[data-cy=edit-button]').contains('Edit ID').click();
     cy.get('[data-cy=id-label]').should('not.be.visible');
 
-    // don't create associated project policies
-    cy.get('app-create-object-modal chef-checkbox').click();
+    // don't create associated project policies or teams
+    cy.get('app-create-object-modal chef-checkbox').click({ multiple: true });
 
     cy.get('[data-cy=create-id]').should('be.visible').clear()
       .type(customWithoutPolsProjectID).should('have.value', customWithoutPolsProjectID);
@@ -125,10 +126,21 @@ describe('project management', () => {
       });
     });
 
+    // verify no associated teams were generated
+    associatedTeams.forEach((team) => {
+      cy.request({
+        auth: { bearer: adminIdToken },
+        url: `/apis/iam/v2/teams/${customWithoutPolsProjectID}-${team}`,
+        failOnStatusCode: false
+      }).then((response) => {
+        expect(response.status).to.equal(404);
+      });
+    });
+
     cy.url().should('include', '/settings/projects');
   });
 
-  it('can create a project with a custom ID and generate associated policies', () => {
+  it('can create a project with a custom ID and generate associated policies and teams', () => {
     cy.get('[data-cy=create-project]').contains('Create Project').click();
     cy.get('app-project-list chef-modal').should('have.class', 'visible');
 
@@ -161,6 +173,16 @@ describe('project management', () => {
       cy.request({
         auth: { bearer: adminIdToken },
         url: `/apis/iam/v2/policies/${customWithPolsProjectID}-${policy}`
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+      });
+    });
+
+    // verify associated teams were generated
+    associatedTeams.forEach((team) => {
+      cy.request({
+        auth: { bearer: adminIdToken },
+        url: `/apis/iam/v2/teams/${customWithPolsProjectID}-${team}`
       }).then((response) => {
         expect(response.status).to.equal(200);
       });

--- a/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/user_mgmt.spec.ts
@@ -77,7 +77,7 @@ describe('user management', () => {
     // save new user
     cy.get('[data-cy=save-user]').click();
     cy.get('app-user-management chef-modal').should('not.be.visible');
-    cy.get('app-notification.info').contains(`Created user: ${username}`);
+    cy.get('app-notification.info').contains(`Created user ${username}`);
     // close notification banner so we can assert the password success notification later
     cy.get('app-notification.info chef-icon').click();
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Optionally add project teams if checkbox selected.

We should be good on length violation concerns since teams have super non-restrictive IDs atm:

https://github.com/chef/automate/blob/master/api/interservice/teams/teams.proto#L16-L20

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

If one of the team creation requests fail, it still creates the project:

![Screen Shot 2020-05-20 at 3 19 19 PM](https://user-images.githubusercontent.com/1899715/82504393-1e360600-9ab0-11ea-9e8a-1a07f115ef9c.png)

Resulting teams created:

![Screen Shot 2020-05-20 at 3 32 07 PM](https://user-images.githubusercontent.com/1899715/82504435-3efe5b80-9ab0-11ea-88dc-ae7777ec5cec.png)

Modal style changes:

![Screen Shot 2020-05-20 at 3 38 14 PM](https://user-images.githubusercontent.com/1899715/82504453-4a518700-9ab0-11ea-9386-5c93404ab15a.png)



