### PR TITLE
Fixed words not wrapping when exceeding the max width

### DIFF
--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -56,12 +56,12 @@
     <ul>
       <li class="service-item" *ngFor="let service of services$ | async; let i = index">
         <div class="header">
-          <div class ="fqdn-line"><chef-icon>storage</chef-icon> {{ service.fqdn || "--"}}</div>
-          <div class ="supervisor-line"><b>Supervisor:</b> {{ service.supervisor_id || "--"}}</div>
-          <div class ="site-line"><b>Site:</b> {{ service.site  || "--"}}</div>
+          <div class ="fqdn-line"><chef-icon>storage</chef-icon> <p class="fqdn-data">{{ service.fqdn || "--"}}</p></div>
+          <div class ="supervisor-line"><b>Supervisor:</b> <p class="supervisor-data">{{ service.supervisor_id || "--"}}</p></div>
+          <div class ="site-line"><b>Site:</b> <p class="site-data">{{ service.site  || "--"}}</p></div>
         </div>
         <div class="body">
-          <div class ="release-line"><chef-icon>grain</chef-icon>{{ service.release || "--"}}</div>
+          <div class ="release-line"><chef-icon>grain</chef-icon><p class="release-data">{{ service.release || "--"}}</p></div>
           <div class ="channel-line">
             <chef-badge *ngIf="service.update_strategy !== 'NONE'">
               {{ service.channel }}: {{ service.update_strategy }}

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -57,8 +57,8 @@
       <li class="service-item" *ngFor="let service of services$ | async; let i = index">
         <div class="header">
           <div class ="fqdn-line"><chef-icon>storage</chef-icon> <p class="fqdn-data">{{ service.fqdn || "--"}}</p></div>
-          <div class ="supervisor-line"><b>Supervisor:</b> <p class="supervisor-data">{{ service.supervisor_id || "--"}}</p></div>
-          <div class ="site-line"><b>Site:</b> <p class="site-data">{{ service.site  || "--"}}</p></div>
+          <div class ="supervisor-line"><strong>Supervisor:</strong><p class="supervisor-data">{{ service.supervisor_id || "--"}}</p></div>
+          <div class ="site-line"><strong>Site:</strong> <p class="site-data">{{ service.site  || "--"}}</p></div>
         </div>
         <div class="body">
           <div class ="release-line"><chef-icon>grain</chef-icon><p class="release-data">{{ service.release || "--"}}</p></div>

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -74,14 +74,12 @@ chef-alert {
 
   .fqdn-line {
     display: flex;
-    align-items: center;
     margin-bottom: 8px;
     font-size: 14px;
   }
 
   .supervisor-line {
     display: flex;
-    align-items: center;
     margin-bottom: 4px;
     font-size: 12px;
 
@@ -92,7 +90,6 @@ chef-alert {
 
   .site-line {
     display: flex;
-    align-items: center;
     font-size: 12px;
 
     b {
@@ -102,7 +99,6 @@ chef-alert {
 
   .release-line {
     display: flex;
-    align-items: center;
     margin-bottom: 8px;
     font-size: 14px;
   }
@@ -312,3 +308,21 @@ chef-alert {
   padding-right: 35px;
 }
 
+.fqdn-data {
+  margin-bottom: 0px;
+  word-break: break-all;
+}
+
+.site-data,
+.supervisor-data {
+  margin-bottom: 0px;
+  font-size: 12px;
+  padding-top: 2px;
+  word-break: break-all;
+}
+
+.release-data {
+  margin-bottom: 0px;
+  font-size: 14px;
+  word-break: break-all;
+}

--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.scss
@@ -83,7 +83,7 @@ chef-alert {
     margin-bottom: 4px;
     font-size: 12px;
 
-    b {
+    strong {
       margin-right: 4px;
     }
   }
@@ -92,7 +92,7 @@ chef-alert {
     display: flex;
     font-size: 12px;
 
-    b {
+    strong {
       margin-right: 4px;
     }
   }

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -408,3 +408,7 @@ chef-radial-chart {
     width: 14px;
   }
 }
+
+chef-td {
+  word-break: break-all;
+}


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
When users reduce the window width on the service group page, data that exceed the max-width of the text field becomes incomplete.
I have added some changes to fix this.

### :chains: Related Resources
https://github.com/chef/automate/issues/2150
### :+1: Definition of Done
I have added some CSS class for the right side bar and now its showing as expected.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
1. existing 
![service-group](https://user-images.githubusercontent.com/12297653/82578673-56217400-9baa-11ea-8f30-64aa8ad80637.png)

2. after fix
![service-group-fix](https://user-images.githubusercontent.com/12297653/82578618-3d18c300-9baa-11ea-81c4-9d93a44b86d2.png)
