### PR TITLE
Keep CCR status in node-state regardless of missing-ness

### DIFF
--- a/components/ingest-service/backend/chef_client_run.go
+++ b/components/ingest-service/backend/chef_client_run.go
@@ -255,6 +255,7 @@ func (ccr *ChefClientRun) initializeNodeInfo() (sharedNodeInfo NodeInfo, err err
 		PlatformVersion:       EmptyStringIfNil(ccr.NodePayload.Automatic["platform_version"]),
 		Source:                ccr.Source,
 		Status:                ccr.Status,
+		ChefRunStatus:         ccr.Status,
 		TotalResourceCount:    ccr.TotalResourceCount,
 		SourceFqdn:            ccr.ChefServerFqdn,
 		ExpandedRunList:       ccr.ExpandedRunList,

--- a/components/ingest-service/backend/chef_client_run_test.go
+++ b/components/ingest-service/backend/chef_client_run_test.go
@@ -78,6 +78,7 @@ func TestFailedCCRToNode(t *testing.T) {
 
 	assert.Equal(t, expectedMessage, translatedNode.ErrorMessage)
 	assert.Equal(t, "failure", translatedNode.Status)
+	assert.Equal(t, "failure", translatedNode.ChefRunStatus)
 	assert.Equal(t, subject.ChefError{}, translatedNode.Error)
 }
 

--- a/components/ingest-service/backend/converge.go
+++ b/components/ingest-service/backend/converge.go
@@ -64,13 +64,20 @@ type NodeAttribute struct {
 
 // NodeInfo defines common fields between Run and Node types
 type NodeInfo struct {
-	EntityUuid            string              `json:"entity_uuid"`
-	EventAction           string              `json:"event_action"`
-	NodeName              string              `json:"node_name"`
-	OrganizationName      string              `json:"organization_name"`
-	RunList               []string            `json:"run_list"`
-	Source                string              `json:"source"`
-	Status                string              `json:"status"`
+	EntityUuid       string   `json:"entity_uuid"`
+	EventAction      string   `json:"event_action"`
+	NodeName         string   `json:"node_name"`
+	OrganizationName string   `json:"organization_name"`
+	RunList          []string `json:"run_list"`
+	Source           string   `json:"source"`
+	// In the backend, status may be modified by other systems/processes and have
+	// new values, for example to mark a node missing
+	Status string `json:"status"`
+	// ChefRunStatus should not be modified and should always contain the Chef
+	// Run's success/failure outcome. This is used to with elasticsearch
+	// aggregations to compute success/failure statistics across different node
+	// cohorts
+	ChefRunStatus         string              `json:"chef_run_status"`
 	TotalResourceCount    int                 `json:"total_resource_count"`
 	Deprecations          []Deprecation       `json:"deprecations,omitempty"`
 	Error                 ChefError           `json:"error,omitempty"`

--- a/components/ingest-service/backend/elastic/mappings/node_state.go
+++ b/components/ingest-service/backend/elastic/mappings/node_state.go
@@ -81,6 +81,9 @@ var nodeProps = `
 	"status": {
 		"type": "keyword"
 	},
+	"chef_run_status": {
+		"type": "keyword"
+	},
 	"deprecations": {
 		"type": "object",
 		"dynamic": true,

--- a/components/ingest-service/test/chef_run_node_state.js
+++ b/components/ingest-service/test/chef_run_node_state.js
@@ -120,6 +120,7 @@ describe("creating node state", function () {
             let source = response.body.hits.hits[0]._source;
             expect(source.entity_uuid).to.equal(entityUuid);
             expect(source.status).to.equal('failure');
+            expect(source.chef_run_status).to.equal('failure');
             expect(source.latest_run_id).to.equal(runID1);
             // Wait for the chefRun2 post.
             return chakram.all([chakram.post(endpoint(), chefRun2.json())]).then(function(responses) {
@@ -133,6 +134,7 @@ describe("creating node state", function () {
                   let source = response.body.hits.hits[0]._source;
                   expect(source.entity_uuid).to.equal(entityUuid);
                   expect(source.status).to.equal('success');
+                  expect(source.chef_run_status).to.equal('success');
                   expect(source.latest_run_id).to.equal(runID2);
                 });
               });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This is in service of the rollouts/change tracking dashboard, where we
want to give the user success/failure statistics grouped by policyfile
versions; in this scenario we need to keep the "old" CCR-based status
around even after a node becomes missing.

### :chains: Related Resources

Part of #3688 

### :athletic_shoe: How to Build and Test the Change

* Build the ingest service
* start all services (probably only need a subset but I started them all)
* use the `send_chef_run_example` helper to send a CCR report (repeat a few times if you like)
* use the `send_chef_run_failure_example` to send a CCR failure report
* Query Elasticsearch with: `curl -Ss -k -X GET http://localhost:10144/node-state/_search -H 'Content-Type: application/json' -d '{"size": 10}' | jq . | less` 
* search with `/status`, you should see stuff like:
```
          "status": "failure",
          "chef_run_status": "failure",
```

```
          "status": "missing",
          "chef_run_status": "success",
```

What you want to see is:
* every node state document has both a `status` and `chef_run_status` field.
* if the `status` is "failure" or "success" then `chef_run_status` should have the same value
* when `status` is "missing", `chef_run_status` should still be set to success/failure (unchanged)
* if you don't have any missing nodes, you can run `send_chef_run_example` a few more times and then wait a minute or so for the mark-nodes-missing job to run.

