### PR TITLE
[Automate-3439] Add sections to the policies dropdown

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -6,7 +6,12 @@
           <chef-form-field>
             <label>
               <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" id="name-input" data-cy="create-name" autocomplete="off">
+              <input chefInput formControlName="name"
+                id="name-input"
+                data-cy="create-name"
+                type="text"
+                (keyup)="handleNameInput($event)"
+                autocomplete="off">
             </label>
             <chef-error *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
               Name is required.
@@ -18,7 +23,12 @@
           <chef-form-field>
             <label>
               <span class="label">ID <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="id" type="text" (keyup)="handleIDInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
+              <input chefInput formControlName="id"
+                id="id-input"
+                data-cy="create-id"
+                type="text"
+                (keyup)="handleIDInput($event)"
+                autocomplete="off"/>
             </label>
             <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
               ID must be 64 characters or less.
@@ -41,7 +51,11 @@
             <span data-cy="id-label">{{ this.createForm?.value.id }}</span>
           </div>
           <chef-toolbar>
-            <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
+            <chef-button tertiary
+              id="edit-button-object-modal"
+              data-cy="edit-button"
+              (click)="modifyID = true"
+            >Edit ID</chef-button>
           </chef-toolbar>
         </div>
         <div class="checkbox-margin" *ngIf="createProjectModal">
@@ -69,8 +83,11 @@
           </app-projects-dropdown>
         </div>
         <div id="button-bar">
