### PR TITLE
onprem Builder server/tuning recommendations

### DIFF
--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -64,7 +64,8 @@ The frequency at which Habitat Supervisors poll the on-premises Chef Builder API
 
 These variables greatly influence the polling rate that the Chef Builder API will have to handle.
 
-The following table can be used as a planning guide for appropriately sizing hardware at differing client workloads.
+#### Planning Guide
+The planning guide can be used for appropriately sizing hardware at differing client workloads.
 
 * `Clients` refers to the total number of Chef Habitat Supervisors running with the `--auto-update` flag plus the total number of Service Instances being managed with an update strategy.
 * `Interval` refers to the value of `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` and assumes they are both set to the same value.

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -74,7 +74,7 @@ The following table can be used as a planning guide for appropriately sizing har
 | 20,000 | 600,000 | 4 vCPU x 16GB RAM (m4.xlarge) |
 | 4,000 | 60,000 | 8 vCPU x 32GB RAM (m4.2xlarge) |
 | 40,000 | 600,000 | 8 vCPU x 32GB RAM (m4.2xlarge) |
-| 8,000 | 60,0000 | 16 vCPU x 64GB RAM (m4.4xlarge) |
+| 8,000 | 60,000 | 16 vCPU x 64GB RAM (m4.4xlarge) |
 | 80,000 | 600,000 | 16 vCPU x 64GB RAM (m4.4xlarge) |
 
 

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -53,6 +53,7 @@ Chef Habitat artifact storage; we do not support using Artifactory for artifact 
 
 ### Hardware Sizing Considerations
 
+#### Environment Variables
 The frequency at which Habitat Supervisors poll the on-premises Chef Builder API for changes can be controlled by three Environment variables in the Chef Habitat Supervisor's runtime.
 
 | Variable | Default | Description |

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -53,20 +53,20 @@ Chef Habitat artifact storage; we do not support using Artifactory for artifact 
 
 ### Hardware Sizing Considerations
 
