### PR TITLE
add cypress api test for installing profile

### DIFF
--- a/e2e/cypress/integration/api/profiles/profiles.spec.ts
+++ b/e2e/cypress/integration/api/profiles/profiles.spec.ts
@@ -1,0 +1,31 @@
+
+describe('Available profile', () => {
+    it('can be installed', () => {
+        const cypressPrefix = 'test-install-available-profile';
+        cy.request({
+            headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+            method: 'POST',
+            url: 'api/v0/compliance/profiles?owner=admin',
+            body: {
+            name: 'linux-baseline',
+            version: '2.2.2'
+            }
+        }).then((resp: Cypress.ObjectLike) => {
+            expect(resp.body.summary.valid).to.equal(true);
+        });
+    });
+    it('can be installed even when lax header present', () => {
+        const cypressPrefix = 'test-install-available-profile';
+        cy.request({
+            headers: { 'api-token': Cypress.env('ADMIN_TOKEN'), 'content-type': 'application/json+lax' },
+            method: 'POST',
+            url: 'api/v0/compliance/profiles?owner=admin',
+            body: {
+            name: 'linux-baseline',
+            version: '2.2.2'
+            }
+        }).then((resp: Cypress.ObjectLike) => {
+            expect(resp.body.summary.valid).to.equal(true);
+        });
+    });
+});

--- a/e2e/cypress/integration/api/profiles/profiles.spec.ts
+++ b/e2e/cypress/integration/api/profiles/profiles.spec.ts
@@ -1,7 +1,7 @@
 
 describe('Available profile', () => {
     // search for profile to get the version
-    let version:string
+    let version: string;
     beforeEach(() => {
         cy.request({
             headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
@@ -9,13 +9,12 @@ describe('Available profile', () => {
             url: 'api/v0/compliance/profiles/search',
             body: {
             filters: [
-                {type: "name", values: ['linux-baseline']}
+                {type: 'name', values: ['linux-baseline']}
             ]
             }
         }).then((resp: Cypress.ObjectLike) => {
-            console.log(resp.body)
             version = resp.body.profiles[0].version;
-        })
+        });
     });
 
 
@@ -36,7 +35,9 @@ describe('Available profile', () => {
     it('can be installed even when lax header present', () => {
         const cypressPrefix = 'test-install-available-profile';
         cy.request({
-            headers: { 'api-token': Cypress.env('ADMIN_TOKEN'), 'content-type': 'application/json+lax' },
+            headers: {
+                'api-token': Cypress.env('ADMIN_TOKEN'),
+                'content-type': 'application/json+lax' },
             method: 'POST',
             url: 'api/v0/compliance/profiles?owner=admin',
             body: {

--- a/e2e/cypress/integration/api/profiles/profiles.spec.ts
+++ b/e2e/cypress/integration/api/profiles/profiles.spec.ts
@@ -1,5 +1,24 @@
 
 describe('Available profile', () => {
+    // search for profile to get the version
+    let version:string
+    beforeEach(() => {
+        cy.request({
+            headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+            method: 'POST',
+            url: 'api/v0/compliance/profiles/search',
+            body: {
+            filters: [
+                {type: "name", values: ['linux-baseline']}
+            ]
+            }
+        }).then((resp: Cypress.ObjectLike) => {
+            console.log(resp.body)
+            version = resp.body.profiles[0].version;
+        })
+    });
+
+
     it('can be installed', () => {
         const cypressPrefix = 'test-install-available-profile';
         cy.request({
@@ -8,7 +27,7 @@ describe('Available profile', () => {
             url: 'api/v0/compliance/profiles?owner=admin',
             body: {
             name: 'linux-baseline',
-            version: '2.2.2'
+            version: version
             }
         }).then((resp: Cypress.ObjectLike) => {
             expect(resp.body.summary.valid).to.equal(true);
@@ -22,7 +41,7 @@ describe('Available profile', () => {
             url: 'api/v0/compliance/profiles?owner=admin',
             body: {
             name: 'linux-baseline',
-            version: '2.2.2'
+            version: version
             }
         }).then((resp: Cypress.ObjectLike) => {
             expect(resp.body.summary.valid).to.equal(true);


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
adding a cypress api test for installing an "available" profile

### :chains: Related Resources
https://github.com/chef/automate/pull/3752

### :+1: Definition of Done
test running in CI for profile install from http call (we already have internal tests for this, but they don't go through the http layer)

### :athletic_shoe: How to Build and Test the Change
run the cypress test! see e2e/readme

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
