### PR TITLE
Jamie/3745 desktop question mark tooltips

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
@@ -1,7 +1,13 @@
 <div class="content-container">
   <div class="header">
     <div class="heading">
-      <h2 class="heading-title">Check-in History</h2>
+      <div class="heading-title-container">
+        <h2 class="heading-title">Check-in History</h2>
+        <chef-icon id="checkin-history-info" style='font-size: 24px'>info_outline</chef-icon>
+        <chef-tooltip for='checkin-history-info'>
+          <p class="tooltip-text">Percentage of checked-in to total desktops at 24 hour intervals.</p>
+        </chef-tooltip>
+      </div>
       <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
     </div>
     <select (change)="dateChanged($event.target.value)">

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
@@ -3,7 +3,7 @@
     <div class="heading">
       <div class="heading-title-container">
         <h2 class="heading-title">Check-in History</h2>
-        <chef-icon id="checkin-history-info" style='font-size: 24px'>info_outline</chef-icon>
+        <chef-icon id="checkin-history-info">info_outline</chef-icon>
         <chef-tooltip for='checkin-history-info'>
           <p class="tooltip-text">Percentage of checked-in to total desktops at 24 hour intervals.</p>
         </chef-tooltip>

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.scss
@@ -1,22 +1,5 @@
 @import "~styles/variables";
 