-          <chef-button primary id="create-button-object-modal" data-cy="save-button"
-            [disabled]="!createForm?.valid || creating || conflictError" (click)="createObject()">
+          <chef-button primary
+            id="create-button-object-modal"
+            data-cy="save-button"
+            [disabled]="!createForm?.valid || creating || conflictError"
+            (click)="createObject()">
             <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
             <span *ngIf="!creating">Create {{ objectNoun | titlecase }}</span>
             <span *ngIf="creating">Creating {{ objectNoun | titlecase }}...</span>

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -70,37 +70,38 @@ describe('CreateObjectModalComponent', () => {
   });
 
   it('upon opening, checked status of all projects is set to false', () => {
-    component.projects = {
-      'proj1':
-        { id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', status: 'NO_RULES', checked: true },
-      'proj3':
-        { id: 'proj3', name: 'proj3', type: 'CUSTOM', status: 'EDITS_PENDING', checked: false },
-      'proj2':
-        { id: 'proj2', name: 'proj2', type: 'CUSTOM', status: 'RULES_APPLIED', checked: true }
-    };
+    component.checkedProjectIDs = ['proj1', 'proj2', 'proj3'];
 
     component.ngOnChanges(
       { visible: new SimpleChange(false, true, true) });
 
-    Object.values(component.projects).forEach(p => {
-      expect(p.checked).toBe(false);
-    });
+    // By resetting this list, that triggers ProjectsDropdownComponent to set all projects false
+    expect(component.checkedProjectIDs.length).toEqual(0);
   });
 
   it('upon opening, checked status of all policies is set to false', () => {
     component.policies = [
-        { id: 'proj1', name: 'proj1', type: 'CHEF_MANAGED', members: [], projects: [],
-          checked: true },
-        { id: 'proj3', name: 'proj3', type: 'CUSTOM', members: [], projects: [], checked: false },
-        { id: 'proj2', name: 'proj2', type: 'CUSTOM', members: [], projects: [], checked: true }
+      {
+        title: 'section1',
+        itemList: [
+          { id: 'proj1', name: 'proj1', checked: true }
+        ]
+      },
+      {
+        title: 'section2',
+        itemList: [
+          { id: 'proj1', name: 'proj1', checked: true },
+          { id: 'proj3', name: 'proj3', checked: false },
+          { id: 'proj2', name: 'proj2', checked: true }
+        ]
+      }
     ];
 
     component.ngOnChanges(
       { visible: new SimpleChange(false, true, true) });
 
-    Object.values(component.policies).forEach(p => {
-      expect(p.checked).toBe(false);
-    });
+    component.policies.forEach(p =>
+      p.itemList.forEach(i => expect(i.checked).toBe(false)));
   });
 
   it('upon opening, dispatches a call to refresh policies', () => {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -101,8 +101,11 @@ describe('CreateObjectModalComponent', () => {
     component.ngOnChanges(
       { visible: new SimpleChange(false, true, true) });
 
-    component.policies.forEach(p =>
-      p.itemList.forEach(i => expect(i.checked).toBe(false)));
+    const checkedStatusOfEveryPolicy =
+      component.policies.flatMap(p => p.itemList.map(i => i.checked));
+    expect(checkedStatusOfEveryPolicy)
+      .withContext('some polices were not reset to false')
+      .toEqual(Array(checkedStatusOfEveryPolicy.length).fill(false));
   });
 
   it('upon opening, dispatches a call to refresh policies', () => {
@@ -208,7 +211,7 @@ describe('CreateObjectModalComponent', () => {
     });
   });
 
-  function genPolicy(id: string, type?: IAMType): Policy {
+  function genPolicy(id: string, type: IAMType): Policy {
     return {
       id,
       name: id,

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -108,6 +108,7 @@ describe('CreateObjectModalComponent', () => {
   it('upon opening, dispatches a call to refresh policies', () => {
     spyOn(store, 'dispatch');
 
+    component.objectNoun = 'token';
     component.ngOnChanges(
       { visible: new SimpleChange(false, true, true) });
 

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -9,10 +9,8 @@ import { takeUntil } from 'rxjs/operators';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
-import {
-  Project, ProjectConstants, ProjectCheckedMap
-} from 'app/entities/projects/project.model';
 import { PolicyChecked } from 'app/entities/policies/policy.model';
+import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { GetPolicies } from 'app/entities/policies/policy.actions';
 import { allPolicies } from 'app/entities/policies/policy.selectors';
 import { ResourceCheckedSection } from '../resource-dropdown/resource-dropdown.component';
@@ -33,7 +31,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   @Output() close = new EventEmitter();
   @Output() createClicked = new EventEmitter<Project[]>();
 
-  public projects: ProjectCheckedMap = {};
   public checkedProjectIDs: string[] = []; // resets project dropdown between modal openings
   public policies: ResourceCheckedSection[] = [];
   public modifyID = false; // Whether the edit ID form is open or not.
@@ -84,7 +81,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
 
       this.store.dispatch(new GetPolicies()); // refresh in case of updates
 
-      Object.values(this.projects).forEach(p => p.checked = false); // reset projects
+      this.checkedProjectIDs = []; // reset projects
       this.projectsUpdatedEvent.emit();
 
       this.policies.forEach(policy =>
@@ -134,13 +131,11 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
 
   closeEvent(): void {
     this.modifyID = false;
-    this.checkedProjectIDs = [];
     this.close.emit();
   }
 
   createObject(): void {
     this.createClicked.emit();
-    this.checkedProjectIDs = [];
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -7,6 +7,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { ChefSorters } from 'app/helpers/auth/sorter';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import {
   Project, ProjectConstants, ProjectCheckedMap
@@ -65,7 +66,10 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       .pipe(takeUntil(this.isDestroyed))
       .subscribe(policies => {
         // OK to leave `checked` undefined--will be initialized upon `visible`
-        const pols = policies as PolicyChecked[];
+        const ingestPolicy = policies.find(p => p.id === 'ingest-access') as PolicyChecked;
+        const pols = [ingestPolicy]
+          .concat(
+            ChefSorters.naturalSort(policies.filter(p => p.id !== 'ingest-access'), 'name'));
         pols.forEach(p =>
           p.section = chefManagedPolicies.includes(p.id) ? 'Chef-managed' : 'Custom');
         this.policies = pols;

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -68,8 +68,8 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
         const chefManagedPolicies = pols.filter(p => p.type === 'CHEF_MANAGED');
         const customPolicies = pols.filter(p => p.type !== 'CHEF_MANAGED');
         this.policies = [
-          { title: 'Chef-managed', resources: chefManagedPolicies},
-          { title: 'Custom', resources: customPolicies}
+          { title: 'Chef-managed', itemList: chefManagedPolicies},
+          { title: 'Custom', itemList: customPolicies}
         ];
       });
   }
@@ -87,9 +87,8 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       Object.values(this.projects).forEach(p => p.checked = false); // reset projects
       this.projectsUpdatedEvent.emit();
 
-      this.policies.forEach(section =>
-        section.resources.forEach(
-          r => r.checked = false)); // reset policies
+      this.policies.forEach(policy =>
+        policy.itemList.forEach(p => p.checked = false)); // reset policies
       this.policiesUpdatedEvent.emit();
 
       if (this.createProjectModal) {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -58,6 +58,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       .pipe(filter(list => list.length > 0),
         takeUntil(this.isDestroyed))
       .subscribe(policies => {
+        // separate into two sections, with ingest on top of chef-managed section
         const pols = ChefSorters.naturalSort(
           policies.filter(p => p.id !== INGEST_POLICY_ID), 'name');
         const customPolicies = pols.filter(p => p.type !== 'CHEF_MANAGED');

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -9,7 +9,6 @@ import { takeUntil } from 'rxjs/operators';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { ChefSorters } from 'app/helpers/auth/sorter';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
-import { PolicyChecked } from 'app/entities/policies/policy.model';
 import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { GetPolicies } from 'app/entities/policies/policy.actions';
 import { allPolicies } from 'app/entities/policies/policy.selectors';
@@ -56,14 +55,14 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
     this.store.select(allPolicies)
       .pipe(takeUntil(this.isDestroyed))
       .subscribe(policies => {
-        // OK to leave `checked` undefined--will be initialized upon `visible`
-        const ingestPolicy = policies.find(p => p.id === 'ingest-access') as PolicyChecked;
-        let pols = ingestPolicy ? [ingestPolicy] : [];
-        pols = pols
-          .concat(
-            ChefSorters.naturalSort(policies.filter(p => p.id !== 'ingest-access'), 'name'));
-        const chefManagedPolicies = pols.filter(p => p.type === 'CHEF_MANAGED');
+        const pols = ChefSorters.naturalSort(
+          policies.filter(p => p.id !== 'ingest-access'), 'name');
         const customPolicies = pols.filter(p => p.type !== 'CHEF_MANAGED');
+        const chefManagedPolicies = pols.filter(p => p.type === 'CHEF_MANAGED');
+        const ingestPolicy = policies.find(p => p.id === 'ingest-access');
+        if (ingestPolicy) {
+          chefManagedPolicies.unshift(ingestPolicy);
+        }
         this.policies = [
           { title: 'Chef-managed', itemList: chefManagedPolicies},
           { title: 'Custom', itemList: customPolicies}

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -15,6 +15,13 @@ import { PolicyChecked } from 'app/entities/policies/policy.model';
 import { GetPolicies } from 'app/entities/policies/policy.actions';
 import { allPolicies } from 'app/entities/policies/policy.selectors';
 
+const chefManagedPolicies = [
+  'ingest-access',
+  'administrator-access',
+  'editor-access',
+  'viewer-access'
+];
+
 @Component({
   selector: 'app-create-object-modal',
   templateUrl: './create-object-modal.component.html',
@@ -56,8 +63,13 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
 
     this.store.select(allPolicies)
       .pipe(takeUntil(this.isDestroyed))
-      // OK to leave `checked` undefined--will be initialized upon `visible`
-      .subscribe(policies => this.policies = policies as PolicyChecked[]);
+      .subscribe(policies => {
+        // OK to leave `checked` undefined--will be initialized upon `visible`
+        const pols = policies as PolicyChecked[];
+        pols.forEach(p =>
+          p.section = chefManagedPolicies.includes(p.id) ? 'Chef-managed' : 'Custom');
+        this.policies = pols;
+      });
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -3,12 +3,15 @@ import { FormsModule } from '@angular/forms';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProjectsDropdownComponent } from './projects-dropdown.component';
-import { StoreModule } from '@ngrx/store';
-import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { StoreModule, Store } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks, NgrxStateAtom } from 'app/ngrx.reducers';
+import { LoadOptionsSuccess } from 'app/services/projects-filter/projects-filter.actions';
+import { ProjectsFilterOptionTuple } from 'app/services/projects-filter/projects-filter.reducer';
 
 describe('ProjectsDropdownComponent', () => {
   let component: ProjectsDropdownComponent;
   let fixture: ComponentFixture<ProjectsDropdownComponent>;
+  let store: Store<NgrxStateAtom>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -25,6 +28,7 @@ describe('ProjectsDropdownComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ProjectsDropdownComponent);
     component = fixture.componentInstance;
+    store = TestBed.inject(Store);
     fixture.detectChanges();
   });
 
@@ -49,5 +53,26 @@ describe('ProjectsDropdownComponent', () => {
       p.itemList.forEach(i => expect(i.checked).toBe(false)));
   });
 
+  it('receives projects in sorted order', () => {
+    const payload: ProjectsFilterOptionTuple = {
+      fetched: [
+        { label: 'zz-proj', checked: true, value: '', type: '' },
+        { label: 'c-proj', checked: true, value: '', type: '' },
+        { label: 'a-proj', checked: true, value: '', type: '' },
+        { label: 'b-proj', checked: true, value: '', type: '' }
+      ],
+      restored: []
+    };
+    const expectedNames = payload.fetched.map(p => p.label);
 
+    store.dispatch(new LoadOptionsSuccess(payload));
+
+    expect(component.projects[0].itemList.map(p => p.name))
+      .toEqual([
+        expectedNames[2],
+        expectedNames[3],
+        expectedNames[1],
+        expectedNames[0]
+      ]);
+  });
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
@@ -31,5 +31,23 @@ describe('ProjectsDropdownComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('upon opening, checked status of all projects is set to false', () => {
+    component.projects = [
+      {
+        itemList: [
+          { id: 'proj1', name: 'proj1', checked: true },
+          { id: 'proj3', name: 'proj3', checked: false },
+          { id: 'proj2', name: 'proj2', checked: true }
+        ]
+      }];
+
+    component.ngOnChanges(
+      { checkedProjectIDs: new SimpleChange([], [], true) });
+
+    component.projects.forEach(p =>
+      p.itemList.forEach(i => expect(i.checked).toBe(false)));
+  });
+
 
 });

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.spec.ts
@@ -1,12 +1,12 @@
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ProjectsDropdownComponent } from './projects-dropdown.component';
 import { StoreModule, Store } from '@ngrx/store';
+
 import { ngrxReducers, runtimeChecks, NgrxStateAtom } from 'app/ngrx.reducers';
 import { LoadOptionsSuccess } from 'app/services/projects-filter/projects-filter.actions';
 import { ProjectsFilterOptionTuple } from 'app/services/projects-filter/projects-filter.reducer';
+import { ProjectsDropdownComponent } from './projects-dropdown.component';
 
 describe('ProjectsDropdownComponent', () => {
   let component: ProjectsDropdownComponent;

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -1,13 +1,13 @@
 import { Component, EventEmitter, Input, Output, OnInit, OnDestroy, OnChanges, SimpleChanges } from '@angular/core';
-
-import { ProjectConstants } from 'app/entities/projects/project.model';
 import { Store } from '@ngrx/store';
-import { NgrxStateAtom } from 'app/ngrx.reducers';
-import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
-import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { ProjectConstants } from 'app/entities/projects/project.model';
+import { assignableProjects } from 'app/services/projects-filter/projects-filter.selectors';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { ResourceCheckedSection } from '../resource-dropdown/resource-dropdown.component';
+import { ResourceCheckedSection } from 'app/components/resource-dropdown/resource-dropdown.component';
 
 @Component({
   selector: 'app-projects-dropdown',
@@ -61,7 +61,7 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.checkedProjectIDs) {
-      // cannot proceed unless we have gotten the available projects list from the back end
+      // cannot proceed unless we have received the available projects list from the back end
       if (this.projects) {
         // Need to trigger OnChanges in ResourceDropdownComponent
         // so we cannot just update the checked property of the existing array elements.

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -7,7 +7,7 @@ import { assignableProjects } from 'app/services/projects-filter/projects-filter
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { ResourceChecked, ResourceCheckedSection } from '../resource-dropdown/resource-dropdown.component';
+import { ResourceCheckedSection } from '../resource-dropdown/resource-dropdown.component';
 
 @Component({
   selector: 'app-projects-dropdown',
@@ -42,7 +42,7 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
       .subscribe((assignable: ProjectsFilterOption[]) => {
         this.projects = [{
           itemList: assignable.map(p => {
-            return <ResourceChecked>{
+            return {
               id: p.value,
               name: p.label,
               type: p.type,

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -7,7 +7,7 @@ import { assignableProjects } from 'app/services/projects-filter/projects-filter
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { ProjectsFilterOption } from 'app/services/projects-filter/projects-filter.reducer';
-import { ResourceChecked } from '../resource-dropdown/resource-dropdown.component';
+import { ResourceChecked, ResourceCheckedSection } from '../resource-dropdown/resource-dropdown.component';
 
 @Component({
   selector: 'app-projects-dropdown',
@@ -30,7 +30,7 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
   // Label to use when none are selected
   public noneSelectedLabel = ProjectConstants.UNASSIGNED_PROJECT_ID;
 
-  public projects: ResourceChecked[];
+  public projects: ResourceCheckedSection[];
 
   private isDestroyed = new Subject<boolean>();
 
@@ -40,8 +40,8 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
     this.store.select(assignableProjects)
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((assignable: ProjectsFilterOption[]) => {
-        this.projects =
-          assignable.map(p => {
+        this.projects = [{
+          resources: assignable.map(p => {
             return <ResourceChecked>{
               id: p.value,
               name: p.label,
@@ -49,7 +49,8 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
               checked: this.checkedProjectIDs
                 && this.checkedProjectIDs.includes(p.value)
             };
-          });
+          })
+        }];
       });
   }
 
@@ -62,11 +63,13 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
     if (changes.checkedProjectIDs && changes.checkedProjectIDs.currentValue && this.projects) {
       // Need to trigger OnChanges in ResourceDropdownComponent
       // so we cannot just update the checked property of the existing array elements.
-      this.projects = this.projects
-        .map(p => ({
-          ...p,
-          checked: (changes.checkedProjectIDs.currentValue as string[]).includes(p.id)
-        }));
+      this.projects = [{
+        resources: this.projects[0].resources
+          .map(p => ({
+            ...p,
+            checked: (changes.checkedProjectIDs.currentValue as string[]).includes(p.id)
+          }))
+      }];
     }
   }
 

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -41,7 +41,7 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
       .pipe(takeUntil(this.isDestroyed))
       .subscribe((assignable: ProjectsFilterOption[]) => {
         this.projects = [{
-          resources: assignable.map(p => {
+          itemList: assignable.map(p => {
             return <ResourceChecked>{
               id: p.value,
               name: p.label,
@@ -64,7 +64,7 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
       // Need to trigger OnChanges in ResourceDropdownComponent
       // so we cannot just update the checked property of the existing array elements.
       this.projects = [{
-        resources: this.projects[0].resources
+        itemList: this.projects[0].itemList
           .map(p => ({
             ...p,
             checked: (changes.checkedProjectIDs.currentValue as string[]).includes(p.id)

--- a/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/projects-dropdown/projects-dropdown.component.ts
@@ -60,16 +60,19 @@ export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.checkedProjectIDs && changes.checkedProjectIDs.currentValue && this.projects) {
-      // Need to trigger OnChanges in ResourceDropdownComponent
-      // so we cannot just update the checked property of the existing array elements.
-      this.projects = [{
-        itemList: this.projects[0].itemList
-          .map(p => ({
-            ...p,
-            checked: (changes.checkedProjectIDs.currentValue as string[]).includes(p.id)
-          }))
-      }];
+    if (changes.checkedProjectIDs) {
+      // cannot proceed unless we have gotten the available projects list from the back end
+      if (this.projects) {
+        // Need to trigger OnChanges in ResourceDropdownComponent
+        // so we cannot just update the checked property of the existing array elements.
+        this.projects = [{
+          itemList: this.projects[0].itemList
+            .map(p => ({
+              ...p,
+              checked: (changes.checkedProjectIDs.currentValue as string[]).includes(p.id)
+            }))
+        }];
+      }
     }
   }
 

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -19,9 +19,9 @@
       </div>
 
       <div id="resource-container">
-        <ng-container *ngFor="let section of filteredSections">
-          <h3 class="resource-section" *ngIf="section.title && section.resources.length">{{ section.title }}</h3>
-          <chef-checkbox *ngFor="let resource of section.resources"
+        <ng-container *ngFor="let section of filteredResources">
+          <h3 class="resource-section" *ngIf="section.title && section.itemList.length">{{ section.title }}</h3>
+          <chef-checkbox *ngFor="let resource of section.itemList"
             [checked]="resource.checked"
             [attr.title]="resource.name"
             (change)="resourceChecked($event.detail, resource)"

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -32,7 +32,7 @@
         </ng-container>
       </div>
 
-      <div class="no-resources" *ngIf="allResourcesCount === 0">
+      <div class="no-resources" *ngIf="allFilteredResourcesCount === 0">
         <p>No {{ objectNounPlural }} found.</p>
         <p>You don't have access to any {{ objectNounPlural }} that match your search.</p>
       </div>

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -19,14 +19,19 @@
       </div>
 
       <div id="resource-container">
-        <chef-checkbox *ngFor="let resource of filteredResources"
-          [checked]="resource.checked"
-          [attr.title]="resource.name"
-          (change)="resourceChecked($event.detail, resource)"
-          (keydown.enter)="closeDropdown()"
-          (keydown.esc)="closeDropdown()"
-          (keydown.arrowup)="moveFocus($event)"
-          (keydown.arrowdown)="moveFocus($event)">{{ resource.name }}</chef-checkbox>
+        <div *ngFor="let section of sections">
+          <span *ngIf="section">[{{ section }}]</span>
+          <span *ngFor="let resource of filteredResources">
+            <chef-checkbox *ngIf="resource.section === section"
+              [checked]="resource.checked"
+              [attr.title]="resource.name"
+              (change)="resourceChecked($event.detail, resource)"
+              (keydown.enter)="closeDropdown()"
+              (keydown.esc)="closeDropdown()"
+              (keydown.arrowup)="moveFocus($event)"
+              (keydown.arrowdown)="moveFocus($event)">{{ resource.name }}</chef-checkbox>
+          </span>
+        </div>
       </div>
 
       <div class="no-resources" *ngIf="filteredResources.length === 0">

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -19,19 +19,17 @@
       </div>
 
       <div id="resource-container">
-        <div *ngFor="let section of filteredSections">
-          <span *ngIf="section.title && section.resources.length">[{{ section.title }}]</span>
-          <span *ngFor="let resource of section.resources">
-            <chef-checkbox
-              [checked]="resource.checked"
-              [attr.title]="resource.name"
-              (change)="resourceChecked($event.detail, resource)"
-              (keydown.enter)="closeDropdown()"
-              (keydown.esc)="closeDropdown()"
-              (keydown.arrowup)="moveFocus($event)"
-              (keydown.arrowdown)="moveFocus($event)">{{ resource.name }}</chef-checkbox>
-          </span>
-        </div>
+        <ng-container *ngFor="let section of filteredSections">
+          <h3 class="resource-section" *ngIf="section.title && section.resources.length">{{ section.title }}</h3>
+          <chef-checkbox *ngFor="let resource of section.resources"
+            [checked]="resource.checked"
+            [attr.title]="resource.name"
+            (change)="resourceChecked($event.detail, resource)"
+            (keydown.enter)="closeDropdown()"
+            (keydown.esc)="closeDropdown()"
+            (keydown.arrowup)="moveFocus($event)"
+            (keydown.arrowdown)="moveFocus($event)">{{ resource.name }}</chef-checkbox>
+        </ng-container>
       </div>
 
       <div class="no-resources" *ngIf="allResourcesCount === 0">

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -19,10 +19,10 @@
       </div>
 
       <div id="resource-container">
-        <div *ngFor="let section of sections">
-          <span *ngIf="section">[{{ section }}]</span>
-          <span *ngFor="let resource of filteredResources">
-            <chef-checkbox *ngIf="resource.section === section"
+        <div *ngFor="let section of filteredSections">
+          <span *ngIf="section.title && section.resources.length">[{{ section.title }}]</span>
+          <span *ngFor="let resource of section.resources">
+            <chef-checkbox
               [checked]="resource.checked"
               [attr.title]="resource.name"
               (change)="resourceChecked($event.detail, resource)"
@@ -34,7 +34,7 @@
         </div>
       </div>
 
-      <div class="no-resources" *ngIf="filteredResources.length === 0">
+      <div class="no-resources" *ngIf="allResourcesCount === 0">
         <p>No {{ objectNounPlural }} found.</p>
         <p>You don't have access to any {{ objectNounPlural }} that match your search.</p>
       </div>

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
@@ -85,6 +85,7 @@ chef-dropdown {
 
   .resource-section {
     font-size: 11px;
+    font-weight: 600;
     color: $chef-dark-grey;
     padding-top: 24px;
     padding-bottom: 1px;

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
@@ -82,20 +82,28 @@ chef-dropdown {
     padding: 14px 18px 0px;
     font-style: italic;
   }
-}
 
-chef-checkbox {
-  display: flex;
-  padding: 9px 18px;
-  align-items: flex-start;
-  white-space: normal; // prevents text from going outside of the element's container
+  .resource-section {
+    font-size: 11px;
+    color: $chef-dark-grey;
+    padding-top: 24px;
+    padding-bottom: 1px;
+    padding-left: 18px;
 
-  &:first-child {
-    padding-top: 18px;
+    &:first-child {
+      padding-top: 12px;
+    }
   }
 
-  &:last-child {
-    padding-bottom: 18px;
+  chef-checkbox {
+    display: flex;
+    padding: 9px 18px;
+    align-items: flex-start;
+    white-space: normal; // prevents text from going outside of the element's container
+
+    &:first-child {
+      padding-top: 18px;
+    }
   }
 }
 

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
@@ -4,7 +4,9 @@ import { FormsModule } from '@angular/forms';
 
 import { using } from 'app/testing/spec-helpers';
 import { ChefPipesModule } from 'app/pipes/chef-pipes.module';
-import { ResourceDropdownComponent, ResourceChecked } from './resource-dropdown.component';
+import {
+  ResourceDropdownComponent, ResourceChecked, ResourceCheckedSection
+} from './resource-dropdown.component';
 
 describe('ResourceDropdownComponent', () => {
   let component: ResourceDropdownComponent;
@@ -31,28 +33,21 @@ describe('ResourceDropdownComponent', () => {
   });
 
   describe('dropdown', () => {
-    beforeEach(() => {
-      component.dropdownState = 'open';
-      component.filteredResources = [
-        {
-          name: 'Project 1',
-          id: 'project-1',
-          checked: false
-        },
-        {
-          name: 'Project 2',
-          id: 'project-2',
-          checked: true
-        }
-      ];
-      fixture.detectChanges();
-    });
 
     it('displays a list of checkbox options', () => {
+      component.filteredResources = [
+        genResourceList(
+          genResource('project 1', false),
+          genResource('project 2', true),
+          genResource('project 3', true)
+        )
+      ];
+      fixture.detectChanges();
+
       const options: HTMLInputElement[] = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
-      expect(options.length).toEqual(component.filteredResources.length);
+      expect(options.length).toEqual(component.filteredResources[0].itemList.length);
       options.forEach((option, index) => {
-        const { name, checked } = component.filteredResources[index];
+        const { name, checked } = component.filteredResources[0].itemList[index];
         expect(option.textContent).toEqual(name);
         expect(option.checked).toEqual(checked);
       });
@@ -67,15 +62,15 @@ describe('ResourceDropdownComponent', () => {
 
     using([
       ['single unchecked resource',
-        [
+        [genResourceList(
           genResource('name1', false)
-        ]],
+        )]],
       ['two resources but none checked',
-        [
+        [genResourceList(
           genResource('name1', false),
           genResource('name2', false)
-        ]]
-    ], function (description: string, resources: ResourceChecked[]) {
+        )]]
+    ], function (description: string, resources: ResourceCheckedSection[]) {
       it(`displays 'none' designator for ${description}`, () => {
         component.resources = resources;
         component.ngOnChanges(
@@ -86,36 +81,36 @@ describe('ResourceDropdownComponent', () => {
 
     using([
       ['single checked resource',
-        [
+        [genResourceList(
           genResource('target resource', true)
-        ]],
+        )]],
       ['two resources but just one checked',
-        [
+        [genResourceList(
           genResource('other resource2', false),
           genResource('target resource', true)
-        ]],
+        )]],
       ['multiple resources but just one checked in the middle',
-        [
+        [genResourceList(
           genResource('other resource1', false),
           genResource('other resource2', false),
           genResource('target resource', true),
           genResource('other resource3', false)
-        ]],
+        )]],
       ['multiple resources but just one checked at the top',
-        [
+        [genResourceList(
           genResource('target resource', true),
           genResource('other resource1', false),
           genResource('other resource2', false),
           genResource('other resource3', false),
           genResource('other resource4', false)
-        ]],
+        )]],
       ['multiple resources but just one checked at the bottom',
-        [
+        [genResourceList(
           genResource('other resource1', false),
           genResource('other resource2', false),
           genResource('target resource', true)
-        ]]
-    ], function (description: string, resources: ResourceChecked[]) {
+        )]]
+    ], function (description: string, resources: ResourceCheckedSection[]) {
       it(`displays resource name for ${description}`, () => {
         component.resources = resources;
         component.ngOnChanges(
@@ -126,26 +121,26 @@ describe('ResourceDropdownComponent', () => {
 
     using([
       ['some checked and some not checked', 3,
-        [
+        [genResourceList(
           genResource('name1', true),
           genResource('name2', false),
           genResource('name3', true),
           genResource('name4', true),
           genResource('name5', false)
-        ]],
+        )]],
       ['all checked', 4,
-        [
+        [genResourceList(
           genResource('name1', true),
           genResource('name2', true),
           genResource('name3', true),
           genResource('name4', true)
-        ]],
+        )]],
       ['just two and both checked', 2,
-        [
+        [genResourceList(
           genResource('name1', true),
           genResource('name2', true)
-        ]]
-    ], function (description: string, count: number, resources: ResourceChecked[]) {
+        )]]
+    ], function (description: string, count: number, resources: ResourceCheckedSection[]) {
       it(`displays resource designator with count for multiple resources with ${description}`,
         () => {
           component.resources = resources;
@@ -156,6 +151,13 @@ describe('ResourceDropdownComponent', () => {
         });
     });
   });
+
+  function genResourceList(...resources: ResourceChecked[]): ResourceCheckedSection {
+    return {
+      title: 'any',
+      itemList: resources
+    };
+  }
 
   function genResource(name: string, checked: boolean): ResourceChecked {
     return {

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
@@ -32,31 +32,246 @@ describe('ResourceDropdownComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('dropdown', () => {
+  it('displays a list of checkbox options', () => {
+    component.filteredResources = [
+      genResourceList(
+        genResource('project 1', false),
+        genResource('project 2', true),
+        genResource('project 3', true)
+      )
+    ];
+    fixture.detectChanges();
 
-    it('displays a list of checkbox options', () => {
-      component.filteredResources = [
-        genResourceList(
-          genResource('project 1', false),
-          genResource('project 2', true),
-          genResource('project 3', true)
-        )
-      ];
-      fixture.detectChanges();
+    const options: HTMLInputElement[] = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
+    expect(options.length).toEqual(component.filteredResources[0].itemList.length);
+    options.forEach((option, index) => {
+      const { name, checked } = component.filteredResources[0].itemList[index];
+      expect(option.textContent).toEqual(name);
+      expect(option.checked).toEqual(checked);
+    });
+  });
 
-      const options: HTMLInputElement[] = Array.from(fixture.nativeElement.querySelectorAll('chef-checkbox'));
-      expect(options.length).toEqual(component.filteredResources[0].itemList.length);
-      options.forEach((option, index) => {
-        const { name, checked } = component.filteredResources[0].itemList[index];
-        expect(option.textContent).toEqual(name);
-        expect(option.checked).toEqual(checked);
-      });
+  it('renders resources WITHOUT sorting ', () => { // thus allowing custom ordering
+    const resources = [genResourceList(
+      genResource('zz', false),
+      genResource('cc', true),
+      genResource('aa', false),
+      genResource('bb', true)
+    )];
+      component.objectNounPlural = 'policies';
+
+    toggleDropdown(); // open
+    changeResources([], resources, true);
+
+    expect(component.filteredResources[0].itemList.map(r => r.name))
+      .toEqual(['zz', 'cc', 'aa', 'bb']);
+  });
+
+  describe('user scenarios', () => {
+    const resources = [genResourceList( // 3 checked items
+      genResource('name1', true),
+      genResource('name2', false),
+      genResource('other_name3', true),
+      genResource('name4', true),
+      genResource('other_name5', false)
+    )];
+
+    const resourcesNew = [genResourceList( // 2 checked items
+      genResource('name1', true),
+      genResource('name4', true),
+      genResource('other_name5', false)
+    )];
+
+    it('retains checked items after closing then re-opening dropdown', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      toggleDropdown(); // close
+      expect(component.dropdownState).toEqual('closed');
+
+      toggleDropdown(); // ... and reopen
+      expect(component.dropdownState).toEqual('open');
+      expect(component.label).toEqual('4 lemurs');
     });
 
+    it('retains checked items after closing, updating resources, then re-opening dropdown', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      toggleDropdown(); // close
+      expect(component.dropdownState).toEqual('closed');
+
+      changeResources(resources, resourcesNew, false); // <----------Update resources
+
+      toggleDropdown(); // ... and reopen
+      expect(component.dropdownState).toEqual('open');
+      expect(component.label).toEqual('4 lemurs');
+    });
+
+    it('clears checked items after force resetting', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      toggleDropdown(); // close
+      expect(component.dropdownState).toEqual('closed');
+
+      component.resourcesUpdated.emit(true); // force update here
+
+      toggleDropdown(); // ... and reopen
+      expect(component.dropdownState).toEqual('open');
+      expect(component.label).toEqual('3 lemurs');
+    });
+
+    it('clears checked items after updating resources then force resetting', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      toggleDropdown(); // close
+      expect(component.dropdownState).toEqual('closed');
+
+      changeResources(resources, resourcesNew, false); // <----------Update resources
+
+      component.resourcesUpdated.emit(true); // force update here
+
+      toggleDropdown(); // ... and reopen
+      expect(component.dropdownState).toEqual('open');
+      expect(component.label).toEqual('2 lemurs');
+    });
+
+    it('applies filter but leaves label unchanged', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      // apply filter
+      component.filterValue = 'other';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(component.filteredResources[0].itemList[0].name).toEqual('other_name3');
+      expect(component.filteredResources[0].itemList[0].checked).toEqual(true);
+      expect(component.filteredResources[0].itemList[1].name).toEqual('other_name5');
+      expect(component.filteredResources[0].itemList[1].checked).toEqual(false);
+    });
+
+    it('applies filter and updates resources but leaves label unchanged', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      // apply filter
+      component.filterValue = 'other';
+      component.handleFilterKeyUp();
+
+      changeResources(resources, resourcesNew, false); // <----------Update resources
+
+      expect(component.label).toEqual('4 lemurs');
+      expect(component.filteredResources[0].itemList[0].name).toEqual('other_name3');
+      expect(component.filteredResources[0].itemList[0].checked).toEqual(true);
+      expect(component.filteredResources[0].itemList[1].name).toEqual('other_name5');
+      expect(component.filteredResources[0].itemList[1].checked).toEqual(false);
+    });
+
+    it('retains checked items after filter applied', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      const target = component.filteredResources[0].itemList[1];
+      expect(target.checked).toEqual(false);
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+
+      // apply filter
+      component.filterValue = 'other';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+
+      // clear filter
+      component.filterValue = '';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+    });
+
+    it('retains checked items after filter applied and resources updated', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      const target = component.filteredResources[0].itemList[1];
+      expect(target.checked).toEqual(false);
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+
+      // apply filter
+      component.filterValue = 'other';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+
+      changeResources(resources, resourcesNew, false); // <----------Update resources
+
+      // clear filter
+      component.filterValue = '';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(target.checked).toEqual(true);
+    });
+
+    it('clears filter upon re-opening', () => {
+      specifyLemursAndOpenDropdown();
+
+      // make a change
+      component.resourceChecked(true, component.filteredResources[0].itemList[1]);
+      expect(component.label).toEqual('4 lemurs');
+
+      // apply filter
+      component.filterValue = 'other';
+      component.handleFilterKeyUp();
+      expect(component.label).toEqual('4 lemurs');
+      expect(component.filteredResources[0].itemList.length).toEqual(2);
+
+      toggleDropdown(); // close
+      expect(component.dropdownState).toEqual('closed');
+
+      toggleDropdown(); // re-open
+      expect(component.filteredResources[0].itemList.length).toEqual(5);
+    });
+
+    function specifyLemursAndOpenDropdown() {
+      expect(component.dropdownState).toEqual('closed');
+
+      component.objectNounPlural = 'lemurs';
+      changeResources([], resources, true);
+      toggleDropdown();
+
+      expect(component.filteredResources).toEqual(resources);
+      expect(component.label).toEqual('3 lemurs');
+      expect(component.dropdownState).toEqual('open');
+    }
+  });
+
+  describe('label', () => {
     it('allows customizing "none" designator', () => {
       component.noneSelectedLabel = 'zilch';
-      component.ngOnChanges(
-        { resources: new SimpleChange([], [], true) });
+      changeResources([], [], true);
       expect(component.label).toEqual('zilch');
     });
 
@@ -72,9 +287,7 @@ describe('ResourceDropdownComponent', () => {
         )]]
     ], function (description: string, resources: ResourceCheckedSection[]) {
       it(`displays 'none' designator for ${description}`, () => {
-        component.resources = resources;
-        component.ngOnChanges(
-          { resources: new SimpleChange([], resources, true) });
+        changeResources([], resources, true);
         expect(component.label).toEqual('None');
       });
     });
@@ -112,9 +325,7 @@ describe('ResourceDropdownComponent', () => {
         )]]
     ], function (description: string, resources: ResourceCheckedSection[]) {
       it(`displays resource name for ${description}`, () => {
-        component.resources = resources;
-        component.ngOnChanges(
-          { resources: new SimpleChange([], resources, true) });
+        changeResources([], resources, true);
         expect(component.label).toEqual('target resource');
       });
     });
@@ -143,14 +354,26 @@ describe('ResourceDropdownComponent', () => {
     ], function (description: string, count: number, resources: ResourceCheckedSection[]) {
       it(`displays resource designator with count for multiple resources with ${description}`,
         () => {
-          component.resources = resources;
           component.objectNounPlural = 'lemurs';
-          component.ngOnChanges(
-            { resources: new SimpleChange([], resources, true) });
+          changeResources([], resources, true);
           expect(component.label).toEqual(`${count} lemurs`);
         });
     });
   });
+
+  function toggleDropdown() {
+    // The event from an actual click on the dropdown fires *both* of these in the order given.
+    component.toggleDropdown();
+    component.handleClickOutside();
+  }
+
+  function changeResources(
+    original: ResourceCheckedSection[], changed: ResourceCheckedSection[], firstChange) {
+    // Programmatic change to an @Input does *not* trigger ngOnChanges like in the actual view,
+    // so have to do that explicitly
+    component.resources = changed;
+    component.ngOnChanges({ resources: new SimpleChange(original, changed, firstChange) });
+  }
 
   function genResourceList(...resources: ResourceChecked[]): ResourceCheckedSection {
     return {

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.spec.ts
@@ -58,7 +58,7 @@ describe('ResourceDropdownComponent', () => {
       genResource('aa', false),
       genResource('bb', true)
     )];
-      component.objectNounPlural = 'policies';
+    component.objectNounPlural = 'policies';
 
     toggleDropdown(); // open
     changeResources([], resources, true);
@@ -376,6 +376,8 @@ describe('ResourceDropdownComponent', () => {
   }
 
   function genResourceList(...resources: ResourceChecked[]): ResourceCheckedSection {
+    // Though title is technically optional, we need to supply it here so we can compare
+    // filteredResources to resources in one step in specifyLemursAndOpenDropdown().
     return {
       title: 'any',
       itemList: resources

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -142,28 +142,27 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   }
 
   private updateLabel(): void {
-    const checkedResources = this.allCheckedResources;
+    const checkedResources = this.allCheckedResourceNames;
     this.label = checkedResources.length === 0 ? this.noneSelectedLabel
       : checkedResources.length === 1 ? checkedResources[0]
         : `${checkedResources.length} ${this.objectNounPlural}`;
   }
 
-  private get allCheckedResources() {
-    const resources: string[] = [];
-    this.resources.forEach(section => {
-      const stuff = section.itemList.filter(r => r.checked).map(r => r.name);
-      resources.push(...stuff);
-    });
-    return resources;
+  private get allCheckedResourceNames(): string[] {
+    return [].concat(
+      ...this.resources.map(
+        resource => resource.itemList.filter(r => r.checked).map(r => r.name)));
   }
 
-  get allFilteredResourcesCount() {
-    let count = 0;
-    this.filteredResources.forEach(section => count += section.itemList.length);
-    return count;
+  get allFilteredResourcesCount(): number {
+    return this.filteredResources.reduce((sum, group) => sum + group.itemList.length, 0);
+  }
+
+  private get allResourcesCount(): number {
+    return this.resources.reduce((sum, group) => sum + group.itemList.length, 0);
   }
 
   get disabled(): boolean {
-    return this.resources.length === 0;
+    return this.resources.length === 0 || this.allResourcesCount === 0;
   }
 }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -110,9 +110,8 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   closeDropdown(): void {
     this.dropdownState = 'closed';
-    const flattenedIDs = [].concat(
-      ...this.snapshotResources.map(
-        resource => resource.itemList.filter(r => r.checked).map(r => r.id)));
+    const flattenedIDs = this.snapshotResources.flatMap(
+      resource => resource.itemList.filter(r => r.checked).map(r => r.id));
     this.onDropdownClosing.emit(flattenedIDs);
   }
 
@@ -130,12 +129,11 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     // Not deep and not shallow!
     // Need the individual resources to point to the same objects
     // so that when one is checked, it is checked in BOTH structures.
-    this.filteredResources = [].concat(
-      ...this.snapshotResources.map(section =>
+    this.filteredResources = this.snapshotResources.flatMap(section =>
         ({
           title: section.title,
           itemList: section.itemList
-        })));
+        }));
     this.allFilteredResourcesCount = this.calculateAllFilteredResourcesCount();
   }
 
@@ -170,19 +168,21 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   }
 
   private calculateAllFilteredResourcesCount(): number {
-    return this.filteredResources.reduce(
-      (sum, group) => sum + group.itemList.length, 0);
+    return this.resourceCount(this.filteredResources);
   }
 
   private get allResourcesCount(): number {
-    return this.resources.reduce(
+    return this.resourceCount(this.resources);
+  }
+
+  private resourceCount(resources: ResourceCheckedSection[]): number {
+    return resources.reduce(
       (sum, group) => sum + group.itemList.length, 0);
   }
 
   private get allCheckedResourceNames(): string[] {
-    return [].concat(
-      ...this.snapshotResources.map(
-        resource => resource.itemList.filter(r => r.checked).map(r => r.name)));
+    return this.snapshotResources.flatMap(
+        resource => resource.itemList.filter(r => r.checked).map(r => r.name));
   }
 
 }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -66,7 +66,8 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.resources) {
-      if (changes.resources.firstChange) { // only update on initialization/first change
+      if (!changes.resources.previousValue || changes.resources.previousValue.length === 0) {
+        // only update if not previously initialized
         this.snapshotResources = cloneDeep(this.resources);
         this.resetFilteredResources();
         this.updateLabel();

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -53,8 +53,11 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   public disabled = false;
 
   ngOnInit(): void {
-    if (this.resourcesUpdated) { // an optional setting
+    // an optional setting allowing caller to force reset to initial state
+    if (this.resourcesUpdated) {
       this.resourcesUpdated.subscribe(() => {
+        this.snapshotResources = cloneDeep(this.resources);
+        this.resetFilteredResources();
         this.updateLabel();
       });
     }
@@ -63,7 +66,9 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.resources) {
       if (changes.resources.firstChange) { // only update on initialization/first change
-        this.setResources();
+        this.snapshotResources = cloneDeep(this.resources);
+        this.resetFilteredResources();
+      } else {
       }
       this.updateLabel();
       this.disabled = this.isDisabled();
@@ -76,7 +81,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     }
     if (this.dropdownState === 'closed') { // opening
       this.filterValue = '';
-      this.setResources();
+      this.resetFilteredResources();
       // we cannot go directly to 'open' because handleClickOutside,
       // firing next on the same event that arrived here, would then immediately close it.
       this.dropdownState = 'opening';
@@ -118,14 +123,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     }
   }
 
-  private setResources(): void {
-
-    // Freeze resources from updating while dropdown is open.
-    // Otherwise, when the next introspect_projects occurs,
-    // all checkboxes in the open dropdown will be cleared!
-    if (this.checkedResourcesCount === 0) {
-      this.snapshotResources = cloneDeep(this.resources);
-    }
+  private resetFilteredResources(): void {
 
     // Not deep and not shallow!
     // Need the individual resources to point to the same objects
@@ -171,11 +169,6 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   private get allResourcesCount(): number {
     return this.resources.reduce(
       (sum, group) => sum + group.itemList.length, 0);
-  }
-
-  private get checkedResourcesCount(): number {
-    return this.snapshotResources.reduce(
-      (sum, group) => sum + group.itemList.filter(r => r.checked).length, 0);
   }
 
   private get allCheckedResourceNames(): string[] {

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -42,7 +42,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   // Provides a level of indirection so that we do not lose *unsaved* checked items:
   // (a) while dropdown is open
   // (b) when dropdown is closed then re-opened
-  public snapshotResources: ResourceCheckedSection[] = [];
+  private snapshotResources: ResourceCheckedSection[] = [];
 
   // Transitory subset of snapshotResources for display based on user's entered filter.
   public filteredResources: ResourceCheckedSection[] = [];
@@ -69,9 +69,8 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
       if (changes.resources.firstChange) { // only update on initialization/first change
         this.snapshotResources = cloneDeep(this.resources);
         this.resetFilteredResources();
-      } else {
+        this.updateLabel();
       }
-      this.updateLabel();
       this.disabled = this.isDisabled();
     }
   }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -44,6 +44,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   public dropdownState: 'closed' | 'opening' | 'open' = 'closed';
   public label = this.noneSelectedLabel;
   public filterValue = '';
+  public disabled = false;
 
   ngOnInit(): void {
     if (this.resourcesUpdated) { // an optional setting
@@ -59,6 +60,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
       if (changes.resources.firstChange) { // only update on initialization/first change
         this.filteredResources = this.copyResources();
       }
+      this.disabled = this.isDisabled();
     }
   }
 
@@ -148,6 +150,10 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
         : `${checkedResources.length} ${this.objectNounPlural}`;
   }
 
+  private isDisabled(): boolean {
+    return this.resources.length === 0 || this.allResourcesCount === 0;
+  }
+
   private get allCheckedResourceNames(): string[] {
     return [].concat(
       ...this.resources.map(
@@ -162,7 +168,4 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     return this.resources.reduce((sum, group) => sum + group.itemList.length, 0);
   }
 
-  get disabled(): boolean {
-    return this.resources.length === 0 || this.allResourcesCount === 0;
-  }
 }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -46,6 +46,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   // Transitory subset of snapshotResources for display based on user's entered filter.
   public filteredResources: ResourceCheckedSection[] = [];
+  public allFilteredResourcesCount = 0;
 
   public dropdownState: 'closed' | 'opening' | 'open' = 'closed';
   public label = this.noneSelectedLabel;
@@ -121,6 +122,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
         this.snapshotResources[i].itemList.filter(r =>
           r.name.toLowerCase().indexOf(this.filterValue.toLowerCase()) > -1);
     }
+    this.allFilteredResourcesCount = this.calculateAllFilteredResourcesCount();
   }
 
   private resetFilteredResources(): void {
@@ -134,6 +136,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
           title: section.title,
           itemList: section.itemList
         })));
+    this.allFilteredResourcesCount = this.calculateAllFilteredResourcesCount();
   }
 
   moveFocus(event: KeyboardEvent): void {
@@ -166,6 +169,11 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     return this.resources.length === 0 || this.allResourcesCount === 0;
   }
 
+  private calculateAllFilteredResourcesCount(): number {
+    return this.filteredResources.reduce(
+      (sum, group) => sum + group.itemList.length, 0);
+  }
+
   private get allResourcesCount(): number {
     return this.resources.reduce(
       (sum, group) => sum + group.itemList.length, 0);
@@ -175,11 +183,6 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     return [].concat(
       ...this.snapshotResources.map(
         resource => resource.itemList.filter(r => r.checked).map(r => r.name)));
-  }
-
-  get allFilteredResourcesCount(): number {
-    return this.filteredResources.reduce(
-      (sum, group) => sum + group.itemList.length, 0);
   }
 
 }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -150,7 +150,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   private get allCheckedResources() {
     const resources: string[] = [];
-    this.filteredResources.forEach(section => {
+    this.resources.forEach(section => {
       const stuff = section.itemList.filter(r => r.checked).map(r => r.name);
       resources.push(...stuff);
     });

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -59,13 +59,9 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     if (changes.resources) {
       this.updateSectionsAndLabel();
       if (changes.resources.firstChange) { // only update on initialization/first change
-        this.filteredResources = this.resourcesInOrder;
+        this.filteredResources = this.resources;
       }
     }
-  }
-
-  get resourcesInOrder(): ResourceChecked[] {
-    return ChefSorters.naturalSort(this.resources, 'name');
   }
 
   toggleDropdown(): void {
@@ -74,7 +70,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     }
     if (this.dropdownState === 'closed') { // opening
       this.filterValue = '';
-      this.filteredResources = this.resourcesInOrder;
+      this.filteredResources = this.resources;
       // we cannot go directly to 'open' because handleClickOutside,
       // firing next on the same event that arrived here, would then immediately close it.
       this.dropdownState = 'opening';
@@ -107,7 +103,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   }
 
   handleFilterKeyUp(): void {
-    this.filteredResources = this.resourcesInOrder.filter(resource =>
+    this.filteredResources = this.resources.filter(resource =>
       resource.id.toLowerCase().indexOf(this.filterValue.toLowerCase()) > -1
     );
   }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -5,12 +5,11 @@ export interface ResourceChecked {
   id: string;
   name: string;
   checked: boolean;
-  section?: string;
 }
 
 export interface ResourceCheckedSection {
   title?: string;
-  resources: ResourceChecked[];
+  itemList: ResourceChecked[];
 }
 
 @Component({
@@ -39,9 +38,9 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   // Emits checked set of resource IDs upon completion.
   @Output() onDropdownClosing = new EventEmitter<string[]>();
 
-  // filteredSections is merely a container to hold the resources
+  // filteredResources is merely a container to hold the resources
   // that can be altered
-  public filteredSections: ResourceCheckedSection[] = [];
+  public filteredResources: ResourceCheckedSection[] = [];
   public dropdownState: 'closed' | 'opening' | 'open' = 'closed';
   public label = this.noneSelectedLabel;
   public filterValue = '';
@@ -58,7 +57,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     if (changes.resources) {
       this.updateLabel();
       if (changes.resources.firstChange) { // only update on initialization/first change
-        this.filteredSections = this.copyResources();
+        this.filteredResources = this.copyResources();
       }
     }
   }
@@ -69,7 +68,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     }
     if (this.dropdownState === 'closed') { // opening
       this.filterValue = '';
-      this.filteredSections = this.copyResources();
+      this.filteredResources = this.copyResources();
       // we cannot go directly to 'open' because handleClickOutside,
       // firing next on the same event that arrived here, would then immediately close it.
       this.dropdownState = 'opening';
@@ -99,14 +98,14 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     this.dropdownState = 'closed';
     const flattenedIDs = [].concat(
       ...this.resources.map(
-        section => section.resources.filter(r => r.checked).map(r => r.id)));
+        resource => resource.itemList.filter(r => r.checked).map(r => r.id)));
     this.onDropdownClosing.emit(flattenedIDs);
   }
 
   handleFilterKeyUp(): void {
-    for (let i = 0; i < this.filteredSections.length; i++) {
-      this.filteredSections[i].resources =
-        this.resources[i].resources.filter(r =>
+    for (let i = 0; i < this.filteredResources.length; i++) {
+      this.filteredResources[i].itemList =
+        this.resources[i].itemList.filter(r =>
           r.name.toLowerCase().indexOf(this.filterValue.toLowerCase()) > -1);
     }
   }
@@ -119,7 +118,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     this.resources.forEach(section =>
       copy.push({
         title: section.title,
-        resources: section.resources
+        itemList: section.itemList
       }));
     return copy;
   }
@@ -151,8 +150,8 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   private get allCheckedResources() {
     const resources: string[] = [];
-    this.filteredSections.forEach(section => {
-      const stuff = section.resources.filter(r => r.checked).map(r => r.name);
+    this.filteredResources.forEach(section => {
+      const stuff = section.itemList.filter(r => r.checked).map(r => r.name);
       resources.push(...stuff);
     });
     return resources;
@@ -160,7 +159,7 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   get allFilteredResourcesCount() {
     let count = 0;
-    this.filteredSections.forEach(section => count += section.resources.length);
+    this.filteredResources.forEach(section => count += section.itemList.length);
     return count;
   }
 

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -6,6 +6,7 @@ export interface ResourceChecked {
   id: string;
   name: string;
   checked: boolean;
+  section?: string;
 }
 
 export interface ResourceCheckedMap {
@@ -42,20 +43,21 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
   // that can be altered
   public filteredResources: ResourceChecked[] = [];
   public dropdownState: 'closed' | 'opening' | 'open' = 'closed';
+  public sections: Set<string>;
   public label = this.noneSelectedLabel;
   public filterValue = '';
 
   ngOnInit(): void {
     if (this.resourcesUpdated) { // an optional setting
       this.resourcesUpdated.subscribe(() => {
-        this.updateLabel();
+        this.updateSectionsAndLabel();
       });
     }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.resources) {
-      this.updateLabel();
+      this.updateSectionsAndLabel();
       if (changes.resources.firstChange) { // only update on initialization/first change
         this.filteredResources = this.resourcesInOrder;
       }
@@ -126,6 +128,12 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
     } else {
       nextElement.focus();
     }
+  }
+
+  private updateSectionsAndLabel(): void {
+    this.updateLabel();
+    this.sections = new Set<string>();
+    this.resources.forEach(r => this.sections.add(r.section));
   }
 
   private updateLabel(): void {

--- a/components/automate-ui/src/app/entities/policies/policy.model.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.ts
@@ -21,10 +21,6 @@ export interface PolicyChecked extends Policy {
   section: string;
 }
 
-export interface PolicyCheckedMap {
-  [id: string]: PolicyChecked;
-}
-
 export type IAMType = 'CHEF_MANAGED' | 'CUSTOM';
 
 // NB: It is strongly encourage to use stringToMember

--- a/components/automate-ui/src/app/entities/policies/policy.model.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.ts
@@ -18,6 +18,7 @@ export interface Statement {
 
 export interface PolicyChecked extends Policy {
   checked: boolean;
+  section: string;
 }
 
 export interface PolicyCheckedMap {

--- a/components/automate-ui/src/app/entities/policies/policy.model.ts
+++ b/components/automate-ui/src/app/entities/policies/policy.model.ts
@@ -16,11 +16,6 @@ export interface Statement {
   projects: string[];
 }
 
-export interface PolicyChecked extends Policy {
-  checked: boolean;
-  section: string;
-}
-
 export type IAMType = 'CHEF_MANAGED' | 'CUSTOM';
 
 // NB: It is strongly encourage to use stringToMember

--- a/components/automate-ui/src/app/entities/projects/project.model.ts
+++ b/components/automate-ui/src/app/entities/projects/project.model.ts
@@ -9,14 +9,6 @@ export interface Project {
   skip_policies?: boolean;
 }
 
-export interface ProjectChecked extends Project {
-  checked: boolean;
-}
-
-export interface ProjectCheckedMap {
-  [id: string]: ProjectChecked;
-}
-
 export class ProjectConstants {
   static readonly UNASSIGNED_PROJECT_ID = '(unassigned)';
   static readonly UNASSIGNED_PROJECT_LABEL = '(unassigned)';

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -14,7 +14,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2017",
+      "es2019",
       "dom"
     ],
     "baseUrl": "./src",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

To improve the UX for creating tokens, this PR enhances the generic dropdown component to accommodate multiple sections. With these changes, the projects dropdown continues to use only a single section, but the policies dropdown is now separated into chef-managed and custom sections. Furthermore, everything is sorted, except that the chef-managed `ingest-access` policy is positioned at the top of the list since that is the one that will usually be needed.

![image](https://user-images.githubusercontent.com/6817500/83049516-2934ed00-a000-11ea-95e4-5af9cf92e91e.png)

The video shows the full contents of the dropdown and how it behaves:

![dropdown sections](https://user-images.githubusercontent.com/6817500/83048912-31405d00-9fff-11ea-9f02-9c93e4cd0e8b.gif)

And this set of unit tests (new tests highlighted) reveals the requirements that were implemented. 

- The yellow items are related to ordering. The generic dropdown component (ResourceDropdownComponent) no longer sorts its inputs, allowing its consumers (ProjectsDropdownComponent and CreateObjectModalComponent) to customize their ordering.
- The blue items cover the requirements from a behavioral perspective. The available project list is asynchronously refreshed, even when the create-token dialog is open. If that list changes while the dialog is open, experiments showed that it is rather confusing if the list in the dialog changes seemingly spontaneously. Not only would there possibly be new projects appearing or existing projects disappearing, but the user's checkmarks so far would be reset. So I opted to make the list refresh only if the create-token dialog is completely closed. Thus, most of the tests in the blue section cover behavior when (a) the project list remains constant and (b) the project list updates, confirming the behavior is the same either way.

<img width="783" alt="image" src="https://user-images.githubusercontent.com/6817500/83045800-f0464980-9ffa-11ea-8cc4-8c85bd19b779.png">

#### PR Bonus
In a recent slack post, I described a performance pitfall with Angular when using function calls instead of properties to provide rendering data in a template. That is, try to always avoid calling an explicit function like this in a template:
```
There are {{ count() }} projects.
```
Also avoid "hidden" functions (aka computed properties):
```
There are {{ count }} projects.
```
... where `count` is something like `get count() { return x + y; }`. Rather, try to always use "fixed" properties:
```
There are {{ count }} projects.
```
... where `count` is a property declared like `let count: number;` or `let count = 509;`.

This PR introduces my first exploration into applying this in practice.
My recommendation, shown with examples here, is to use the "declared properties" approach rather than the "pure pipes" approach, mainly because even if you only want a custom pipe in a single file, it needs to be specified globally (in the sense of putting it in a module file).

The file resource-dropdown.component.ts had two culprits: `disabled` and `allFilteredResourceCount`.

Here is how I fixed `disabled` -- because it was a computed property, no changes were needed in the template. The trick is just to realize that its value only changes when the `@Input` named `resources` changes, so I just needed to set it in `ngOnChanges`.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/6817500/83079191-27831d80-a030-11ea-822a-a24b8a6f8c0b.png">

The `allFilteredResourceCount` is also a computed property, but still provides a slightly different use case. Its value was not dependent upon some `@Input`, but dependent upon a local, `filteredResources`. So I only needed to update it when `filteredResources` changed.

<img width="683" alt="image" src="https://user-images.githubusercontent.com/6817500/83079443-b728cc00-a030-11ea-84a5-c7736b5d7c70.png">


### :chains: Related Resources
NA

### :+1: Definition of Done
- The policies dropdown when creating a token now has sections. The chef managed section has the ingest policy at the top.
- If either section is reduced to no entries by applying a filter, the section header goes away as well.
- The projects dropdown remains with a single section, though it has no section header, so it looks exactly as it did before.
- Closing and re-opening either dropdown retains whatever was checked.
- Closing and re-opening the modal resets all items to unchecked.
- Filtering has no effect on checked items nor on the dropdown label.

### :athletic_shoe: How to Build and Test the Change
After rebuilding/reloading the UI, navigate to Settings >> Tokens >> Create Token.
Use the projects and policies dropdowns, with and without filters.

If you want to exercise how asynchronous project updates affect the dropdowns, adjust projects-filter.effects.ts::POLLING_INTERVAL_IN_SECONDS to e.g. 10 seconds. Then, add or remove a project from the command line or separate browser window.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
