### PR TITLE
automate-ui: Omit<T,K> is builtin

### DIFF
--- a/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
+++ b/components/automate-ui/src/app/modules/policy/details/policy-details.component.ts
@@ -19,9 +19,6 @@ import { RemovePolicyMembers } from 'app/entities/policies/policy.actions';
 
 export type PolicyTabName = 'definition' | 'members';
 
-// from https://stackoverflow.com/a/50689136
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 const POLICY_DETAILS_ROUTE = /^\/settings\/policies/;
 
 @Component({


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Removes a type declaration that actually is already a builtin type.
See https://www.typescriptlang.org/docs/handbook/utility-types.html#omittk

### :+1: Definition of Done

Tests pass.

### :athletic_shoe: How to Build and Test the Change

Don't. 😉 

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
