### PR TITLE
Apps Tab: Filter Bar APIs Bug Bonanza

### DIFF
--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -173,8 +173,7 @@ function applications_integration() {
 
   # Go based integration tests
   A2_SVC_NAME="applications-service" A2_SVC_PATH="/hab/svc/applications-service" go_test \
-	  "github.com/chef/automate/components/applications-service/integration_test" \
-	  -bench=. -benchmem -v
+	  "github.com/chef/automate/components/applications-service/integration_test"
 }
 
 document "applications_publish_raw_message" <<DOC

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -295,7 +295,7 @@ func (db *Postgres) GetServices(
 
 func (db *Postgres) GetServicesDistinctValues(fieldName, queryFragment string, filters map[string][]string) ([]string, error) {
 	// We do not want to filter on the fieldname we are looking up, because a user may want to use multiple values for searching
-	delete(filters, fieldName)
+	delete(filters, filterNameForField(fieldName))
 	// Pass "AND" for firstKeyword because we build the WHERE with the query fragment
 	whereConstraints, err := buildWhereConstraintsFromFilters(filters, "AND", false)
 	if err != nil {
@@ -329,6 +329,17 @@ func (db *Postgres) GetServicesDistinctValues(fieldName, queryFragment string, f
 		return nil, err
 	}
 	return matches, nil
+}
+
+func filterNameForField(fieldName string) string {
+	switch fieldName {
+	case "service_name":
+		return "service"
+	case "group_name":
+		return "group"
+	default:
+		return fieldName
+	}
 }
 
 func columnNameForField(fieldName string) string {

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -548,7 +548,7 @@ func buildORStatementFromValues(field string, values []string) string {
 
 	for _, value := range values {
 		if secondStatement {
-			ORConstraint = ORConstraint + " OR"
+			ORConstraint = ORConstraint + " OR "
 		}
 
 		if strings.ContainsAny(value, "?*") { // Wild cards detected, lookout!
@@ -556,12 +556,12 @@ func buildORStatementFromValues(field string, values []string) string {
 			pgWild = strings.Replace(pgWild, "?", "_", -1)
 			ORConstraint = ORConstraint + fmt.Sprintf(" %s LIKE '%s'", field, pgutils.EscapeLiteralForPG(pgWild))
 		} else {
-			ORConstraint = ORConstraint + fmt.Sprintf(" %s = '%s'", field, pgutils.EscapeLiteralForPG(value))
+			ORConstraint = ORConstraint + fmt.Sprintf("%s = '%s'", field, pgutils.EscapeLiteralForPG(value))
 		}
 		secondStatement = true
 	}
 
-	return ORConstraint
+	return fmt.Sprintf(" (%s)", ORConstraint)
 }
 
 func buildHealthStatementFromValues(values []string) string {
@@ -572,19 +572,19 @@ func buildHealthStatementFromValues(values []string) string {
 
 	for _, value := range values {
 		if secondStatement {
-			ORConstraint = ORConstraint + " OR"
+			ORConstraint = ORConstraint + " OR "
 		}
 		if value == "disconnected" {
 			ORConstraint = " disconnected"
 		} else {
-			ORConstraint = ORConstraint + fmt.Sprintf(" %s = '%s'", "health",
+			ORConstraint = ORConstraint + fmt.Sprintf("%s = '%s'", "health",
 				pgutils.EscapeLiteralForPG(strings.ToUpper(value)))
 		}
 
 		secondStatement = true
 	}
 
-	return ORConstraint
+	return fmt.Sprintf(" (%s)", ORConstraint)
 }
 
 // orderByStatementFromSortField returns the ORDER BY statement from the provided sort field,

--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -510,7 +510,7 @@ func buildWhereConstraintsFromFilters(filters map[string][]string, firstKeyword 
 			whereConstraints = whereConstraints + buildORStatementFromValues("environment", values)
 
 		case "group":
-			whereConstraints = whereConstraints + buildORStatementFromValues("s.service_group_name_suffix", values)
+			whereConstraints = whereConstraints + buildORStatementFromValues("service_group_name_suffix", values)
 
 		case "service":
 			whereConstraints = whereConstraints + buildORStatementFromValues("name", values)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixes a few bugs in the applications tab database logic:
- Code that converts filters from the application layer to SQL `WHERE` clauses specified the `service_group_name_suffix` column name incorrectly (looks like an incomplete refactoring)
- search suggestions for service name and group name are not correct when there's already one suggestion; added some translation between the names of the fields in filters vs. search bar to prevent "over filtering" in the database layer.
- Use parens to enforce desired grouping of `WHERE` clauses; previously the generated code did not take into account the lexical precedence of the `OR` operator, leading to incorrect query results being returned.
- In the service groups query, apply all relevant filters to the query part that computes service group health statistics and releases. (fixes #3793) 

### :chains: Related Resources

- The operator precedence bug was reported in a private slack channel
- The `service_group_name_suffix` bug was discovered by me when developing a reproduction case for the previous bug
- #3793

### :athletic_shoe: How to Build and Test the Change

*To See the Buggy Behavior:*
- Using a release circa `20200520145933` will have the bugs (if you are trying to test this in a future where the bugs are fixed in the mainline release)
- start all services in the studio, use `applications_populate_database` to make sample data
- trigger the `OR` logic in the filter bar by providing multiple values for attributes. This URL will do it: https://a2-dev.test/applications/service-groups?origin=custom&origin=mycorp&environment=qa&environment=demo 
- click on the selected row or refresh the page several times. You will different sets of nodes shown in the right side panel
- clear the filters
- filter by any valid `Group Name`
- now try to filter by `Group Name` again: the suggestions will not populate and you will see 500s if you look in the service logs or browser dev tools
- clear those filters
- search for application = `mobile-app-api`, environment = `production`, service = `mobile-api-frontend` to narrow it down: https://a2-dev.test/applications/service-groups?application=mobile-app-api&environment=production&service=mobile-api-frontend
- Then search for buildstamp = `20190115181111` or site = `us-west-1`
- though the results all have the same release `custom/mobile-api-frontend/1.9.2/20190115181111` the table row says "multiple releases".

If you switch to a version of the applications service with the bugs all fixed you should instead see:
- Only services that match all the filters are shown in the right side panel when using `OR` logic (give it 10ish refreshes to be sure)
- The suggestions in the filter bar populate correctly when attempting to specify multiple values for the Group Name attribute
- Whenever a service group has multiple releases but the filter criteria specify a subset of the group that has only one release, the specific release is shown and "multiple releases" is not shown.
