### PR TITLE
include input of gcp_project_id for gcp scans

### DIFF
--- a/components/compliance-service/inspec/cli.go
+++ b/components/compliance-service/inspec/cli.go
@@ -52,7 +52,7 @@ func isTimeoutSane(timeout time.Duration, max time.Duration) error {
 }
 
 // Scan a target node with all specified profiles
-func Scan(paths []string, target *TargetConfig, timeout time.Duration, env map[string]string) ([]byte, []byte, *Error) {
+func Scan(paths []string, target *TargetConfig, timeout time.Duration, env map[string]string, inputs map[string]string) ([]byte, []byte, *Error) {
 	if err := isTimeoutSane(timeout, 12*time.Hour); err != nil {
 		return nil, nil, NewInspecError(INVALID_PARAM, err.Error())
 	}
@@ -67,6 +67,11 @@ func Scan(paths []string, target *TargetConfig, timeout time.Duration, env map[s
 	env["HOME"] = os.Getenv("HOME")
 
 	args := append([]string{binName, "exec"}, paths...)
+
+	for k, v := range inputs {
+		args = append(args, fmt.Sprintf("--input %s=%s", k, v))
+	}
+
 	stdOut, stdErr, err := run(args, target, timeout, env)
 
 	stdOutErr := ""

--- a/components/compliance-service/inspec/cli_test.go
+++ b/components/compliance-service/inspec/cli_test.go
@@ -1,11 +1,14 @@
 package inspec
 
 import (
+	"io/ioutil"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestInspecErrReturnsCorrectErr(t *testing.T) {
@@ -34,4 +37,24 @@ func TestInspecErrReturnsCorrectErr(t *testing.T) {
 	err = getInspecError("", stdErr, blankErr, target, time.Duration(90))
 	assert.Equal(t, &Error{Type: "authentication failed", Message: "Authentication failed for test\n\nNet::SSH::AuthenticationFailed"}, err)
 
+}
+
+func TestWriteInputsToYmlFile(t *testing.T) {
+	inputs := make(map[string]string)
+	inputs["key1"] = "val1"
+	inputs["key2"] = "val2"
+	err := writeInputsToYmlFile(inputs, "/tmp/test-file.yml")
+	require.NoError(t, err)
+
+	yamlFile, err := ioutil.ReadFile("/tmp/test-file.yml")
+	require.NoError(t, err)
+
+	var res map[string]string
+	err = yaml.Unmarshal(yamlFile, &res)
+	require.NoError(t, err)
+
+	expected := make(map[string]string)
+	expected["key1"] = "val1"
+	expected["key2"] = "val2"
+	assert.Equal(t, expected, res)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
gcp project id is required as an input to the exec command; this change adds it

i'm looking into testing

### :chains: Related Resources
https://github.com/chef/automate/issues/3851

### :+1: Definition of Done
gcp scans work again

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
go to https://chef.okta.com/app/UserHome
open last pass, search for creds with `GCP creds`
you should see `GCP creds (compliance)` in the shared-allyalls
copy the json creds
go to automate/settings/node-integrations
select gcp
add the json creds and create the integration
go to available profiles and "get" the `CIS Google Cloud Platform Foundation Benchmark Level 1` profile
run scan job against gcp integration using gcp profile

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

