### PR TITLE
automate-3459 Visualize the check-in history of individual desktop

### DIFF
--- a/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
@@ -1,35 +1,44 @@
 import { Action } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 
-import { DailyCheckInCountCollection,
+import { DailyCheckInCountCollection, NodeRunsDailyStatusCollection,
   TopErrorsCollection, CountedDurationCollection, Desktop, TermFilter } from './desktop.model';
 
 export enum DesktopActionTypes {
-  GET_DAILY_CHECK_IN_TIME_SERIES              = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES',
-  GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS      = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::SUCCESS',
-  GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE      = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::FAILURE',
-  SET_DAYS_AGO_SELECTED                       = 'DESKTOP::SET::DAYS_AGO_SELECTED',
-  GET_TOP_ERRORS_COLLECTION                   = 'DESKTOP::GET::TOP_ERRORS_COLLECTION',
-  GET_TOP_ERRORS_COLLECTION_SUCCESS           = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::SUCCESS',
-  GET_TOP_ERRORS_COLLECTION_FAILURE           = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::FAILURE',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS         = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_SUCCESS = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::SUCCESS',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_FAILURE = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::FAILURE',
-  GET_DESKTOPS                                = 'DESKTOP::GET::DESKTOPS',
-  GET_DESKTOPS_SUCCESS                        = 'DESKTOP::GET::DESKTOPS::SUCCESS',
-  GET_DESKTOPS_FAILURE                        = 'DESKTOP::GET::DESKTOPS::FAILURE',
-  GET_DESKTOPS_TOTAL                          = 'DESKTOP::GET::DESKTOPS_TOTAL',
-  GET_DESKTOPS_TOTAL_SUCCESS                  = 'DESKTOP::GET::DESKTOPS_TOTAL::SUCCESS',
-  GET_DESKTOPS_TOTAL_FAILURE                  = 'DESKTOP::GET::DESKTOPS_TOTAL::FAILURE',
-  UPDATE_DESKTOPS_FILTER_CURRENT_PAGE         = 'DESKTOP::UPDATE::DESKTOPS_FILTER_CURRENT_PAGE',
-  ADD_DESKTOPS_FILTER_TERM                    = 'DESKTOP::ADD::DESKTOPS_FILTER_TERM',
-  UPDATE_DESKTOPS_FILTER_TERMS                = 'DESKTOP::UPDATE::DESKTOPS_FILTER_TERMS',
-  REMOVE_DESKTOPS_FILTER_TERM                 = 'DESKTOP::REMOVE::DESKTOPS_FILTER_TERM',
-  UPDATE_DESKTOPS_SORT_TERM                   = 'DESKTOP::UPDATE::DESKTOPS_SORT_TERM'
+  GET_DAILY_CHECK_IN_TIME_SERIES                  = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES',
+  GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS          = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::SUCCESS',
+  GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE          = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::FAILURE',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES          = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_SUCCESS  = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::SUCCESS',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE  = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::FAILURE',
+  GET_TOP_ERRORS_COLLECTION                       = 'DESKTOP::GET::TOP_ERRORS_COLLECTION',
+  GET_TOP_ERRORS_COLLECTION_SUCCESS               = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::SUCCESS',
+  GET_TOP_ERRORS_COLLECTION_FAILURE               = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::FAILURE',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS             = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_SUCCESS     = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::SUCCESS',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_FAILURE     = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::FAILURE',
+  GET_DESKTOPS                                    = 'DESKTOP::GET::DESKTOPS',
+  GET_DESKTOPS_SUCCESS                            = 'DESKTOP::GET::DESKTOPS::SUCCESS',
+  GET_DESKTOPS_FAILURE                            = 'DESKTOP::GET::DESKTOPS::FAILURE',
+  GET_DESKTOPS_TOTAL                              = 'DESKTOP::GET::DESKTOPS_TOTAL',
+  GET_DESKTOPS_TOTAL_SUCCESS                      = 'DESKTOP::GET::DESKTOPS_TOTAL::SUCCESS',
+  GET_DESKTOPS_TOTAL_FAILURE                      = 'DESKTOP::GET::DESKTOPS_TOTAL::FAILURE',
+  SET_SELECTED_DESKTOP                            = 'DESKTOP::SET::DESKTOP',
+  SET_SELECTED_DAYS_AGO                           = 'DESKTOP::SET::DAYS_AGO',
+  UPDATE_DESKTOPS_FILTER_CURRENT_PAGE             = 'DESKTOP::UPDATE::DESKTOPS_FILTER_CURRENT_PAGE',
+  ADD_DESKTOPS_FILTER_TERM                        = 'DESKTOP::ADD::DESKTOPS_FILTER_TERM',
+  UPDATE_DESKTOPS_FILTER_TERMS                    = 'DESKTOP::UPDATE::DESKTOPS_FILTER_TERMS',
+  REMOVE_DESKTOPS_FILTER_TERM                     = 'DESKTOP::REMOVE::DESKTOPS_FILTER_TERM',
+  UPDATE_DESKTOPS_SORT_TERM                       = 'DESKTOP::UPDATE::DESKTOPS_SORT_TERM'
 }
 
-export class SetDaysAgoSelected implements Action {
-  readonly type = DesktopActionTypes.SET_DAYS_AGO_SELECTED;
+export class SetSelectedDesktop implements Action {
+  readonly type = DesktopActionTypes.SET_SELECTED_DESKTOP;
+  constructor(public payload: {desktop: Desktop}) { }
+}
+
+export class SetSelectedDaysAgo implements Action {
+  readonly type = DesktopActionTypes.SET_SELECTED_DAYS_AGO;
   constructor(public payload: {daysAgo: number}) { }
 }
 
@@ -44,6 +53,21 @@ export class GetDailyCheckInTimeSeriesSuccess implements Action {
 
 export class GetDailyCheckInTimeSeriesFailure implements Action {
   readonly type = DesktopActionTypes.GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class GetDailyNodeRunsStatusTimeSeries implements Action {
+  readonly type = DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES;
+  constructor(public nodeId: string, public daysAgo: number ) { }
+}
+
+export class GetDailyNodeRunsStatusTimeSeriesSuccess implements Action {
+  readonly type = DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_SUCCESS;
+  constructor(public payload: NodeRunsDailyStatusCollection) { }
+}
+
+export class GetDailyNodeRunsStatusTimeSeriesFailure implements Action {
+  readonly type = DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE;
   constructor(public payload: HttpErrorResponse) { }
 }
 
@@ -129,10 +153,14 @@ export class UpdateDesktopSortTerm implements Action {
 }
 
 export type DesktopActions =
-  | SetDaysAgoSelected
+  | SetSelectedDaysAgo
+  | SetSelectedDesktop
   | GetDailyCheckInTimeSeries
   | GetDailyCheckInTimeSeriesSuccess
   | GetDailyCheckInTimeSeriesFailure
+  | GetDailyNodeRunsStatusTimeSeries
+  | GetDailyNodeRunsStatusTimeSeriesSuccess
+  | GetDailyNodeRunsStatusTimeSeriesFailure
   | GetTopErrorsCollection
   | GetTopErrorsCollectionSuccess
   | GetTopErrorsCollectionFailure

--- a/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
@@ -9,6 +9,9 @@ import {
   GetDailyCheckInTimeSeries,
   GetDailyCheckInTimeSeriesSuccess,
   GetDailyCheckInTimeSeriesFailure,
+  GetDailyNodeRunsStatusTimeSeries,
+  GetDailyNodeRunsStatusTimeSeriesSuccess,
+  GetDailyNodeRunsStatusTimeSeriesFailure,
   DesktopActionTypes,
   GetTopErrorsCollection,
   GetTopErrorsCollectionSuccess,
@@ -38,7 +41,7 @@ export class DesktopEffects {
 
   @Effect()
   setDaysAgoSelected$ = this.actions$.pipe(
-    ofType(DesktopActionTypes.SET_DAYS_AGO_SELECTED),
+    ofType(DesktopActionTypes.SET_SELECTED_DAYS_AGO),
     map(() => new GetDailyCheckInTimeSeries())
   );
 
@@ -65,6 +68,27 @@ export class DesktopEffects {
         message: `Could not get time series: ${msg || error}`
       });
     }));
+
+  @Effect()
+    getDailyNodeRunsStatusTimeSeries$ =
+      this.actions$.pipe(ofType<GetDailyNodeRunsStatusTimeSeries>(
+        DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES),
+        mergeMap(({ nodeId, daysAgo }) =>
+          this.requests.getDailyNodeRunsStatusCountCollection(nodeId, daysAgo).pipe(
+            map(dailyNodeRunsStatusCountCollection =>
+              new GetDailyNodeRunsStatusTimeSeriesSuccess(dailyNodeRunsStatusCountCollection)),
+              catchError((error) => of(new GetDailyNodeRunsStatusTimeSeriesFailure(error))))));
+
+    @Effect()
+    getDailyNodeRunsStatusSeriesFailure$ = this.actions$.pipe(
+      ofType(DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE),
+      map(({ payload: { error } }: GetDailyNodeRunsStatusTimeSeriesFailure) => {
+        const msg = error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get time series: ${msg || error}`
+        });
+      }));
 
   @Effect()
   getTopErrorCollection$ =

--- a/components/automate-ui/src/app/entities/desktop/desktop.model.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.model.ts
@@ -11,6 +11,11 @@ export enum SortOrder {
   Descending = 'DESC'
 }
 
+export interface Selected {
+  desktop: Desktop;
+  daysAgo: number;
+}
+
 export interface DailyCheckInCountCollection {
   buckets: DailyCheckInCount[];
   updated: Date;
@@ -21,6 +26,26 @@ export interface DailyCheckInCount {
   end: Date;
   checkInCount: number;
   total: number;
+}
+
+export interface DailyNodeRuns {
+  durations: NodeRunsDailyStatusCollection;
+  daysAgo: number;
+  nodeId: string;
+  status: string;
+}
+
+export interface DailyNodeRunsStatus {
+  start: Date;
+  end: Date;
+  status: string;
+  run_id: string;
+  label?: string;
+}
+
+export interface NodeRunsDailyStatusCollection {
+  buckets: DailyNodeRunsStatus[];
+  updated: Date;
 }
 
 export interface DayPercentage {

--- a/components/automate-ui/src/app/entities/desktop/desktop.requests.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.requests.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { reduce } from 'lodash/fp';
 import { DailyCheckInCountCollection, DailyCheckInCount,
+  NodeRunsDailyStatusCollection,
   TopErrorsCollection, TopErrorsItem,
   CountedDurationCollection, CountedDurationItem, Desktop, Filter } from './desktop.model';
 
@@ -19,6 +20,17 @@ interface RespDailyCheckInCount {
   end: Date;
   count: number;
   total: number;
+}
+
+interface RespNodeRunsDailyStatusCollection {
+  durations: RespNodeRunsDailyStatus[];
+}
+
+interface RespNodeRunsDailyStatus {
+  start: Date;
+  end: Date;
+  status: string;
+  run_id: string;
 }
 
 interface RespTopNodeErrors {
@@ -73,6 +85,14 @@ export class DesktopRequests {
       `${CONFIG_MGMT_URL}/stats/checkin_counts_timeseries?days_ago=${daysAgo}`)
       .pipe(map(respDailyCheckInCountCollection =>
         this.createDailyCheckInCountCollection(respDailyCheckInCountCollection)));
+  }
+
+  public getDailyNodeRunsStatusCountCollection(nodeId: string, daysAgo: number):
+    Observable<NodeRunsDailyStatusCollection> {
+      return this.http.get<RespNodeRunsDailyStatusCollection>(
+        `${CONFIG_MGMT_URL}/node_runs_daily_status_time_series?node_id=${nodeId}&days_ago=${daysAgo}`)
+        .pipe(map(respNodeRunsDailyStatusCollection =>
+          this.createNodeRunsDailyStatusCollection(respNodeRunsDailyStatusCollection)));
   }
 
   public getTopErrorsCollection(): Observable<TopErrorsCollection> {
@@ -206,4 +226,12 @@ export class DesktopRequests {
     };
   }
 
+  private createNodeRunsDailyStatusCollection(
+    respNodeRunsDailyStatusCollection: RespNodeRunsDailyStatusCollection):
+      NodeRunsDailyStatusCollection {
+      return {
+        buckets: respNodeRunsDailyStatusCollection.durations,
+        updated: new Date()
+      };
+  }
 }

--- a/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
@@ -14,9 +14,24 @@ export const dailyCheckInCountCollection = createSelector(
   (state) => state.dailyCheckInCountCollection
 );
 
+export const getSelected = createSelector(
+  desktopState,
+  (state) => state.selected
+);
+
 export const getSelectedDaysAgo = createSelector(
   desktopState,
-  (state) => state.selectedDaysAgo
+  (state) => state.selected.daysAgo
+);
+
+export const getSelectedDesktop = createSelector(
+  desktopState,
+  (state) => state.selected.desktop
+);
+
+export const getDailyNodeRuns = createSelector(
+  desktopState,
+  (state) => state.dailyNodeRuns
 );
 
 export const topErrorsCollection = createSelector(

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
@@ -8,7 +8,8 @@ import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 
 import {
   GetDailyCheckInTimeSeries,
-  SetDaysAgoSelected,
+  SetSelectedDesktop,
+  SetSelectedDaysAgo,
   GetTopErrorsCollection,
   GetUnknownDesktopDurationCounts,
   GetDesktops,
@@ -162,7 +163,7 @@ export class DashboardComponent implements OnInit {
   }
 
   handleDaysAgoChange(daysAgo: number) {
-    this.store.dispatch(new SetDaysAgoSelected({daysAgo}));
+    this.store.dispatch(new SetSelectedDaysAgo({daysAgo}));
   }
 
   onDesktopListClose() {
@@ -207,6 +208,7 @@ export class DashboardComponent implements OnInit {
 
   public onDesktopSelected(desktop: Desktop) {
     this.selectedDesktop = desktop;
+    this.store.dispatch(new SetSelectedDesktop({desktop}));
     this.desktopDetailVisible = true;
     this.desktopListFullscreened = false;
   }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -72,12 +72,13 @@
             <span>{{ history.status | titlecase }}</span>
             <chef-tooltip
               [ngClass]="['checkin-tooltip', history.status]"
-              [attr.for]="'checkin-item-'+i+'text'">
+              [attr.for]="'checkin-item-'+i+'text'"
+              interactable>
               <p class="checkin-tooltip-info">
                 <span class="checkin-tooltip-text">{{ history.status | titlecase }}</span>
                 <span class="checkin-tooltip-date">{{ history.end | datetime: DateTime.RFC2822 }}</span>
               </p>
-              <a class="checkin-tooltip-link" href="">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
+              <a class="checkin-tooltip-link" [routerLink]="['/infrastructure/client-runs', desktop.id, 'runs', history.run_id]">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
             </chef-tooltip>
           </chef-td>
           <chef-td class="date-cell">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -78,7 +78,7 @@
                 <span class="checkin-tooltip-text">{{ history.status | titlecase }}</span>
                 <span class="checkin-tooltip-date">{{ history.end | datetime: DateTime.RFC2822 }}</span>
               </p>
-              <a class="checkin-tooltip-link" [routerLink]="['/infrastructure/client-runs', desktop.id, 'runs', history.run_id]">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
+              <a *ngIf="history.run_id" class="checkin-tooltip-link" target="_blank" href="{{ getRunDetailsUrl(history.run_id) }}">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
             </chef-tooltip>
           </chef-td>
           <chef-td class="date-cell">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -16,13 +16,10 @@
 
   <div class="checkin-history">
     <div class="checkin-history-header">
-      <h3>Check-in History <span *ngIf="showCheckinDebug">(debug)</span></h3>
+      <h3>Check-in History</h3>
       <div class="heading-actions">
-        <chef-button secondary (click)="showCheckinDebug = !showCheckinDebug">
-          <chef-icon>settings</chef-icon>
-        </chef-button>
         <chef-button secondary (click)="updateCheckInDays()">
-          <span>Last {{ (checkinNumDays === 14 ? 2 : 4) }} Weeks</span>
+          <span>Last {{ (checkinNumDays === 15 ? 2 : 4) }} Weeks</span>
           <chef-icon>expand_more</chef-icon>
         </chef-button>
         <chef-button secondary>
@@ -31,31 +28,7 @@
         </chef-button>
       </div>
     </div>
-    <div class="debug-actions" *ngIf="showCheckinDebug">
-      <div class="button-toggle">
-        <chef-button secondary (click)="checkinTableType = 'grid'">
-          <chef-icon>view_module</chef-icon>
-        </chef-button>
-        <chef-button secondary (click)="checkinTableType = 'list'">
-          <chef-icon>view_list</chef-icon>
-        </chef-button>
-        <chef-button secondary (click)="checkinTableType = 'json'">
-          <chef-icon>code</chef-icon>
-        </chef-button>
-        <span>{{ checkinTableType }}</span>
-      </div>
-
-      <div class="button-toggle">
-        <span>{{ checkinGridFlexType }}</span>
-        <chef-button secondary (click)="checkinGridFlexType = 'wrap'">
-          <chef-icon>wrap_text</chef-icon>
-        </chef-button>
-        <chef-button secondary (click)="checkinGridFlexType = 'stretch'">
-          <chef-icon>dehaze</chef-icon>
-        </chef-button>
-      </div>
-    </div>
-    <chef-table class="checkin-history-table {{showCheckinDebug ? 'outline' : ''}}" [ngClass]="[checkinTableType, checkinGridFlexType]" *ngIf="checkinTableType !== 'json'">
+    <chef-table class="checkin-history-table grid">
       <chef-thead>
         <chef-tr>
           <chef-th class="status-cell">Status</chef-th>
@@ -78,7 +51,12 @@
                 <span class="checkin-tooltip-text">{{ history.status | titlecase }}</span>
                 <span class="checkin-tooltip-date">{{ history.end | datetime: DateTime.RFC2822 }}</span>
               </p>
-              <a *ngIf="history.run_id" class="checkin-tooltip-link" target="_blank" href="{{ getRunDetailsUrl(history.run_id) }}">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
+              <a *ngIf="history.run_id"
+                class="checkin-tooltip-link"
+                target="_blank"
+                [routerLink]="['/infrastructure/client-runs', desktop.id, 'runs', history.run_id]"
+                >View Client Run Details <chef-icon>open_in_new</chef-icon>
+              </a>
             </chef-tooltip>
           </chef-td>
           <chef-td class="date-cell">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -21,7 +21,7 @@
         <chef-button secondary (click)="showCheckinDebug = !showCheckinDebug">
           <chef-icon>settings</chef-icon>
         </chef-button>
-        <chef-button secondary (click)="checkinNumDays = (checkinNumDays === 14 ? 28 : 14)">
+        <chef-button secondary (click)="updateCheckInDays()">
           <span>Last {{ (checkinNumDays === 14 ? 2 : 4) }} Weeks</span>
           <chef-icon>expand_more</chef-icon>
         </chef-button>
@@ -64,37 +64,31 @@
         </chef-tr>
       </chef-thead>
       <chef-tbody>
-        <chef-tr *ngFor="let item of checkinHistory; index as i">
-          <chef-td class="status-cell" [id]="'checkin-item-'+i+'text'">
-            <chef-icon>{{ item.icon }}</chef-icon>
-            <span>{{ item.text | titlecase }}</span>
+        <chef-tr *ngFor="let history of checkInHistory; index as i">
+          <chef-td class="status-cell">
+            <chef-icon [id]="'checkin-item-'+i+'text'" [ngClass]="history.status">
+              {{ historyIcons[history.status] }}
+            </chef-icon>
+            <span>{{ history.status | titlecase }}</span>
             <chef-tooltip
-              [ngClass]="['checkin-tooltip', item.text]"
+              [ngClass]="['checkin-tooltip', history.status]"
               [attr.for]="'checkin-item-'+i+'text'">
               <p class="checkin-tooltip-info">
-                <span class="checkin-tooltip-text">{{ item.text | titlecase }}</span>
-                <span class="checkin-tooltip-date">{{ item.date | datetime: DateTime.RFC2822 }}</span>
+                <span class="checkin-tooltip-text">{{ history.status | titlecase }}</span>
+                <span class="checkin-tooltip-date">{{ history.end | datetime: DateTime.RFC2822 }}</span>
               </p>
               <a class="checkin-tooltip-link" href="">View Client Run Details <chef-icon>open_in_new</chef-icon></a>
             </chef-tooltip>
           </chef-td>
           <chef-td class="date-cell">
-            <span>{{ item.date | datetime: DateTime.RFC2822 }}</span>
+            <span>{{ history.end | datetime: DateTime.RFC2822 }}</span>
           </chef-td>
-          <chef-td class="relative-date-cell" [ngSwitch]="i">
-            <span *ngSwitchCase="0">Today</span>
-            <span *ngSwitchCase="7">1 week ago</span>
-            <span *ngSwitchDefault>{{ ceil(i / 7) }} weeks ago</span>
+          <chef-td class="relative-date-cell">
+            <span>{{ history.label }}</span>
           </chef-td>
         </chef-tr>
       </chef-tbody>
     </chef-table>
-    <chef-snippet
-      *ngIf="checkinTableType === 'json'"
-      class="checkin-history-json"
-      [code]="checkinHistory | json"
-      lang="json">
-    </chef-snippet>
   </div>
 
   <div class="detail-info">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -163,8 +163,7 @@ h3 {
     }
   }
 
-  chef-tr:nth-child(7n + 1),
-  chef-tr:last-child {
+  chef-tr:nth-child(7n + 1) {
     chef-td {
       &.relative-date-cell {
         > span {
@@ -191,11 +190,11 @@ h3 {
         justify-content: flex-start;
 
         span {
-          transform: translateX(15px);
+          transform: translateX(17px);
         }
 
         &::before {
-          transform: translateX(15px);
+          transform: translateX(17px);
         }
 
         &::after {
@@ -230,128 +229,6 @@ h3 {
       }
     }
   }
-
-  &.stretch {
-    chef-tbody {
-      flex-flow: row nowrap;
-      justify-content: space-between;
-      position: relative;
-
-      &::before {
-        display: block;
-        height: 1px;
-        background: $chef-grey;
-        position: absolute;
-        left: 15px;
-        right: 15px;
-        bottom: 20px;
-        content: '';
-
-        @include carbon--breakpoint-down(lg) {
-          left: 11px;
-          right: 11px;
-        }
-
-        @include carbon--breakpoint-down(md) {
-          left: 7px;
-          right: 7px;
-        }
-      }
-    }
-
-    chef-tr:first-child {
-      chef-td {
-        &.relative-date-cell {
-          span,
-          &::before {
-            @include carbon--breakpoint-down(lg) {
-              transform: translateX(11px);
-            }
-
-            @include carbon--breakpoint-down(md) {
-              transform: translateX(7px);
-            }
-          }
-        }
-      }
-    }
-
-    chef-tr:last-child {
-      chef-td {
-        &.relative-date-cell {
-          justify-content: flex-end;
-
-          span,
-          &::before {
-            transform: translateX(-15px);
-
-            @include carbon--breakpoint-down(lg) {
-              transform: translateX(-11px);
-            }
-
-            @include carbon--breakpoint-down(md) {
-              transform: translateX(-7px);
-            }
-          }
-        }
-      }
-    }
-
-    chef-td.status-cell {
-      > chef-icon {
-        @include carbon--breakpoint-down(lg) {
-          font-size: 18px;
-        }
-
-        @include carbon--breakpoint-down(md) {
-          font-size: 14px;
-          padding: 0;
-        }
-      }
-    }
-  }
-
-  &.outline {
-    chef-tr {
-      outline: 1px dashed pink;
-      outline-offset: -1px;
-    }
-  }
-}
-
-.checkin-history-table.list {
-  .status-cell {
-    flex-basis: 30%;
-
-    > chef-icon {
-      margin-right: $spacing-05;
-    }
-  }
-
-  .relative-date-cell {
-    flex-basis: 20%;
-    color: transparent;
-  }
-
-  .date-cell {
-    flex-basis: 50%;
-  }
-
-  chef-tr:nth-child(7n + 1) {
-    .relative-date-cell {
-      color: inherit;
-    }
-  }
-
-  .checkin-tooltip {
-    display: none;
-  }
-}
-
-.checkin-history-json {
-  border: 1px solid $chef-grey;
-  border-radius: $global-radius;
-  overflow: hidden;
 }
 
 .checkin-tooltip {
@@ -376,16 +253,16 @@ h3 {
   }
 }
 
+.checkin-tooltip-link {
+  display: block;
+  margin-top: $spacing-05;
+}
+
 .checkin-tooltip-info,
 .checkin-tooltip-link {
   margin: 0;
   font-size: 14px;
   white-space: nowrap;
-
-  &:last-child {
-    display: block;
-    margin-top: $spacing-05;
-  }
 
   chef-icon {
     margin-left: $spacing-03;
@@ -393,49 +270,9 @@ h3 {
   }
 }
 
-.checkin-tooltip.unknown {
+.checkin-tooltip.missing {
   .checkin-tooltip-date,
   .checkin-tooltip-link {
     display: none;
-  }
-}
-
-.debug-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: $spacing-05;
-  background: $chef-lightest-grey;
-  overflow: hidden;
-  border-radius: $global-radius;
-  border: 1px solid $chef-grey;
-
-  chef-button {
-    #{--background-color}: $chef-lightest-grey;
-    margin: 0;
-
-    &:hover {
-      #{--background-color}: $chef-light-grey;
-    }
-  }
-
-  .button-toggle {
-    display: flex;
-    align-items: center;
-
-    chef-button {
-      border-radius: 0;
-      border: none;
-      border-right: 1px solid $chef-grey;
-    }
-
-    &:last-child chef-button {
-      border-right: none;
-      border-left: 1px solid $chef-grey;
-    }
-
-    > span {
-      margin: 0 $spacing-03;
-    }
   }
 }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -122,6 +122,24 @@ h3 {
       display: none;
     }
 
+    span:last-child {
+      display: block;
+    }
+
+    chef-icon {
+      &.converged, &.unchanged {
+        color: #4FC293;
+      }
+
+      &.missing, &.unknown {
+        color: #7C8296;
+      }
+
+      &.failure, &.error {
+        color: #EB372C;
+      }
+    }
+
     &.date-cell {
       display: none;
     }
@@ -134,7 +152,8 @@ h3 {
       span {
         position: absolute;
         white-space: nowrap;
-        font-size: 12px;
+        font-size: 10px;
+        text-transform: uppercase;
       }
     }
 
@@ -142,7 +161,7 @@ h3 {
       cursor: pointer;
 
       > chef-icon {
-        font-size: 26px;
+        font-size: 30px;
         padding: 0 2px;
       }
     }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -122,21 +122,17 @@ h3 {
       display: none;
     }
 
-    span:last-child {
-      display: block;
-    }
-
     chef-icon {
       &.converged, &.unchanged {
-        color: #4FC293;
+        color: $status-success;
       }
 
       &.missing, &.unknown {
-        color: #7C8296;
+        color: $lavender-dark-3;
       }
 
       &.failure, &.error {
-        color: #EB372C;
+        color: $status-error;
       }
     }
 
@@ -167,7 +163,8 @@ h3 {
     }
   }
 
-  chef-tr:nth-child(7n + 1) {
+  chef-tr:nth-child(7n + 1),
+  chef-tr:last-child {
     chef-td {
       &.relative-date-cell {
         > span {
@@ -362,20 +359,20 @@ h3 {
   border-right: $spacing-03 solid transparent;
   padding-right: $spacing-03;
 
-  &.error {
-    border-left-color: #E61F36;
+  &.error, &.failure {
+    border-left-color: $status-error;
   }
 
   &.converged {
-    border-left-color: #23AE9A;
+    border-left-color: $status-success;
   }
 
   &.unchanged {
-    border-left-color: #23AE9A;
+    border-left-color: $status-success;
   }
 
-  &.unknown {
-    border-left-color: $chef-unknown;
+  &.unknown, &.missing {
+    border-left-color: $status-unknown;
   }
 }
 

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -4,7 +4,7 @@ import { takeUntil } from 'rxjs/operators';
 import { DateTime } from 'app/helpers/datetime/datetime';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { GetDailyNodeRunsStatusTimeSeries } from 'app/entities/desktop/desktop.actions';
 import { getDailyNodeRuns } from 'app/entities/desktop/desktop.selectors';
 
@@ -37,13 +37,12 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
     unknown: 'help',
     missing: 'help'
   };
-  private subscription: Subscription;
-  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   constructor(
     private store: Store<NgrxStateAtom>
   ) {
-    this.subscription = this.store.select(getDailyNodeRuns).pipe(
+    this.store.select(getDailyNodeRuns).pipe(
       takeUntil(this.isDestroyed)
       ).subscribe((dailyNodeRuns) => {
       this.checkInHistory = this.addCheckInLabels(dailyNodeRuns.durations.buckets);
@@ -55,7 +54,6 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscription.unsubscribe();
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
@@ -80,6 +78,10 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
       if (isStartOfWeek) { --numWeeks; }
     });
     return checkInHistory;
+  }
+
+  getRunDetailsUrl(runId: string): string {
+    return `/infrastructure/client-runs/${this.desktop.id}/runs/${runId}`;
   }
 
   public close(): void {

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -22,7 +22,6 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   @Output() fullscreenToggled: EventEmitter<void> = new EventEmitter();
 
   public checkInHistory: DailyNodeRunsStatus[];
-  public ceil = Math.ceil;
   public DateTime = DateTime;
   public showCheckinDebug = false;
   public checkinTableType = 'grid';

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -1,26 +1,23 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { Desktop } from 'app/entities/desktop/desktop.model';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Desktop, DailyNodeRunsStatus } from 'app/entities/desktop/desktop.model';
 import { DateTime } from 'app/helpers/datetime/datetime';
+import { Store } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { GetDailyNodeRunsStatusTimeSeries } from 'app/entities/desktop/desktop.actions';
+import { getDailyNodeRuns } from 'app/entities/desktop/desktop.selectors';
 
-const historyTypes = [
-  { text: 'converged', icon: 'check_box' },
-  { text: 'unchanged', icon: 'indeterminate_check_box' },
-  { text: 'error', icon: 'error' },
-  { text: 'unknown', icon: 'help' }
-];
-
-const checkinHistory = Array.from(new Array(29)).map((_v, i) => {
-  const historyType = historyTypes[Math.floor(Math.random() * historyTypes.length)];
-  const date = new Date();
-  return { ...historyType, date: new Date(date.setDate(date.getDate() - i)) };
-});
+// const checkinHistory = Array.from(new Array(29)).map((_v, i) => {
+//   const historyType = historyTypes[Math.floor(Math.random() * historyTypes.length)];
+//   const date = new Date();
+//   return { ...historyType, date: new Date(date.setDate(date.getDate() - i)) };
+// });
 
 @Component({
   selector: 'app-desktop-detail',
   templateUrl: './desktop-detail.component.html',
   styleUrls: ['./desktop-detail.component.scss']
 })
-export class DesktopDetailComponent {
+export class DesktopDetailComponent implements OnInit {
 
   @Input() desktop: Desktop;
   @Input() fullscreened = false;
@@ -28,15 +25,54 @@ export class DesktopDetailComponent {
   @Output() closed: EventEmitter<any> = new EventEmitter();
   @Output() fullscreenToggled: EventEmitter<void> = new EventEmitter();
 
+  public checkInHistory: DailyNodeRunsStatus[];
   public ceil = Math.ceil;
   public DateTime = DateTime;
   public showCheckinDebug = false;
   public checkinTableType = 'grid';
   public checkinGridFlexType = 'wrap';
   public checkinNumDays = 14;
+  public historyIcons = {
+    converged: 'check_box',
+    unchanged: 'indeterminate_check_box',
+    failure: 'warning',
+    error: 'warning',
+    unknown: 'help',
+    missing: 'help'
+  };
 
-  get checkinHistory() {
-    return checkinHistory.slice(0, this.checkinNumDays + 1);
+  constructor(
+    private store: Store<NgrxStateAtom>
+  ) {
+    this.store.select(getDailyNodeRuns).subscribe((dailyNodeRuns) => {
+      this.checkInHistory = this.addCheckInLabels(dailyNodeRuns.durations.buckets);
+    });
+  }
+
+  ngOnInit() {
+    this.getCheckInHistory();
+  }
+
+  getCheckInHistory() {
+    this.store.dispatch(new GetDailyNodeRunsStatusTimeSeries(this.desktop.id, this.checkinNumDays));
+  }
+
+  updateCheckInDays() {
+    this.checkinNumDays = (this.checkinNumDays === 14 ? 28 : 14);
+    this.getCheckInHistory();
+  }
+
+  addCheckInLabels(checkInHistory: DailyNodeRunsStatus[]): DailyNodeRunsStatus[] {
+    let numWeeks = Math.floor(checkInHistory.length / 7);
+    checkInHistory.forEach((history: DailyNodeRunsStatus, index: number) => {
+      const isStartOfWeek = index % 7 === 0;
+      const startOfWeekLabelText = numWeeks > 1 ? `${numWeeks} weeks ago` : `${numWeeks} week ago`;
+      const isToday = index === (checkInHistory.length - 1);
+      const labelText = isToday ? 'Today' : '';
+      history.label = isStartOfWeek ? startOfWeekLabelText : labelText;
+      if (isStartOfWeek) { --numWeeks; }
+    });
+    return checkInHistory;
   }
 
   public close(): void {

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -27,7 +27,7 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   public showCheckinDebug = false;
   public checkinTableType = 'grid';
   public checkinGridFlexType = 'wrap';
-  public checkinNumDays = 14;
+  public checkinNumDays = 15;
   // These are Material Icon names from https://material.io/resources/icons/
   public historyIcons = {
     converged: 'check_box',
@@ -63,14 +63,14 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   }
 
   updateCheckInDays() {
-    this.checkinNumDays = (this.checkinNumDays === 14 ? 28 : 14);
+    this.checkinNumDays = (this.checkinNumDays === 15 ? 29 : 15);
     this.getCheckInHistory();
   }
 
   addCheckInLabels(checkInHistory: DailyNodeRunsStatus[]): DailyNodeRunsStatus[] {
     let numWeeks = Math.floor(checkInHistory.length / 7);
     checkInHistory.forEach((history: DailyNodeRunsStatus, index: number) => {
-      const isStartOfWeek = index % 7 === 0;
+      const isStartOfWeek = (index % 7 === 0) && numWeeks > 0;
       const startOfWeekLabelText = numWeeks > 1 ? `${numWeeks} weeks ago` : `${numWeeks} week ago`;
       const isToday = index === (checkInHistory.length - 1);
       const labelText = isToday ? 'Today' : '';
@@ -78,10 +78,6 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
       if (isStartOfWeek) { --numWeeks; }
     });
     return checkInHistory;
-  }
-
-  getRunDetailsUrl(runId: string): string {
-    return `/infrastructure/client-runs/${this.desktop.id}/runs/${runId}`;
   }
 
   public close(): void {

--- a/components/automate-ui/src/styles/_colors.scss
+++ b/components/automate-ui/src/styles/_colors.scss
@@ -23,6 +23,7 @@ $lavender-light-6: #C9D7F4;
 $lavender-light-7: #C2D2F3;
 $lavender-dark-1: #A8B8DA;
 $lavender-dark-2: #95A3C2;
+$lavender-dark-3: #7C8296;
 $grape-light-1: #D0D4EE;
 $grape-light-2: #BFC5E8;
 $grape-light-3: #AEB6E2;
@@ -37,6 +38,7 @@ $orchid: #C86DD7;
 $daylily: #FEA900;
 $crimson: #E71D36;
 $rose: #E61F36;
+$winter-green: #4FC293;
 
 
 // LOCAL COLOR VARIABLES

--- a/components/automate-ui/src/styles/_variables.scss
+++ b/components/automate-ui/src/styles/_variables.scss
@@ -19,7 +19,6 @@ $chef-info-alert: $fuchsia;
 $chef-info-alert-light: $fuchsia-light;
 $chef-info-alert-dark: $fuchsia-dark;
 //greyscale
-
 $chef-dark-grey: $sirocco;
 $chef-darker: $darksea;
 $chef-darkest: $charcoal;
@@ -30,6 +29,10 @@ $chef-lightest-grey: $haze;
 $chef-white: $white;
 $chef-black: $black;
 $transparent-white: rgba(255, 255, 255, 0.85);
+//status
+$status-error: $rose;
+$status-success: $winter-green;
+$status-unknown: $lavender-dark-3;
 //chart
 $chef-ok: $blue-de-france;
 $chef-unknown: $gray;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
For a desktop that is unknown or has errors, IT managers would like to look at its check-in history in the past and understand how the status has changed across two or four weeks. They would also like to dive deep into the individual run details to further investigate the root cause.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/3459

### :+1: Definition of Done

1. Display the daily check-in status for the current desktop across small, medium, large, and x-large sizes.
2. Users can change the history length from the default two weeks to four weeks.
3. Every status icon in the check-in history reflects the most meaningful client run status on that day.
4. When hovering over the status icon, show a tooltip with links to the run details page under

### :athletic_shoe: How to Build and Test the Change
hab studio enter
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
load_desktop_reports

From the desktop page, scroll down to "Top 10 errors" and select one error.
![image](https://user-images.githubusercontent.com/6817500/83172593-aaf24c80-a0cc-11ea-8c1c-75714360f563.png)

On the resultant right-hand pane, select one of the failed nodes (`node_failed_68` here):
![image](https://user-images.githubusercontent.com/6817500/83172628-b9406880-a0cc-11ea-92cd-4189f956939b.png)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-05-27 at 4 29 25 PM](https://user-images.githubusercontent.com/4108100/83074271-80a27f80-a037-11ea-90ac-85ae5283854a.png)
![Screen Shot 2020-05-27 at 4 29 32 PM](https://user-images.githubusercontent.com/4108100/83074274-813b1600-a037-11ea-90d1-56c44e1d5380.png)