-The frequency at which Habitat Supervisors poll the on-premises Chef Builder API for changes can be controlled by two Environment variables in the Chef Habitat Supervisor's runtime.
+The frequency at which Habitat Supervisors poll the on-premises Chef Builder API for changes can be controlled by three Environment variables in the Chef Habitat Supervisor's runtime.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `HAB_SUP_UPDATE_MS` | 60000 | Frequency in milliseconds governing how often to check for Supervisor updates when running with an [update strategy](https://www.habitat.sh/docs/using-habitat/#using-updates) |
-| `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | 60000 | Frequency in milliseconds governing how often to check for Service updates when running with an [update strategy](https://www.habitat.sh/docs/using-habitat/#using-updates) |
+| `HAB_SUP_UPDATE_MS` | 60000 | Frequency in milliseconds governing how often to check for Supervisor updates when running with the [--auto-update](https://www.habitat.sh/docs/habitat-cli/#hab-sup-run) flag. |
+| `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | 60000 | Frequency in milliseconds governing how often to check for service updates when running with an [update strategy](https://www.habitat.sh/docs/using-habitat/#using-updates) |
+| `HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK` | no default | If set to `1`, will enable the Supervisor to utilize the `HAB_UPDATE_STRATEGY_FREQUENCY_MS` variable value from the line above for service updates. |
 
 These variables greatly influence the polling rate that the Chef Builder API will have to handle.
 
 The following table can be used as a planning guide for appropriately sizing hardware at differing client workloads.
 
-`Clients` refers to the total number of Chef Habitat Supervisors and total number of Service Instances being managed with an update strategy.
-
-`Interval` refers to the value of `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` and assumes they are both set to the same value.
+* `Clients` refers to the total number of Chef Habitat Supervisors and total number of Service Instances being managed with an update strategy.
+* `Interval` refers to the value of `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` and assumes they are both set to the same value.
 
 | Clients | Interval | Server Spec |
 | --- | --- | --- |
@@ -90,7 +90,7 @@ Chef Automate and Chef Habitat Builder require:
 * Run the installation and bootstrapping procedures as the superuser or use `sudo` at the start of each command.
 
 To operate optimally at larger scales, several OS optimizations can be made to improve performance. The following is an example
-of how to make this tuning changes for a RHEL based system:
+of how to make some recommended tuning changes for a RHEL based system:
 
 ```
 cat > /etc/sysctl.d/00-chef.conf <<EOF

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -56,7 +56,7 @@ Chef Habitat artifact storage; we do not support using Artifactory for artifact 
 The frequency at which Habitat Supervisors poll the on-premises Chef Builder API for changes can be controlled by two Environment variables in the Chef Habitat Supervisor's runtime.
 
 | Variable | Default | Description |
-| --- | --- | ---|
+| --- | --- | --- |
 | `HAB_SUP_UPDATE_MS` | 60000 | Frequency in milliseconds governing how often to check for Supervisor updates when running with an [update strategy](https://www.habitat.sh/docs/using-habitat/#using-updates) |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | 60000 | Frequency in milliseconds governing how often to check for Service updates when running with an [update strategy](https://www.habitat.sh/docs/using-habitat/#using-updates) |
 
@@ -69,7 +69,7 @@ The following table can be used as a planning guide for appropriately sizing har
 `Interval` refers to the value of `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` and assumes they are both set to the same value.
 
 | Clients | Interval | Server Spec |
-| --- | --- | --- | ---|
+| --- | --- | --- |
 | 2,000 | 60,000 | 4 vCPU x 16GB RAM (m4.xlarge) |
 | 20,000 | 600,000 | 4 vCPU x 16GB RAM (m4.xlarge) |
 | 4,000 | 60,000 | 8 vCPU x 32GB RAM (m4.2xlarge) |

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -65,7 +65,7 @@ These variables greatly influence the polling rate that the Chef Builder API wil
 
 The following table can be used as a planning guide for appropriately sizing hardware at differing client workloads.
 
-* `Clients` refers to the total number of Chef Habitat Supervisors and total number of Service Instances being managed with an update strategy.
+* `Clients` refers to the total number of Chef Habitat Supervisors running with the `--auto-update` flag plus the total number of Service Instances being managed with an update strategy.
 * `Interval` refers to the value of `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` and assumes they are both set to the same value.
 
 | Clients | Interval | Server Spec |
@@ -89,8 +89,7 @@ Chef Automate and Chef Habitat Builder require:
 * The shell that starts Automate should have a max open files setting of at least 65535
 * Run the installation and bootstrapping procedures as the superuser or use `sudo` at the start of each command.
 
-To operate optimally at larger scales, several OS optimizations can be made to improve performance. The following is an example
-of how to make some recommended tuning changes for a RHEL based system:
+To operate optimally at larger scales, several OS optimizations can be made to improve performance. The following is an example of how to make some recommended tuning changes for a RHEL based system:
 
 ```
 cat > /etc/sysctl.d/00-chef.conf <<EOF

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -23,7 +23,7 @@ Bootstrapping Chef Habitat Builder requires:
 * An existing Chef Habitat [public Builder](https://bldr.habitat.sh) account.
 
 ##
-### Unsupported Topologies
+## Unsupported Topologies
 
 * High Availability/DR/Multinode Builder
 

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -22,7 +22,6 @@ Bootstrapping Chef Habitat Builder requires:
 * An outward bound HTTPS connection
 * An existing Chef Habitat [public Builder](https://bldr.habitat.sh) account.
 
-##
 ## Unsupported Topologies
 
 * High Availability/DR/Multinode Builder


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

I'd like to update the documentation by adding some recommendations for server sizing and OS tuning when using the on-prem Builder API deployment.  These recommendations result from several rounds of extensive load testing with the Automate Builder API.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
