### PR TITLE
experimental one node view: various fixes

### DIFF
--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -54,55 +54,58 @@
               <chef-td (click)="filterFor('name', node.name)"> {{ node.name }}</chef-td>
               <chef-td (click)="filterFor('platform_name', node.platform)">{{ node.platform }} {{ node.platform_version }}</chef-td>
               <chef-td (click)="filterFor('manager_type', node.manager)">{{ node.manager }}</chef-td>
-              <chef-td (click)="filterFor('last_contact', node.last_contact)">{{ node.last_contact }}</chef-td>
+              <chef-td (click)="filterFor('last_contact', node.last_contact)">{{ node.last_contact | datetime: DateTime.RFC2822 }}</chef-td>
               <chef-td>
-                <chef-icon [attr.id]="node.name" class="status-icon--pointer" [ngClass]="node.scan_data.status"
+                <chef-icon [attr.id]="'node-'+i+'-scan'" class="status-icon--pointer" [ngClass]="node.scan_data.status"
                 (click)="filterFor('last_scan_status', node.scan_data.status)">
                   {{ statusIcon(node.scan_data.status) }}
                 </chef-icon>
+                <chef-tooltip 
+                [attr.for]="'node-'+i+'-scan'"
+                [ngClass]="['run-info-tooltip', node.scan_data.status]"
+                interactable>
+                <p class="run-info-tooltip-info">
+                  <span class="run-info-tooltip-text">{{ node.scan_data.status | lowercase }}</span>
+                  <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                </p>
+                <a *ngIf="node.scan_data.id"
+                  class="run-info-tooltip-link"
+                  target="_blank"
+                  [routerLink]="['/compliance/reports/nodes', node.id]"
+                  >View InSpec Scan Details <chef-icon>open_in_new</chef-icon>
+                </a>
+                <small>previous status: {{node.scan_data.penultimate_status | lowercase }}</small>
+                </chef-tooltip>
                 <chef-icon class="status-icon" [ngClass]="node.scan_data.penultimate_status"
                 (click)="filterFor('last_scan_penultimate_status', node.scan_data.penultimate_status)">
                   {{ statusIcon(node.scan_data.penultimate_status) }}
                 </chef-icon> 
-                <chef-tooltip 
-                  [attr.for]="node.name"
-                  [ngClass]="['run-info-tooltip', node.scan_data.status]"
-                  interactable>
-                  <p class="run-info-tooltip-info">
-                    <span class="run-info-tooltip-text">{{ node.scan_data.status | titlecase }}</span>
-                    <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>
-                  </p>
-                  <a *ngIf="node.scan_data.id"
-                    class="run-info-tooltip-link"
-                    target="_blank"
-                    [routerLink]="['/compliance/reports/nodes', node.id]"
-                    >View InSpec Scan Details <chef-icon>open_in_new</chef-icon>
-                  </a>
-                </chef-tooltip>
               </chef-td>
               <chef-td>
-                <chef-icon class="status-icon" [ngClass]="node.run_data.status"
+                <chef-icon [attr.id]="'node-'+i+'-run'" class="status-icon--pointer" [ngClass]="node.run_data.status"
                 (click)="filterFor('last_run_status', node.run_data.status)">
                   {{ statusIcon(node.run_data.status) }}
                 </chef-icon>
