### PR TITLE
use json_build_object instead of string_agg for pg nodes

### DIFF
--- a/components/automate-gateway/integration/nodes_test.go
+++ b/components/automate-gateway/integration/nodes_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chef/automate/api/external/common/query"
 	gwnodes "github.com/chef/automate/api/external/nodes"
 	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/api/interservice/compliance/common"
 	"github.com/chef/automate/api/interservice/compliance/jobs"
 	"github.com/chef/automate/api/interservice/nodemanager/nodes"
 )
@@ -172,6 +173,7 @@ func (suite *GatewayTestSuite) TestGatewayNodesClient() {
 		Id:              nodeID.Id,
 		Name:            "test node",
 		Manager:         "automate",
+		Tags:            []*common.Kv{&common.Kv{}},
 		Platform:        "redhat",
 		PlatformVersion: "7.7",
 		ManagerIds:      []string{"e69dc612-7e67-43f2-9b19-256afd385820"},

--- a/components/automate-gateway/integration/nodes_test.go
+++ b/components/automate-gateway/integration/nodes_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/chef/automate/api/external/common/query"
 	gwnodes "github.com/chef/automate/api/external/nodes"
 	"github.com/chef/automate/api/external/secrets"
-	"github.com/chef/automate/api/interservice/compliance/common"
 	"github.com/chef/automate/api/interservice/compliance/jobs"
 	"github.com/chef/automate/api/interservice/nodemanager/nodes"
 )
@@ -173,7 +172,6 @@ func (suite *GatewayTestSuite) TestGatewayNodesClient() {
 		Id:              nodeID.Id,
 		Name:            "test node",
 		Manager:         "automate",
-		Tags:            []*common.Kv{&common.Kv{}},
 		Platform:        "redhat",
 		PlatformVersion: "7.7",
 		ManagerIds:      []string{"e69dc612-7e67-43f2-9b19-256afd385820"},

--- a/components/compliance-service/api/tests/25_nodes_spec.rb
+++ b/components/compliance-service/api/tests/25_nodes_spec.rb
@@ -130,7 +130,7 @@ describe File.basename(__FILE__) do
       tags: [
         Common::Kv.new(key: "department", value: "marketing"),
         Common::Kv.new(key: "boss", value: "John"),
-        Common::Kv.new(key: "test", value: "Dot.Comma,Big;\"Trouble")
+        Common::Kv.new(key: "test&6^\"BAD", value: "Dot.Comma,Big;\"Trouble")
       ]
     )
     node_id2 = node2['id']
@@ -191,7 +191,7 @@ describe File.basename(__FILE__) do
               "value": "John"
             },
             {
-              "key": "test",
+              "key": "test&6^\"BAD",
               "value": "Dot.Comma,Big;\"Trouble"
             },
           ],
@@ -206,7 +206,6 @@ describe File.basename(__FILE__) do
           "id": node_id1,
           "name": "M$",
           "manager": "automate",
-          "tags": [{}],
           "status": "unknown",
           "managerIds": [
             "e69dc612-7e67-43f2-9b19-256afd385820"
@@ -253,7 +252,6 @@ describe File.basename(__FILE__) do
       "id": node_id1,
       "name": "M$",
       "manager": "automate",
-      "tags": [{}],
       "status": "unknown",
       "managerIds": [
         "e69dc612-7e67-43f2-9b19-256afd385820"
@@ -289,7 +287,7 @@ describe File.basename(__FILE__) do
           "value": "John"
         },
         {
-          "key": "test",
+          "key": "test&6^\"BAD",
           "value": "Dot.Comma,Big;\"Trouble"
         }
       ],
@@ -583,7 +581,7 @@ describe File.basename(__FILE__) do
       ),
       field: "tags"
     )
-    assert_same_elements(["department", "boss", "test"], tag_keys["fields"])
+    assert_same_elements(["department", "boss", "test&6^\"BAD"], tag_keys["fields"])
 
     names = MANAGER_GRPC manager, :search_node_fields, Manager::FieldQuery.new(
       node_manager_id: "e69dc612-7e67-43f2-9b19-256afd385820",

--- a/components/compliance-service/api/tests/25_nodes_spec.rb
+++ b/components/compliance-service/api/tests/25_nodes_spec.rb
@@ -129,7 +129,8 @@ describe File.basename(__FILE__) do
       ),
       tags: [
         Common::Kv.new(key: "department", value: "marketing"),
-        Common::Kv.new(key: "boss", value: "John")
+        Common::Kv.new(key: "boss", value: "John"),
+        Common::Kv.new(key: "test", value: "Dot.Comma,Big;\"Trouble")
       ]
     )
     node_id2 = node2['id']