-.heading-title {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 18px;
-}
-
-.heading-time {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 10px;
-}
-
 .header {
   display: flex;
   align-items: flex-start;
@@ -24,6 +7,46 @@
 
   select {
     display: block;
+  }
+}
+
+.heading {
+
+  .heading-title-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: .25em;
+    
+    .heading-title {
+      color: var(--chef-primary-dark);
+      margin-top: 0;
+      margin-bottom: 0;
+      font-weight: inherit;
+      font-style: inherit;
+      font-size: 18px;
+    }
+    
+    chef-icon {
+      margin-left: 4px;
+      cursor: help;
+    }
+
+    chef-tooltip {
+      width: 288px;
+
+      .tooltip-text {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .heading-time {
+    color: var(--chef-primary-dark);
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-weight: inherit;
+    font-style: inherit;
+    font-size: 10px;
   }
 }
 

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.scss
@@ -16,7 +16,7 @@
     display: flex;
     align-items: center;
     margin-bottom: .25em;
-    
+
     .heading-title {
       color: var(--chef-primary-dark);
       margin-top: 0;
@@ -25,9 +25,10 @@
       font-style: inherit;
       font-size: 18px;
     }
-    
+
     chef-icon {
       margin-left: 4px;
+      font-size: 24px;
       cursor: help;
     }
 

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CheckInTimeSeriesComponent } from './check-in-time-series.component';
+import { By } from '@angular/platform-browser';
 
 describe('CheckInTimeSeriesComponent', () => {
   let fixture: ComponentFixture<CheckInTimeSeriesComponent>;
@@ -22,5 +23,17 @@ describe('CheckInTimeSeriesComponent', () => {
 
   it('should exist', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('information tooltip', () => {
+    it('should have an element on page with matching id', () => {
+      const debugElement = fixture.debugElement.query(By.css('#checkin-history-info'));
+      expect(debugElement).toBeTruthy();
+    });
+
+    it('should contain "for" attribute linked to matching element', () => {
+      const tooltip = fixture.debugElement.query(By.css('chef-tooltip')).nativeElement;
+      expect(tooltip.getAttribute('for')).toEqual('checkin-history-info');
+    });
   });
 });

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
@@ -1,22 +1,22 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DailyCheckInComponent } from './daily-check-in.component';
+import { CheckInTimeSeriesComponent } from './check-in-time-series.component';
 
-describe('DailyCheckInComponent', () => {
-  let fixture: ComponentFixture<DailyCheckInComponent>;
-  let component: DailyCheckInComponent;
+describe('CheckInTimeSeriesComponent', () => {
+  let fixture: ComponentFixture<CheckInTimeSeriesComponent>;
+  let component: CheckInTimeSeriesComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
       declarations: [
-        DailyCheckInComponent
+        CheckInTimeSeriesComponent
       ],
       providers: [],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
 
-    fixture = TestBed.createComponent(DailyCheckInComponent);
+    fixture = TestBed.createComponent(CheckInTimeSeriesComponent);
     component = fixture.componentInstance;
   });
 

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -1,7 +1,13 @@
 <div class="content-container">
   <div class="header">
     <div class="heading">
-      <h2 class="heading-title">Daily Check-in</h2>
+      <div class="heading-title-container">
+        <h2 class="heading-title">Daily Check-in</h2>
+        <chef-icon id="daily-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
+        <chef-tooltip for='daily-checkin-info'>
+          <p class="tooltip-text">Check-in status in the last 24 hours.</p>
+        </chef-tooltip>
+      </div>
       <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
     </div>
     <app-chart-progress-bar size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -3,7 +3,7 @@
     <div class="heading">
       <div class="heading-title-container">
         <h2 class="heading-title">Daily Check-in</h2>
-        <chef-icon id="daily-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
+        <chef-icon id="daily-checkin-info">info_outline</chef-icon>
         <chef-tooltip for='daily-checkin-info'>
           <p class="tooltip-text">Check-in status in the last 24 hours.</p>
         </chef-tooltip>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.scss
@@ -1,22 +1,47 @@
 @import "~styles/variables";
 @import "@carbon/layout/scss/layout";
 
-.heading-title {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 18px;
+.heading {
+
+  .heading-title-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: .25em;
+
+    .heading-title {
+      color: var(--chef-primary-dark);
+      margin-top: 0;
+      margin-bottom: 0;
+      font-weight: inherit;
+      font-style: inherit;
+      font-size: 18px;
+    }
+
+    chef-icon {
+      margin-left: 4px;
+      cursor: help;
+    }
+
+    chef-tooltip {
+      width: 288px;
+
+      .tooltip-text {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .heading-time {
+    color: var(--chef-primary-dark);
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-weight: inherit;
+    font-style: inherit;
+    font-size: 10px;
+  }
 }
 
-.heading-time {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 10px;
-}
+
 
 app-chart-progress-bar {
   margin: $spacing-07 0 $spacing-09 0;

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.scss
@@ -19,6 +19,7 @@
 
     chef-icon {
       margin-left: 4px;
+      font-size: 24px;
       cursor: help;
     }
 

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DailyCheckInComponent } from './daily-check-in.component';
+import { DebugElement } from '@angular/core';
+
+
+
+describe('DailyCheckInComponent', () => {
+  let fixture: ComponentFixture<DailyCheckInComponent>;
+  let component: DailyCheckInComponent;
+  let element: DebugElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [ DailyCheckInComponent ],
+      providers: [],
+      schemas: []
+    });
+
+    fixture = TestBed.createComponent(DailyCheckInComponent);
+    component = fixture.componentInstance;
+    element = fixture.debugElement;
+  });
+
+  it('should exist', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DailyCheckInComponent } from './daily-check-in.component';
+import { By } from '@angular/platform-browser';
 
 describe('DailyCheckInComponent', () => {
   let fixture: ComponentFixture<DailyCheckInComponent>;
@@ -22,5 +23,17 @@ describe('DailyCheckInComponent', () => {
 
   it('should exist', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('information tooltip', () => {
+    it('should have an element on page with matching id', () => {
+      const debugElement = fixture.debugElement.query(By.css('#daily-checkin-info'));
+      expect(debugElement).toBeTruthy();
+    });
+
+    it('should contain "for" attribute linked to matching element', () => {
+      const tooltip = fixture.debugElement.query(By.css('chef-tooltip')).nativeElement;
+      expect(tooltip.getAttribute('for')).toEqual('daily-checkin-info');
+    });
   });
 });

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -2,7 +2,7 @@
   <div class="heading">
     <div class="heading-title-container">
       <h2 class="heading-title">Top 10 Errors</h2>
-      <chef-icon id="top-errors-info" style='font-size: 24px'>info_outline</chef-icon>
+      <chef-icon id="top-errors-info">info_outline</chef-icon>
       <chef-tooltip for='top-errors-info'>
         <p class="tooltip-text">Most common error messages and classes returned from Chef Infra Client runs across all desktops.</p>
       </chef-tooltip>

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -1,6 +1,14 @@
 <div class="content-container">
-  <h2 class="heading-title">Top 10 Errors</h2>
-  <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+  <div class="heading">
+    <div class="heading-title-container">
+      <h2 class="heading-title">Top 10 Errors</h2>
+      <chef-icon id="top-errors-info" style='font-size: 24px'>info_outline</chef-icon>
+      <chef-tooltip for='top-errors-info'>
+        <p class="tooltip-text">Most common error messages and classes returned from Chef Infra Client runs across all desktops.</p>
+      </chef-tooltip>
+    </div>
+    <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+  </div>
   <chef-table class="chart-list">
     <chef-tbody>
       <chef-tr

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
@@ -2,7 +2,7 @@
 @import "@carbon/layout/scss/layout";
 
 .heading {
-  
+
   .heading-title-container {
     display: flex;
     align-items: center;
@@ -10,6 +10,7 @@
 
     chef-icon {
       margin-left: 4px;
+      font-size: 24px;
       cursor: help;
     }
 
@@ -31,7 +32,7 @@
     font-size: 18px;
   }
 }
-  
+
 .heading-time {
   color: var(--chef-primary-dark);
   margin-top: 0;

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
@@ -1,14 +1,37 @@
 @import "~styles/variables";
 @import "@carbon/layout/scss/layout";
 
-.heading-title {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 18px;
-}
+.heading {
+  
+  .heading-title-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: .25em;
 
+    chef-icon {
+      margin-left: 4px;
+      cursor: help;
+    }
+
+    chef-tooltip {
+      width: 288px;
+
+      .tooltip-text {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  .heading-title {
+    color: var(--chef-primary-dark);
+    margin-top: 0;
+    margin-bottom: 0;
+    font-weight: inherit;
+    font-style: inherit;
+    font-size: 18px;
+  }
+}
+  
 .heading-time {
   color: var(--chef-primary-dark);
   margin-top: 0;

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TopErrorsComponent } from './top-errors.component';
+import { By } from '@angular/platform-browser';
 
 describe('TopErrorsComponent', () => {
   let fixture: ComponentFixture<TopErrorsComponent>;
@@ -22,5 +23,17 @@ describe('TopErrorsComponent', () => {
 
   it('should exist', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('information tooltip', () => {
+    it('should have an element on page with matching id', () => {
+      const debugElement = fixture.debugElement.query(By.css('#top-errors-info'));
+      expect(debugElement).toBeTruthy();
+    });
+
+    it('should contain "for" attribute linked to matching element', () => {
+      const tooltip = fixture.debugElement.query(By.css('chef-tooltip')).nativeElement;
+      expect(tooltip.getAttribute('for')).toEqual('top-errors-info');
+    });
   });
 });

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
@@ -1,22 +1,22 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DailyCheckInComponent } from './daily-check-in.component';
+import { TopErrorsComponent } from './top-errors.component';
 
-describe('DailyCheckInComponent', () => {
-  let fixture: ComponentFixture<DailyCheckInComponent>;
-  let component: DailyCheckInComponent;
+describe('TopErrorsComponent', () => {
+  let fixture: ComponentFixture<TopErrorsComponent>;
+  let component: TopErrorsComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
       declarations: [
-        DailyCheckInComponent
+        TopErrorsComponent
       ],
       providers: [],
-      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
 
-    fixture = TestBed.createComponent(DailyCheckInComponent);
+    fixture = TestBed.createComponent(TopErrorsComponent);
     component = fixture.componentInstance;
   });
 

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
@@ -2,7 +2,7 @@
   <div class="heading">
     <div class="heading-title-container">
       <h2 class="heading-title">Time since Last Check-in</h2>
-      <chef-icon id="since-last-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
+      <chef-icon id="since-last-checkin-info">info_outline</chef-icon>
       <chef-tooltip for='since-last-checkin-info'>
         <p class="tooltip-text">Count of desktops that haven't checked-in over different periods of time.</p>
       </chef-tooltip>

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
@@ -1,5 +1,11 @@
 <div class="content-container">
-  <h2 class="heading-title">Time since Last Check-in</h2>
+  <div class="heading-container">
+    <h2 class="heading-title">Time since Last Check-in</h2>
+    <chef-icon id="since-last-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
+    <chef-tooltip for='since-last-checkin-info'>
+      <p>Count of desktops that haven't checked-in over different periods of time.</p>
+    </chef-tooltip>
+  </div>
   <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
   <chef-table class="chart-list">
     <chef-tbody>

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
@@ -1,12 +1,14 @@
 <div class="content-container">
-  <div class="heading-container">
-    <h2 class="heading-title">Time since Last Check-in</h2>
-    <chef-icon id="since-last-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
-    <chef-tooltip for='since-last-checkin-info'>
-      <p>Count of desktops that haven't checked-in over different periods of time.</p>
-    </chef-tooltip>
+  <div class="heading">
+    <div class="heading-title-container">
+      <h2 class="heading-title">Time since Last Check-in</h2>
+      <chef-icon id="since-last-checkin-info" style='font-size: 24px'>info_outline</chef-icon>
+      <chef-tooltip for='since-last-checkin-info'>
+        <p class="tooltip-text">Count of desktops that haven't checked-in over different periods of time.</p>
+      </chef-tooltip>
+    </div>
+    <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
   </div>
-  <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
   <chef-table class="chart-list">
     <chef-tbody>
       <chef-tr

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
@@ -1,6 +1,23 @@
 @import "~styles/variables";
 @import "@carbon/layout/scss/layout";
 
+.heading-container {
+  display: flex;
+
+  chef-icon {
+    margin-left: 4px;
+    cursor: help;
+  }
+
+  chef-tooltip {
+    width: 288px;
+
+    p {
+      margin-bottom: 0;
+    }
+  }
+}
+
 .heading-title {
   color: var(--chef-primary-dark);
   margin-top: 0;

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
@@ -1,38 +1,44 @@
 @import "~styles/variables";
 @import "@carbon/layout/scss/layout";
 
-.heading-container {
-  display: flex;
+.heading {
 
-  chef-icon {
-    margin-left: 4px;
-    cursor: help;
-  }
+  .heading-title-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: .25em;
 
-  chef-tooltip {
-    width: 288px;
-
-    p {
+    .heading-title {
+      color: var(--chef-primary-dark);
+      margin-top: 0;
       margin-bottom: 0;
+      font-weight: inherit;
+      font-style: inherit;
+      font-size: 18px;
+    }
+
+    chef-icon {
+      margin-left: 4px;
+      cursor: help;
+    }
+
+    chef-tooltip {
+      width: 288px;
+
+      .tooltip-text {
+        margin-bottom: 0;
+      }
     }
   }
-}
 
-.heading-title {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 18px;
-}
-
-.heading-time {
-  color: var(--chef-primary-dark);
-  margin-top: 0;
-  margin-bottom: 12px;
-  font-weight: inherit;
-  font-style: inherit;
-  font-size: 10px;
+  .heading-time {
+    color: var(--chef-primary-dark);
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-weight: inherit;
+    font-style: inherit;
+    font-size: 10px;
+  }
 }
 
 .chart-list-item {

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
@@ -19,6 +19,7 @@
 
     chef-icon {
       margin-left: 4px;
+      font-size: 24px;
       cursor: help;
     }
 

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UnknownDesktopDurationCountsComponent } from './unknown-desktop-duration-counts.component';
+import { By } from '@angular/platform-browser';
 
 describe('UnknownDesktopDurationCountsComponent', () => {
   let fixture: ComponentFixture<UnknownDesktopDurationCountsComponent>;
@@ -22,5 +23,17 @@ describe('UnknownDesktopDurationCountsComponent', () => {
 
   it('should exist', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('information tooltip', () => {
+    it('should have an element on page with matching id', () => {
+      const debugElement = fixture.debugElement.query(By.css('#since-last-checkin-info'));
+      expect(debugElement).toBeTruthy();
+    });
+
+    it('should contain "for" attribute linked to matching element', () => {
+      const tooltip = fixture.debugElement.query(By.css('chef-tooltip')).nativeElement;
+      expect(tooltip.getAttribute('for')).toEqual('since-last-checkin-info');
+    });
   });
 });

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
@@ -1,0 +1,26 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UnknownDesktopDurationCountsComponent } from './unknown-desktop-duration-counts.component';
+
+describe('UnknownDesktopDurationCountsComponent', () => {
+  let fixture: ComponentFixture<UnknownDesktopDurationCountsComponent>;
+  let component: UnknownDesktopDurationCountsComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [
+        UnknownDesktopDurationCountsComponent
+      ],
+      providers: [],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(UnknownDesktopDurationCountsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should exist', () => {
+    expect(component).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding tooltips for information about what each section is for on Desktop

I also added the scaffolding necessary for each of the 4 components involved.  I was unable to find a good way to unit test hover actions, so I ended up NOT adding tests for these tooltips.  I think this is okay as we have tests already for chef-tooltip, and the text is not dynamic anyways, so theres no real special/unique test to be done for these.

### :chains: Related Resources
Adds: https://github.com/chef/automate/issues/3745

### :+1: Definition of Done
Tooltips are visible when hovering over the information icon, matching the messaging from the spec.  Current tooltip styling remains.

### :athletic_shoe: How to Build and Test the Change
in hab: `build components/automate-ui-devproxy`
in automate-ui: `make serve`

navigate to https://a2-dev.test/desktop
- look for the 4 info icons, one in each section (Daily Check-in, Check-in History, Time since last check-in, Top errors).  They look like an 'i' with a circle around it
- hover over each one of the info icons and view the tooltip

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
After:
<img width="1221" alt="Screen Shot 2020-06-09 at 11 27 27 AM" src="https://user-images.githubusercontent.com/16737484/84185704-3f9d6880-aa44-11ea-89bd-72f02c648c77.png">
