### PR TITLE
fix too small text a11y

### DIFF
--- a/components/automate-ui/src/app/page-components/delta-viewer/delta-viewer.component.scss
+++ b/components/automate-ui/src/app/page-components/delta-viewer/delta-viewer.component.scss
@@ -17,7 +17,7 @@
   }
 
   .d2h-tag {
-    font-size: 9px;
+    font-size: 11px;
   }
 
   .d2h-diff-table {

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.html
@@ -47,10 +47,10 @@
           </app-event-icon>
         </div>
 
-        <p class="event-group-text">
+        <h2 class="display4">
           <strong>{{groupedEvent.eventCount}} {{getEventTypeLabel(groupedEvent)}}</strong>
           {{getFormattedEventType(groupedEvent)}} {{displayRequestorPreposition(groupedEvent.requestorName)}} <em>{{displayRequestorName(groupedEvent.requestorName)}}</em>
-        </p>
+        </h2>
       </li>
       <li *ngFor="let event of groupedEvents" class="event-group-item">
         <div class="event-icon">

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
@@ -133,14 +133,20 @@ chef-side-panel {
   }
 }
 
-.event-group-text {
-  margin: 0;
-  font-size: 10px;
-
-
+.event-group-text,
+.event-group-list h2.display4 {
   & > strong {
     display: block;
     margin-bottom: 4px;
+  }
+}
+
+.event-group-text {
+  margin: 0;
+  font-size: 11px;
+
+
+  & > strong {
     font-size: 12px;
   }
 

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
@@ -15,14 +15,14 @@
   flex-basis: 100px;
 
   & > .event-time {
-    padding-bottom: 5pt;
-    padding-top: 5pt;
+    padding-bottom: 4pt;
+    padding-top: 4pt;
   }
 
   & > .event-day,
   & > .event-date {
-    font-size: .625em;
-    line-height: 10pt;
+    font-size: 11px;
+    line-height: 16px;
   }
 }
 

--- a/components/automate-ui/src/app/page-components/resource-item/resource-item.component.scss
+++ b/components/automate-ui/src/app/page-components/resource-item/resource-item.component.scss
@@ -55,7 +55,7 @@
         border-radius: $global-radius;
         color: $white;
         cursor: pointer;
-        font-size: .75em;
+        font-size: 11px;
         padding: .5em 1em;
       }
 

--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.html
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.html
@@ -1,7 +1,4 @@
 <div class="suggester-wrapper" (focusout)="handleFocusOut()" tabindex="0">
-  <label class="hidden-label" for="search_box">
-    <span class="visually-hidden">Filter Node View Search Box</span>
-  </label>
   <div class="suggester-input-wrapper">
     <span (click)="handleCategoryClick()"
       class="category-marker"
@@ -10,6 +7,7 @@
     </span>
     <input #search_box
           id="search_box"
+          aria-label="Search"
           (click)="handleFocus($event)"
           (focus)="handleFocus($event)"
           (keyup)="handleInput($event.key, search_box.value)"

--- a/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
+++ b/components/automate-ui/src/app/pages/service-groups/service-groups.component.scss
@@ -360,7 +360,7 @@ chef-radial-chart {
   height: 70px;
 
   .percent {
-    font-size: 10px;
+    font-size: 11px;
     font-weight: bolder;
 
     .value {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
we had some pages with text that was smaller than 11px which causes a11y assessments to fail. this fixes it.

### :chains: Related Resources
fixes #3844

### :+1: Definition of Done
text size is all at least 11px

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
#### event feed
##### before
<img width="974" alt="event-feed-before" src="https://user-images.githubusercontent.com/5489125/83342764-104e6500-a2a8-11ea-8c71-452b4b73dc14.png">

<img width="497" alt="event-feed-right-panel-before" src="https://user-images.githubusercontent.com/5489125/83355332-bf745600-a313-11ea-86bb-a3bac597cfb1.png">

##### after
<img width="929" alt="event-feed-after" src="https://user-images.githubusercontent.com/5489125/83342769-15131900-a2a8-11ea-851e-66fdb2deeb9d.png">

<img width="460" alt="event-feed-right-panel-after" src="https://user-images.githubusercontent.com/5489125/83355339-c602cd80-a313-11ea-9344-df9e1ca0c9ac.png">

#### apps
##### before
<img width="977" alt="apps-before" src="https://user-images.githubusercontent.com/5489125/83342770-1a706380-a2a8-11ea-9c2f-b6c350645231.png">

##### after
<img width="1003" alt="apps-after" src="https://user-images.githubusercontent.com/5489125/83342772-1e9c8100-a2a8-11ea-9c23-41be211c78ba.png">

#### client run node detail diffs
##### before
<img width="1184" alt="client-run-node-detail-diff-before" src="https://user-images.githubusercontent.com/5489125/83355475-8b4d6500-a314-11ea-8be0-f1f19d2559fc.png">

##### after
<img width="1185" alt="client-run-node-detail-diff-after" src="https://user-images.githubusercontent.com/5489125/83355671-c9975400-a315-11ea-8992-134c4051c8fa.png">
