### PR TITLE
[infra-proxy-service] formalise chef server error response to user-readable message.

### DIFF
--- a/components/infra-proxy-service/server/clients.go
+++ b/components/infra-proxy-service/server/clients.go
@@ -19,7 +19,7 @@ func (s *Server) GetClients(ctx context.Context, req *request.Clients) (*respons
 
 	clients, err := c.client.Clients.List()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "client")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Clients{
@@ -36,7 +36,7 @@ func (s *Server) GetClient(ctx context.Context, req *request.Client) (*response.
 
 	ic, err := c.client.Clients.Get(req.Name)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "client")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Client{

--- a/components/infra-proxy-service/server/clients.go
+++ b/components/infra-proxy-service/server/clients.go
@@ -5,8 +5,6 @@ import (
 	"sort"
 
 	chef "github.com/go-chef/chef"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/chef/automate/api/interservice/infra_proxy/request"
 	"github.com/chef/automate/api/interservice/infra_proxy/response"
@@ -14,15 +12,14 @@ import (
 
 // GetClients get clients list
 func (s *Server) GetClients(ctx context.Context, req *request.Clients) (*response.Clients, error) {
-
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	clients, err := c.client.Clients.List()
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "client")
 	}
 
 	return &response.Clients{
@@ -34,12 +31,12 @@ func (s *Server) GetClients(ctx context.Context, req *request.Clients) (*respons
 func (s *Server) GetClient(ctx context.Context, req *request.Client) (*response.Client, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	ic, err := c.client.Clients.Get(req.Name)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "client")
 	}
 
 	return &response.Client{

--- a/components/infra-proxy-service/server/cookbooks.go
+++ b/components/infra-proxy-service/server/cookbooks.go
@@ -18,12 +18,12 @@ func (s *Server) GetCookbooks(ctx context.Context, req *request.Cookbooks) (*res
 
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	cookbookList, err := c.client.Cookbooks.List()
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "cookbook")
 	}
 
 	return &response.Cookbooks{
@@ -36,12 +36,12 @@ func (s *Server) GetCookbookVersions(ctx context.Context, req *request.CookbookV
 
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	res, err := c.client.Cookbooks.GetAvailableVersions(req.Name, "")
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "cookbook")
 	}
 
 	cookbook, success := res[req.Name]
@@ -59,11 +59,10 @@ func (s *Server) GetCookbook(ctx context.Context, req *request.Cookbook) (*respo
 
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
-		s.service.Logger.Debug("Cookbook Fetch: missing cookbook name")
 		return nil, status.Error(codes.InvalidArgument, "must supply cookbook name")
 	}
 
@@ -74,7 +73,7 @@ func (s *Server) GetCookbook(ctx context.Context, req *request.Cookbook) (*respo
 
 	cookbook, err := c.client.Cookbooks.GetVersion(req.Name, version)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "cookbook")
 	}
 
 	return &response.Cookbook{
@@ -103,7 +102,7 @@ func (s *Server) GetCookbookFileContent(ctx context.Context, req *request.Cookbo
 	var writer bytes.Buffer
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	clientReq, err := c.client.NewRequest("GET", req.Url, nil)

--- a/components/infra-proxy-service/server/cookbooks.go
+++ b/components/infra-proxy-service/server/cookbooks.go
@@ -23,7 +23,7 @@ func (s *Server) GetCookbooks(ctx context.Context, req *request.Cookbooks) (*res
 
 	cookbookList, err := c.client.Cookbooks.List()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "cookbook")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Cookbooks{
@@ -41,7 +41,7 @@ func (s *Server) GetCookbookVersions(ctx context.Context, req *request.CookbookV
 
 	res, err := c.client.Cookbooks.GetAvailableVersions(req.Name, "")
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "cookbook")
+		return nil, ParseAPIError(err)
 	}
 
 	cookbook, success := res[req.Name]
@@ -73,7 +73,7 @@ func (s *Server) GetCookbook(ctx context.Context, req *request.Cookbook) (*respo
 
 	cookbook, err := c.client.Cookbooks.GetVersion(req.Name, version)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "cookbook")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Cookbook{

--- a/components/infra-proxy-service/server/databags.go
+++ b/components/infra-proxy-service/server/databags.go
@@ -31,7 +31,7 @@ func (s *Server) CreateDataBag(ctx context.Context, req *request.CreateDataBag) 
 		})
 
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "databag")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.CreateDataBag{
@@ -49,7 +49,7 @@ func (s *Server) GetDataBags(ctx context.Context, req *request.DataBags) (*respo
 	if req.Name != "" {
 		dataBags, err := c.client.DataBags.ListItems(req.Name)
 		if err != nil {
-			return nil, ParseAPIError(err, req.Name, "databag")
+			return nil, ParseAPIError(err)
 		}
 
 		return &response.DataBags{
@@ -60,7 +60,7 @@ func (s *Server) GetDataBags(ctx context.Context, req *request.DataBags) (*respo
 
 	dataBags, err := c.client.DataBags.List()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "databag")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.DataBags{
@@ -77,7 +77,7 @@ func (s *Server) GetDataBagItem(ctx context.Context, req *request.DataBag) (*res
 
 	ic, err := c.client.DataBags.GetItem(req.Name, req.Item)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "databag")
+		return nil, ParseAPIError(err)
 	}
 
 	data, err := json.Marshal(ic)
@@ -118,7 +118,7 @@ func (s *Server) DeleteDataBag(ctx context.Context, req *request.DataBag) (*resp
 
 	data, err := c.client.DataBags.Delete(req.Name)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "databag")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.DataBag{

--- a/components/infra-proxy-service/server/databags.go
+++ b/components/infra-proxy-service/server/databags.go
@@ -18,7 +18,7 @@ import (
 func (s *Server) CreateDataBag(ctx context.Context, req *request.CreateDataBag) (*response.CreateDataBag, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
@@ -31,7 +31,7 @@ func (s *Server) CreateDataBag(ctx context.Context, req *request.CreateDataBag) 
 		})
 
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "databag")
 	}
 
 	return &response.CreateDataBag{
@@ -41,16 +41,15 @@ func (s *Server) CreateDataBag(ctx context.Context, req *request.CreateDataBag) 
 
 // GetDataBags get data bags list
 func (s *Server) GetDataBags(ctx context.Context, req *request.DataBags) (*response.DataBags, error) {
-
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name != "" {
 		dataBags, err := c.client.DataBags.ListItems(req.Name)
 		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, ParseAPIError(err, req.Name, "databag")
 		}
 
 		return &response.DataBags{
@@ -61,7 +60,7 @@ func (s *Server) GetDataBags(ctx context.Context, req *request.DataBags) (*respo
 
 	dataBags, err := c.client.DataBags.List()
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "databag")
 	}
 
 	return &response.DataBags{
@@ -73,12 +72,12 @@ func (s *Server) GetDataBags(ctx context.Context, req *request.DataBags) (*respo
 func (s *Server) GetDataBagItem(ctx context.Context, req *request.DataBag) (*response.DataBag, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	ic, err := c.client.DataBags.GetItem(req.Name, req.Item)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "databag")
 	}
 
 	data, err := json.Marshal(ic)
@@ -98,7 +97,7 @@ func (s *Server) GetDataBagItem(ctx context.Context, req *request.DataBag) (*res
 func (s *Server) DeleteDataBag(ctx context.Context, req *request.DataBag) (*response.DataBag, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
@@ -119,7 +118,7 @@ func (s *Server) DeleteDataBag(ctx context.Context, req *request.DataBag) (*resp
 
 	data, err := c.client.DataBags.Delete(req.Name)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, req.Name, "databag")
 	}
 
 	return &response.DataBag{

--- a/components/infra-proxy-service/server/environments.go
+++ b/components/infra-proxy-service/server/environments.go
@@ -15,15 +15,14 @@ import (
 
 // GetEnvironments get environments list
 func (s *Server) GetEnvironments(ctx context.Context, req *request.Environments) (*response.Environments, error) {
-
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	environments, err := c.client.Environments.List()
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "environment")
 	}
 
 	return &response.Environments{
@@ -35,12 +34,12 @@ func (s *Server) GetEnvironments(ctx context.Context, req *request.Environments)
 func (s *Server) GetEnvironment(ctx context.Context, req *request.Environment) (*response.Environment, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	en, err := c.client.Environments.Get(req.Name)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, req.Name, "environment")
 	}
 
 	defaultAttributes, err := json.Marshal(en.DefaultAttributes)
@@ -69,7 +68,7 @@ func (s *Server) GetEnvironment(ctx context.Context, req *request.Environment) (
 func (s *Server) DeleteEnvironment(ctx context.Context, req *request.Environment) (*response.Environment, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
@@ -78,7 +77,7 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *request.Environment
 
 	environment, err := c.client.Environments.Delete(req.Name)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, req.Name, "environment")
 	}
 
 	return &response.Environment{

--- a/components/infra-proxy-service/server/environments.go
+++ b/components/infra-proxy-service/server/environments.go
@@ -22,7 +22,7 @@ func (s *Server) GetEnvironments(ctx context.Context, req *request.Environments)
 
 	environments, err := c.client.Environments.List()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "environment")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Environments{
@@ -39,7 +39,7 @@ func (s *Server) GetEnvironment(ctx context.Context, req *request.Environment) (
 
 	en, err := c.client.Environments.Get(req.Name)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "environment")
+		return nil, ParseAPIError(err)
 	}
 
 	defaultAttributes, err := json.Marshal(en.DefaultAttributes)
@@ -77,7 +77,7 @@ func (s *Server) DeleteEnvironment(ctx context.Context, req *request.Environment
 
 	environment, err := c.client.Environments.Delete(req.Name)
 	if err != nil {
-		return nil, ParseAPIError(err, req.Name, "environment")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Environment{

--- a/components/infra-proxy-service/server/nodes.go
+++ b/components/infra-proxy-service/server/nodes.go
@@ -56,7 +56,7 @@ func (c *ChefClient) fetchAffectedNodes(ctx context.Context, chefType, name, ver
 
 	res, err := c.client.Search.PartialExec("node", url, query)
 	if err != nil {
-		return nil, ParseAPIError(err, name, "node")
+		return nil, ParseAPIError(err)
 	}
 
 	return &res, nil

--- a/components/infra-proxy-service/server/nodes.go
+++ b/components/infra-proxy-service/server/nodes.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 
 	chef "github.com/go-chef/chef"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/chef/automate/api/interservice/infra_proxy/request"
 	"github.com/chef/automate/api/interservice/infra_proxy/response"
@@ -17,12 +15,12 @@ import (
 func (s *Server) GetAffectedNodes(ctx context.Context, req *request.AffectedNodes) (*response.AffectedNodes, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	res, err := c.fetchAffectedNodes(ctx, req.ChefType, req.Name, req.Version)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	return &response.AffectedNodes{
@@ -58,7 +56,7 @@ func (c *ChefClient) fetchAffectedNodes(ctx context.Context, chefType, name, ver
 
 	res, err := c.client.Search.PartialExec("node", url, query)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, name, "node")
 	}
 
 	return &res, nil

--- a/components/infra-proxy-service/server/policyfiles.go
+++ b/components/infra-proxy-service/server/policyfiles.go
@@ -21,7 +21,7 @@ func (s *Server) GetPolicyfiles(ctx context.Context, req *request.Policyfiles) (
 
 	policyGroups, err := c.client.PolicyGroups.List()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "policyfile")
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Policyfiles{
@@ -38,7 +38,7 @@ func (s *Server) GetPolicyfile(ctx context.Context, req *request.Policyfile) (*r
 
 	policy, err := c.client.Policies.GetRevisionDetails(req.Name, req.RevisionId)
 	if err != nil {
-		return nil, ParseAPIError(err, "", "policyfile")
+		return nil, ParseAPIError(err)
 	}
 
 	defaultAttrs, err := json.Marshal(policy.DefaultAttributes)
@@ -53,7 +53,7 @@ func (s *Server) GetPolicyfile(ctx context.Context, req *request.Policyfile) (*r
 
 	result, err := c.GetRoleList()
 	if err != nil {
-		return nil, ParseAPIError(err, "", "role")
+		return nil, ParseAPIError(err)
 	}
 
 	runList, err := GetExpandRunlistFromRole(policy.RunList, &result)

--- a/components/infra-proxy-service/server/policyfiles.go
+++ b/components/infra-proxy-service/server/policyfiles.go
@@ -14,16 +14,14 @@ import (
 
 // GetPolicyfiles gets a list of all policy files
 func (s *Server) GetPolicyfiles(ctx context.Context, req *request.Policyfiles) (*response.Policyfiles, error) {
-
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	policyGroups, err := c.client.PolicyGroups.List()
-
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "policyfile")
 	}
 
 	return &response.Policyfiles{
@@ -35,12 +33,12 @@ func (s *Server) GetPolicyfiles(ctx context.Context, req *request.Policyfiles) (
 func (s *Server) GetPolicyfile(ctx context.Context, req *request.Policyfile) (*response.Policyfile, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	policy, err := c.client.Policies.GetRevisionDetails(req.Name, req.RevisionId)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, ParseAPIError(err, "", "policyfile")
 	}
 
 	defaultAttrs, err := json.Marshal(policy.DefaultAttributes)
@@ -55,7 +53,7 @@ func (s *Server) GetPolicyfile(ctx context.Context, req *request.Policyfile) (*r
 
 	result, err := c.GetRoleList()
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, "", "role")
 	}
 
 	runList, err := GetExpandRunlistFromRole(policy.RunList, &result)

--- a/components/infra-proxy-service/server/roles.go
+++ b/components/infra-proxy-service/server/roles.go
@@ -43,7 +43,7 @@ type RoleListResult struct {
 func (s *Server) CreateRole(ctx context.Context, req *request.CreateRole) (*response.Role, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
@@ -91,7 +91,7 @@ func (s *Server) CreateRole(ctx context.Context, req *request.CreateRole) (*resp
 		})
 
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err)
 	}
 
 	return &response.Role{

--- a/components/infra-proxy-service/server/roles.go
+++ b/components/infra-proxy-service/server/roles.go
@@ -119,15 +119,14 @@ func (c *ChefClient) GetRoleList() (RoleListResult, error) {
 
 // GetRoles get roles list
 func (s *Server) GetRoles(ctx context.Context, req *request.Roles) (*response.Roles, error) {
-
 	client, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	result, err := client.GetRoleList()
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, "", "role")
 	}
 
 	return &response.Roles{
@@ -141,12 +140,12 @@ func (s *Server) GetRoles(ctx context.Context, req *request.Roles) (*response.Ro
 func (s *Server) GetRole(ctx context.Context, req *request.Role) (*response.Role, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	result, err := c.GetRoleList()
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, req.Name, "role")
 	}
 
 	role := findRoleFromRoleList(req.Name, &result)
@@ -183,7 +182,7 @@ func (s *Server) GetRole(ctx context.Context, req *request.Role) (*response.Role
 func (s *Server) DeleteRole(ctx context.Context, req *request.Role) (*response.Role, error) {
 	c, err := s.createClient(ctx, req.OrgId, req.ServerId)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid org ID: %s", err.Error())
+		return nil, err
 	}
 
 	if req.Name == "" {
@@ -192,7 +191,7 @@ func (s *Server) DeleteRole(ctx context.Context, req *request.Role) (*response.R
 
 	err = c.client.Roles.Delete(req.Name)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, ParseAPIError(err, req.Name, "role")
 	}
 
 	return &response.Role{

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/felixge/httpsnoop v1.0.0 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20180503022059-e9ed3c6dfb39
-	github.com/go-chef/chef v0.20.1
+	github.com/go-chef/chef v0.21.0
 	github.com/go-delve/delve v1.3.1
 	github.com/go-gorp/gorp v2.0.1-0.20180410155428-6032c66e0f5f+incompatible
 	github.com/gocarina/gocsv v0.0.0-20170928100509-7099e67763c2

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.1-0.20180503022059-e9ed3c6dfb39 h1:8aiwjJixH9Dws9c0mE6yeghmrVhe6csuB+onSjeW31Q=
 github.com/ghodss/yaml v1.0.1-0.20180503022059-e9ed3c6dfb39/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chef/chef v0.20.1 h1:7j653Pk7CrTGALp7xxVI2W7wdj4Y/dq7p3wkhcnwUDw=
-github.com/go-chef/chef v0.20.1/go.mod h1:y3ffcKqjT0vdGFnUx+1yVORHV+gPxeZ5fd0kjkDVpto=
+github.com/go-chef/chef v0.21.0 h1:sfAgY3dZjYLlGphs1rSk/QjmQdiV4BVInr32+Tw5r74=
+github.com/go-chef/chef v0.21.0/go.mod h1:y3ffcKqjT0vdGFnUx+1yVORHV+gPxeZ5fd0kjkDVpto=
 github.com/go-delve/delve v1.3.1 h1:LI0X4aAE0N7ay8uR48aMJ6GNTxamIpcxi1THjwJjenI=
 github.com/go-delve/delve v1.3.1/go.mod h1:LLw6qJfIsRK9WcwV2IRRqsdlgrqzOeuGrQOCOIhDpt8=
 github.com/go-gorp/gorp v2.0.1-0.20180410155428-6032c66e0f5f+incompatible h1:cWM8mu5v0FdhuVs0oqlVI5IcEXfTaAw9Xu025fBqkeQ=

--- a/vendor/github.com/go-chef/chef/reader.go
+++ b/vendor/github.com/go-chef/chef/reader.go
@@ -18,3 +18,15 @@ func JSONReader(v interface{}) (r io.Reader, err error) {
 	r = bytes.NewReader(buf.Bytes())
 	return
 }
+
+// JSONSeeker handles arbitrary types and synthesizes a streaming encoder for them.
+func JSONSeeker(v interface{}) (r io.ReadSeeker, err error) {
+	if debug_on() {
+		jsonout, err := json.Marshal(v)
+		fmt.Printf("\n\nJSON IN: %+v \n JSON ERR: %+v\n", string(jsonout), err)
+	}
+	buf := new(bytes.Buffer)
+	err = json.NewEncoder(buf).Encode(v)
+	r = bytes.NewReader(buf.Bytes())
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/felixge/httpsnoop
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.1-0.20180503022059-e9ed3c6dfb39
 github.com/ghodss/yaml
-# github.com/go-chef/chef v0.20.1
+# github.com/go-chef/chef v0.21.0
 github.com/go-chef/chef
 # github.com/go-delve/delve v1.3.1
 github.com/go-delve/delve/cmd/dlv


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
At present go-chef lib not populating the error message from API response. Added better user-readable error messages based on the error response code.

### :chains: Related Resources
Fixes https://github.com/chef/automate/issues/3754

### :+1: Definition of Done

- Better user-readable message for chef-server API error responses.

### :athletic_shoe: How to Build and Test the Change
- `rebuild components/infra-proxy-service`
- `rebuild components/automate-gateway`

Steps to test:

- Use the latest chef-server test environment detail from channel pined message.
- Invalid org admin key detail.

```
curl -sSkH "api-token: $(get_admin_token)"  https://a2-dev.test/api/v0/infra/servers/test/orgs/chef-org/cookbooks?pretty
{
  "error": "The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.",
  "code": 2,
  "message": "The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.",
  "details": [
  ]
}

```

- GetEnvironment which does not exists 
```
curl -sSkH "api-token: $(get_admin_token)"  https://a2-dev.test/api/v0/infra/servers/chef-server-dev-test/orgs/chef-org-dev/environments/wix1?pretty
{
  "error": "no environment found with name \"wix1\"",
  "code": 5,
  "message": "no environment found with name \"wix1\"",
  "details": [
  ]
}
```


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
