### PR TITLE
Ensure notification content aligns vertically

### DIFF
--- a/components/automate-ui/src/app/components/notification/notification.component.html
+++ b/components/automate-ui/src/app/components/notification/notification.component.html
@@ -1,5 +1,5 @@
-  <chef-icon role="button" (click)="handleClose()">close</chef-icon>
-  <p>
-    <ng-content></ng-content>
-  </p>
-  <div class="shine"></div>
+<p>
+  <ng-content></ng-content>
+</p>
+<div class="shine"></div>
+<chef-icon role="button" (click)="handleClose()">close</chef-icon>

--- a/components/automate-ui/src/app/components/notification/notification.component.scss
+++ b/components/automate-ui/src/app/components/notification/notification.component.scss
@@ -8,7 +8,6 @@
   color: $chef-white;
   background-color: $chef-dark-grey;
   padding: 0.5em;
-  padding-right: 1.5em;
   overflow: hidden;
 
   p {
@@ -43,14 +42,7 @@
   }
 
   chef-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    top: 0;
-    right: 0;
-    height: 30px;
-    width: 30px;
+    margin-left: auto;
     cursor: pointer;
   }
 


### PR DESCRIPTION
This commit adjusts the notification styling to ensure notification icons and text remain vertically aligned.

**Before**
![notbef](https://user-images.githubusercontent.com/479121/83210154-5a541100-a117-11ea-9de1-51c0de80c916.png)

**After**
![notaft](https://user-images.githubusercontent.com/479121/83210159-5e802e80-a117-11ea-8d15-ef1a4f3c720f.png)
