### PR TITLE
make our chef automate logo acessible

### DIFF
--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -1,7 +1,9 @@
 <header role="banner">
   <nav role="navigation" class="navigation-wrapper">
     <div role="menuitem" class="logo-wrapper">
-      <a tabindex="0" routerLink="/" class="logo" title="logo link to homepage"></a>
+      <a tabindex="0" routerLink="/" class="logo" title="Chef Software Logo">
+        <img alt="Chef Sotware Logo" src="../assets/img/logos/AutomateLogo-default.svg" />
+      </a>
     </div>
     <div class="navigation-menu">
       <app-authorized [allOf]="[

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.scss
@@ -24,9 +24,8 @@ header {
   .logo-wrapper {
     margin-left: 16px;
 
-    a.logo {
+    a.logo img {
       display: block;
-      background: $default-logo transparent no-repeat center;
       width: 160px;
       height: $navigation-height;
 


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
before we had empty link, and no alt text on the logo which resulted in accessibility failures 🚫 . this pr brings the image into the HTML and adds alt text.

### :chains: Related Resources
fixes #3816 

### :+1: Definition of Done
everything still looks the same but now the logo is accessible, yay!

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
everything should look the same