### PR TITLE
Desktop Compliance Profiles Page Update

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -25,11 +25,11 @@
             (input)="onSearchInput($event)"/>
         </div>
 
-        <chef-tab-selector class="profiles-tabs" [value]="selectedTab" (change)="onTabChange($event)">
+        <chef-tab-selector *ngIf="isAvailableProfilesVisible" class="profiles-tabs" [value]="selectedTab" (change)="onTabChange($event)">
             <chef-option value='installed'>
               <span *ngIf="userProfilesDataLoaded">{{ filteredProfiles.length }}</span> Profiles
             </chef-option>
-            <chef-option *ngIf="!isDesktopView" value='available'>
+            <chef-option value='available'>
               <span *ngIf="availableProfilesDataLoaded">{{ filteredAvailableProfiles.length }}</span> Available
             </chef-option>
           </chef-tab-selector>
@@ -88,18 +88,35 @@
           </chef-modal>
 
           <app-authorized [allOf]="['streaming::/compliance/profiles', 'post']">
-            <chef-toolbar>
-              <chef-button primary (click)="showUploadModal()" *ngIf="!profilesEmpty">
+            <div *ngIf="profilesEmpty" class="empty-state">
+              <div class="empty-state" *ngIf="isAvailableProfilesVisible" >
+                <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a> or upload your own profile to get started!</p>
+              </div>
+              <div class="empty-state" *ngIf="!isAvailableProfilesVisible" >
+                <p>Upload a profile to get started!</p>
+              </div>
+              <chef-button primary (click)="showUploadModal()" >
                 <chef-icon>cloud_upload</chef-icon>
                 <span>Upload Profile</span>
               </chef-button>
-            </chef-toolbar>
-
-            <div class="empty-help" *ngIf="profilesEmpty">
-              <img class="help-icon" src="/assets/img/profiles.svg" alt="">
-              <div class="help-msg">
-                <p>Seems like you need to install some profiles!</p>
-                <p>Install pre-packaged compliance profiles from the "Available" tab or <a (click)="showUploadModal()">upload your own</a>.</p>
+            </div>
+            <div *ngIf="!profilesEmpty">
+              <chef-toolbar>
+                <chef-button primary (click)="showUploadModal()" >
+                  <chef-icon>cloud_upload</chef-icon>
+                  <span>Upload Profile</span>
+                </chef-button>
+              </chef-toolbar>
+            </div>
+          </app-authorized>
+          <app-authorized not [allOf]="['streaming::/compliance/profiles', 'post']">
+            <div *ngIf="profilesEmpty">
+              <div class="empty-state" *ngIf="isAvailableProfilesVisible" >
+                <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a>!</p>
+              </div>
+              <div class="empty-state" *ngIf="!isAvailableProfilesVisible" >
+                <p>It looks like no one has uploaded any profiles yet and you don't have permission to upload them.
+                  If this is a mistake, then reach out to your administrator.</p>
               </div>
             </div>
           </app-authorized>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -17,7 +17,7 @@
         <chef-heading>Profiles</chef-heading>
         <chef-subheading>Compliance profiles manage security and compliance scans.</chef-subheading>
 
-        <div class="profiles-search">
+        <div class="profiles-search" *ngIf="!profilesEmpty || isAvailableProfilesVisible">
           <input
             chefInput
             type="text"
@@ -88,36 +88,31 @@
           </chef-modal>
 
           <app-authorized [allOf]="['streaming::/compliance/profiles', 'post']">
-            <div *ngIf="profilesEmpty" class="empty-state">
-              <div class="empty-state" *ngIf="isAvailableProfilesVisible" >
-                <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a> or upload your own profile to get started!</p>
+            <chef-toolbar>
+              <div *ngIf="profilesEmpty" class="empty-state">
+                  <div *ngIf="isAvailableProfilesVisible" >
+                    <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a> or upload your own profile to get started!</p>
+                  </div>
+                  <div *ngIf="!isAvailableProfilesVisible" >
+                    <p>Upload a profile to get started!</p>
+                  </div>
+                  <chef-button primary (click)="showUploadModal()" >
+                    <chef-icon>cloud_upload</chef-icon>
+                    <span>Upload Profile</span>
+                  </chef-button>
               </div>
-              <div class="empty-state" *ngIf="!isAvailableProfilesVisible" >
-                <p>Upload a profile to get started!</p>
+              <div *ngIf="!profilesEmpty">
+                  <chef-button primary (click)="showUploadModal()" >
+                    <chef-icon>cloud_upload</chef-icon>
+                    <span>Upload Profile</span>
+                  </chef-button>
               </div>
-              <chef-button primary (click)="showUploadModal()" >
-                <chef-icon>cloud_upload</chef-icon>
-                <span>Upload Profile</span>
-              </chef-button>
-            </div>
-            <div *ngIf="!profilesEmpty">
-              <chef-toolbar>
-                <chef-button primary (click)="showUploadModal()" >
-                  <chef-icon>cloud_upload</chef-icon>
-                  <span>Upload Profile</span>
-                </chef-button>
-              </chef-toolbar>
-            </div>
+            </chef-toolbar>
           </app-authorized>
           <app-authorized not [allOf]="['streaming::/compliance/profiles', 'post']">
-            <div *ngIf="profilesEmpty">
-              <div class="empty-state" *ngIf="isAvailableProfilesVisible" >
-                <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a>!</p>
-              </div>
-              <div class="empty-state" *ngIf="!isAvailableProfilesVisible" >
-                <p>It looks like no one has uploaded any profiles yet and you don't have permission to upload them. <br/>
-                If this is a mistake, then reach out to your administrator.</p>
-              </div>
+            <div *ngIf="profilesEmpty" class="empty-state">
+              <p>It looks like no one has uploaded any profiles yet and you don't have permission to upload them. <br/>
+              If this is a mistake, then reach out to your administrator.</p>
             </div>
           </app-authorized>
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -29,7 +29,7 @@
             <chef-option value='installed'>
               <span *ngIf="userProfilesDataLoaded">{{ filteredProfiles.length }}</span> Profiles
             </chef-option>
-            <chef-option value='available'>
+            <chef-option *ngIf="!isDesktopView" value='available'>
               <span *ngIf="availableProfilesDataLoaded">{{ filteredAvailableProfiles.length }}</span> Available
             </chef-option>
           </chef-tab-selector>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -115,8 +115,8 @@
                 <p>Get a profile from the <a (click)="selectTab('available')">Available tab</a>!</p>
               </div>
               <div class="empty-state" *ngIf="!isAvailableProfilesVisible" >
