### PR TITLE
Removing the automate-cds service from the automate product

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -25,8 +25,8 @@ steps:
             - HAB_NONINTERACTIVE=true
 
   #
-  # A2 products generation - Detect if the products.meta or package.meta files has been up without generating 
-  # meta files.
+  # A2 products generation - Detect if the products.meta or package.meta files has been update 
+  # without generating meta files.
   #
   - label: "[codegen] A2 products generation"
     command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -25,6 +25,25 @@ steps:
             - HAB_NONINTERACTIVE=true
 
   #
+  # A2 products generation - Detect if the products.meta or package.meta files has been up without generating 
+  # meta files.
+  #
+  - label: "[codegen] A2 products generation"
+    command:
+      - hab studio run "source .studiorc && verify_products_generation"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - HAB_STUDIO_SUP=false
+            - HAB_NONINTERACTIVE=true
+
+  #
   # Repo Health - These are tests that apply to the repository as a
   # whole.
   #

--- a/.studio/common
+++ b/.studio/common
@@ -179,6 +179,24 @@ function verify_all_protobuf_components() {
   go_component_make api lint unit
 }
 
+document "verify_products_generation" <<DOC
+  Verify that all products.meta and package.meta files have been compiled
+DOC
+function verify_products_generation() {
+  install_if_missing core/git git
+
+  deployment_generate || return $?
+
+  git add .
+  git diff --staged --exit-code --ignore-submodules=all
+  result=$?
+
+  if [ $result != 0 ]; then
+    echo "Run 'deployment_generate' to fix this problem"
+    return $result
+  fi
+}
+
 document "link_component_bin" <<DOC
   Link binaries from COMPONENT/cmd/* to /hab/bin
 DOC

--- a/components/automate-deployment/pkg/services/internal/generated/gen.go
+++ b/components/automate-deployment/pkg/services/internal/generated/gen.go
@@ -523,8 +523,7 @@ var ProductMetadataJSON = `
         "chef/infra-proxy-service",
         "chef/config-mgmt-service",
         "chef/data-feed-service",
-        "chef/event-gateway",
-        "chef/automate-cds"
+        "chef/event-gateway"
       ],
       "packages": null,
       "dependencies": [
@@ -541,7 +540,9 @@ var ProductMetadataJSON = `
       "name": "automate-dev",
       "aliases": null,
       "type": "product",
-      "services": [],
+      "services": [
+        "chef/automate-cds"
+      ],
       "packages": null,
       "dependencies": [
         "automate"

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -83,6 +83,7 @@ shared_buffers = "1GB"
     deployment_type = "local"
     manifest_cache_expiry = "0s"
     package_cleanup_mode = "disabled"
+    products = ["automate-dev"]
     [deployment.v1.svc.admin_user]
       # Default admin user settings
       username = "admin"

--- a/integration/tests/security.sh
+++ b/integration/tests/security.sh
@@ -13,7 +13,7 @@ do_deploy() {
         --manifest-dir "$test_manifest_path" \
         --admin-password chefautomate \
         --product workflow \
-        --product automate \
+        --product automate-dev \
         --product chef-server \
         --product builder \
         --accept-terms-and-mlsa \


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Removing the automate-cds service from the "automate" product. The automate-cds service as unintentionally added to the "automate" product by updating the products.meta file and not running the "deployment_generate" command. This is also adding a test so that does not happen again. 

### :+1: Definition of Done

The automate-cds service does not start on normally Automate installs. 

### :athletic_shoe: How to Build and Test the Change
1. Remove the `products = ["automate-dev"]` line from the dev/config.toml file. 
1. Run `start_all_services`
1. Ensure the automate-cds is not running. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
