### PR TITLE
Standardize remaining "required" indicators in UI

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
@@ -46,7 +46,7 @@
       <div class="note">Required fields are marked with an asterisk (*).</div>
       <form class="apply" [formGroup]="applyForm" (ngSubmit)="onApplyLicenseFormSubmit()" novalidate>
         <chef-form-field>
-          <label for="licenseKey">License Key *</label>
+          <label for="licenseKey">License Key <span aria-hidden="true">*</span></label>
           <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="10" autofocus></textarea>
           <chef-error *ngIf="applyForm.get('licenseKey').hasError('required') && applyForm.get('licenseKey').dirty">License key required</chef-error>
         </chef-form-field>

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -33,14 +33,14 @@
         <form class="trial" [formGroup]="trialForm" (ngSubmit)="onTrialLicenseFormSubmit()" novalidate>
           <div class="name-container">
             <chef-form-field>
-              <label for="firstName">First Name *</label>
+              <label for="firstName">First Name <span aria-hidden="true">*</span></label>
               <div class="suggester-input-wrapper">
                 <input chefInput name="firstName" id="firstName" formControlName="firstName" type="text" autofocus>
               </div>
               <chef-error *ngIf="trialForm.get('firstName').hasError('required') && trialForm.get('firstName').dirty">First name required.</chef-error>
             </chef-form-field>
             <chef-form-field>
-              <label for="firstName">Last Name *</label>
+              <label for="firstName">Last Name <span aria-hidden="true">*</span></label>
               <div class="suggester-input-wrapper">
                 <input chefInput name="lastName" id="lastName" formControlName="lastName" type="text">
               </div>
@@ -49,7 +49,7 @@
           </div>
           <div class="email-container">
             <chef-form-field>
-              <label for="email">Email *</label>
+              <label for="email">Email <span aria-hidden="true">*</span></label>
               <div class="suggester-input-wrapper">
                 <input chefInput name="email" id="email" formControlName="email" type="text">
               </div>

--- a/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-form.html
+++ b/components/automate-ui/src/app/pages/+compliance/+credentials/components/credentials-form.html
@@ -14,7 +14,7 @@
 
     <form [formGroup]="sshForm" novalidate [ngClass]="{'credentials-form__form-error': saveErrorOccurred, 'credentials-form__form': true}">
       <chef-form-field>
-        <label>Assign a unique name for your key<span class="t-critical">&nbsp;*</span></label>
+        <label>Assign a unique name for your key <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="name" type="text" placeholder="friendly name for credential" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(sshForm.get('name'))">
           Credential name is required
@@ -22,7 +22,7 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>SSH Username<span class="t-critical">&nbsp;*</span></label>
+        <label>SSH Username <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="username" type="text" placeholder="username for private ssh" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(sshForm.get('username'))">
           Username is required
@@ -30,7 +30,7 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>SSH password<span class="t-critical">&nbsp;*</span></label>
+        <label>SSH password <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="password" type="password" placeholder="password for private ssh" />
         <chef-error *ngIf="credentialsLogic.showSSHPasswordOrSSHPublicKeyFormControlValidationError(sshForm.get('password'), sshForm.get('key'))">
           SSH Password or RSA Key is required
@@ -38,7 +38,7 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>RSA key<span class="t-critical">&nbsp;*</span></label>
+        <label>RSA key <span class="t-critical" aria-hidden="true">*</span></label>
         <textarea rows="10" cols="100" chefInput
         placeholder="-----BEGIN RSA PRIVATE KEY -----"
         formControlName="key"></textarea>
@@ -57,7 +57,7 @@
 
     <form [formGroup]="winRMForm" novalidate [ngClass]="{'credentials-form__form-error': saveErrorOccurred}">
       <chef-form-field>
-        <label>Assign a unique name for your key<span class="t-critical">&nbsp;*</span></label>
+        <label>Assign a unique name for your key <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="name" type="text" placeholder="friendly name for credential" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(winRMForm.get('name'))">
           Credential name is required
@@ -65,7 +65,7 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>WinRM username<span class="t-critical">&nbsp;*</span></label>
+        <label>WinRM username <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="username" type="text" placeholder="username for WinRM" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(winRMForm.get('username'))">
           Username is required
@@ -73,7 +73,7 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>WinRM password<span class="t-critical">&nbsp;*</span></label>
+        <label>WinRM password <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="password" type="password" placeholder="password for WinRM" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(winRMForm.get('password'))">
           WinRM Password is required
@@ -90,7 +90,7 @@
 
     <form [formGroup]="sudoForm" novalidate [ngClass]="{'credentials-form__form-error': saveErrorOccurred}">
       <chef-form-field>
-        <label>Assign a unique name for your key<span class="t-critical">&nbsp;*</span></label>
+        <label>Assign a unique name for your key <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="name" type="text" placeholder="friendly name for credential" />
         <chef-error *ngIf="credentialsLogic.showFormControlValidationError(sudoForm.get('name'))">
           Credential name is required
@@ -98,12 +98,12 @@
       </chef-form-field>
 
       <chef-form-field>
-        <label>Sudo password<span class="t-critical">&nbsp;*</span></label>
+        <label>Sudo password <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput formControlName="password" type="password" placeholder="password for sudo" />
       </chef-form-field>
 
       <chef-form-field>
-        <label>Sudo options<span class="t-critical">&nbsp;*</span></label>
+        <label>Sudo options <span class="t-critical" aria-hidden="true">*</span></label>
         <input chefInput
               formControlName="options"
               type="text"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Quick scan of the code base revealed just these few
that were not using the accessibility-friendly
"aria-hidden" on the required marker (*).

Quoting the MDN [web docs on accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute):
> Adding aria-hidden="true" to an element removes that element and all of its children from the accessibility tree. This can improve the experience for assistive technology users by hiding:
> 
> purely decorative content, such as icons or images
> duplicated content, such as repeated text
> offscreen or collapsed content, such as menus
> 

### :chains: Related Resources
NA

### :+1: Definition of Done
All uses of the asterisk to indicate a required field are wrapped in an element specifying `aria-hidden="true"` in the UI templates.

### :athletic_shoe: How to Build and Test the Change
No visible changes.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).