-                <p>It looks like no one has uploaded any profiles yet and you don't have permission to upload them.
-                  If this is a mistake, then reach out to your administrator.</p>
+                <p>It looks like no one has uploaded any profiles yet and you don't have permission to upload them. <br/>
+                If this is a mistake, then reach out to your administrator.</p>
               </div>
             </div>
           </app-authorized>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.html
@@ -26,58 +26,58 @@
         </div>
 
         <chef-tab-selector *ngIf="isAvailableProfilesVisible" class="profiles-tabs" [value]="selectedTab" (change)="onTabChange($event)">
-            <chef-option value='installed'>
-              <span *ngIf="userProfilesDataLoaded">{{ filteredProfiles.length }}</span> Profiles
-            </chef-option>
-            <chef-option value='available'>
-              <span *ngIf="availableProfilesDataLoaded">{{ filteredAvailableProfiles.length }}</span> Available
-            </chef-option>
-          </chef-tab-selector>
-        </chef-page-header>
+          <chef-option value='installed'>
+            <span *ngIf="userProfilesDataLoaded">{{ filteredProfiles.length }}</span> Profiles
+          </chef-option>
+          <chef-option value='available'>
+            <span *ngIf="availableProfilesDataLoaded">{{ filteredAvailableProfiles.length }}</span> Available
+          </chef-option>
+        </chef-tab-selector>
+      </chef-page-header>
 
-        <div class="empty-help setup-help" *ngIf="!profilesEnabled">
-          <img class="help-icon" src="/assets/img/services.svg" alt="">
-          <div class="help-msg">
-            <p>You will need to enable the compliance profile asset store to use this feature.</p>
-            <p>Enable the service by adding this line:</p>
-            <chef-snippet code="compliance_profiles['enable'] = true" lang="ruby"></chef-snippet>
-            <p>into <code>/etc/delivery/delivery.rb</code> and running <code>automate-ctl reconfigure</code>. The <code>automate-ctl status</code> command should now list the status of the compliance_profiles service.</p>
-          </div>
+      <div class="empty-help setup-help" *ngIf="!profilesEnabled">
+        <img class="help-icon" src="/assets/img/services.svg" alt="">
+        <div class="help-msg">
+          <p>You will need to enable the compliance profile asset store to use this feature.</p>
+          <p>Enable the service by adding this line:</p>
+          <chef-snippet code="compliance_profiles['enable'] = true" lang="ruby"></chef-snippet>
+          <p>into <code>/etc/delivery/delivery.rb</code> and running <code>automate-ctl reconfigure</code>. The <code>automate-ctl status</code> command should now list the status of the compliance_profiles service.</p>
         </div>
+      </div>
 
         <!--only show content if profile store is enabled-->
-        <div *ngIf="profilesEnabled" class="profiles-content">
+      <div *ngIf="profilesEnabled" class="profiles-content">
 
           <!--profiles tab-->
-          <div *ngIf="selectedTab === 'installed'">
+        <div *ngIf="selectedTab === 'installed'">
 
-            <chef-modal
-              id="upload-modal"
-              [visible]="uploadModalVisible"
-              (closeModal)="hideUploadModal()">
-              <h2 id="upload-modal-title" slot="title">Upload an archived profile (.tar.gz or .zip)</h2>
-              <p id="upload-modal-subtitle">See the <a href="https://www.inspec.io/docs/reference/cli/#archive" target="_blank">Inspec CLI documentation</a> for more info on creating a profile archive.</p>
-              <chef-table class="file-upload-list">
-                <ng-container *ngFor="let file of fileUploads; trackBy: trackBy">
-                  <chef-tr>
-                    <chef-td>
-                      <chef-icon class="failed" *ngIf="file.failed">report_problem</chef-icon>
-                      <chef-icon class="passed" *ngIf="file.loaded">check_circle</chef-icon>
-                      <chef-loading-spinner size="14" *ngIf="file.loading"></chef-loading-spinner>
-                      <span>{{ file.name }}</span>
-                    </chef-td>
-                    <chef-td>
-                      <span *ngIf="file.loading && file.percent < 100" class="upload-percent">{{ file.percent }}%</span>
-                      <span *ngIf="file.loading && file.percent === 100" class="upload-percent">Verifying...</span>
-                      <chef-button *ngIf="file.failed" caution secondary (click)="toggleUploadResult(file)">
-                        <chef-icon>report_problem</chef-icon>
-                      </chef-button>
-                    </chef-td>
-                  </chef-tr>
-                  <div class="result-detail" *ngIf="isOpenUploadResult(file)">
-                    <pre>{{ file.response }}</pre>
-                  </div>
-              </ng-container>
+          <chef-modal
+            id="upload-modal"
+            [visible]="uploadModalVisible"
+            (closeModal)="hideUploadModal()">
+            <h2 id="upload-modal-title" slot="title">Upload an archived profile (.tar.gz or .zip)</h2>
+            <p id="upload-modal-subtitle">See the <a href="https://www.inspec.io/docs/reference/cli/#archive" target="_blank">Inspec CLI documentation</a> for more info on creating a profile archive.</p>
+            <chef-table class="file-upload-list">
+              <ng-container *ngFor="let file of fileUploads; trackBy: trackBy">
+                <chef-tr>
+                  <chef-td>
+                    <chef-icon class="failed" *ngIf="file.failed">report_problem</chef-icon>
+                    <chef-icon class="passed" *ngIf="file.loaded">check_circle</chef-icon>
+                    <chef-loading-spinner size="14" *ngIf="file.loading"></chef-loading-spinner>
+                    <span>{{ file.name }}</span>
+                  </chef-td>
+                  <chef-td>
+                    <span *ngIf="file.loading && file.percent < 100" class="upload-percent">{{ file.percent }}%</span>
+                    <span *ngIf="file.loading && file.percent === 100" class="upload-percent">Verifying...</span>
+                    <chef-button *ngIf="file.failed" caution secondary (click)="toggleUploadResult(file)">
+                      <chef-icon>report_problem</chef-icon>
+                    </chef-button>
+                  </chef-td>
+                </chef-tr>
+                <div class="result-detail" *ngIf="isOpenUploadResult(file)">
+                  <pre>{{ file.response }}</pre>
+                </div>
+            </ng-container>
             </chef-table>
             <div class="actions">
               <label class="custom-file-input">
@@ -96,13 +96,13 @@
                   <div *ngIf="!isAvailableProfilesVisible" >
                     <p>Upload a profile to get started!</p>
                   </div>
