### PR TITLE
fix broken aria menu

### DIFF
--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -57,9 +57,9 @@
         <div role="menuitem" class="nav-link"><a routerLink="/settings" routerLinkActive="active" tabindex="0">Settings</a></div>
       </app-authorized>
     </div>
-    <div class="right-nav" role="menu">
+    <div class="right-nav">
       <app-projects-filter></app-projects-filter>
-      <app-profile></app-profile>
+      <app-profile role="menu"></app-profile>
     </div>
   </nav>
 </header>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -58,7 +58,7 @@
       </app-authorized>
     </div>
     <div class="right-nav">
-      <app-projects-filter></app-projects-filter>
+      <app-projects-filter role="menuitem"></app-projects-filter>
       <app-profile role="menu"></app-profile>
     </div>
   </nav>

--- a/components/automate-ui/src/app/page-components/navbar/navbar.component.html
+++ b/components/automate-ui/src/app/page-components/navbar/navbar.component.html
@@ -57,7 +57,7 @@
         <div role="menuitem" class="nav-link"><a routerLink="/settings" routerLinkActive="active" tabindex="0">Settings</a></div>
       </app-authorized>
     </div>
-    <div class="right-nav" role="menubar">
+    <div class="right-nav" role="menu">
       <app-projects-filter></app-projects-filter>
       <app-profile></app-profile>
     </div>

--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -22,6 +22,7 @@
           (keydown.arrowup)="handleArrowUp($event)"
           (keydown.arrowdown)="handleArrowDown($event)"
           class="profile"
+          role="menuitem"
           #focusElement>Profile</a>
       </li>
       <li class="dropdown-list-item">
@@ -40,6 +41,7 @@
               (keydown.arrowdown)="handleArrowDown($event)"
               data-cy="welcome-modal-button"
               class="welcome-modal-button"
+              role="menuitem"
               #focusElement>About</button>
           </li>
           <li>
@@ -47,6 +49,7 @@
               (click)="closeDropdown()"
               (keydown.arrowup)="handleArrowUp($event)"
               (keydown.arrowdown)="handleArrowDown($event)"
+              role="menuitem"
               #focusElement>
               License <chef-icon aria-hidden="true" class="dropdown-link-icon">launch</chef-icon>
             </a>
@@ -56,6 +59,7 @@
               (click)="closeDropdown()"
               (keydown.arrowup)="handleArrowUp($event)"
               (keydown.arrowdown)="handleArrowDown($event)"
+              role="menuitem"
               #focusElement>
               Release Notes <chef-icon aria-hidden="true" class="dropdown-link-icon">launch</chef-icon>
             </a>
@@ -68,6 +72,7 @@
           (keydown.tab)="closeDropdown()"
           (keydown.arrowup)="handleArrowUp($event)"
           (keydown.arrowdown)="handleArrowDown($event)"
+          role="menuitem"
           #focusElement>
           Sign Out
         </button>

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -44,7 +44,6 @@
         <div id="drop-list" class="dropdown-content">
           <chef-checkbox
             *ngFor="let option of filteredOptions"
-            role="menuitem"
             [attr.title]="option.label"
             [checked]="option.checked"
             (change)="handleOptionChange($event, option.label)"

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -12,7 +12,7 @@
   <chef-icon *ngIf="dropdownCaretVisible" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
 <chef-click-outside omit="dropdown-label" (clickOutside)="handleEscape()" *ngIf="dropdownActive">
-  <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()" role="">
+  <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()">
 
       <div class="dropdown-body">
 

--- a/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
+++ b/components/automate-ui/src/app/page-components/projects-filter-dropdown/projects-filter-dropdown.component.html
@@ -12,7 +12,7 @@
   <chef-icon *ngIf="dropdownCaretVisible" aria-hidden>keyboard_arrow_down</chef-icon>
 </button>
 <chef-click-outside omit="dropdown-label" (clickOutside)="handleEscape()" *ngIf="dropdownActive">
-  <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()">
+  <chef-dropdown class="dropdown" id="projects-filter-dropdown" [attr.visible]="dropdownActive" (keydown.esc)="handleEscape()" role="">
 
       <div class="dropdown-body">
 
@@ -44,6 +44,7 @@
         <div id="drop-list" class="dropdown-content">
           <chef-checkbox
             *ngFor="let option of filteredOptions"
+            role="menuitem"
             [attr.title]="option.label"
             [checked]="option.checked"
             (change)="handleOptionChange($event, option.label)"


### PR DESCRIPTION
Signed-off-by: susanev <susan.ra.evans@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
the aria-menu in the top right of the nav was broken, now its not

the projects filter isn't really a menu, though it is a menu item of the top nav, so made it a menuitem
made the user menu its own menu, with all the menu items, menuitems

i have no idea if im doing this the best way, if anyone has better ideas pls share. or feel free to adopt.

### :chains: Related Resources
fixes #3842 

### :+1: Definition of Done
everything works and now the aria menu isn't broken

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-ui-devproxy`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
zero.
