### PR TITLE
Desktop: Disable the mark node missing and delete missing node controls

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -133,7 +133,8 @@
             <div class="checkbox-container">
               <chef-checkbox
               [checked]="!clientRunsLabelMissing.value.disabled"
-              (change)="handleFormActivation(clientRunsLabelMissing, $event.detail)">
+              (change)="handleFormActivation(clientRunsLabelMissing, $event.detail)"
+              disabled="isDesktopView">
               </chef-checkbox>
             </div>
           
@@ -158,7 +159,8 @@
             <div class="checkbox-container">
               <chef-checkbox
               [checked]="!clientRunsRemoveNodes.value.disabled"
-              (change)="handleFormActivation(clientRunsRemoveNodes, $event.detail)">
+              (change)="handleFormActivation(clientRunsRemoveNodes, $event.detail)"
+              disabled="isDesktopView">
               </chef-checkbox>
             </div>
             <p>Remove nodes labeled as missing after

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -134,7 +134,7 @@
               <chef-checkbox
               [checked]="!clientRunsLabelMissing.value.disabled"
               (change)="handleFormActivation(clientRunsLabelMissing, $event.detail)"
-              disabled="isDesktopView">
+              [disabled]="isDesktopView">
               </chef-checkbox>
             </div>
           
@@ -160,7 +160,7 @@
               <chef-checkbox
               [checked]="!clientRunsRemoveNodes.value.disabled"
               (change)="handleFormActivation(clientRunsRemoveNodes, $event.detail)"
