### PR TITLE
Client Runs Delete check boxes not showing up. 

### DIFF
--- a/components/automate-ui/src/app/page-components/deletable-node-control/deletable-node-control.component.html
+++ b/components/automate-ui/src/app/page-components/deletable-node-control/deletable-node-control.component.html
@@ -16,7 +16,7 @@
       <strong>{{nodesSelectedForDelete.size}} node{{ nodesSelectedForDelete.size | i18nPlural: pluralMapping }}</strong>.
     </p>
     <p>This action can not be undone.</p>
-    <chef-button primary caution (click)="closeModal(true)">
+    <chef-button class="delete-button-confirm" primary caution (click)="closeModal(true)">
       Delete {{nodesSelectedForDelete.size }} node{{ nodesSelectedForDelete.size | i18nPlural: pluralMapping }}
     </chef-button>
     <chef-button tertiary (click)="closeModal(false)">Cancel</chef-button>

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -374,7 +374,7 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     this.authorizedChecker = new AuthorizedChecker(this.store);
     this.authorizedChecker.setPermissions([
       {
-        endpoint: '/ingest/events/chef/node-multiple-deletes',
+        endpoint: '/api/v0/ingest/events/chef/node-multiple-deletes',
         paramList: [],
         verb: 'post'
       }

--- a/e2e/cypress/integration/ui/client-runs/delete_missing_node.spec.ts
+++ b/e2e/cypress/integration/ui/client-runs/delete_missing_node.spec.ts
@@ -1,0 +1,69 @@
+import { uuidv4 } from '../../../support/helpers';
+
+describe('delete missing node from UI', () => {
+  const cypressPrefix = 'ui-delete-missing-node';
+  const clientRunsNodeId = uuidv4();
+  const nodeName = `${cypressPrefix}-${Cypress.moment().format('MMDDYYhhmmss.sss')}`;
+
+  before(() => {
+    // Add node that ran a month ago
+    cy.fixture('converge/avengers1.json').then((node) => {
+      const runEndDate = Cypress.moment().subtract(1, 'month');
+      node.entity_uuid = clientRunsNodeId;
+      node.node_name = nodeName;
+      node.start_time = runEndDate.subtract(5, 'minute').toISOString();
+      node.end_time = runEndDate.toISOString();
+      cy.sendToDataCollector(node);
+    });
+
+    cy.waitForClientRunsNode(clientRunsNodeId);
+
+    // Update the mark nodes missing job to mark the nodes missing
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'POST',
+      url: 'api/v0/retention/nodes/missing-nodes/config',
+      body: {
+        threshold: '1h',
+        running: true,
+        every: '15m'
+      }
+    });
+
+    // wait for nodes to be marked missing
+    cy.waitUntilNodeIsMissing(clientRunsNodeId);
+  });
+
+  after(() => {
+    // Set the ConfigureNodesMissingScheduler threshold back
+    cy.request({
+      headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
+      method: 'POST',
+      url: 'api/v0/retention/nodes/missing-nodes/config',
+      body: {
+        threshold: '24h',
+        running: true,
+        every: '15m'
+      }
+    });
+  });
+
+  it('from client runs page delete nodes', () => {
+    cy.adminLogin('/infrastructure/client-runs').then(() => {
+      cy.get('app-welcome-modal').invoke('hide');
+    });
+
+    // Check the check box to delete all missing nodes
+    cy.get('chef-checkbox.header').click();
+
+
+    // Click the delete all button
+    cy.get('chef-button.delete-button').click();
+
+    // Click the confim delete button
+    cy.get('chef-modal chef-button.delete-button-confirm').click();
+
+    // wait until all nodes are delete API check
+    cy.waitUntilConfigMgmtNodeIsDeleted(clientRunsNodeId);
+  });
+});


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixing a bug where admin users were not provided the checkboxes to delete missing nodes. The problem was the API path used was incorrect. The incorrect path that was being used was "/ingest/events/chef/node-multiple-deletes", but it was correct path is "/api/v0/ingest/events/chef/node-multiple-deletes".

### :chains: Related Resources
#3802

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui-devproxy && start_all_services && start_automate_ui_background`
1. Add a older node with `send_chef_run_example`
1. Watch the UI logs for the UI to start up. `ui_logs`
1. Mark the node missing by changing the mark node missing job. 
1. Go to https://a2-dev.test/settings/data-lifecycle
1. Update the "When no Chef Infra Client run data has been received from a node in" to 0. 
1. Go to https://a2-dev.test/infrastructure/client-runs
1. Ensure the checkboxes next to the nodes are visible and checkable. 


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/83062580-c2b9ca00-a013-11ea-84d8-6038b1dd2426.png)
