### PR TITLE
[automate-ui] tsconfig update

### DIFF
--- a/components/automate-ui/README.md
+++ b/components/automate-ui/README.md
@@ -74,14 +74,6 @@ error TS6200: Definitions of the following identifiers conflict with those in an
 There are very few reports of others experiencing this problem and no resolution presents itself.
 Reference: https://stackoverflow.com/a/57592510
 
-### Package @types/node: ~12.12.29
-
-Reason: The major version should match our node version, which is 12.13.1, so I have constrained it to the highest version less than that.
-That is a guess on my part, could not really confirm what version one should be running, through these references:
-
-- https://www.npmjs.com/package/@types/node
-- https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
-
 ### Package immutable: ^3.8.2
 
 Reason: Later releases are release candidates; should only be using production-releases.

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -72,7 +72,6 @@
     "@types/jasmine": "=3.3.10",
     "@types/jasminewd2": "^2.0.8",
     "@types/lodash": "^4.14.150",
-    "@types/node": "^12.12.37",
     "ajv": "^6.12.2",
     "angular2-template-loader": "^0.6.2",
     "axe-webdriverjs": "^2.3.0",

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "lib": [
+      "es2020"
+    ],
+    "module": "commonjs",
+    "target": "es2019",
     "downlevelIteration": true,
     "importHelpers": true,
     "outDir": "./dist/out-tsc",
@@ -9,17 +14,11 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
     "typeRoots": [
       "node_modules/@types"
     ],
-    "lib": [
-      "es2019",
-      "dom"
-    ],
     "baseUrl": "./src",
     "allowJs": true,
-    "module": "esnext",
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },

--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -2,7 +2,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "lib": [
-      "es2020"
+      "es2020",
+      "dom"
     ],
     "module": "commonjs",
     "target": "es2019",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Found what seems like [a reliable reference](https://stackoverflow.com/a/59787575/115690) for properly setting key tsconfig options.

While getting this to work, also came across [this reference](https://stackoverflow.com/a/49299180/115690) indicating
it is better not to include the `@types/node` package, so removed that here as well.

### :chains: Related Resources
NA

### :+1: Definition of Done
UI builds and lints without error

### :athletic_shoe: How to Build and Test the Change
`npm install` to update your node_modules directory with the `@types/node` package deletion. You should see no changes to package.json or package-lock.json after this step.

`ng build` or `make serve` works without errors or warnings
`make lint` reports no errors or warnings
`make unit` reports no errors or warnings

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).