### PR TITLE
Chef servers list fix

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
@@ -13,7 +13,7 @@
             Display Name is required.
           </chef-error>
           </chef-form-field>
-          <span class="detail light">Don't worry, {{ objectNoun }} names can be changed later.</span>
+          <span class="detail light">Don't worry, server names can be changed later.</span>
         </div>
         <div *ngIf="modifyID" class="id-margin">
           <chef-form-field>
@@ -31,10 +31,10 @@
               Only lowercase letters, numbers, hyphens, and underscores are allowed.
             </chef-error>
             <chef-error *ngIf="conflictError">
-              {{ objectNoun | titlecase }} ID "{{createForm.get('id').value}}" already exists.
+              Server ID "{{createForm.get('id').value}}" already exists.
             </chef-error>
           </chef-form-field>
-          <span class="detail light">{{ objectNoun | titlecase }} IDs are unique, permanent, and cannot be changed later.</span>
+          <span class="detail light">Server IDs are unique, permanent, and cannot be changed later.</span>
         </div>
         <div *ngIf="!modifyID" class="id-margin">
           <div id="id-fields">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
@@ -14,7 +14,6 @@ export class CreateChefServerModalComponent implements OnInit {
   @Output() close = new EventEmitter();
   @Output() createClicked = new EventEmitter();
   @Input() createForm: FormGroup;
-  @Input() objectNoun: string;
   public modifyID = false; // Whether the edit ID form is open or not.
 
   public conflictError = false;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This was a copy/paste error, bringing in a variable that was never fulfilled here. Yet, that variable was part of the page rendering, so it is a user-facing bug.

### :chains: Related Resources

### :+1: Definition of Done
We see "server" instead of empty string in three places.
(1) shows the incorrect empty string in one place. (2), (3), and (4) show the corrected text with the word "server" inserted.

![image](https://user-images.githubusercontent.com/6817500/82716741-ef559680-9c4d-11ea-8424-fa4fa3bb260e.png)


### :athletic_shoe: How to Build and Test the Change
1. rebuild automate-ui
2. navigate to Infrastructure >> Chef Servers >> Add Chef Server; you will see (2) in the illustration immediately.
3. Select "edit ID" to expose (4) above.
4. Enter an already used id to expose (3) above.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
