### PR TITLE
[Automate-3869] filter box formatting fix

### DIFF
--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.html
@@ -14,7 +14,11 @@
     <chef-dropdown [attr.visible]="dropdownState === 'open'">
 
       <div id="filter-container">
-        <input id="{{ objectNounPlural }}" type="text" [(ngModel)]="filterValue" placeholder="Filter {{ objectNounPlural }}..."
+        <input chefInput
+          id="{{ objectNounPlural }}"
+          type="text"
+          [(ngModel)]="filterValue"
+          placeholder="Filter {{ objectNounPlural }}..."
           (keyup)="handleFilterKeyUp()" />
       </div>
 

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -44,7 +44,7 @@
                 formControlName="threshold"
                 [resetOrigin]="shouldResetValues"
                 type="number"
-                min="0" 
+                min="0"
                 (keydown)="preventNegatives($event.key)"
               />days
             </p>
@@ -89,7 +89,8 @@
 
             <p>When no health check reports have been received for a service in
               <input
-                aria-label="Amount of time before labeling a service disconnected" chefInput
+                aria-label="Amount of time before labeling a service disconnected"
+                chefInput
                 formControlName="threshold"
                 [resetOrigin]="shouldResetValues"
                 type="number"
@@ -105,7 +106,7 @@
               </mat-form-field>
               , label the service as disconnected</p>
           </div>
-          
+
           <div class="checkbox-row secondary-row" [formGroup]="serviceGroupRemoveServices">
             <div class="checkbox-container">
               <chef-tooltip follow position="top" for='service-group-remove-services'>
@@ -122,7 +123,8 @@
             </div>
             <p>Remove services labeled as disconnected after
               <input
-                aria-label="Amount of time before removing disconnected services" chefInput
+                aria-label="Amount of time before removing disconnected services"
+                chefInput
                 formControlName="threshold"
                 [resetOrigin]="shouldResetValues"
                 type="number"
@@ -170,7 +172,7 @@
               [disabled]="isDesktopView">
               </chef-checkbox>
             </div>
-          
+
             <p>When no Chef Infra Client run data has been received from a node in
               <input
                 aria-label="Amount of time before labeling a node as missing"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added back an inadvertently dropped `chefInput` to restore missing formatting on the filter box control in dropdowns:

![image](https://user-images.githubusercontent.com/6817500/83688722-b351f800-a5a2-11ea-966b-f8b7f663d3f6.png)


### :chains: Related Resources
PR #3841 Add missing labels to inputs

### :+1: Definition of Done
Formatting restored

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ui
Navigate to Settings >> Tokens >> Create Token >> _open dropdown_

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).