-              disabled="isDesktopView">
+              [disabled]="isDesktopView">
               </chef-checkbox>
             </div>
             <p>Remove nodes labeled as missing after

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.spec.ts
@@ -17,10 +17,29 @@ import {
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { TelemetryService } from '../../services/telemetry/telemetry.service';
 import { AutomateSettingsComponent } from './automate-settings.component';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
 
 import { using } from 'app/testing/spec-helpers';
 
 let mockJobSchedulerStatus: JobSchedulerStatus = null;
+
+class MockProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(_product: string): boolean {
+    return false;
+  }
+}
+
+class MockDesktopProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(product: string): boolean {
+    return product === 'desktop';
+  }
+}
 
 class MockTelemetryService {
   track() { }
@@ -43,331 +62,395 @@ describe('AutomateSettingsComponent', () => {
   let component: AutomateSettingsComponent;
   let fixture: ComponentFixture<AutomateSettingsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        FormsModule,
-        ReactiveFormsModule,
-        MatFormFieldModule,
-        MatSelectModule,
-        BrowserAnimationsModule,
-        HttpClientTestingModule,
-        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      declarations: [
-        AutomateSettingsComponent
-      ],
-      providers: [
-        FormBuilder,
-        FeatureFlagsService,
-        { provide: TelemetryService, useClass: MockTelemetryService }
-      ],
-      schemas: [
-        CUSTOM_ELEMENTS_SCHEMA
-      ]
-    })
-    .compileComponents();
-  }));
+  describe('Desktop view', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          FormsModule,
+          ReactiveFormsModule,
+          MatFormFieldModule,
+          MatSelectModule,
+          BrowserAnimationsModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          AutomateSettingsComponent
+        ],
+        providers: [
+          FormBuilder,
+          FeatureFlagsService,
+          { provide: TelemetryService, useClass: MockTelemetryService },
+          { provide: ProductDeployedService, useClass: MockDesktopProductDeployedService }
+        ],
+        schemas: [
+          CUSTOM_ELEMENTS_SCHEMA
+        ]
+      })
+      .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AutomateSettingsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  afterEach(() => {
-    fixture.destroy();
-  });
-
-  it('exists', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('sets defaults for all form groups', () => {
-    expect(component.automateSettingsForm).not.toEqual(null);
-    expect(component.automateSettingsForm instanceof FormGroup).toBe(true);
-    expect(Object.keys(component.automateSettingsForm.controls)).toEqual(ALL_FORMS);
-  });
-
-  describe('handleFormActivation()', () => {
-
-    using(ALL_FORMS
-        // Service Groups are not currently uncheckable through the UI
-        .filter( form => !['serviceGroupNoHealthChecks', 'serviceGroupRemoveServices']
-        .includes(form)),
-        function( form: string) {
-      it(`deactivates the associated ${form} form`, () => {
-        expect(component[form].value.disabled).toEqual(false);
-        component.handleFormActivation(component[form], false);
-        expect(component[form].value.disabled).toEqual(true);
-        expect(component[form].get('unit').disabled).toBe(true);
-        expect(component[form].get('threshold').disabled).toBe(true);
-      });
+    beforeEach(() => {
+      fixture = TestBed.createComponent(AutomateSettingsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
     });
 
-    using(ALL_FORMS
-        // Service Groups are not currently uncheckable through the UI
-        .filter( form => !['serviceGroupsNoHealthChecks', 'serviceGroupRemoveServices']
-        .includes(form)),
-        function (form: string) {
-          it(`activates the associated ${form} form`, () => {
-        component[form].patchValue({disabled: true}); // Deactivate form to start
-        expect(component[form].value.disabled).toEqual(true);
-        component.handleFormActivation(component[form], true);
-        expect(component[form].value.disabled).toEqual(false);
-        expect(component[form].get('unit').disabled).toBe(false);
-        expect(component[form].get('threshold').disabled).toBe(false);
-      });
+    afterEach(() => {
+      fixture.destroy();
     });
 
-  });
-
-  describe('when jobSchedulerStatus is null', () => {
-    it('does not update the forms', () => {
-      const formBeforeUpdate = component.automateSettingsForm;
-      component.updateForm(null);
-      expect(component.automateSettingsForm).toEqual(formBeforeUpdate);
-    });
-  });
-
-  describe('when jobSchedulerStatus is set', () => {
-    beforeAll(() => {
-      const eventFeedRemoveData: IngestJob = {
-        name: 'periodic_purge',
-        category: JobCategories.EventFeed,
-        disabled: true,
-        threshold: '',
-        purge_policies: {
-          elasticsearch: [
-            {
-              name: 'feed',
-              older_than_days: 53,
-              disabled: false
-            }
-          ]
-        }
-      };
-
-      const infraNestedForms: IngestJob = {
-        name: 'periodic_purge_timeseries',
-        category: JobCategories.Infra,
-        disabled: false,
-        threshold: '',
-        purge_policies: {
-          elasticsearch: [
-            {
-              name: 'actions',
-              older_than_days: 22, // default is 30, since disabled
-              disabled: true       // is true older than should be null
-            },
-            {
-              name: 'converge-history',
-              older_than_days: 12,
-              disabled: false
-            }
-          ]
-        }
-      };
-
-      const complianceForms: IngestJob = {
-        category: JobCategories.Compliance,
-        name: 'periodic_purge',
-        threshold: '',
-        disabled: true,
-        purge_policies: {
-          elasticsearch: [
-            {
-              name: 'compliance-reports',
-              older_than_days: 105,
-              disabled: false
-            },
-            {
-              name: 'compliance-scans',
-              older_than_days: 92,
-              disabled: false
-            }
-          ]
-        }
-      };
-
-      const clientRunsRemoveData: IngestJob = {
-        category: JobCategories.Infra,
-        name: 'missing_nodes',
-        disabled : false,
-        threshold : '7d'
-      };
-
-      const clientRunsLabelMissing: IngestJob = {
-        category: JobCategories.Infra,
-        name: 'missing_nodes_for_deletion',
-        disabled: false,
-        threshold: '14m'
-      };
-
-      mockJobSchedulerStatus = new JobSchedulerStatus([
-        eventFeedRemoveData,
-        infraNestedForms,
-        clientRunsRemoveData,
-        clientRunsLabelMissing,
-        complianceForms
-      ]);
-    });
-
-    function genInjestJob(category: string, name: string, threshold: string, disabled: boolean) {
-      return { category, name, threshold, disabled };
-    }
-
-
-    function genNestedIngestJob(category: string, name: string, nested_name: string,
-                                threshold: number, disabled: boolean) {
-      return {
-        name,
-        category,
-        purge_policies: {
-          elasticsearch: [
-            {
-              name: nested_name,
-              older_than_days: threshold,
-              disabled
-            }
-          ]
-        }
-      };
-    }
-
-    using([
-      // Event Feed
-      ['eventFeedRemoveData', 'feed',
-          genNestedIngestJob('event_feed', 'periodic_purge', 'feed', 1, false)],
-      ['eventFeedServerActions', 'actions',
-          genNestedIngestJob('infra', 'periodic_purge_timeseries', 'actions', 2, false)],
-
-      // Services --> not yet enabled
-      // ['serviceGroupNoHealthChecks'],
-      // ['serviceGroupRemoveServices'],
-
-      // Client Runs
-      ['clientRunsRemoveData', 'converge-history',
-          genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, false)],
-
-        // Compliance
-      ['complianceRemoveReports', 'compliance-reports',
-          genNestedIngestJob('compliance', 'periodic_purge', 'compliance-reports', 8, false)],
-      ['complianceRemoveScans', 'compliance-scans',
-          genNestedIngestJob('compliance', 'periodic_purge', 'compliance-scans', 9, false)]
-    ], function(formName: string, nestedName: string, job: IngestJob) {
-      it(`when updating ${formName} form,
-            the form data is extracted from the nested form`, () => {
-        const thisJobScheduler = new JobSchedulerStatus([job]);
-        component.updateForm(thisJobScheduler);
-
-        const newFormValues = component[formName].value;
-        const jobData = job.purge_policies.elasticsearch.find(item => item.name === nestedName);
-
-        expect(newFormValues.threshold).toEqual(jobData.older_than_days);
-        expect(newFormValues.disabled).toEqual(jobData.disabled);
-      });
+    it('exists', () => {
+      expect(component).toBeTruthy();
     });
 
     using([
       // Client Runs
-      ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', false)],
-      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', false)]
-    ], function (formName: string, job: IngestJob) {
-      it(`when updating ${formName} form,
-            the form data is extracted from the non-nested form`, () => {
-        const thisJobScheduler = new JobSchedulerStatus([job]);
-        component.updateForm(thisJobScheduler);
-
-        const newFormValues = component[formName].value;
-
-        // non-nested threshold is stored differently, so we need to separate it
-        // into threshold and unit first.
-        const [jobThreshold, jobUnit] = [job.threshold.slice(0, job.threshold.length - 1),
-                                        job.threshold.slice(-1)];
-        expect(newFormValues.threshold).toEqual(jobThreshold);
-        expect(newFormValues.unit).toEqual(jobUnit);
-        expect(newFormValues.disabled).toEqual(job.disabled);
+      ['clientRunsRemoveNodes'],
+      ['clientRunsLabelMissing']
+    ], function (formName: string) {
+      it(`form ${formName} is disabled`, () => {
+        const form = component[formName].value;
+        expect(form.disabled).toEqual(true);
       });
+    });
+  });
+
+  describe('non Desktop view', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          FormsModule,
+          ReactiveFormsModule,
+          MatFormFieldModule,
+          MatSelectModule,
+          BrowserAnimationsModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          AutomateSettingsComponent
+        ],
+        providers: [
+          FormBuilder,
+          FeatureFlagsService,
+          { provide: TelemetryService, useClass: MockTelemetryService },
+          { provide: ProductDeployedService, useClass: MockProductDeployedService }
+        ],
+        schemas: [
+          CUSTOM_ELEMENTS_SCHEMA
+        ]
+      })
+      .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(AutomateSettingsComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      fixture.destroy();
+    });
+
+    it('exists', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('sets defaults for all form groups', () => {
+      expect(component.automateSettingsForm).not.toEqual(null);
+      expect(component.automateSettingsForm instanceof FormGroup).toBe(true);
+      expect(Object.keys(component.automateSettingsForm.controls)).toEqual(ALL_FORMS);
     });
 
     using([
-      // Event Feed
-      ['eventFeedRemoveData', 'feed',
-        genNestedIngestJob('event_feed', 'periodic_purge', 'feed', 1, true)],
-      ['eventFeedServerActions', 'actions',
-        genNestedIngestJob('infra', 'periodic_purge_timeseries', 'actions', 2, true)],
-
-      // Services --> not yet enabled
-      // ['serviceGroupNoHealthChecks'],
-      // ['serviceGroupRemoveServices'],
-
       // Client Runs
-      ['clientRunsRemoveData', 'converge-history',
-        genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, true)],
-
-      // Compliance
-      ['complianceRemoveReports', 'compliance-reports',
-        genNestedIngestJob('compliance', 'periodic_purge', 'compliance-reports', 8, true)],
-      ['complianceRemoveScans', 'compliance-scans',
-        genNestedIngestJob('compliance', 'periodic_purge', 'compliance-scans', 9, true)]
-    ], function (formName: string, nestedName: string, job: IngestJob) {
-        it(`when ${formName} form is saved as disabled, threshold is undefined
-            because it is not present in the nested form anymore`, () => {
-        const thisJobScheduler = new JobSchedulerStatus([job]);
-        component.updateForm(thisJobScheduler);
-
-        const newFormValues = component[formName].value;
-        const jobData = job.purge_policies.elasticsearch.find(item => item.name === nestedName);
-
-        expect(newFormValues.threshold).toEqual(undefined);
-        expect(newFormValues.disabled).toEqual(jobData.disabled);
+      ['clientRunsRemoveNodes'],
+      ['clientRunsLabelMissing']
+    ], function (formName: string) {
+      it(`form ${formName} is enabled`, () => {
+        const form = component[formName].value;
+        expect(form.disabled).toEqual(false);
       });
     });
 
-    using([
-      // Client Runs
-      ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', true)],
-      ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', true)]
-    ], function (formName: string, job: IngestJob) {
-      it(`when ${formName} form is saved as disabled, unit and threshold are undefined
-            because they are not present in the non-nested form anymore`, () => {
-        const thisJobScheduler = new JobSchedulerStatus([job]);
-        component.updateForm(thisJobScheduler);
+    describe('handleFormActivation()', () => {
 
-        const newFormValues = component[formName].value;
-
-        expect(newFormValues.threshold).toEqual(undefined);
-        expect(newFormValues.unit).toEqual(undefined);
-        expect(newFormValues.disabled).toEqual(job.disabled);
-      });
-    });
-
-
-
-    describe('when user applyChanges()', () => {
-      it('saves settings', () => {
-        component.updateForm(mockJobSchedulerStatus);
-        component.applyChanges();
-
-        // expect(component.notificationVisible).toBe(true);
-        expect(component.notificationType).toEqual('info');
-        expect(component.notificationMessage)
-        .toEqual('Settings saved.');
+      using(ALL_FORMS
+          // Service Groups are not currently uncheckable through the UI
+          .filter( form => !['serviceGroupNoHealthChecks', 'serviceGroupRemoveServices']
+          .includes(form)),
+          function( form: string) {
+        it(`deactivates the associated ${form} form`, () => {
+          expect(component[form].value.disabled).toEqual(false);
+          component.handleFormActivation(component[form], false);
+          expect(component[form].value.disabled).toEqual(true);
+          expect(component[form].get('unit').disabled).toBe(true);
+          expect(component[form].get('threshold').disabled).toBe(true);
+        });
       });
 
-      xdescribe('and there is an error', () => {
-        it('triggers a notification error (shows a banner)', () => {
-          component.updateForm(mockJobSchedulerStatus);
-          component.applyChanges();
-          expect(component.notificationType).toEqual('error');
-          expect(component.notificationMessage)
-            .toEqual('Unable to update one or more settings. Verify the console logs.');
-          expect(component.notificationVisible).toEqual(true);
+      using(ALL_FORMS
+          // Service Groups are not currently uncheckable through the UI
+          .filter( form => !['serviceGroupsNoHealthChecks', 'serviceGroupRemoveServices']
+          .includes(form)),
+          function (form: string) {
+            it(`activates the associated ${form} form`, () => {
+          component[form].patchValue({disabled: true}); // Deactivate form to start
+          expect(component[form].value.disabled).toEqual(true);
+          component.handleFormActivation(component[form], true);
+          expect(component[form].value.disabled).toEqual(false);
+          expect(component[form].get('unit').disabled).toBe(false);
+          expect(component[form].get('threshold').disabled).toBe(false);
         });
       });
 
     });
 
+    describe('when jobSchedulerStatus is null', () => {
+      it('does not update the forms', () => {
+        const formBeforeUpdate = component.automateSettingsForm;
+        component.updateForm(null);
+        expect(component.automateSettingsForm).toEqual(formBeforeUpdate);
+      });
+    });
+
+    describe('when jobSchedulerStatus is set', () => {
+      beforeAll(() => {
+        const eventFeedRemoveData: IngestJob = {
+          name: 'periodic_purge',
+          category: JobCategories.EventFeed,
+          disabled: true,
+          threshold: '',
+          purge_policies: {
+            elasticsearch: [
+              {
+                name: 'feed',
+                older_than_days: 53,
+                disabled: false
+              }
+            ]
+          }
+        };
+
+        const infraNestedForms: IngestJob = {
+          name: 'periodic_purge_timeseries',
+          category: JobCategories.Infra,
+          disabled: false,
+          threshold: '',
+          purge_policies: {
+            elasticsearch: [
+              {
+                name: 'actions',
+                older_than_days: 22, // default is 30, since disabled
+                disabled: true       // is true older than should be null
+              },
+              {
+                name: 'converge-history',
+                older_than_days: 12,
+                disabled: false
+              }
+            ]
+          }
+        };
+
+        const complianceForms: IngestJob = {
+          category: JobCategories.Compliance,
+          name: 'periodic_purge',
+          threshold: '',
+          disabled: true,
+          purge_policies: {
+            elasticsearch: [
+              {
+                name: 'compliance-reports',
+                older_than_days: 105,
+                disabled: false
+              },
+              {
+                name: 'compliance-scans',
+                older_than_days: 92,
+                disabled: false
+              }
+            ]
+          }
+        };
+
+        const clientRunsRemoveData: IngestJob = {
+          category: JobCategories.Infra,
+          name: 'missing_nodes',
+          disabled : false,
+          threshold : '7d'
+        };
+
+        const clientRunsLabelMissing: IngestJob = {
+          category: JobCategories.Infra,
+          name: 'missing_nodes_for_deletion',
+          disabled: false,
+          threshold: '14m'
+        };
+
+        mockJobSchedulerStatus = new JobSchedulerStatus([
+          eventFeedRemoveData,
+          infraNestedForms,
+          clientRunsRemoveData,
+          clientRunsLabelMissing,
+          complianceForms
+        ]);
+      });
+
+      function genInjestJob(category: string, name: string, threshold: string, disabled: boolean) {
+        return { category, name, threshold, disabled };
+      }
+
+
+      function genNestedIngestJob(category: string, name: string, nested_name: string,
+                                  threshold: number, disabled: boolean) {
+        return {
+          name,
+          category,
+          purge_policies: {
+            elasticsearch: [
+              {
+                name: nested_name,
+                older_than_days: threshold,
+                disabled
+              }
+            ]
+          }
+        };
+      }
+
+      using([
+        // Event Feed
+        ['eventFeedRemoveData', 'feed',
+            genNestedIngestJob('event_feed', 'periodic_purge', 'feed', 1, false)],
+        ['eventFeedServerActions', 'actions',
+            genNestedIngestJob('infra', 'periodic_purge_timeseries', 'actions', 2, false)],
+
+        // Services --> not yet enabled
+        // ['serviceGroupNoHealthChecks'],
+        // ['serviceGroupRemoveServices'],
+
+        // Client Runs
+        ['clientRunsRemoveData', 'converge-history',
+            genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, false)],
+
+          // Compliance
+        ['complianceRemoveReports', 'compliance-reports',
+            genNestedIngestJob('compliance', 'periodic_purge', 'compliance-reports', 8, false)],
+        ['complianceRemoveScans', 'compliance-scans',
+            genNestedIngestJob('compliance', 'periodic_purge', 'compliance-scans', 9, false)]
+      ], function(formName: string, nestedName: string, job: IngestJob) {
+        it(`when updating ${formName} form,
+              the form data is extracted from the nested form`, () => {
+          const thisJobScheduler = new JobSchedulerStatus([job]);
+          component.updateForm(thisJobScheduler);
+
+          const newFormValues = component[formName].value;
+          const jobData = job.purge_policies.elasticsearch.find(item => item.name === nestedName);
+
+          expect(newFormValues.threshold).toEqual(jobData.older_than_days);
+          expect(newFormValues.disabled).toEqual(jobData.disabled);
+        });
+      });
+
+      using([
+        // Client Runs
+        ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', false)],
+        ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', false)]
+      ], function (formName: string, job: IngestJob) {
+        it(`when updating ${formName} form,
+              the form data is extracted from the non-nested form`, () => {
+          const thisJobScheduler = new JobSchedulerStatus([job]);
+          component.updateForm(thisJobScheduler);
+
+          const newFormValues = component[formName].value;
+
+          // non-nested threshold is stored differently, so we need to separate it
+          // into threshold and unit first.
+          const [jobThreshold, jobUnit] = [job.threshold.slice(0, job.threshold.length - 1),
+                                          job.threshold.slice(-1)];
+          expect(newFormValues.threshold).toEqual(jobThreshold);
+          expect(newFormValues.unit).toEqual(jobUnit);
+          expect(newFormValues.disabled).toEqual(job.disabled);
+        });
+      });
+
+      using([
+        // Event Feed
+        ['eventFeedRemoveData', 'feed',
+          genNestedIngestJob('event_feed', 'periodic_purge', 'feed', 1, true)],
+        ['eventFeedServerActions', 'actions',
+          genNestedIngestJob('infra', 'periodic_purge_timeseries', 'actions', 2, true)],
+
+        // Services --> not yet enabled
+        // ['serviceGroupNoHealthChecks'],
+        // ['serviceGroupRemoveServices'],
+
+        // Client Runs
+        ['clientRunsRemoveData', 'converge-history',
+          genNestedIngestJob('infra', 'periodic_purge_timeseries', 'converge-history', 7, true)],
+
+        // Compliance
+        ['complianceRemoveReports', 'compliance-reports',
+          genNestedIngestJob('compliance', 'periodic_purge', 'compliance-reports', 8, true)],
+        ['complianceRemoveScans', 'compliance-scans',
+          genNestedIngestJob('compliance', 'periodic_purge', 'compliance-scans', 9, true)]
+      ], function (formName: string, nestedName: string, job: IngestJob) {
+          it(`when ${formName} form is saved as disabled, threshold is undefined
+              because it is not present in the nested form anymore`, () => {
+          const thisJobScheduler = new JobSchedulerStatus([job]);
+          component.updateForm(thisJobScheduler);
+
+          const newFormValues = component[formName].value;
+          const jobData = job.purge_policies.elasticsearch.find(item => item.name === nestedName);
+
+          expect(newFormValues.threshold).toEqual(undefined);
+          expect(newFormValues.disabled).toEqual(jobData.disabled);
+        });
+      });
+
+      using([
+        // Client Runs
+        ['clientRunsRemoveNodes', genInjestJob('infra', 'missing_nodes_for_deletion', '5m', true)],
+        ['clientRunsLabelMissing', genInjestJob('infra', 'missing_nodes', '6h', true)]
+      ], function (formName: string, job: IngestJob) {
+        it(`when ${formName} form is saved as disabled, unit and threshold are undefined
+              because they are not present in the non-nested form anymore`, () => {
+          const thisJobScheduler = new JobSchedulerStatus([job]);
+          component.updateForm(thisJobScheduler);
+
+          const newFormValues = component[formName].value;
+
+          expect(newFormValues.threshold).toEqual(undefined);
+          expect(newFormValues.unit).toEqual(undefined);
+          expect(newFormValues.disabled).toEqual(job.disabled);
+        });
+      });
+
+      describe('when user applyChanges()', () => {
+        it('saves settings', () => {
+          component.updateForm(mockJobSchedulerStatus);
+          component.applyChanges();
+
+          // expect(component.notificationVisible).toBe(true);
+          expect(component.notificationType).toEqual('info');
+          expect(component.notificationMessage)
+          .toEqual('Settings saved.');
+        });
+
+        xdescribe('and there is an error', () => {
+          it('triggers a notification error (shows a banner)', () => {
+            component.updateForm(mockJobSchedulerStatus);
+            component.applyChanges();
+            expect(component.notificationType).toEqual('error');
+            expect(component.notificationMessage)
+              .toEqual('Unable to update one or more settings. Verify the console logs.');
+            expect(component.notificationVisible).toEqual(true);
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Desktop: Disable the mark node missing and delete missing node controls

### :chains: Related Resources

#3244 

### :athletic_shoe: How to Build and Test the Change
1. Start all service and run the automate UI locally. `build components/automate-ui-devproxy/ && start_all_services && start_automate_ui_background && ui_logs`
1. Enable Desktop view with the `enable_desktop` command
1. Go to the https://a2-dev.test/settings/data-lifecycle page
1. Ensure the control with "When no Chef Infra Client run data has been received from a node in" and "Remove nodes labeled as missing after" are disabled like the image below. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/82609456-69fcb400-9b71-11ea-97d6-0020097efffa.png)