+                <chef-tooltip 
+                [attr.for]="'node-'+i+'-run'"
+                [ngClass]="['run-info-tooltip', node.run_data.status]"
+                interactable>
+                <p class="run-info-tooltip-info">
+                  <span class="run-info-tooltip-text">{{ node.run_data.status | lowercase }}</span>
+                  <span class="run-info-tooltip-date">{{ node.run_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                </p>
+                <a *ngIf="node.run_data.id"
+                  class="run-info-tooltip-link"
+                  target="_blank"
+                  [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]"
+                  >View Infra Run Details <chef-icon>open_in_new</chef-icon>
+                </a>
+                <small>previous status: {{node.run_data.penultimate_status | lowercase }}</small>
+                </chef-tooltip>
                 <chef-icon class="status-icon" [ngClass]="node.run_data.penultimate_status"
                 (click)="filterFor('last_run_penultimate_status', node.run_data.penultimate_status)">
                   {{ statusIcon(node.run_data.penultimate_status) }}
                 </chef-icon> 
-                <chef-tooltip
-                [ngClass]="['run-info-tooltip', node.run_data.status]"
-                interactable>
-                  <p class="run-info-tooltip-info">
-                    <span class="run-info-tooltip-text">{{ node.run_data.status | titlecase }}</span>
-                    <span class="run-info-tooltip-date">{{ node.run_data.end_time | datetime: DateTime.RFC2822 }}</span>
-                  </p>
-                  <a *ngIf="node.run_data.id"
-                    class="run-info-tooltip-link"
-                    target="_blank"
-                    [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]"
-                    >View Infra Run Details <chef-icon>open_in_new</chef-icon>
-                  </a>
-                </chef-tooltip>
               </chef-td>    
               <chef-td (click)="filterFor('state', node.state)">{{ node.state }}</chef-td>
               <chef-td>{{ displayNodeTags(node.tags) }}</chef-td>

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -64,10 +64,20 @@
                 (click)="filterFor('last_scan_penultimate_status', node.scan_data.penultimate_status)">
                   {{ statusIcon(node.scan_data.penultimate_status) }}
                 </chef-icon> 
-                <chef-tooltip >
-                  <p>Scan Data:</p>
-                  <a [routerLink]="['/compliance/reports/nodes', node.id]">{{node.scan_data.end_time}</a>
-                </chef-tooltip>  
+                <chef-tooltip
+                [ngClass]="['run-info-tooltip', node.scan_data.status]"
+                interactable>
+                  <p class="run-info-tooltip-info">
+                    <span class="run-info-tooltip-text">{{ node.scan_data.status | titlecase }}</span>
+                    <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                  </p>
+                  <a *ngIf="node.scan_data.id"
+                    class="run-info-tooltip-link"
+                    target="_blank"
+                    [routerLink]="['/compliance/reports/nodes', node.id]"
+                    >View InSpec Scan Details <chef-icon>open_in_new</chef-icon>
+                  </a>
+                </chef-tooltip>
               </chef-td>
               <chef-td>
                 <chef-icon class="status-icon" [ngClass]="node.run_data.status"
@@ -78,10 +88,20 @@
                 (click)="filterFor('last_run_penultimate_status', node.run_data.penultimate_status)">
                   {{ statusIcon(node.run_data.penultimate_status) }}
                 </chef-icon> 
-                <chef-tooltip>
-                  <p>Run Data:</p>
-                  <a [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]">{{node.run_data.end_time}</a>
-                </chef-tooltip>  
+                <chef-tooltip
+                [ngClass]="['run-info-tooltip', node.run_data.status]"
+                interactable>
+                  <p class="run-info-tooltip-info">
+                    <span class="run-info-tooltip-text">{{ node.run_data.status | titlecase }}</span>
+                    <span class="run-info-tooltip-date">{{ node.run_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                  </p>
+                  <a *ngIf="node.run_data.id"
+                    class="run-info-tooltip-link"
+                    target="_blank"
+                    [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]"
+                    >View Infra Run Details <chef-icon>open_in_new</chef-icon>
+                  </a>
+                </chef-tooltip>
               </chef-td>    
               <chef-td (click)="filterFor('state', node.state)">{{ node.state }}</chef-td>
               <chef-td>{{ displayNodeTags(node.tags) }}</chef-td>

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -55,57 +55,57 @@
               <chef-td (click)="filterFor('platform_name', node.platform)">{{ node.platform }} {{ node.platform_version }}</chef-td>
               <chef-td (click)="filterFor('manager_type', node.manager)">{{ node.manager }}</chef-td>
               <chef-td (click)="filterFor('last_contact', node.last_contact)">{{ node.last_contact | datetime: DateTime.RFC2822 }}</chef-td>
-              <chef-td>
-                <chef-icon [attr.id]="'node-'+i+'-scan'" class="status-icon--pointer" [ngClass]="node.scan_data.status"
+              <chef-td [attr.id]="'node-'+i+'-scan'" class="pointer">
+                <chef-icon class="status-icon" [ngClass]="node.scan_data.status"
                 (click)="filterFor('last_scan_status', node.scan_data.status)">
                   {{ statusIcon(node.scan_data.status) }}
                 </chef-icon>
-                <chef-tooltip 
-                [attr.for]="'node-'+i+'-scan'"
-                [ngClass]="['run-info-tooltip', node.scan_data.status]"
-                interactable>
-                <p class="run-info-tooltip-info">
-                  <span class="run-info-tooltip-text">{{ node.scan_data.status | lowercase }}</span>
-                  <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>
-                </p>
-                <a *ngIf="node.scan_data.id"
-                  class="run-info-tooltip-link"
-                  target="_blank"
-                  [routerLink]="['/compliance/reports/nodes', node.id]"
-                  >View InSpec Scan Details <chef-icon>open_in_new</chef-icon>
-                </a>
-                <small>previous status: {{node.scan_data.penultimate_status | lowercase }}</small>
-                </chef-tooltip>
                 <chef-icon class="status-icon" [ngClass]="node.scan_data.penultimate_status"
                 (click)="filterFor('last_scan_penultimate_status', node.scan_data.penultimate_status)">
                   {{ statusIcon(node.scan_data.penultimate_status) }}
                 </chef-icon> 
+                <chef-tooltip 
+                  [attr.for]="'node-'+i+'-scan'"
+                  [ngClass]="['run-info-tooltip', node.scan_data.status]"
+                  interactable>
+                  <p class="run-info-tooltip-info">
+                    <span class="run-info-tooltip-text">{{ node.scan_data.status | lowercase }}</span>
+                    <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                  </p>
+                  <a *ngIf="node.scan_data.id"
+                    class="run-info-tooltip-link"
+                    target="_blank"
+                    [routerLink]="['/compliance/reports/nodes', node.id]"
+                    >View InSpec Scan Details <chef-icon>open_in_new</chef-icon>
+                  </a>
+                  <small>previous status: {{node.scan_data.penultimate_status | lowercase }}</small>
+                </chef-tooltip>
               </chef-td>
-              <chef-td>
-                <chef-icon [attr.id]="'node-'+i+'-run'" class="status-icon--pointer" [ngClass]="node.run_data.status"
+              <chef-td [attr.id]="'node-'+i+'-run'" class="pointer">
+                <chef-icon class="status-icon" [ngClass]="node.run_data.status"
                 (click)="filterFor('last_run_status', node.run_data.status)">
                   {{ statusIcon(node.run_data.status) }}
                 </chef-icon>
-                <chef-tooltip 
-                [attr.for]="'node-'+i+'-run'"
-                [ngClass]="['run-info-tooltip', node.run_data.status]"
-                interactable>
-                <p class="run-info-tooltip-info">
-                  <span class="run-info-tooltip-text">{{ node.run_data.status | lowercase }}</span>
-                  <span class="run-info-tooltip-date">{{ node.run_data.end_time | datetime: DateTime.RFC2822 }}</span>
-                </p>
-                <a *ngIf="node.run_data.id"
-                  class="run-info-tooltip-link"
-                  target="_blank"
-                  [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]"
-                  >View Infra Run Details <chef-icon>open_in_new</chef-icon>
-                </a>
-                <small>previous status: {{node.run_data.penultimate_status | lowercase }}</small>
-                </chef-tooltip>
                 <chef-icon class="status-icon" [ngClass]="node.run_data.penultimate_status"
                 (click)="filterFor('last_run_penultimate_status', node.run_data.penultimate_status)">
                   {{ statusIcon(node.run_data.penultimate_status) }}
                 </chef-icon> 
+                <chef-tooltip 
+                  [attr.for]="'node-'+i+'-run'"
+                  [ngClass]="['run-info-tooltip', node.run_data.status]"
+                  interactable>
+                  <p class="run-info-tooltip-info">
+                    <span class="run-info-tooltip-text">{{ node.run_data.status | lowercase }}</span>
+                    <span class="run-info-tooltip-date">{{ node.run_data.end_time | datetime: DateTime.RFC2822 }}</span>
+                  </p>
+                  <a *ngIf="node.run_data.id"
+                    class="run-info-tooltip-link"
+                    target="_blank"
+                    [routerLink]="['/infrastructure/client-runs', node.id, 'runs', node.run_data.id]"
+                    >View Infra Run Details <chef-icon>open_in_new</chef-icon>
+                  </a>
+                  <small>previous status: {{node.run_data.penultimate_status | lowercase }}</small>
+                </chef-tooltip>
               </chef-td>    
               <chef-td (click)="filterFor('state', node.state)">{{ node.state }}</chef-td>
               <chef-td>{{ displayNodeTags(node.tags) }}</chef-td>

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -56,7 +56,7 @@
               <chef-td (click)="filterFor('manager_type', node.manager)">{{ node.manager }}</chef-td>
               <chef-td (click)="filterFor('last_contact', node.last_contact)">{{ node.last_contact }}</chef-td>
               <chef-td>
-                <chef-icon class="status-icon" [ngClass]="node.scan_data.status"
+                <chef-icon [attr.id]="node.name" class="status-icon--pointer" [ngClass]="node.scan_data.status"
                 (click)="filterFor('last_scan_status', node.scan_data.status)">
                   {{ statusIcon(node.scan_data.status) }}
                 </chef-icon>
@@ -64,9 +64,10 @@
                 (click)="filterFor('last_scan_penultimate_status', node.scan_data.penultimate_status)">
                   {{ statusIcon(node.scan_data.penultimate_status) }}
                 </chef-icon> 
-                <chef-tooltip
-                [ngClass]="['run-info-tooltip', node.scan_data.status]"
-                interactable>
+                <chef-tooltip 
+                  [attr.for]="node.name"
+                  [ngClass]="['run-info-tooltip', node.scan_data.status]"
+                  interactable>
                   <p class="run-info-tooltip-info">
                     <span class="run-info-tooltip-text">{{ node.scan_data.status | titlecase }}</span>
                     <span class="run-info-tooltip-date">{{ node.scan_data.end_time | datetime: DateTime.RFC2822 }}</span>

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.html
@@ -55,7 +55,7 @@
               <chef-td (click)="filterFor('platform_name', node.platform)">{{ node.platform }} {{ node.platform_version }}</chef-td>
               <chef-td (click)="filterFor('manager_type', node.manager)">{{ node.manager }}</chef-td>
               <chef-td (click)="filterFor('last_contact', node.last_contact)">{{ node.last_contact | datetime: DateTime.RFC2822 }}</chef-td>
-              <chef-td [attr.id]="'node-'+i+'-scan'" class="pointer">
+              <chef-td [attr.id]="'node-'+i+'-scan'" class="help-pointer">
                 <chef-icon class="status-icon" [ngClass]="node.scan_data.status"
                 (click)="filterFor('last_scan_status', node.scan_data.status)">
                   {{ statusIcon(node.scan_data.status) }}
@@ -81,7 +81,7 @@
                   <small>previous status: {{node.scan_data.penultimate_status | lowercase }}</small>
                 </chef-tooltip>
               </chef-td>
-              <chef-td [attr.id]="'node-'+i+'-run'" class="pointer">
+              <chef-td [attr.id]="'node-'+i+'-run'" class="help-pointer">
                 <chef-icon class="status-icon" [ngClass]="node.run_data.status"
                 (click)="filterFor('last_run_status', node.run_data.status)">
                   {{ statusIcon(node.run_data.status) }}

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -4,7 +4,7 @@
 chef-td {
   font-size: 80%;
 
-  &.pointer {
+  &.help-pointer {
     cursor: help;
   }
 }

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -66,8 +66,13 @@ chef-icon.SKIPPED {
     color: inherit;
   }
 }
+.run-info-tooltip-text {
+  display: block;
+  font-weight: 700;
+  padding-bottom: 3px;
+}
 
-.run-info-tooltip.missing {
+.run-info-tooltip.UNKNOWN {
   .run-info-tooltip-date,
   .run-info-tooltip-link {
     display: none;

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -66,6 +66,7 @@ chef-icon.SKIPPED {
     color: inherit;
   }
 }
+
 .run-info-tooltip-text {
   display: block;
   font-weight: 700;

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -3,6 +3,10 @@
 
 chef-td {
   font-size: 80%;
+
+  &.pointer {
+    cursor: help;
+  }
 }
 
 chef-tr {
@@ -23,13 +27,6 @@ chef-icon.UNKNOWN {
 
 chef-icon.SKIPPED {
   color: $chef-dark-grey;
-}
-
-.status-icon {
-
-  &--pointer {
-    cursor: pointer;
-  }
 }
 
 .run-info-tooltip {

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -25,13 +25,17 @@ chef-icon.SKIPPED {
   color: $chef-dark-grey;
 }
 
+.status-icon {
+
+  &--pointer {
+    cursor: pointer;
+  }
+}
+
 .run-info-tooltip {
   border-left: $spacing-03 solid;
   border-right: $spacing-03 solid transparent;
   padding-right: $spacing-03;
-  bottom: 100%;
-  left: 50%;
-  margin-left: -60px; 
 
   &.FAILED {
     border-left-color: $status-error;
@@ -43,10 +47,6 @@ chef-icon.SKIPPED {
 
   &.UKNOWN, &.SKIPPED {
     border-left-color: $status-unknown;
-  }
-  &.hydrated { 
-    visibility: visible;
-    opacity: 1;
   }
 }
 

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -1,4 +1,5 @@
 @import "~styles/variables";
+@import "@carbon/layout/scss/layout";
 
 chef-td {
   font-size: 80%;
@@ -24,6 +25,51 @@ chef-icon.SKIPPED {
   color: $chef-dark-grey;
 }
 
-chef-tooltip {
-  width: 400px;
+.run-info-tooltip {
+  border-left: $spacing-03 solid;
+  border-right: $spacing-03 solid transparent;
+  padding-right: $spacing-03;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -60px; 
+
+  &.FAILED {
+    border-left-color: $status-error;
+  }
+
+  &.PASSED {
+    border-left-color: $status-success;
+  }
+
+  &.UKNOWN, &.SKIPPED {
+    border-left-color: $status-unknown;
+  }
+  &.hydrated { 
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
+.run-info-tooltip-link {
+  display: block;
+  margin-top: $spacing-05;
+}
+
+.run-info-tooltip-info,
+.run-info-tooltip-link {
+  margin: 0;
+  font-size: 14px;
+  white-space: nowrap;
+
+  chef-icon {
+    margin-left: $spacing-03;
+    color: inherit;
+  }
+}
+
+.run-info-tooltip.missing {
+  .run-info-tooltip-date,
+  .run-info-tooltip-link {
+    display: none;
+  }
 }

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.scss
@@ -31,8 +31,6 @@ chef-icon.SKIPPED {
 
 .run-info-tooltip {
   border-left: $spacing-03 solid;
-  border-right: $spacing-03 solid transparent;
-  padding-right: $spacing-03;
 
   &.FAILED {
     border-left-color: $status-error;

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -22,8 +22,8 @@ export class NodesListComponent implements OnInit, OnDestroy {
   ) { }
 
   nodesList;
-  nodesListSort;
-  nodesListSortOrder;
+  nodesListSort = 'last_contact';
+  nodesListSortOrder = 'DESC';
   nodesListFilters = [];
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
 

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -81,13 +81,11 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   filterFor(type: string, item: string): void {
     if (type === 'last_contact') {
-      const baseTime = item.split('T');
       // for a last contact filter, we send in two dates - beg of day and end of day
-      // so we split on T to get the date and then just add the times ourselves
       this.nodesListFilters.push({key: type,
         values: [
-          baseTime[0] + 'T00:00:00Z',
-          baseTime[0] + 'T23:59:59Z'
+          moment(item).startOf('day').toISOString(),
+          moment(item).endOf('day').toISOString()
         ]
       });
     } else {

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -80,7 +80,18 @@ export class NodesListComponent implements OnInit, OnDestroy {
   }
 
   filterFor(type: string, item: string): void {
-    this.nodesListFilters.push({key: type, values: [item]});
+    if (type === 'last_contact') {
+      const baseTime = moment(item).format(DateTime.REPORT_DATE);
+      // for a last contact filter, we send in two dates - beg of day and end of day
+      this.nodesListFilters.push({key: type, 
+        values: [
+          baseTime+'T00:00:00Z', 
+          baseTime+'T23:59:59Z'
+        ]
+      });
+    } else {
+      this.nodesListFilters.push({key: type, values: [item]});
+    }
     const params = {
       page: 1, per_page: 100,
       sort: this.nodesListSort, order: this.nodesListSortOrder,
@@ -93,9 +104,9 @@ export class NodesListComponent implements OnInit, OnDestroy {
     this.nodesListFilters.forEach((filter) => {
       filter.values.forEach((val) => {
         if (filter.exclude) {
-        filters.push(filter.key + ':' + val + ':negated=true');
+        filters.push(filter.key + '::' + val + '::negated=true');
         } else {
-          filters.push(filter.key + ':' + val + ':negated=false');
+          filters.push(filter.key + '::' + val + '::negated=false');
         }
       });
     });
@@ -106,7 +117,7 @@ export class NodesListComponent implements OnInit, OnDestroy {
   }
 
   isMatchingFilter(stringFilter: string): {filter: {key, values}} {
-    const arr = stringFilter.split(':');
+    const arr = stringFilter.split('::');
     for (let i = 0 ; i < this.nodesListFilters.length; i++) {
       if (this.nodesListFilters[i].key === arr[0]) {
         for (let j = 0 ; j < this.nodesListFilters[i].values.length; j++) {

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -21,6 +21,7 @@ export class NodesListComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>
   ) { }
 
+  public DateTime = DateTime;
   nodesList;
   nodesListSort = 'last_contact';
   nodesListSortOrder = 'DESC';

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -84,10 +84,10 @@ export class NodesListComponent implements OnInit, OnDestroy {
       const baseTime = item.split('T');
       // for a last contact filter, we send in two dates - beg of day and end of day
       // so we split on T to get the date and then just add the times ourselves
-      this.nodesListFilters.push({key: type, 
+      this.nodesListFilters.push({key: type,
         values: [
-          baseTime[0]+'T00:00:00Z', 
-          baseTime[0]+'T23:59:59Z'
+          baseTime[0] + 'T00:00:00Z',
+          baseTime[0] + 'T23:59:59Z'
         ]
       });
     } else {

--- a/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
+++ b/components/automate-ui/src/app/modules/nodes/nodes-list/nodes-list.component.ts
@@ -81,12 +81,13 @@ export class NodesListComponent implements OnInit, OnDestroy {
 
   filterFor(type: string, item: string): void {
     if (type === 'last_contact') {
-      const baseTime = moment(item).format(DateTime.REPORT_DATE);
+      const baseTime = item.split('T');
       // for a last contact filter, we send in two dates - beg of day and end of day
+      // so we split on T to get the date and then just add the times ourselves
       this.nodesListFilters.push({key: type, 
         values: [
-          baseTime+'T00:00:00Z', 
-          baseTime+'T23:59:59Z'
+          baseTime[0]+'T00:00:00Z', 
+          baseTime[0]+'T23:59:59Z'
         ]
       });
     } else {

--- a/components/nodemanager-service/pgdb/nodes.go
+++ b/components/nodemanager-service/pgdb/nodes.go
@@ -665,7 +665,7 @@ func validateNodeFilters(filters []*common.Filter) error {
 		case "state":
 			for _, item := range filter.Values {
 				if !isValidState(item) {
-					return &errorutils.InvalidError{Msg: fmt.Sprintf("Invalid state filter: %s. state must be one of the following: 'RUNNING', 'STOPPED', 'TERMINATED'", item)}
+					return &errorutils.InvalidError{Msg: fmt.Sprintf("Invalid state filter: %s. state must be one of the following: 'RUNNING', 'STOPPED', 'TERMINATED', 'MISSING'", item)}
 				}
 			}
 		case "statechange_timerange":
@@ -711,7 +711,7 @@ func isValidState(item string) bool {
 		return true // this covers the empty string case
 	}
 	switch item {
-	case "STOPPED", "RUNNING", "TERMINATED":
+	case "STOPPED", "RUNNING", "TERMINATED", "MISSING":
 		return true
 	default:
 		return false


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

- set default sort on page load to be last contact, desc
- added tooltip (with help from @SEAjamieD, thank you!) to the infra and inspec run status hover
- fixed up the filtering logic in the ui code to handle daterange filters
- added "missing" as valid node state filter value

### :+1: Definition of Done
nodes page is sorted by last contact, desc on initial page load
tooltip on status that links to client run/inspec scan details
handle timerange filters in the ui code

### :athletic_shoe: How to Build and Test the Change
rebuild nodemanager-service and ui
load_compliance_reports
go to a2-dev.test/nodes
check the sorting (last contact, desc)
try to filter by a time in last contact, expect it to return all nodes that had a last contact on that day
hover over a run or scan status and see the tooltip, follow the link to client run or inspec scan details

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
