### PR TITLE
ensure nodes returned match filter status when in "deep filtering" mode

### DIFF
--- a/components/compliance-service/api/tests/02_deep_nodes_spec.rb
+++ b/components/compliance-service/api/tests/02_deep_nodes_spec.rb
@@ -70,7 +70,7 @@ describe File.basename(__FILE__) do
     }.to_json
     assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
 
-    # Test filter by profile_id, one node back  CONTROL!
+    # Test filter by profile_id, control - four nodes back
     actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
         Reporting::ListFilter.new(type: 'profile_id', values: ['09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988']),
         Reporting::ListFilter.new(type: "control", values: ["nginx-04"]),
@@ -255,6 +255,30 @@ describe File.basename(__FILE__) do
             "totalPassed"=>1
         }.to_json
     assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
+
+    # Test filter by profile_id, passed status filter: expect 0 nodes
+    actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'profile_id', values: ['41a02784bfea15592ba2748d55927d8d1f9da205816ef18d3bb2ebe4c5ce18a9']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'status', values: ['passed'])
+    ])
+    expected_nodes =
+        {
+            "total" => 5,
+            "totalFailed"=>1,
+            "totalSkipped"=>4
+        }.to_json
+
+    assert_equal_json_sorted(expected_nodes, actual_nodes.to_json)
+
+    # Test filter by profile_id, failed status filter: expect 1 node
+    actual_nodes = GRPC reporting, :list_nodes, Reporting::Query.new(filters: [
+        Reporting::ListFilter.new(type: 'profile_id', values: ['41a02784bfea15592ba2748d55927d8d1f9da205816ef18d3bb2ebe4c5ce18a9']),
+        Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+        Reporting::ListFilter.new(type: 'status', values: ['failed'])
+    ])
+
+    assert_equal(1, actual_nodes['nodes'].length)
 
     # Test filter by profile_id and waived control
     # TODO: CONFIRM WITH THE TEAM BECAUSE AT THE MOMENT latestReport and node status is deep, where profiles array(inc status) is shallow

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -173,12 +173,8 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 					// we are filtering by a profile or profile + control (deep filtering).
 					// so here we ensure we only add the node to the list object if the status matches the
 					// requested status.
-					if len(filters["status"]) == 0 {
+					if len(filters["status"]) == 0 || contains(filters["status"], latestReport.Status) {
 						nodes = append(nodes, &node)
-					} else {
-						if contains(filters["status"], latestReport.Status) {
-							nodes = append(nodes, &node)
-						}
 					}
 				} else {
 					return nil, emptyTotals, errors.Wrapf(err, "%s unmarshal error: ", myName)

--- a/components/compliance-service/reporting/relaxting/nodes.go
+++ b/components/compliance-service/reporting/relaxting/nodes.go
@@ -168,7 +168,18 @@ func (backend *ES2Backend) GetNodes(from int32, size int32, filters map[string][
 
 					latestReport.Controls = convertToRSControlSummary(nodeControlSummary)
 					latestReport.Status = status
-					nodes = append(nodes, &node)
+
+					// status is assigned after we've retrieved the nodes from es in the case where
+					// we are filtering by a profile or profile + control (deep filtering).
+					// so here we ensure we only add the node to the list object if the status matches the
+					// requested status.
+					if len(filters["status"]) == 0 {
+						nodes = append(nodes, &node)
+					} else {
+						if contains(filters["status"], latestReport.Status) {
+							nodes = append(nodes, &node)
+						}
+					}
 				} else {
 					return nil, emptyTotals, errors.Wrapf(err, "%s unmarshal error: ", myName)
 				}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

this was first reported by a customer, conveyed to the team via slack (https://chefio.slack.com/archives/CARK1CBNX/p1591285512151700)
can also see it in acceptance, 
navigate to: https://a2-local-inplace-upgrade-acceptance.cd.chef.co/compliance/reports/nodes?profile_id=1adea07f55a844017c8da6ce7055a93418646bd0eb9040cef38fefd5e11b94d2&control_id=au-export&status=failed

click on failed nodes, see the list of not-failed-nodes there

### :chains: Related Resources
none

### :+1: Definition of Done
nodes in the node list match the requested status filter

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
load a bunch of inspec scans
(load_compliance_reports, load_compliance_scans, chef_load_compliance_nodes)
go to compliance - reports - controls list
pick a control that has results across at least two statuses
filter by that control
go to the compliance - reports - nodes list and ensure filtering is correct

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [n/a] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
