### PR TITLE
Cleanup abandoned a2 instances nightly

### DIFF
--- a/.expeditor/cleanup-abandoned-a2-instances.sh
+++ b/.expeditor/cleanup-abandoned-a2-instances.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+get_route53_hosted_zone_id() {
+  local dns_name
+  dns_name="$1"
+
+  aws --profile chef-cd route53 list-hosted-zones-by-name --output text --dns-name "$dns_name" --query "HostedZones[?Name == '$dns_name'].[Id]"
+}
+
+get_a2_route53_records() {
+  hosted_zone_id="$(get_route53_hosted_zone_id "cd.chef.co.")"
+
+  aws --profile chef-cd route53 list-resource-record-sets --hosted-zone-id "$hosted_zone_id" --output text --query "ResourceRecordSets[?starts_with(@.Name, 'a2-')].[ResourceRecords[]|[0].Value, Name]"
+}
+
+terminate_abandoned_a2_instances() {
+  while read -r ip record_name; do
+    hostname="${record_name%.}"
+
+    date="$(aws --profile chef-cd ec2 describe-instances --output text --no-paginate --query "Reservations[?Instances[?(Tags[?Key == 'Name'].Value|[0] == '$hostname') && (PrivateIpAddress == '$ip')]].[Instances|[0].LaunchTime]")"
+
+    get_a2_hostname_instances_launched_before_date "$date" | terminate_amazon_instances
+  done
+}
+
+get_a2_hostname_instances_launched_before_date() {
+  aws --profile chef-cd ec2 describe-instances --output text --no-paginate --query "Reservations[?Instances[?(Tags[?Key == 'Name'].Value|[0] == '$hostname') && (LaunchTime < '$date')]].[Instances|[0].InstanceId]"
+}
+
+terminate_amazon_instances() {
+  while read -r instance_id; do
+    terminate_amazon_instance "$instance_id"
+  done
+}
+
+terminate_amazon_instance() {
+  local instance_id
+  instance_id="$1"
+
+  if aws --profile chef-cd ec2 terminate-instances --instance-ids "$instance_id"; then
+    echo "Terminated amazon instance $instance_id"
+  else
+    echo "Failed to terminate amazon instance $instance_id"
+  fi
+}
+
+get_a2_route53_records | terminate_abandoned_a2_instances

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,6 +15,9 @@ schedules:
   - name: nightly_tests
     description: "Run nightly tests against development environment"
     cronline: "0 6 * * *"
+  - name: cleanup_abandoned_a2_instances
+    description: Cleanup abandoned a2instances
+    cronline: "0 1 * * *" # every day at 1am
 
 # These are our Buildkite pipelines where deploys take place
 pipelines:
@@ -180,3 +183,6 @@ subscriptions:
   - workload: docker_image_published:chefes/buildkite:*
     actions:
       - bash:.expeditor/update_docker_image_version_in_verify_pipeline.sh
+  - workload: schedule_triggered:{{agent_id}}:cleanup_abandoned_a2_instances:*
+    actions:
+      - bash:.expeditor/cleanup-abandoned-a2-instances.sh


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This just terminates any a2 fresh-install test instances from our dev/acceptance pipelines that can be left abandoned after a failed deploy.