### PR TITLE
Jamie/3744 extra fixes

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/desktop.module.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop.module.ts
@@ -15,7 +15,9 @@ import {
   UnknownDesktopDurationCountsComponent
 } from './unknown-desktop-duration-counts/unknown-desktop-duration-counts.component';
 import { InsightComponent } from './insight/insight.component';
-import { InsightAttributesDropdownComponent } from 'app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component';
+import {
+  InsightAttributesDropdownComponent
+} from 'app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component';
 import { DesktopRoutingModule } from './desktop-routing.module';
 
 @NgModule({

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding, Input, Output, EventEmitter } from '@angular/core';
 import { Desktop, TermFilter } from 'app/entities/desktop/desktop.model';
+import { FilterUpdate } from 'app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model';
 
 @Component({
   selector: 'app-insight',
@@ -46,7 +47,7 @@ export class InsightComponent {
     this.attributesMenuOpen = !this.attributesMenuOpen;
   }
 
-  public updateFilters(event) {
+  public updateFilters(event: FilterUpdate) {
     console.log(event);
   }
 }

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.html
@@ -4,8 +4,13 @@
   <ul class="bx--row">
     <ng-container *ngFor="let option of options">
       <div class="filter-button-container">
-        <li class="filter-button" (click)="handleSelect($event)" (keyup.enter)="handleSelect($event)"
-        tabindex="0" role="button" [attr.aria-pressed]="false" [attr.data-filtervalue]="option.id">
+        <li class="filter-button"
+          (click)="handleSelect($event)"
+          (keyup.enter)="handleSelect($event)"
+          tabindex="0"
+          role="button"
+          [attr.aria-pressed]="false"
+          [attr.data-filtervalue]="option.id">
           <span>{{ option.name }}<i class="check">&#x2713;</i></span>
         </li>
       </div>
@@ -21,3 +26,4 @@
       <chef-button primary [disabled]="disableSubmit" (click)="handleUpdate()">Update</chef-button>
     </div>
   </div>
+  

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.html
@@ -3,8 +3,8 @@
   </div>
   <ul class="bx--row">
     <ng-container *ngFor="let option of options">
-      <div class="filter-button-container">
-        <li class="filter-button"
+      <li class="filter-button-container">
+        <div class="filter-button"
           (click)="handleSelect($event)"
           (keyup.enter)="handleSelect($event)"
           tabindex="0"
@@ -12,11 +12,11 @@
           [attr.aria-pressed]="false"
           [attr.data-filtervalue]="option.id">
           <span>{{ option.name }}<i class="check">&#x2713;</i></span>
-        </li>
-      </div>
+        </div>
+      </li>
     </ng-container>
   </ul>
-  <div class="action-button-row">
+  <div class="bx--row action-button-row">
     <chef-checkbox [checked]="saveAsDefault" (change)="handleSaveAsDefaultChange()">
       Save as default
     </chef-checkbox>

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.scss
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.scss
@@ -20,6 +20,11 @@
   .bx--row {
     margin-left: 0;
     margin-right: 0;
+
+    &.action-button-row {
+      justify-content: space-between;
+      margin-top: $spacing-03;
+    }
   }
 
   .instruction {
@@ -27,18 +32,11 @@
   }
 
   ul {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: wrap;
+    columns: 2;
     list-style-type: none;
     padding: 0;
     margin-top: 15px;
     margin-bottom: 0;
-    min-height: 420px;
-
-    @include carbon--breakpoint-up(md) {
-      max-height: 392px;
-    }
 
     .filter-button-container {
       width: 100%;
@@ -47,10 +45,8 @@
 
       @include carbon--breakpoint-up(md) {
         width: 50%;
-
-        &:nth-child(-n + 10) {
-          padding-right: $spacing-03;
-        }
+        padding-left: $spacing-02;
+        padding-right: $spacing-02;
       }
     }
 
@@ -74,7 +70,7 @@
         width: 100%;
         height: 100%;
         background: $chef-white;
-        font-size: 12px;
+        font-size: $spacing-04;
         pointer-events: none;
       }
 
@@ -87,11 +83,5 @@
         }
       }
     }
