### PR TITLE
Allow tooltips to be configured for interaction

### DIFF
--- a/components/chef-ui-library/src/atoms/chef-tooltip/chef-tooltip.scss
+++ b/components/chef-ui-library/src/atoms/chef-tooltip/chef-tooltip.scss
@@ -66,6 +66,10 @@ chef-tooltip {
   &.visible {
     opacity: 1;
     transition-property: opacity;
+
+    &.interactable {
+      pointer-events: all;
+    }
   }
 
   &.follow {


### PR DESCRIPTION
This commit allows `chef-tooltips` to be made interactable by adding an `interactable` attribute. Fixes https://github.com/chef/automate/issues/3791

![](https://user-images.githubusercontent.com/479121/82920783-f8d44c80-9f34-11ea-875d-9bd108a4f2be.gif)

