### PR TITLE
automate-ui/role-details: pretty role JSON in "Copy Definition"

### DIFF
--- a/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
+++ b/components/automate-ui/src/app/modules/roles/details/role-details.component.ts
@@ -62,6 +62,6 @@ export class RoleDetailsComponent implements OnInit, OnDestroy {
   }
 
   public roleToString(role: Role): string {
-    return JSON.stringify(role);
+    return JSON.stringify(role, null, '  ');
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When copying the definition of a policy, the result is "pretty", i.e., contains
line breaks and indentation. This was done in #3551.

The Role's "Copy Definition" string wasn't adapted to this.


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

#3331 + #3551 

### :+1: Definition of Done

When clicking "Copy Definiton", the copied string is pretty, too.

### :athletic_shoe: How to Build and Test the Change

Rebuild the ui, go to a role's details page, click "Copy Definition".
Paste the result somewhere.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