-  }
-
-  .action-button-row {
-    @extend .bx--row;
-    justify-content: space-between;
-    margin-top: $spacing-03;
   }
 }

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.spec.ts
@@ -8,7 +8,7 @@ import { FilterName } from './insight-attributes-dropdown.model';
 const testOptions = [
   { name: FilterName.PlatformVersion, id: 'platform_version_filter' },
   { name: FilterName.Domain, id: 'domain_filter' },
-  { name: FilterName.MacAddress, id: 'macaddress_filter' },
+  { name: FilterName.MacAddress, id: 'mac_address_filter' },
   { name: FilterName.CloudProvider, id: 'cloud_provider_filter' },
   { name: FilterName.Hostname, id: 'hostname_filter' },
   { name: FilterName.Tag, id: 'tag_filter' }
@@ -64,7 +64,7 @@ describe('OverviewTrendComponent', () => {
       fixture.detectChanges();
     });
 
-    it('adds the selected buttons id to the selectedOptions array', () => {
+    it('adds the selected button id to the selectedOptions array', () => {
       const list = fixture.debugElement.nativeElement.querySelectorAll('.filter-button');
       list[0].click();
       list[1].click();
@@ -74,51 +74,61 @@ describe('OverviewTrendComponent', () => {
       expect(component.selectedOptions).toContain('platform_version_filter');
       expect(component.selectedOptions).toContain('domain_filter');
       expect(component.selectedOptions).toContain('hostname_filter');
-      expect(component.selectedOptions).not.toContain('macaddress_filter');
+      expect(component.selectedOptions).not.toContain('mac_address_filter');
       expect(component.selectedOptions).not.toContain('cloud_provider_filter');
     });
 
     it('allows a maximum of 5 selected options', () => {
       const list = fixture.debugElement.nativeElement.querySelectorAll('.filter-button');
-      expect(list.length).toBe(component.options.length);
+      expect(list.length).toBeGreaterThan(5);
 
       list.forEach(option => option.click());
 
       expect(component.selectedOptions.length).toBe(5);
     });
 
-    it('enables the submit when filters are different than previous selection', () => {
+    it('enables the submit button when filters are different than previous selection', () => {
       component.selectedOptions = ['platform_version_filter', 'domain_filter'];
       component.lastSelectedOptions = ['platform_version_filter', 'domain_filter'];
-      const updateButton = fixture.debugElement.nativeElement.querySelector('chef-button[primary]');
+      const submitButton = fixture.debugElement.nativeElement.querySelector('chef-button[primary]');
       const list = fixture.debugElement.nativeElement.querySelectorAll('.filter-button');
+      const PLATFORM_FILTER_INDEX = 0;
+      const DOMAIN_FILTER_INDEX = 4;
 
-      expect(updateButton.disabled).toBeTruthy();
+      expect(submitButton.disabled).toBeTruthy();
 
-      list[0].click();
+      list[PLATFORM_FILTER_INDEX].click();
       fixture.detectChanges();
-      expect(updateButton.disabled).toBeFalsy();
+      expect(submitButton.disabled).toBeFalsy();
 
-      list[4].click();
+      list[DOMAIN_FILTER_INDEX].click();
       fixture.detectChanges();
-      expect(updateButton.disabled).toBeFalsy();
+      expect(submitButton.disabled).toBeFalsy();
 
-      list[0].click();
-      list[4].click();
+      list[PLATFORM_FILTER_INDEX].click();
+      list[DOMAIN_FILTER_INDEX].click();
       fixture.detectChanges();
-      expect(updateButton.disabled).toBeTruthy();
+      expect(submitButton.disabled).toBeTruthy();
     });
 
     it('updates selected class and aria-pressed value', () => {
+      let allSelected = fixture.debugElement.nativeElement
+        .querySelectorAll('.filter-button.selected');
+      let allPressed = fixture.debugElement.nativeElement
+        .querySelectorAll('[aria-pressed="true"]');
+
+      expect(allSelected.length).toBe(0);
+      expect(allPressed.length).toBe(0);
+
       const list = fixture.debugElement.nativeElement.querySelectorAll('.filter-button');
       list[0].click();
       list[1].click();
       list[4].click();
       fixture.detectChanges();
 
-      const allSelected = fixture.debugElement.nativeElement
+      allSelected = fixture.debugElement.nativeElement
         .querySelectorAll('.filter-button.selected');
-      const allPressed = fixture.debugElement.nativeElement
+      allPressed = fixture.debugElement.nativeElement
         .querySelectorAll('[aria-pressed="true"]');
 
       expect(allSelected.length).toBe(3);

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
@@ -61,7 +61,7 @@ export class InsightAttributesDropdownComponent implements OnInit {
 
   public handleCancel(): void {
     this.selectedOptions.forEach(option => {
-      const target = document.querySelector('.filter-button[data-filterValue="' + option + '"]');
+      const target = document.querySelector(`.filter-button[data-filterValue="${option}"]`);
       target.classList.remove('selected');
       target.setAttribute('aria-pressed', 'off');
     });

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
@@ -2,6 +2,11 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FilterOption, FilterableOptions } from './insight-attributes-dropdown.model';
 import { isEqual } from 'lodash/fp';
 
+export interface FilterUpdate {
+  filters: string[];
+  saveAsDefault: boolean;
+}
+
 @Component({
   selector: 'app-insight-attributes-dropdown',
   templateUrl: './insight-attributes-dropdown.component.html',
@@ -11,8 +16,8 @@ export class InsightAttributesDropdownComponent implements OnInit {
 
   @Input() saveAsDefault = true;
   @Input() lastSelectedOptions: string[] = []; // these are filter ids
-  @Output() onUpdateFilters: EventEmitter<any> = new EventEmitter();
-  @Output() onToggleMenu: EventEmitter<any> = new EventEmitter();
+  @Output() onUpdateFilters: EventEmitter<FilterUpdate> = new EventEmitter();
+  @Output() onToggleMenu: EventEmitter<null> = new EventEmitter();
 
   public options: FilterOption[] = FilterableOptions;
   public selectedOptions: string[] = []; // these are filter ids

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component.ts
@@ -1,11 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { FilterOption, FilterableOptions } from './insight-attributes-dropdown.model';
+import { FilterOption, FilterableOptions, FilterUpdate } from './insight-attributes-dropdown.model';
 import { isEqual } from 'lodash/fp';
-
-export interface FilterUpdate {
-  filters: string[];
-  saveAsDefault: boolean;
-}
 
 @Component({
   selector: 'app-insight-attributes-dropdown',

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model.ts
@@ -27,22 +27,22 @@ export enum FilterName {
 
 export const FilterableOptions: FilterOption[] = [
   { name: FilterName.PlatformVersion, id: 'platform_version'},
-  { name: FilterName.Domain, id: 'domain'},
-  { name: FilterName.Tag, id: 'tag'},
-  { name: FilterName.ChefVersion, id: 'chef_version'},
-  { name: FilterName.IpAddress, id: 'ip_address'},
-  { name: FilterName.Ip6Address, id: 'ip_6_address'},
-  { name: FilterName.MacAddress, id: 'mac_address'},
-  { name: FilterName.Uptime, id: 'uptime'},
-  { name: FilterName.MemoryTotal, id: 'memory_total'},
-  { name: FilterName.VirtualizationSystem, id: 'virtualization_system'},
   { name: FilterName.VirtualizationRole, id: 'virtualization_role'},
+  { name: FilterName.Domain, id: 'domain'},
   { name: FilterName.KernelRelease, id: 'kernel_release'},
+  { name: FilterName.Tag, id: 'tag'},
   { name: FilterName.KernelVersion, id: 'kernel_version'},
+  { name: FilterName.ChefVersion, id: 'chef_version'},
   { name: FilterName.Hostname, id: 'hostname'},
+  { name: FilterName.IpAddress, id: 'ip_address'},
   { name: FilterName.Timezone, id: 'timezone'},
+  { name: FilterName.Ip6Address, id: 'ip_6_address'},
   { name: FilterName.LastCheckInTime, id: 'last_check_in_time'},
+  { name: FilterName.MacAddress, id: 'mac_address'},
   { name: FilterName.DMIsystemManufacturer, id: 'dmi_system_manufacturer'},
+  { name: FilterName.Uptime, id: 'uptime'},
   { name: FilterName.DMIsystemSerialNumber, id: 'dmi_system_serial_number'},
-  { name: FilterName.CloudProvider, id: 'cloud_provider'}
+  { name: FilterName.MemoryTotal, id: 'memory_total'},
+  { name: FilterName.CloudProvider, id: 'cloud_provider'},
+  { name: FilterName.VirtualizationSystem, id: 'virtualization_system'}
 ];

--- a/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model.ts
+++ b/components/automate-ui/src/app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model.ts
@@ -3,6 +3,11 @@ export interface FilterOption {
   id: string;
 }
 
+export interface FilterUpdate {
+  filters: string[];
+  saveAsDefault: boolean;
+}
+
 export enum FilterName {
   PlatformVersion = 'Platform Version',
   Domain = 'Domain',


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Extra fixes left over from 3744.  Mostly test based.  There is one that affects the layout when zooming out to less than 100%.

### :chains: Related Resources
Adds upon: https://github.com/chef/automate/pull/3765

### :+1: Definition of Done
Zooming out or in, does not break the list of attributes.
Everything should look the same as original ticket: https://github.com/chef/automate/pull/3765

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
cd components/automate-ui `make serve`

navigate to https://a2-dev.test/desktop
click on any of the Time since last check in options to see the detail screen. In the top right, click on the Attributes dropdown.

- tab through and hit enter, or click on each option to see it selected with a checkmark
- after 5 have been selected, notice that no more can be selected
- hitting update will emit the selected id's to the parent component and print them in the console
- hitting cancel will clear the selection and close the dropdown
- clicking the save as default checkbox prints the checkbox state to the console

### :white_check_mark: Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Before:
![Chef Automate (9)](https://user-images.githubusercontent.com/16737484/83300143-4c9c9b00-a1ac-11ea-879d-1a86f7e17d7a.gif)
