### PR TITLE
Fix rendering of license form

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -76,13 +76,6 @@
     .email-container {
       margin-bottom: 20px;
     }
-
-    span {
-      display: block;
-      margin-top: 20px;
-      font-size: 12px;
-      text-align: center;
-    }
   }
 
   .info {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A recent PR added the accessibility annotation for the asterisks in the form but they were not formatted correctly. (Other pages in that PR are rendering correctly.)

It turns out that for this particular form `<span>` elements had some block-like formatting, yet that was quite obsolete as there were no other `<span>` elements on the page(!), so just removed it.

### :chains: Related Resources
PR #3825

### :+1: Definition of Done
Form is corrected:
![image](https://user-images.githubusercontent.com/6817500/84215192-637ba100-aa7a-11ea-9a3e-64675d8fe496.png)

### :athletic_shoe: How to Build and Test the Change
In hab studio, find your current license:
```
chef-automate dev psql chef_license_control_service -- -c \
"select db_id, active from licenses;"
```
There should be one row showing active as `t`. (There may likely be only one row total.) Remember the corresponding `db_id` for that row so you can restore it after.

Now deactivate the license...
```
chef-automate dev psql chef_license_control_service -- -c \
"update licenses set active=null;"
```
Then refresh your browser and the license form will appear.

To restore your system after testing, reset the license to active by replacing `YOUR_SAVED_DBID` with the value from above.
```
chef-automate dev psql chef_license_control_service -- -c \
"update licenses set active=true where db_id=YOUR_SAVED_DBID;"
```
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
