### PR TITLE
Expand product deps before configuring services

### DIFF
--- a/components/automate-deployment/pkg/deployment/deployment.go
+++ b/components/automate-deployment/pkg/deployment/deployment.go
@@ -167,9 +167,7 @@ func ContainsCollection(c *dc.ConfigRequest, collectionName string) bool {
 func CollectionsForConfig(c *dc.ConfigRequest) []string {
 	var collections []string
 	if len(c.GetV1().GetSvc().GetProducts()) > 0 {
-		c := c.GetV1().GetSvc().GetProducts()
-		collections = make([]string, len(c))
-		copy(collections, c)
+		collections = services.RequiredProducts(c.GetV1().GetSvc().GetProducts())
 	} else {
 		collections = []string{services.AutomateCollectionName}
 

--- a/components/automate-deployment/pkg/services/services.go
+++ b/components/automate-deployment/pkg/services/services.go
@@ -4,6 +4,7 @@ package services
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -43,6 +44,26 @@ func MetadataForPackage(pkgName string) *product.PackageMetadata {
 		return packageMetadataMap[pkgName].Metadata
 	}
 	return nil
+}
+
+func RequiredProducts(productsIn []string) []string {
+	requiredProducts := make([]string, 0, 16)
+
+	visited := map[string]bool{}
+
+	for _, collectionName := range productsIn {
+		collection := collectionMap[collectionName]
+		if collection != nil {
+			deps := getRequiredCollections(collectionName, visited)
+			for _, d := range deps {
+				if d.Type == product.ProductType {
+					requiredProducts = append(requiredProducts, d.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(requiredProducts)
+	return requiredProducts
 }
 
 func ContainsCollection(needle string, haystack []string) bool {

--- a/components/automate-deployment/pkg/services/services_test.go
+++ b/components/automate-deployment/pkg/services/services_test.go
@@ -279,3 +279,11 @@ func TestContainsCollection(t *testing.T) {
 		assert.True(t, ContainsCollection("core", []string{"automate-full"}))
 	})
 }
+
+func TestRequiredProducts(t *testing.T) {
+	assert.Equal(t, []string{"automate", "desktop", "workflow"}, RequiredProducts([]string{"desktop", "workflow"}))
+	assert.Equal(t, []string{"automate", "desktop"}, RequiredProducts([]string{"desktop"}))
+	assert.Equal(t, []string{"automate", "builder", "desktop"}, RequiredProducts([]string{"desktop", "builder"}))
+	assert.Equal(t, []string{"automate", "builder", "desktop"}, RequiredProducts([]string{"desktop", "depot"}))
+	assert.Equal(t, []string{"automate", "builder", "desktop"}, RequiredProducts([]string{"desktop", "depot", "automate-full"}))
+}


### PR DESCRIPTION
Instead of the ui getting [desktop], such a thing
will expand into [automate, desktop]