@@ -188,7 +189,11 @@ describe File.basename(__FILE__) do
             {
               "key": "boss",
               "value": "John"
-            }
+            },
+            {
+              "key": "test",
+              "value": "Dot.Comma,Big;\"Trouble"
+            },
           ],
           "status": "unknown",
           "managerIds": [
@@ -201,6 +206,7 @@ describe File.basename(__FILE__) do
           "id": node_id1,
           "name": "M$",
           "manager": "automate",
+          "tags": [{}],
           "status": "unknown",
           "managerIds": [
             "e69dc612-7e67-43f2-9b19-256afd385820"
@@ -247,6 +253,7 @@ describe File.basename(__FILE__) do
       "id": node_id1,
       "name": "M$",
       "manager": "automate",
+      "tags": [{}],
       "status": "unknown",
       "managerIds": [
         "e69dc612-7e67-43f2-9b19-256afd385820"
@@ -280,6 +287,10 @@ describe File.basename(__FILE__) do
         {
           "key": "boss",
           "value": "John"
+        },
+        {
+          "key": "test",
+          "value": "Dot.Comma,Big;\"Trouble"
         }
       ],
       "status": "unknown",
@@ -572,7 +583,7 @@ describe File.basename(__FILE__) do
       ),
       field: "tags"
     )
-    assert_same_elements(["department", "boss"], tag_keys["fields"])
+    assert_same_elements(["department", "boss", "test"], tag_keys["fields"])
 
     names = MANAGER_GRPC manager, :search_node_fields, Manager::FieldQuery.new(
       node_manager_id: "e69dc612-7e67-43f2-9b19-256afd385820",

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -57,7 +57,7 @@ SELECT
   COALESCE(n.source_id, '') AS source_id,
   COALESCE(n.source_region, '') AS source_region,
   COALESCE(n.source_account_id, '') AS source_account_id,
-  COALESCE(('[' || string_agg(DISTINCT '{"key":"' || t.key || '"' || ',"value": "' || t.value || '"}', ',') || ']'), '[]') :: JSON AS tags,
+  COALESCE(json_agg(json_build_object('key', t.key, 'value', t.value)), '[]') AS tags,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT m.manager_id), NULL)), '[]') AS manager_ids,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT p.project_id), NULL)), '[]') AS projects,
   COUNT(*) OVER () AS total_count
@@ -928,7 +928,9 @@ func (db *DB) QueryManualNodesFields(ctx context.Context, filters []*common.Filt
 			results = append(results, node.Name)
 		case "tags":
 			for _, kv := range node.Tags {
-				results = append(results, kv.Key)
+				if len(kv.Key) > 0 {
+					results = append(results, kv.Key)
+				}
 			}
 		}
 	}

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -57,7 +57,7 @@ SELECT
   COALESCE(n.source_id, '') AS source_id,
   COALESCE(n.source_region, '') AS source_region,
   COALESCE(n.source_account_id, '') AS source_account_id,
-  COALESCE(json_agg(DISTINCT jsonb_build_object('key', t.key, 'value', t.value)), '[]') AS tags,
+  COALESCE(json_agg(DISTINCT jsonb_build_object('key', t.key, 'value', t.value)) FILTER (WHERE t.id IS NOT NULL), '[]') AS tags,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT m.manager_id), NULL)), '[]') AS manager_ids,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT p.project_id), NULL)), '[]') AS projects,
   COUNT(*) OVER () AS total_count
@@ -928,9 +928,7 @@ func (db *DB) QueryManualNodesFields(ctx context.Context, filters []*common.Filt
 			results = append(results, node.Name)
 		case "tags":
 			for _, kv := range node.Tags {
-				if len(kv.Key) > 0 {
-					results = append(results, kv.Key)
-				}
+				results = append(results, kv.Key)
 			}
 		}
 	}

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -57,7 +57,7 @@ SELECT
   COALESCE(n.source_id, '') AS source_id,
   COALESCE(n.source_region, '') AS source_region,
   COALESCE(n.source_account_id, '') AS source_account_id,
-  COALESCE(json_agg(json_build_object('key', t.key, 'value', t.value)), '[]') AS tags,
+  COALESCE(json_agg(DISTINCT jsonb_build_object('key', t.key, 'value', t.value)), '[]') AS tags,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT m.manager_id), NULL)), '[]') AS manager_ids,
   COALESCE(array_to_json(array_remove(array_agg(DISTINCT p.project_id), NULL)), '[]') AS projects,
   COUNT(*) OVER () AS total_count


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
the string agg was resulting in mixups where a double quote
inside a tag would cause the entire nodes search api call to fail
bc it couldn't parse the tag.

### :chains: Related Resources
https://github.com/chef/automate/issues/3724

### :+1: Definition of Done
can add a node with a tag that has a double quote in it and still read the nodes list

### :athletic_shoe: How to Build and Test the Change
rebuild nodemanager
navigate to scan jobs/nodes - add node
add a node with a bad tag like `Dot.Comma,Big;\"Trouble`
make sure scan jobs nodes list is still readable

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
