### PR TITLE
Fix race condition where cypress test only passed if other two notifications had already timed out

### DIFF
--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -161,10 +161,12 @@ describe('project management', () => {
     cy.get('[data-cy=save-button]').click();
     cy.get('app-project-list chef-modal').should('not.be.visible');
 
-    // verify success notification and then dismiss it
+    // verify success notification
     cy.get('app-notification.info')
       .contains(`Created project ${customWithPolsProjectID} and associated policies`);
-    cy.get('app-notification.info chef-icon').click();
+
+    // dismiss all three success notifications
+    cy.get('app-notification.info chef-icon').click({ multiple: true });
 
     cy.contains(customWithPolsProjectID).should('exist');
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Needed to pass multiple to the notification dismissal cypress code since there are three notifications for this case to dismiss. 
