### PR TITLE
Ensure simple-line-graph styles remain scoped

### DIFF
--- a/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.html
+++ b/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.html
@@ -1,9 +1,9 @@
 <svg #svg [attr.viewBox]="viewBox" [ngStyle]="{'width': width}" (window:resize)="onResize()">
-    <defs>
-      <linearGradient id="chef-gradient-purple" x1="0%" y1="0%" x2="100%" y2="0%" gradientTransform="rotate(315)">
-        <stop id="stop1" offset="0%" />
-        <stop id="stop2" offset="100%" />
-      </linearGradient>
-    </defs>
-  </svg>
-  <div class="label-container"></div>
+  <defs>
+    <linearGradient id="chef-gradient-purple" x1="0%" y1="0%" x2="100%" y2="0%" gradientTransform="rotate(315)">
+      <stop id="stop1" offset="0%" />
+      <stop id="stop2" offset="100%" />
+    </linearGradient>
+  </defs>
+</svg>
+<div class="label-container"></div>

--- a/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.scss
+++ b/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.scss
@@ -12,179 +12,179 @@
     padding: 1px;
     background: $chef-white;
   }
-}
 
-::ng-deep {
-  svg {
-    background: $chef-white;
-    padding: .5em;
-  }
-
-  path,
-  line,
-  .tick,
-  .grid {
-    stroke: $eggplant-light-1;
-    stroke-width: 1px;
-  }
-
-  .line {
-    fill: transparent;
-    stroke: $chef-black;
-    stroke-width: 1px;
-  }
-
-  .y-axis {
-    transform: translateX(20px);
-  }
-
-  .x-axis {
-    .tick line {
-      display: none;
-    }
-  }
-
-  circle.point {
-    fill: $eggplant-dark-2;
-  }
-
-  .ring {
-    position: absolute;
-    stroke-width: 1;
-    fill: none;
-    stroke: url(#chef-gradient-purple);
-
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transition: .5s opacity;
-
-    &.active {
-      opacity: 1;
-      visibility: visible;
-    }
-  }
-
-  .graph-button {
-    display: flex;
-    position: absolute;
-    z-index: 5;
-    background: transparent;
-    padding: 1px;
-    border: none;
-    border-radius: 4px;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: transform 500ms;
-
-    &.active {
-      background: $chef-dark-purple;  // fallback background
-      background: $chef-purple-gradient;
-      transition: background 500ms, color 500ms;
-    }
-
-    &.turnt {
-      transition: transform 500ms; // keep in sync with label transition duration in ts file
-      font-size: 8px;
-      transform: rotate(-45deg) translate(-10px, 10px);
-    }
-
-    .inner {
-      display: flex;
-      border: none;
-      border-radius: 3px;
+  ::ng-deep {
+    svg {
       background: $chef-white;
-      height: 16px;
-      font-size: 10px;
-      font-family: 'muli';
-      padding: 2px;
+      padding: .5em;
+    }
+
+    path,
+    line,
+    .tick,
+    .grid {
+      stroke: $eggplant-light-1;
+      stroke-width: 1px;
+    }
+
+    .line {
+      fill: transparent;
+      stroke: $chef-black;
+      stroke-width: 1px;
+    }
+
+    .y-axis {
+      transform: translateX(20px);
+    }
+
+    .x-axis {
+      .tick line {
+        display: none;
+      }
+    }
+
+    circle.point {
+      fill: $eggplant-dark-2;
+    }
+
+    .ring {
+      position: absolute;
+      stroke-width: 1;
+      fill: none;
+      stroke: url(#chef-gradient-purple);
+
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: .5s opacity;
+
+      &.active {
+        opacity: 1;
+        visibility: visible;
+      }
+    }
+
+    .graph-button {
+      display: flex;
+      position: absolute;
+      z-index: 5;
+      background: transparent;
+      padding: 1px;
+      border: none;
+      border-radius: 4px;
       align-items: center;
       justify-content: center;
-      pointer-events: none;
-      transition: background 500ms, color 500ms;
+      cursor: pointer;
+      transition: transform 500ms;
+
+      &.active {
+        background: $chef-dark-purple;  // fallback background
+        background: $chef-purple-gradient;
+        transition: background 500ms, color 500ms;
+      }
+
+      &.turnt {
+        transition: transform 500ms; // keep in sync with label transition duration in ts file
+        font-size: 8px;
+        transform: rotate(-45deg) translate(-10px, 10px);
+      }
+
+      .inner {
+        display: flex;
+        border: none;
+        border-radius: 3px;
+        background: $chef-white;
+        height: 16px;
+        font-size: 10px;
+        font-family: 'muli';
+        padding: 2px;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        transition: background 500ms, color 500ms;
+      }
     }
-  }
 
-  .graph-tooltip {
-    position: absolute;
-    min-height: 40px;
-    font-size: 12px;
-    padding: 8px 10px;
-    padding-left: 16px; // extra 8px to account for ::before gradient
-    background: $chef-white;
-    border-radius: $chef-border-radius;
-    box-shadow: 0 0 1em 0 rgba(0, 0, 0, .21);
-    opacity: 0;
-    visibility: hidden;
-    transition: 500ms;
-
-    &::before {
-      content: '';
+    .graph-tooltip {
       position: absolute;
-      top: 0;
-      left: 0;
-      width: 8px;
-      height: 100%;
+      min-height: 40px;
+      font-size: 12px;
+      padding: 8px 10px;
+      padding-left: 16px; // extra 8px to account for ::before gradient
+      background: $chef-white;
+      border-radius: $chef-border-radius;
+      box-shadow: 0 0 1em 0 rgba(0, 0, 0, .21);
+      opacity: 0;
+      visibility: hidden;
+      transition: 500ms;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 8px;
+        height: 100%;
+        background: $chef-dark-purple;
+        background: $chef-purple-gradient;
+        border-bottom-left-radius: $chef-border-radius;
+        border-top-left-radius: $chef-border-radius;
+      }
+
+      &::after {
+        display: block;
+        content: '';
+        width: 0.75em;
+        height: 0.75em;
+        position: absolute;
+        background-color: $chef-white;
+        transform: translateX(-50%) translateY(-50%) rotate(45deg);
+        top: 100%;
+        left: calc(50% - .75em);
+      }
+
+      &.active {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(-10px);
+      }
+    }
+
+    // lock styles
+    circle.point.lock {
+      fill: $chef-dark-purple;
+      fill: url('#chef-gradient-purple');
+    }
+
+    .graph-button.lock {
       background: $chef-dark-purple;
       background: $chef-purple-gradient;
-      border-bottom-left-radius: $chef-border-radius;
-      border-top-left-radius: $chef-border-radius;
+
+      .inner {
+        color: $chef-white;
+        background-color: transparent;
+        opacity: 1;
+        visibility: visible;
+      }
     }
 
-    &::after {
-      display: block;
-      content: '';
-      width: 0.75em;
-      height: 0.75em;
-      position: absolute;
-      background-color: $chef-white;
-      transform: translateX(-50%) translateY(-50%) rotate(45deg);
-      top: 100%;
-      left: calc(50% - .75em);
+    .graph-tooltip.lock {
+      opacity: 0;
+      visibility: hidden;
     }
 
-    &.active {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(-10px);
-    }
-  }
-
-  // lock styles
-  circle.point.lock {
-    fill: $chef-dark-purple;
-    fill: url('#chef-gradient-purple');
-  }
-
-  .graph-button.lock {
-    background: $chef-dark-purple;
-    background: $chef-purple-gradient;
-
-    .inner {
-      color: $chef-white;
-      background-color: transparent;
+    .ring.lock  {
       opacity: 1;
       visibility: visible;
     }
-  }
 
-  .graph-tooltip.lock {
-    opacity: 0;
-    visibility: hidden;
-  }
+    // linear gradient
+    #stop1 {
+      stop-color: $chef-light-purple;
+    }
 
-  .ring.lock  {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  // linear gradient
-  #stop1 {
-    stop-color: $chef-light-purple;
-  }
-
-  #stop2 {
-    stop-color: $chef-dark-purple;
+    #stop2 {
+      stop-color: $chef-dark-purple;
+    }
   }
 }


### PR DESCRIPTION
The top-level `ng-deep`selector was causing some styles to leak out of the `simple-line-graph`'s scoped styles and affecting other charts. This commit fixes this by moving the deep selector block into `:host` block.

![b](https://user-images.githubusercontent.com/479121/83168817-4e446100-a0cf-11ea-9e95-e45684c46b97.gif)