### PR TITLE
Corrected initialization gating for project dropdown

### DIFF
--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.ts
@@ -66,8 +66,12 @@ export class ResourceDropdownComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.resources) {
-      if (!changes.resources.previousValue || changes.resources.previousValue.length === 0) {
-        // only update if not previously initialized
+      const priorResources: ResourceCheckedSection[] = changes.resources.previousValue;
+      // only update if not previously initialized
+      if (!priorResources
+        || priorResources.length === 0
+        || priorResources[0].itemList.length === 0
+        || priorResources[0].itemList.some(p => p.checked === null)) {
         this.snapshotResources = cloneDeep(this.resources);
         this.resetFilteredResources();
         this.updateLabel();


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Need to keep pushing updates through until _both_ the list of checked items _and_ the list of available projects have been populated from the back end, signaled by the `checked` property being changed from null to true or false.
Why this was a bit tricky is due to the fact that we must guard against _further_ updates after the first "complete" update so that, while the dropdown is open, its contents remain constant for the user. (How it could change comes from the periodic refresh (every 2 minutes) of projects.)

### :chains: Related Resources
PR #3810 Add sections to the policies dropdown

### :+1: Definition of Done
Upon opening team details or token details, whether through inter-page navigation or particularly through browser refresh, the project dropdown is correctly initialized (both the label while still closed and the contents once opened).

<img width="260" alt="image" src="https://user-images.githubusercontent.com/6817500/84297209-05929c00-ab02-11ea-9235-40effb626e80.png">

### :athletic_shoe: How to Build and Test the Change
 - Rebuild automate-ui
 - Navigate to Settings >> Projects and create a couple projects if you have none
 - Navigate to Settings >> Teams or Settings >> Tokens
 - Assign one or more projects to your team (token). You may use an existing one or create a new one.
 - From the list view, open the details for your target team (token).
 - Observe that the previously saved projects are correctly rendered.
 - Refresh the browser page and observe they are still correctly rendered--this is primarily where the race condition occurred.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