-                  <chef-button primary (click)="showUploadModal()" >
+                  <chef-button class="upload-button" primary (click)="showUploadModal()" >
                     <chef-icon>cloud_upload</chef-icon>
                     <span>Upload Profile</span>
                   </chef-button>
               </div>
               <div *ngIf="!profilesEmpty">
-                  <chef-button primary (click)="showUploadModal()" >
+                  <chef-button class="upload-button" primary (click)="showUploadModal()" >
                     <chef-icon>cloud_upload</chef-icon>
                     <span>Upload Profile</span>
                   </chef-button>

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -15,9 +15,23 @@
 
 .profiles-content {
   margin: 35px;
+}
 
-  .empty-help {
+a {
+  cursor: pointer;
+}
+
+.empty-state {
+  text-align: center;
+  chef-button {
     margin: 0;
+    left: 50%;
+  }
+
+  p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 42px;
   }
 }
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -19,6 +19,7 @@
 
 a {
   cursor: pointer;
+  text-decoration: underline;
 }
 
 .empty-state {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -28,6 +28,7 @@ a {
 
 .empty-state {
   text-align: center;
+
   chef-button {
     margin: 0;
     left: 50%;

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.scss
@@ -5,7 +5,7 @@
 }
 
 .profiles-search {
-  padding: 32px 0 14px;
+  padding: 18px 0 14px;
 
   chef-input {
     width: 100%;
@@ -13,8 +13,12 @@
   }
 }
 
+chef-subheading {
+  padding-bottom: 14px;
+}
+
 .profiles-content {
-  margin: 35px;
+  padding: 35px;
 }
 
 a {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -18,8 +18,10 @@ import { ProductDeployedService } from 'app/services/product-deployed/product-de
 import { MockComponent } from 'ng2-mock-component';
 
 class MockProductDeployedService {
-  isProductDeployed(_product: string): boolean {
-    return false;
+  constructor(private products: string[]) { }
+
+  isProductDeployed(product: string): boolean {
+    return this.products.some((installedProduct: String) => installedProduct === product);
   }
 }
 
@@ -46,360 +48,617 @@ describe('ProfilesOverviewComponent', () => {
     token: 'TestToken'
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule,
-        HttpClientTestingModule,
-        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
-      ],
-      declarations: [
-        ProfileOverviewComponent,
-        // This returns true for all app-authorized checks on the page.
-        MockComponent({ selector: 'app-authorized',
-          inputs: ['allOf'],
-          template: '<ng-content *ngIf="true"></ng-content>' })
-      ],
-      providers: [
-        {provide: ProfilesService, useClass: MockProfilesService},
-        {provide: ChefSessionService, useValue: mockSession},
-        {provide: UploadService, useClass: MockUploadService},
-        FeatureFlagsService,
-        { provide: ProductDeployedService, useClass: MockProductDeployedService }
-      ],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
-    });
-    store = TestBed.inject(Store);
-    spyOn(store, 'dispatch').and.callThrough();
-    fixture = TestBed.createComponent(ProfileOverviewComponent);
-    component = fixture.componentInstance;
-    element = fixture.debugElement;
-  });
-
-  it('0 profiles allowed upload permissions', () => {
-    fixture.detectChanges();
-
-    // 0 profiles
-    component.profilesEmpty = true;
-    fixture.detectChanges();
-
-    // has upload permissions. Using the app-authorized true in the declarations
-
-
-    // Search bar is visible
-    const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
-    expect(inputs.length > 0).toEqual(true);
-    expect(inputs.some( input => {
-      return input.attributes['placeholder'] === 'Search profiles...';
-    })).toEqual(true);
-
-    // tabs are visble.
-    const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
-    expect(selectors.length > 0).toEqual(true);
-
-    // profile list table is hidden
-    const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
-    expect(tables.length).toEqual(0);
-
-    // upload button is visible
-    const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
-    expect(buttons.length).toEqual(1);
-  });
-
-  it('one or more profiles allowed upload permissions', () => {
-    fixture.detectChanges();
-
-    // one or more profiles
-    component.profilesEmpty = false;
-    fixture.detectChanges();
-
-    // has upload permissions. Using the app-authorized true in the declarations
-
-    // Search bar is visible
-    const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
-    expect(inputs.length > 0).toEqual(true);
-    expect(inputs.some( input => {
-      return input.attributes['placeholder'] === 'Search profiles...';
-    })).toEqual(true);
-
-    // tabs are visible.
-    const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
-    expect(selectors.length > 0).toEqual(true);
-
-    // profile list table is visible
-    const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
-    expect(tables.length).toEqual(1);
-
-    // upload button is visible
-    const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
-    expect(buttons.length).toEqual(1);
-  });
-
-  it('sets profilesListLoading to true', () => {
-    expect(component.profilesListLoading).toEqual(true);
-  });
-
-  it('sets availableListLoading to true', () => {
-    expect(component.availableListLoading).toEqual(true);
-  });
-
-  describe('ngOnInit()', () => {
-    it('loads all installed profiles', () => {
-      spyOn(component, 'loadProfiles').and.callThrough();
-      component.ngOnInit();
-      expect(component.loadProfiles).toHaveBeenCalled();
+  describe('non-Desktop with user upload permissions', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          ProfileOverviewComponent,
+          // This returns true for all app-authorized checks on the page.
+          MockComponent({ selector: 'app-authorized',
+            inputs: ['allOf'],
+            template: '<ng-content *ngIf="true"></ng-content>' })
+        ],
+        providers: [
+          {provide: ProfilesService, useClass: MockProfilesService},
+          {provide: ChefSessionService, useValue: mockSession},
+          {provide: UploadService, useClass: MockUploadService},
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useValue: new MockProductDeployedService([]) }
+        ],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      });
+      store = TestBed.inject(Store);
+      spyOn(store, 'dispatch').and.callThrough();
+      fixture = TestBed.createComponent(ProfileOverviewComponent);
+      component = fixture.componentInstance;
+      element = fixture.debugElement;
     });
 
-    it('loads all available profiles', () => {
-      spyOn(component, 'loadAvailableProfiles').and.callThrough();
-      component.ngOnInit();
-      expect(component.loadAvailableProfiles).toHaveBeenCalled();
+    it('Zero profiles installed', () => {
+      fixture.detectChanges();
+
+      // 0 profiles installed
+      component.profilesEmpty = true;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are visble.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(true);
+
+      // profile list table is hidden
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(0);
+
+      // upload button is visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(1);
     });
 
-    it('sets profilesEmpty to false', () => {
-      component.ngOnInit();
-      expect(component.profilesEmpty).toBe(false);
+    it('one or more profiles installed', () => {
+      fixture.detectChanges();
+
+      // one or more profiles installed
+      component.profilesEmpty = false;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are visible.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(true);
+
+      // profile list table is visible
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(1);
+
+      // upload button is visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(1);
     });
 
-    it('calls checkForUpdatesAvailable', () => {
-      spyOn(component, 'checkForUpdatesAvailable');
-      spyOn(component, 'loadProfiles').and.returnValue(observableOf([]));
-      spyOn(component, 'loadAvailableProfiles').and.returnValue(observableOf([]));
-      component.ngOnInit();
-      expect(component.checkForUpdatesAvailable).toHaveBeenCalled();
-    });
-  });
-
-  describe('loadProfiles()', () => {
-    it('fetches all profiles', () => {
-      spyOn(component.profilesService, 'getAllProfiles').and.returnValue(observableOf([]));
-      component.loadProfiles();
-      expect(component.profilesService.getAllProfiles).toHaveBeenCalled();
+    it('sets profilesListLoading to true', () => {
+      expect(component.profilesListLoading).toEqual(true);
     });
 
-    it('sets profilesListLoading to false', done => {
-      spyOn(component.profilesService, 'getAllProfiles').and.returnValue(observableOf([]));
-      component.loadProfiles().subscribe(_profiles => {
-        expect(component.profilesListLoading).toEqual(false);
-        done();
+    it('sets availableListLoading to true', () => {
+      expect(component.availableListLoading).toEqual(true);
+    });
+
+    describe('ngOnInit()', () => {
+      it('loads all installed profiles', () => {
+        spyOn(component, 'loadProfiles').and.callThrough();
+        component.ngOnInit();
+        expect(component.loadProfiles).toHaveBeenCalled();
+      });
+
+      it('loads all available profiles', () => {
+        spyOn(component, 'loadAvailableProfiles').and.callThrough();
+        component.ngOnInit();
+        expect(component.loadAvailableProfiles).toHaveBeenCalled();
+      });
+
+      it('sets profilesEmpty to false', () => {
+        component.ngOnInit();
+        expect(component.profilesEmpty).toBe(false);
+      });
+
+      it('calls checkForUpdatesAvailable', () => {
+        spyOn(component, 'checkForUpdatesAvailable');
+        spyOn(component, 'loadProfiles').and.returnValue(observableOf([]));
+        spyOn(component, 'loadAvailableProfiles').and.returnValue(observableOf([]));
+        component.ngOnInit();
+        expect(component.checkForUpdatesAvailable).toHaveBeenCalled();
       });
     });
 
-    describe('when profiles asset store is enabled', () => {
-      beforeEach(() => {
+    describe('loadProfiles()', () => {
+      it('fetches all profiles', () => {
         spyOn(component.profilesService, 'getAllProfiles').and.returnValue(observableOf([]));
-      });
-
-      it('sets profilesEnabled to true', () => {
         component.loadProfiles();
-        expect(component.profilesEnabled).toEqual(true);
+        expect(component.profilesService.getAllProfiles).toHaveBeenCalled();
       });
 
-      describe('when profiles length is 0', () => {
-        it('sets profilesEmpty to true', () => {
+      it('sets profilesListLoading to false', done => {
+        spyOn(component.profilesService, 'getAllProfiles').and.returnValue(observableOf([]));
+        component.loadProfiles().subscribe(_profiles => {
+          expect(component.profilesListLoading).toEqual(false);
+          done();
+        });
+      });
+
+      describe('when profiles asset store is enabled', () => {
+        beforeEach(() => {
+          spyOn(component.profilesService, 'getAllProfiles').and.returnValue(observableOf([]));
+        });
+
+        it('sets profilesEnabled to true', () => {
           component.loadProfiles();
           expect(component.profilesEnabled).toEqual(true);
+        });
+
+        describe('when profiles length is 0', () => {
+          it('sets profilesEmpty to true', () => {
+            component.loadProfiles();
+            expect(component.profilesEnabled).toEqual(true);
+          });
+        });
+      });
+
+      describe('when profiles asset store is not enabled', () => {
+        beforeEach(() => {
+          const resp = { status: 404 };
+          spyOn(component.profilesService, 'getAllProfiles').and.returnValue(throwError(resp));
+          spyOn(component.profilesService, 'getVersion').and.returnValue(throwError(resp));
+        });
+
+        it('sets profilesEnabled to false', done => {
+          component.loadProfiles().subscribe(null, _profiles => {
+            expect(component.profilesEnabled).toEqual(false);
+            done();
+          });
         });
       });
     });
 
-    describe('when profiles asset store is not enabled', () => {
+    describe('loadAvailableProfiles()', () => {
       beforeEach(() => {
-        const resp = { status: 404 };
-        spyOn(component.profilesService, 'getAllProfiles').and.returnValue(throwError(resp));
-        spyOn(component.profilesService, 'getVersion').and.returnValue(throwError(resp));
+        spyOn(component.availableProfilesService, 'getAllProfiles')
+          .and.returnValue(observableOf([]));
       });
 
-      it('sets profilesEnabled to false', done => {
-        component.loadProfiles().subscribe(null, _profiles => {
-          expect(component.profilesEnabled).toEqual(false);
+      it('fetches all profiles', () => {
+        component.loadAvailableProfiles();
+        expect(component.availableProfilesService.getAllProfiles).toHaveBeenCalled();
+      });
+
+      it('sets availableListLoading to false', done => {
+        component.loadAvailableProfiles().subscribe(_profiles => {
+          expect(component.availableListLoading).toEqual(false);
           done();
         });
       });
     });
-  });
 
-  describe('loadAvailableProfiles()', () => {
-    beforeEach(() => {
-      spyOn(component.availableProfilesService, 'getAllProfiles')
-        .and.returnValue(observableOf([]));
-    });
-
-    it('fetches all profiles', () => {
-      component.loadAvailableProfiles();
-      expect(component.availableProfilesService.getAllProfiles).toHaveBeenCalled();
-    });
-
-    it('sets availableListLoading to false', done => {
-      component.loadAvailableProfiles().subscribe(_profiles => {
-        expect(component.availableListLoading).toEqual(false);
-        done();
-      });
-    });
-  });
-
-  describe('getProfiles()', () => {
-    const profiles = [
-      { 'name': 'profile1', 'version': '2.1.0' },
-      { 'name': 'profile2', 'version': '1.9.0' }
-    ];
-    it('uploads all profiles', () => {
-      spyOn(component.availableProfilesService, 'installMarketProfile')
-        .and.returnValue(observableOf({}));
-      component.getProfiles(profiles);
-      expect(component.availableProfilesService.installMarketProfile)
-        .toHaveBeenCalledWith('profile1', '2.1.0');
-      expect(component.availableProfilesService.installMarketProfile)
-        .toHaveBeenCalledWith('profile2', '1.9.0');
-    });
-    describe('when response status is 200', () => {
-      beforeEach(() => {
-        spyOn(component, 'refreshProfiles');
+    describe('getProfiles()', () => {
+      const profiles = [
+        { 'name': 'profile1', 'version': '2.1.0' },
+        { 'name': 'profile2', 'version': '1.9.0' }
+      ];
+      it('uploads all profiles', () => {
         spyOn(component.availableProfilesService, 'installMarketProfile')
-          .and.returnValue(observableOf({ status: 200 }));
-        component.getProfiles(
-          [{ 'name': 'profile1', 'version': '2.1.0' }, { 'name': 'profile2', 'version': '1.9.0' }]);
+          .and.returnValue(observableOf({}));
+        component.getProfiles(profiles);
+        expect(component.availableProfilesService.installMarketProfile)
+          .toHaveBeenCalledWith('profile1', '2.1.0');
+        expect(component.availableProfilesService.installMarketProfile)
+          .toHaveBeenCalledWith('profile2', '1.9.0');
       });
+      describe('when response status is 200', () => {
+        beforeEach(() => {
+          spyOn(component, 'refreshProfiles');
+          spyOn(component.availableProfilesService, 'installMarketProfile')
+            .and.returnValue(observableOf({ status: 200 }));
+          component.getProfiles(
+            [{ 'name': 'profile1', 'version': '2.1.0' },
+              { 'name': 'profile2', 'version': '1.9.0' }]);
+        });
 
-      it('calls load profiles', () => {
-        expect(component.refreshProfiles).toHaveBeenCalled();
+        it('calls load profiles', () => {
+          expect(component.refreshProfiles).toHaveBeenCalled();
+        });
+      });
+      describe('when response status is an 400', () => {
+        beforeEach(() => {
+          spyOn(component, 'refreshProfiles');
+          spyOn(component, 'showDownloadError');
+          spyOn(component.availableProfilesService, 'installMarketProfile')
+            .and.returnValue(throwError({ status: 400 }));
+          component.getProfiles(
+            [{ 'name': 'profile1', 'version': '2.1.0' },
+              { 'name': 'profile2', 'version': '1.9.0' }]);
+        });
+
+        it('does not call refreshProfiles', () => {
+          expect(component.refreshProfiles).not.toHaveBeenCalled();
+        });
+
+        it('displays the error', () => {
+          expect(component.showDownloadError).toHaveBeenCalled();
+        });
       });
     });
-    describe('when response status is an 400', () => {
+
+    describe('when profilesEnabled is true', () => {
       beforeEach(() => {
-        spyOn(component, 'refreshProfiles');
-        spyOn(component, 'showDownloadError');
-        spyOn(component.availableProfilesService, 'installMarketProfile')
-          .and.returnValue(throwError({ status: 400 }));
-        component.getProfiles(
-          [{ 'name': 'profile1', 'version': '2.1.0' }, { 'name': 'profile2', 'version': '1.9.0' }]);
+        fixture.detectChanges();
+        component.profilesEnabled = true;
+        fixture.detectChanges();
       });
 
-      it('does not call refreshProfiles', () => {
-        expect(component.refreshProfiles).not.toHaveBeenCalled();
-      });
-
-      it('displays the error', () => {
-        expect(component.showDownloadError).toHaveBeenCalled();
+      it('does not display setup help', () => {
+        const setupHelp = element.query(By.css('.setup-help'));
+        expect(setupHelp).toBeNull();
       });
     });
-  });
 
-  describe('when profilesEnabled is true', () => {
-    beforeEach(() => {
-      fixture.detectChanges();
-      component.profilesEnabled = true;
-      fixture.detectChanges();
-    });
-
-    it('does not display setup help', () => {
-      const setupHelp = element.query(By.css('.setup-help'));
-      expect(setupHelp).toBeNull();
-    });
-  });
-
-  describe('when profilesEnabled is false', () => {
-    beforeEach(() => {
-      fixture.detectChanges();
-      component.profilesEnabled = false;
-      fixture.detectChanges();
-    });
-
-    it('displays setup help', () => {
-      const setupHelp = element.query(By.css('.setup-help'));
-      expect(setupHelp).not.toBeNull();
-    });
-  });
-
-  describe('showDownloadError()', () => {
-    it('shows download error notification', () => {
-      component.showDownloadError();
-      expect(component.downloadErrorVisible).toBe(true);
-    });
-  });
-
-  describe('hideDownloadError()', () => {
-    it('hides download error notification', () => {
-      component.hideDownloadError();
-      expect(component.downloadErrorVisible).toBe(false);
-    });
-  });
-
-  describe('checkForUpdatesAvailable', () => {
-
-    it('sets profileUpdatesAvailable to an empty array', () => {
-      const profiles = [];
-      component.checkForUpdatesAvailable(profiles);
-      expect(component.profileUpdatesAvailable).toEqual([]);
-    });
-    describe('when a profile is marked with latest version', () => {
-
+    describe('when profilesEnabled is false', () => {
       beforeEach(() => {
-        const profiles = [
-          {name: 'apache', version: '2.1.0', latest_version: '2.2.0'},
-          {name: 'linux', version: '1.1.0', latest_version: '1.8.0'},
-          {name: 'ssh', version: '1.1.0'}
-        ];
-        component.availableProfiles = [
-          {name: 'apache', version: '2.2.0'},
-          {name: 'linux', version: '1.8.0'},
-          {name: 'ssh', version: '1.1.0'}
-        ];
+        fixture.detectChanges();
+        component.profilesEnabled = false;
+        fixture.detectChanges();
+      });
+
+      it('displays setup help', () => {
+        const setupHelp = element.query(By.css('.setup-help'));
+        expect(setupHelp).not.toBeNull();
+      });
+    });
+
+    describe('showDownloadError()', () => {
+      it('shows download error notification', () => {
+        component.showDownloadError();
+        expect(component.downloadErrorVisible).toBe(true);
+      });
+    });
+
+    describe('hideDownloadError()', () => {
+      it('hides download error notification', () => {
+        component.hideDownloadError();
+        expect(component.downloadErrorVisible).toBe(false);
+      });
+    });
+
+    describe('checkForUpdatesAvailable', () => {
+
+      it('sets profileUpdatesAvailable to an empty array', () => {
+        const profiles = [];
         component.checkForUpdatesAvailable(profiles);
-      });
-
-      it('adds the corresponding market profile to the profileUpdatesAvailable array', () => {
-        expect(component.profileUpdatesAvailable).toEqual([
-          {name: 'apache', version: '2.2.0', installed_version: '2.1.0'},
-          {name: 'linux', version: '1.8.0', installed_version: '1.1.0'}
-        ]);
-      });
-    });
-
-    describe('when a profile has no latest_version field ', () => {
-
-      beforeEach(() => {
-        const profiles = [
-          {name: 'apache', version: '2.1.0'},
-          {name: 'linux', version: '1.1.0'},
-          {name: 'ssh', version: '1.1.0'}
-        ];
-        component.availableProfiles = [
-          {name: 'apache', version: '2.1.0'},
-          {name: 'linux', version: '1.1.0'},
-          {name: 'ssh', version: '1.1.0'}
-        ];
-        component.checkForUpdatesAvailable(profiles);
-      });
-
-      it('adds nothing to the profileUpdatesAvailable array', () => {
         expect(component.profileUpdatesAvailable).toEqual([]);
       });
+      describe('when a profile is marked with latest version', () => {
+
+        beforeEach(() => {
+          const profiles = [
+            {name: 'apache', version: '2.1.0', latest_version: '2.2.0'},
+            {name: 'linux', version: '1.1.0', latest_version: '1.8.0'},
+            {name: 'ssh', version: '1.1.0'}
+          ];
+          component.availableProfiles = [
+            {name: 'apache', version: '2.2.0'},
+            {name: 'linux', version: '1.8.0'},
+            {name: 'ssh', version: '1.1.0'}
+          ];
+          component.checkForUpdatesAvailable(profiles);
+        });
+
+        it('adds the corresponding market profile to the profileUpdatesAvailable array', () => {
+          expect(component.profileUpdatesAvailable).toEqual([
+            {name: 'apache', version: '2.2.0', installed_version: '2.1.0'},
+            {name: 'linux', version: '1.8.0', installed_version: '1.1.0'}
+          ]);
+        });
+      });
+
+      describe('when a profile has no latest_version field ', () => {
+
+        beforeEach(() => {
+          const profiles = [
+            {name: 'apache', version: '2.1.0'},
+            {name: 'linux', version: '1.1.0'},
+            {name: 'ssh', version: '1.1.0'}
+          ];
+          component.availableProfiles = [
+            {name: 'apache', version: '2.1.0'},
+            {name: 'linux', version: '1.1.0'},
+            {name: 'ssh', version: '1.1.0'}
+          ];
+          component.checkForUpdatesAvailable(profiles);
+        });
+
+        it('adds nothing to the profileUpdatesAvailable array', () => {
+          expect(component.profileUpdatesAvailable).toEqual([]);
+        });
+      });
+    });
+
+    describe('showAvailableUpdates()', () => {
+      it('sets viewAvailableUpdatesList to true', () => {
+        component.viewAvailableUpdatesList = false;
+        component.showAvailableUpdates();
+        expect(component.viewAvailableUpdatesList).toBe(true);
+      });
+    });
+
+    describe('hideAvailableUpdates()', () => {
+      it('sets viewAvailableUpdatesList to false', () => {
+        component.viewAvailableUpdatesList = true;
+        component.hideAvailableUpdates();
+        expect(component.viewAvailableUpdatesList).toBe(false);
+      });
+    });
+
+    describe('onDestroy', () => {
+      it('removes the loader screen', () => {
+        spyOn(component.layoutFacade, 'ShowPageLoading');
+
+        component.ngOnDestroy();
+        expect(component.layoutFacade.ShowPageLoading).toHaveBeenCalledWith(false);
+      });
     });
   });
 
-  describe('showAvailableUpdates()', () => {
-    it('sets viewAvailableUpdatesList to true', () => {
-      component.viewAvailableUpdatesList = false;
-      component.showAvailableUpdates();
-      expect(component.viewAvailableUpdatesList).toBe(true);
+  describe('non-Desktop without user upload permissions', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          ProfileOverviewComponent,
+          // This returns false for all app-authorized checks on the page.
+          MockComponent({ selector: 'app-authorized',
+            inputs: ['allOf'],
+            template: '<ng-content *ngIf="false"></ng-content>' })
+        ],
+        providers: [
+          {provide: ProfilesService, useClass: MockProfilesService},
+          {provide: ChefSessionService, useValue: mockSession},
+          {provide: UploadService, useClass: MockUploadService},
+          FeatureFlagsService,
+          { provide: ProductDeployedService, useValue: new MockProductDeployedService([]) }
+        ],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      });
+      store = TestBed.inject(Store);
+      spyOn(store, 'dispatch').and.callThrough();
+      fixture = TestBed.createComponent(ProfileOverviewComponent);
+      component = fixture.componentInstance;
+      element = fixture.debugElement;
+    });
+
+    it('Zero profiles installed', () => {
+      fixture.detectChanges();
+
+      // 0 profiles installed
+      component.profilesEmpty = true;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are visble.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(true);
+
+      // profile list table is hidden
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(0);
+
+      // upload button is not visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(0);
+    });
+
+    it('one or more profiles installed', () => {
+      fixture.detectChanges();
+
+      // one or more profiles installed
+      component.profilesEmpty = false;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are visible.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(true);
+
+      // profile list table is visible
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(1);
+
+      // upload button is not visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(0);
     });
   });
 
-  describe('hideAvailableUpdates()', () => {
-    it('sets viewAvailableUpdatesList to false', () => {
-      component.viewAvailableUpdatesList = true;
-      component.hideAvailableUpdates();
-      expect(component.viewAvailableUpdatesList).toBe(false);
+  describe('Desktop installed with user upload permissions', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          ProfileOverviewComponent,
+          // This returns true for all app-authorized checks on the page.
+          MockComponent({ selector: 'app-authorized',
+            inputs: ['allOf'],
+            template: '<ng-content *ngIf="true"></ng-content>' })
+        ],
+        providers: [
+          {provide: ProfilesService, useClass: MockProfilesService},
+          {provide: ChefSessionService, useValue: mockSession},
+          {provide: UploadService, useClass: MockUploadService},
+          FeatureFlagsService,
+          // This installs the Desktop offering
+          { provide: ProductDeployedService, useValue: new MockProductDeployedService(['desktop']) }
+        ],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      });
+      store = TestBed.inject(Store);
+      spyOn(store, 'dispatch').and.callThrough();
+      fixture = TestBed.createComponent(ProfileOverviewComponent);
+      component = fixture.componentInstance;
+      element = fixture.debugElement;
+    });
+
+    it('Zero profiles', () => {
+      fixture.detectChanges();
+
+      // 0 profiles installed
+      component.profilesEmpty = true;
+      fixture.detectChanges();
+
+      // Search bar should not be visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(false);
+
+      // Profiles and Available tabs are not visble.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(false);
+
+      // profile list table is hidden
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(0);
+
+      // upload button is visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(1);
+    });
+
+    it('one or more profiles', () => {
+      fixture.detectChanges();
+
+      // one or more profiles installed
+      component.profilesEmpty = false;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are not visible.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(false);
+
+      // profile list table is visible
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(1);
+
+      // upload button is visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(1);
     });
   });
 
-  describe('onDestroy', () => {
-    it('removes the loader screen', () => {
-      spyOn(component.layoutFacade, 'ShowPageLoading');
+  describe('Desktop installed without user upload permissions', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          HttpClientTestingModule,
+          StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+        ],
+        declarations: [
+          ProfileOverviewComponent,
+          // This returns false for all app-authorized checks on the page.
+          MockComponent({ selector: 'app-authorized',
+            inputs: ['allOf'],
+            template: '<ng-content *ngIf="false"></ng-content>' })
+        ],
+        providers: [
+          {provide: ProfilesService, useClass: MockProfilesService},
+          {provide: ChefSessionService, useValue: mockSession},
+          {provide: UploadService, useClass: MockUploadService},
+          FeatureFlagsService,
+          // This installs the Desktop offering
+          { provide: ProductDeployedService, useValue: new MockProductDeployedService(['desktop']) }
+        ],
+        schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      });
+      store = TestBed.inject(Store);
+      spyOn(store, 'dispatch').and.callThrough();
+      fixture = TestBed.createComponent(ProfileOverviewComponent);
+      component = fixture.componentInstance;
+      element = fixture.debugElement;
+    });
 
-      component.ngOnDestroy();
-      expect(component.layoutFacade.ShowPageLoading).toHaveBeenCalledWith(false);
+    it('Zero profiles', () => {
+      fixture.detectChanges();
+
+      // 0 profiles installed
+      component.profilesEmpty = true;
+      fixture.detectChanges();
+
+      // Search bar should not be visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(false);
+
+      // Profiles and Available tabs are not visble.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(false);
+
+      // profile list table is hidden
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(0);
+
+      // upload button is not visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(0);
+    });
+
+    it('one or more profiles', () => {
+      fixture.detectChanges();
+
+      // one or more profiles installed
+      component.profilesEmpty = false;
+      fixture.detectChanges();
+
+      // Search bar is visible
+      const inputs: DebugElement[] = fixture.debugElement.queryAll(By.css('input'));
+      expect(inputs.length > 0).toEqual(true);
+      expect(inputs.some( input => {
+        return input.attributes['placeholder'] === 'Search profiles...';
+      })).toEqual(true);
+
+      // Profiles and Available tabs are not visible.
+      const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
+      expect(selectors.length > 0).toEqual(false);
+
+      // profile list table is visible
+      const tables: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-table'));
+      expect(tables.length).toEqual(1);
+
+      // upload button is not visible
+      const buttons: DebugElement[] = fixture.debugElement.queryAll(By.css('.upload-button'));
+      expect(buttons.length).toEqual(0);
     });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -11,6 +11,16 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { ProfilesService } from 'app/services/profiles/profiles.service';
 import { UploadService } from 'app/services/profiles/upload.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
+
+class MockProductDeployedService {
+
+  constructor() {}
+
+  isProductDeployed(_product: string): boolean {
+    return false;
+  }
+}
 
 class MockProfilesService {
   getAllProfiles(): Observable<Array<Object>> {
@@ -49,7 +59,8 @@ describe('ProfilesOverviewComponent', () => {
         {provide: ProfilesService, useClass: MockProfilesService},
         {provide: ChefSessionService, useValue: mockSession},
         {provide: UploadService, useClass: MockUploadService},
-        FeatureFlagsService
+        FeatureFlagsService,
+        { provide: ProductDeployedService, useClass: MockProductDeployedService }
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     });

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.spec.ts
@@ -122,7 +122,7 @@ describe('ProfilesOverviewComponent', () => {
       return input.attributes['placeholder'] === 'Search profiles...';
     })).toEqual(true);
 
-    // tabs are visble.
+    // tabs are visible.
     const selectors: DebugElement[] = fixture.debugElement.queryAll(By.css('.profiles-tabs'));
     expect(selectors.length > 0).toEqual(true);
 

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -2,7 +2,8 @@ import { combineLatest as observableCombineLatest,
          throwError as observableThrowError,
          forkJoin as observableForkJoin,
          Subject,
-         Observable } from 'rxjs';
+         Observable, 
+         of} from 'rxjs';
 
 import { map, takeUntil, catchError } from 'rxjs/operators';
 import {
@@ -144,6 +145,11 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
 
   // load profiles available to the user
   loadAvailableProfiles() {
+    if (!this.isAvailableProfilesVisible) {
+      this.availableListLoading = false;
+      this.availableProfilesDataLoaded = true;
+      return of([]);
+    }
     this.availableListLoading = true;
     return this.availableProfilesService.getAllProfiles().pipe(
       map(availableProfiles => {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -73,7 +73,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   // Empty Page
   profilesEmpty = false;
 
-  public isDesktopView = false;
+  public isAvailableProfilesVisible = false;
 
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
@@ -85,7 +85,7 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
     private layoutFacade: LayoutFacadeService,
     private productDeployedService: ProductDeployedService
   ) {
-    this.isDesktopView = this.productDeployedService.isProductDeployed('desktop');
+    this.isAvailableProfilesVisible = !this.productDeployedService.isProductDeployed('desktop');
   }
 
   ngOnInit() {
@@ -291,5 +291,9 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
     this.layoutFacade.ShowPageLoading(false);
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  selectTab(tabToSelect: 'installed' | 'available') {
+    this.selectedTab = tabToSelect;
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -1,9 +1,11 @@
-import { combineLatest as observableCombineLatest,
-         throwError as observableThrowError,
-         forkJoin as observableForkJoin,
-         Subject,
-         Observable, 
-         of} from 'rxjs';
+import {
+  combineLatest as observableCombineLatest,
+  throwError as observableThrowError,
+  forkJoin as observableForkJoin,
+  Subject,
+  Observable,
+  of
+} from 'rxjs';
 
 import { map, takeUntil, catchError } from 'rxjs/operators';
 import {

--- a/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+profile/+profile-overview/profile-overview.component.ts
@@ -18,6 +18,7 @@ import { UploadService } from 'app/services/profiles/upload.service';
 import { AvailableProfilesService } from 'app/services/profiles/available-profiles.service';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
 import { find } from 'lodash';
+import { ProductDeployedService } from 'app/services/product-deployed/product-deployed.service';
 
 interface Profile {
     name: String;
@@ -72,6 +73,8 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
   // Empty Page
   profilesEmpty = false;
 
+  public isDesktopView = false;
+
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   constructor(
@@ -79,8 +82,11 @@ export class ProfileOverviewComponent implements OnInit, OnDestroy {
     private availableProfilesService: AvailableProfilesService,
     private uploadService: UploadService,
     private chefSessionService: ChefSessionService,
-    private layoutFacade: LayoutFacadeService
-  ) {}
+    private layoutFacade: LayoutFacadeService,
+    private productDeployedService: ProductDeployedService
+  ) {
+    this.isDesktopView = this.productDeployedService.isProductDeployed('desktop');
+  }
 
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Compliance);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Update the Compliance Profile page to include the case of the Desktop Offering is installed. This also updates wording and style for other cases. We want to hide and show the search bar, "X Profiles" "X Available" tabs, profile table, upload button, and text depending on if the Desktop Offering is installed, one or more profiles are installed, and the user has permissions to upload a profile. 

### :chains: Related Resources
#3749

### :+1: Definition of Done
All the below cases look correct. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui-devproxy && start_all_services && start_automate_ui_background && ui_logs`
1. Open https://a2-dev.test/compliance/compliance-profiles and ensure it looks like the below first case labeled "Non-Desktop, zero profiles, can upload profiles."
1. Select the "X Available" tab and ![image](https://user-images.githubusercontent.com/1679247/83307733-339ae680-a1ba-11ea-8e9b-b764e7ded02d.png) and profile.
1. Ensure the page looks like the below second case labeled "Non-Desktop, one or more profiles, can upload profiles."
1. Go to https://a2-dev.test/settings/users and create a user named "comp"
1. Go to https://a2-dev.test/settings/policies/compliance-viewer-access#members and add the user comp to the "Compliance Viewers" policy.
1. Log in as the comp user and go to the https://a2-dev.test/compliance/compliance-profiles page
1. Ensure the page looks like the below third case labeled "Non-Desktop, zero profiles, can not upload profiles."
1. Log back in as admin and remove the comp user from the "compliance-viewer-access" policy and add them to the "compliance-editor-access" policy. 
1. Log back in as the comp user and install a profile. 
1. Log back in as the admin user and move the comp user back to only the "compliance-viewer-access" policy. 
1. Log back in as the comp user and go to the profiles page https://a2-dev.test/compliance/compliance-profiles. 
1. Ensure the page looks like the below forth case labeled "Non-Desktop, one or more profiles, can not upload profiles."
1. Now we need to test these four cases with the Desktop offering installed. 
1. Run `enable_desktop` in hab studio and run through the above four cases. 


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Cases:
- [x] Non-Desktop, zero profiles, can upload profiles.
 - Show search bar
 - Show tabs with the available profiles tab
 - Hide the profiles list
 - Show the upload profiles button.
 - Display the string "Get a profile from the Available tab or upload your own profile to get started!"
![image](https://user-images.githubusercontent.com/1679247/83305410-8c1bb500-a1b5-11ea-993f-d6890867157f.png)

- [x] Non-Desktop, one or more profiles, can upload profiles.
 - Show search bar
 - Show tabs with the available profiles tab
 - Show profiles list
 - Show the upload profiles button. 
![image](https://user-images.githubusercontent.com/1679247/83305307-5e367080-a1b5-11ea-9e2b-3f8a47b0ba41.png)

- [x] Non-Desktop, zero profiles, can not upload profiles.
 - Show search bar
 - Show tabs with the available profiles tab
 - Hide the profiles list
 - Hide the upload profiles button.
 - Display the string "It looks like no one has uploaded any profiles yet and you don't have permission to upload them. If this is a mistake, then reach out to your administrator."
![image](https://user-images.githubusercontent.com/1679247/83306983-7b207300-a1b8-11ea-903f-dacaac220656.png)

- [x] Non-Desktop, one or more profiles, can not upload profiles.
 - Show search bar
 - Show tabs with the available profiles tab
 - Show profiles list
 - Hide the upload profiles button. 
![image](https://user-images.githubusercontent.com/1679247/83305500-bff6da80-a1b5-11ea-9360-94b6fe8a386c.png)

- [x] Desktop, zero profiles, can upload profiles.
 - Hide tabs with the available profiles tab. 
 - Hide profiles list
 - Show the upload profiles button. 
 - Display the string "Upload a profile to get started!"
![image](https://user-images.githubusercontent.com/1679247/83304584-f5022d80-a1b3-11ea-866a-6ec8af62ee2f.png)

- [x] Desktop, zero profiles, can not upload profile.
 - Hide tabs with the available profiles tab. 
 - Hide profiles list
 - Hide the upload profiles button. 
 - Display the string "It looks like no one has uploaded any profiles yet and you don't have permission to upload them.If this is a mistake, then reach out to your administrator."
![image](https://user-images.githubusercontent.com/1679247/83304753-41e60400-a1b4-11ea-8bf1-6e77002f00c0.png)

- [x] Desktop, one or more profiles, can upload profiles.  
 - Hide tabs with the available profiles tab. 
 - Show profiles list
 - Show the upload profiles button. 
 - Show search bar
![image](https://user-images.githubusercontent.com/1679247/83304625-09462a80-a1b4-11ea-967a-c9c41ceb0ebc.png)

- [x] Desktop, one or more profiles, can not upload profile. 
 - Hide tabs with the available profiles tab. 
 - Show profiles list
 - Hide the upload profiles button. 
 - Show search bar
![image](https://user-images.githubusercontent.com/1679247/83305113-03047e00-a1b5-11ea-8d4e-a6595a51bb76.png)


