### PR TITLE
reporting node detail: show waived control results in ui

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -201,17 +201,6 @@
                   </chef-toggle>
                   <ng-container [ngSwitch]="openControlPane(control)">
                     <div *ngSwitchCase="'results'">
-                      <ng-container *ngIf="control.status !== 'waived'">
-                        <div class="result-item" *ngFor="let result of control.results">
-                          <div class="result-item-header">
-                            <chef-icon class="status-icon" [ngClass]="result.status">{{ statusIcon(result.status) }}</chef-icon>
-                            <p>{{ result.code_desc }}</p>
-                          </div>
-                          <div class="result-item-body" *ngIf="result.message.length || result.skip_message.length">
-                            <chef-snippet [code]="result.message + result.skip_message"></chef-snippet>
-                          </div>
-                        </div>
-                      </ng-container>
                       <div *ngIf="control.status === 'waived'">
                         <p>This control was waived.</p>
                         <dl class="waiver-details">
@@ -220,6 +209,16 @@
                           <dt>Reason:</dt>
                           <dd>{{ control.waiver_data.justification }}</dd>
                         </dl>
+                      </div>
+                      <!-- show results of control even if waived -->
+                      <div class="result-item" *ngFor="let result of control.results">
+                        <div class="result-item-header">
+                          <chef-icon class="status-icon" [ngClass]="result.status">{{ statusIcon(result.status) }}</chef-icon>
+                          <p>{{ result.code_desc }}</p>
+                        </div>
+                        <div class="result-item-body" *ngIf="result.message.length || result.skip_message.length">
+                          <chef-snippet [code]="result.message + result.skip_message"></chef-snippet>
+                        </div>
                       </div>
                     </div>
                     <chef-snippet


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
show results of a control in the ui even if waived

### :chains: Related Resources
https://github.com/chef/automate/issues/3852

### :+1: Definition of Done
waived results in ui - node detail page

### :athletic_shoe: How to Build and Test the Change
rebuild ui
load_compliance_reports
see results on waived controls on reporting node detail page
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="1078" alt="Screen Shot 2020-05-31 at 17 12 25" src="https://user-images.githubusercontent.com/10341541/83364991-6ed81980-a362-11ea-8588-e82cc2088b90.png">
<img width="1080" alt="Screen Shot 2020-05-31 at 17 14 06" src="https://user-images.githubusercontent.com/10341541/83364992-70094680-a362-11ea-85cf-d257d3b76a1a.png">

