### PR TITLE
Reorganize backup and restore pages

### DIFF
--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -27,8 +27,7 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 
 ## Backup to a Filesystem
 
-One backup option is to store backups in a configurable backup directory.
-The backup directory should be on network-attached storage or synced periodically to a disk on another machine.
+To store backups in a configurable backup directory, the backup directory should be on network-attached storage or synced periodically to a disk on another machine.
 This best practice ensures that you can restore from your backup data during a hardware failure.
 
 The default backup directory is `/var/opt/chef-automate/backups`. If it does not exist, the deployment process creates it.
@@ -56,7 +55,7 @@ To store backups offline in single-file archives, single-file archives must incl
 
 The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
 
-A timestamp-based directory has a date-based name, such as such as `20180518010336`, in the `automate-elasticsearch-data` directory.
+A timestamp-based directory has a date-based name, such as `20180518010336`, in the `automate-elasticsearch-data` directory.
 
 To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings.
 
@@ -149,7 +148,7 @@ The output shows the backup progress for each service. A successful backup displ
 Success: Created backup 20180518010336
 ```
 
-Incorrect directory permissions may cause filesystem backups to fail.
+Restores from a filesystem backup may fail with incorrect directory permissions.
 Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -16,9 +16,7 @@ The `chef-automate backup create` command creates a single backup that contains 
 By default, Chef Automate stores backups to the filesystem in the directory `/var/opt/chef-automate/backups`.
 You can also configure Chef Automate to store backups in Amazon S3 buckets.
 
-## Setting Up Backups
-
-### Backup Space Requirements
+## Backup Space Requirements
 
 This amount of space needed for a backup varies depending on your Chef Automate use. You need enough free space for:
 
@@ -27,7 +25,7 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 * Elasticsearch snapshots of your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot.
 * Chef Habitat Builder artifacts
 
-### Backup to a Filesystem
+## Backup to a Filesystem
 
 One backup option is to store backups in a configurable backup directory.
 The backup directory should be on network-attached storage or synced periodically to a disk on another machine.
@@ -50,26 +48,21 @@ To configure your Chef Automate installation's backup directory to another locat
     chef-automate config patch backup_config.toml
     ```
 
-    After applying your configuration, the `backup_config.toml` file is no longer necessary, and its removal can occur.
+    Remove the `backup_config.toml` file after applying your configuration, as it is no longer necessary.
 
-#### Store a Filesystem Backup in a Single-file Archive
+### Store a Filesystem Backup in a Single-file Archive
 
-Some users prefer to store backups offline in single-file archives.
-Such archives must include both the configuration data and the reporting data contained in the standard backup.
+To store backups offline in single-file archives, single-file archives must include both the configuration data and the reporting data contained in the standard backup.
 
-The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory.
-You must archive both of these directory types in any single-file backups you create.
+The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
 
-A timestamp-based directory distinguishes itself in the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
+A timestamp-based directory has a date-based name, such as such as `20180518010336`, in the `automate-elasticsearch-data` directory.
 
-Because externally-deployed Elasticsearch nodes lacks access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings.
-You can configure backups to use either the local filesystem or an Amazon S3 bucket.
+To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings.
 
-### Backup to S3
+## Backup to S3
 
-Another backup option is to store backups in an existing Amazon S3 bucket.
-
-Supported S3-related settings are below:
+To store backups in an existing Amazon S3 bucket, use the supported S3-related settings below:
 
 ```toml
 [global.v1.backups]
@@ -103,11 +96,11 @@ Supported S3-related settings are below:
   -----END CERTIFICATE-----
 ```
 
-#### S3 Permissions
+### S3 Permissions
 
-The following IAM policy describes the lowest permissions Chef Automate requires to run backup and restore operations.
+The following IAM policy describes the basic permissions Chef Automate requires to run backup and restore operations.
 
-```JSON
+```json
 {
   "Statement": [
     {
@@ -236,8 +229,7 @@ y
 Success: Backups deleted
 ```
 
-Chef Automate does not provide a mechanism to prune all but a certain number of the most recent backups.
-You can manage this manually by parsing the output of `chef-automate backup list` and applying the command `chef-automate backup delete`.
+To prune all but a certain number of the most recent backups manually, parsing the output of `chef-automate backup list` and applying the command `chef-automate backup delete`.
 For example:
 
 ```bash

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -11,7 +11,10 @@ toc = true
     weight = 70
 +++
 
-Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure. The command `chef-automate backup create` creates a single backup that contains data for all products deployed with Chef Automate, including [Chef Infra Server]({{< ref "infra-server.md" >}}) and [Chef Habitat Builder on-prem]({{< ref "on-prem-builder.md" >}}). By default, Chef Automate stores backups to the filesystem in the directory `/var/opt/chef-automate/backups`. You can also configure Chef Automate to store backups in S3.
+Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure.
+The `chef-automate backup create` command creates a single backup that contains data for all products deployed with Chef Automate, including [Chef Infra Server]({{< ref "infra-server.md" >}}) and [Chef Habitat Builder on-prem]({{< ref "on-prem-builder.md" >}}).
+By default, Chef Automate stores backups to the filesystem in the directory `/var/opt/chef-automate/backups`.
+You can also configure Chef Automate to store backups in Amazon S3 buckets.
 
 ## Setting Up Backups
 
@@ -26,13 +29,15 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 
 ### Backup to a Filesystem
 
-Backups can be stored in a configurable backup directory. The backup directory should be on network-attached storage or synced periodically to a disk on another machine, to ensure that you can restore from your backup data during a hardware failure.
+One backup option is to store backups in a configurable backup directory.
+The backup directory should be on network-attached storage or synced periodically to a disk on another machine.
+This best practice ensures that you can restore from your backup data during a hardware failure.
 
 The default backup directory is `/var/opt/chef-automate/backups`. If it does not exist, the deployment process creates it.
 
 To configure your Chef Automate installation's backup directory to another location:
 
-1. Create a `backup_config.toml` file in your current directory with the following content, replacing `/path/to/backups` with the path to your backup directory:
+1. Create a `backup_config.toml` file in your current directory with the following content. Replace `/path/to/backups` with the path to your backup directory:
 
     ```toml
     [global.v1.backups.filesystem]
@@ -45,26 +50,26 @@ To configure your Chef Automate installation's backup directory to another locat
     chef-automate config patch backup_config.toml
     ```
 
-    Once this command is applied, the `backup_config.toml` file is no longer necessary, and can be removed.
+    After applying your configuration, the `backup_config.toml` file is no longer necessary, and its removal can occur.
 
 #### Store a Filesystem Backup in a Single-file Archive
 
-Some users prefer to store backups offline in single-file archives. Such archives must
-include both the configuration data and the reporting data contained in the standard
-backup.
+Some users prefer to store backups offline in single-file archives.
+Such archives must include both the configuration data and the reporting data contained in the standard backup.
 
 The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration, and the reporting data stored in the `automate-elasticsearch-data` directory.
 You must archive both of these directory types in any single-file backups you create.
 
-A timestamp-based directory can be distinguished from the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
+A timestamp-based directory distinguishes itself in the `automate-elasticsearch-data` directory by its file name format, such as `20180518010336`.
 
-Because externally-deployed Elasticsearch nodes will not have access to Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
+Because externally-deployed Elasticsearch nodes lacks access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings.
+You can configure backups to use either the local filesystem or an Amazon S3 bucket.
 
 ### Backup to S3
 
-Backups can be stored in an existing S3 bucket.
+Another backup option is to store backups in an existing Amazon S3 bucket.
 
-The following settings are supported:
+Supported S3-related settings are below:
 
 ```toml
 [global.v1.backups]
@@ -145,14 +150,14 @@ Make a backup with the [`backup create`]({{< ref "cli-chef-automate/#chef-automa
 chef-automate backup create
 ```
 
-The command shows the backup progress for each service. A successful backup displays a success message containing the timestamp of the backup:
+The output shows the backup progress for each service. A successful backup displays a success message containing the timestamp of the backup:
 
 ```shell
 Success: Created backup 20180518010336
 ```
 
-Incorrect directory permissions may cause filesystem backups to fail. Run the
-[`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
+Incorrect directory permissions may cause filesystem backups to fail.
+Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell
 sudo chef-automate backup fix-repo-permissions <path>
@@ -188,7 +193,7 @@ Listing backups from local directory /var/opt/chef-automate/backups
 20180508201952    completed  8 minutes old
 ```
 
-For backups stored in an S3 bucket, use:
+For backups stored in an Amazon S3 bucket, use:
 
 ```shell
 chef-automate backup list s3://bucket_name/base_path
@@ -231,19 +236,22 @@ y
 Success: Backups deleted
 ```
 
-Chef Automate does not provide a mechanism to prune all but a certain number of the most recent backups. You can manage this manually by parsing the output of `chef-automate backup list` and applying the command `chef-automate backup delete`. For example:
+Chef Automate does not provide a mechanism to prune all but a certain number of the most recent backups.
+You can manage this manually by parsing the output of `chef-automate backup list` and applying the command `chef-automate backup delete`.
+For example:
 
 ```bash
 export KEEP=10; chef-automate backup list --result-json backup.json > /dev/null && jq "[.result.backups[].id] | sort | reverse | .[]" -rM backup.json | tail -n +$(($KEEP+1)) | xargs -L1 -i chef-automate backup delete --yes {}
 ```
 
 ## Troubleshooting
-Set the log level to `debug` before re-running a failed backup to output debug info to
-the Chef Automate log:
+
+Set the log level to `debug` before re-running a failed backup to output debug info to the Chef Automate log:
 
 ```shell
 chef-automate debug set-log-level deployment-service debug
 ```
 
 ## References
-[`chef-automate backup` command reference]({{< ref "cli-chef-automate/#chef-automate-backup" >}})
+
+See the [`chef-automate backup` command reference]({{< ref "cli-chef-automate/#chef-automate-backup" >}}).

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -20,9 +20,9 @@ You can also configure Chef Automate to store backups in Amazon S3 buckets.
 
 This amount of space needed for a backup varies depending on your Chef Automate use. You need enough free space for:
 
-* Complete copies of each Chef Automate service PostgreSQL database.
+* Complete copies of each Chef Automate service PostgreSQL database
 * Complete copies of your configuration files
-* Elasticsearch snapshots of your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot.
+* Elasticsearch snapshots of your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot
 * Chef Habitat Builder artifacts
 
 ## Backup to a Filesystem
@@ -41,13 +41,13 @@ To configure your Chef Automate installation's backup directory to another locat
       path = "/path/to/backups"
     ```
 
-2. Run the following command to apply your configuration:
+1. Run the following command to apply your configuration:
 
     ```shell
     chef-automate config patch backup_config.toml
     ```
 
-    Remove the `backup_config.toml` file after applying your configuration, as it is no longer necessary.
+1. Remove the now-redundant `backup_config.toml` file.
 
 ### Store a Filesystem Backup in a Single-file Archive
 
@@ -57,7 +57,7 @@ The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}
 
 A timestamp-based directory has a date-based name, such as `20180518010336`, in the `automate-elasticsearch-data` directory.
 
-To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings.
+To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must [configure Elasticsearch backup]({{< relref "install.md#configuring-external-elasticsearch" >}}) settings separately from Chef Automate's primary backup settings.
 
 ## Backup to S3
 
@@ -195,7 +195,7 @@ where `bucket_name` is the name of the S3 bucket and `base_path` is an optional 
 
 ### Delete Backups
 
-To delete backups from a running instance of Chef Automate, first find the relevant backup ID with `chef-automate backup list` and then delete it using [`chef automate backup delete ID`]({{< ref "cli-chef-automate/#chef-automate-backup-delete" >}}).
+To delete backups from a running instance of Chef Automate, first find the backup ID with `chef-automate backup list` and then delete the backup using [`chef automate backup delete ID`]({{< ref "cli-chef-automate/#chef-automate-backup-delete" >}}).
 
 ```shell
 chef-automate backup list
@@ -205,7 +205,7 @@ chef-automate backup list
 20181026184012    completed  15 seconds old
 ```
 
-You can delete a single backup with `chef-automate backup delete`:
+Delete a single backup with `chef-automate backup delete`:
 
 ```shell
 chef-automate backup delete 20181026183901
@@ -216,7 +216,7 @@ y
 Success: Backups deleted
 ```
 
-To delete multiple backups:
+To delete two or more backups, use `chef-automate backup delete` followed by the backup IDs:
 
 ```shell
 chef-automate backup delete 20181026183954 20181026184012
@@ -237,7 +237,7 @@ export KEEP=10; chef-automate backup list --result-json backup.json > /dev/null 
 
 ## Troubleshooting
 
-Set the log level to `debug` before re-running a failed backup to output debug info to the Chef Automate log:
+To debug a failed backup, set the log level to `debug` and re-run the backup. This outputs the debug information to the Chef Automate log:
 
 ```shell
 chef-automate debug set-log-level deployment-service debug

--- a/components/automate-chef-io/content/docs/install.md
+++ b/components/automate-chef-io/content/docs/install.md
@@ -10,7 +10,7 @@ toc = true
     weight = 30
 +++
 
-Before beginning your installation, check the [System Requirements]({{< relref "system-requirements.md" >}}) for Automate.
+Before beginning your installation, check the [System Requirements]({{< relref "system-requirements.md" >}}) for Chef Automate.
 
 See [Airgapped Installation]({{< relref "airgapped-installation.md" >}}) for installing Chef Automate to a host with no inbound or outbound internet traffic.
 
@@ -166,7 +166,7 @@ Add the following to your config.toml:
 #  ssl_verify_depth = "2"
 ```
 
-Because externally-deployed Elasticsearch nodes will not have access to Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
+Because externally-deployed Elasticsearch nodes will not have access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
 
 ##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
@@ -238,7 +238,7 @@ location = "s3"
 # protocol = "https"
 ```
 
-#### Configuring An External PostgreSQL Database
+#### Configuring an External PostgreSQL Database
 
 Add the following to your config.toml:
 

--- a/components/automate-chef-io/content/docs/install.md
+++ b/components/automate-chef-io/content/docs/install.md
@@ -170,12 +170,11 @@ Because externally-deployed Elasticsearch nodes will not have access to Automate
 
 ##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
-To configure local filesystem backups of Chef Automate data stored in an
-externally-deployed Elasticsearch cluster:
+To configure local filesystem backups of Chef Automate data stored in an externally-deployed Elasticsearch cluster:
 
 1. Ensure that the filesystems you intend to use for backups are mounted to the same path on all Elasticsearch master and data nodes.
-2. Configure the Elasticsearch `path.repo` setting on each node as described in the Elasticsearch documentation.
-3. Add the following to your config.toml:
+1. Configure the Elasticsearch `path.repo` setting on each node as described in the Elasticsearch documentation.
+1. Add the following to your config.toml:
 
 ```toml
 [global.v1.external.elasticsearch.backup]
@@ -190,13 +189,12 @@ path = "/var/opt/chef-automate/backups"
 
 ##### Backup Externally-Deployed Elasticsearch to S3
 
-To configure S3 backups of Chef Automate data stored in an externally-deployed
-Elasticsearch cluster:
+To configure S3 backups of Chef Automate data stored in an externally-deployed Elasticsearch cluster:
 
 1. Install the [`repository-s3` plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3.html) on all nodes in your Elasticsearch cluster.
-2. If you wish to use IAM authentication to provide your Elasticsearch nodes access to the S3 bucket, you must apply the appropriate IAM policy to each host system in the cluster.
-3. Configure each Elasticsearch node with a S3 client configuration containing the proper S3 endpoint, credentials, and other settings as [described in the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html).
-4. Enable S3 backups by adding the following settings to your config.toml:
+1. If you wish to use IAM authentication to provide your Elasticsearch nodes access to the S3 bucket, you must apply the appropriate IAM policy to each host system in the cluster.
+1. Configure each Elasticsearch node with a S3 client configuration containing the proper S3 endpoint, credentials, and other settings as [described in the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html).
+1. Enable S3 backups by adding the following settings to your config.toml:
 
 ```toml
 [global.v1.external.elasticsearch.backup]

--- a/components/automate-chef-io/content/docs/install.md
+++ b/components/automate-chef-io/content/docs/install.md
@@ -149,6 +149,8 @@ Add the following to your config.toml:
 # [global.v1.external.elasticsearch.auth]
 #   scheme = "basic_auth"
 # [global.v1.external.elasticsearch.auth.basic_auth]
+## Create this elasticsearch user before starting the Automate deployment;
+## Automate assumes it exists.
 #   username = "<admin username>"
 #   password = "<admin password>"
 # [global.v1.external.elasticsearch.ssl]
@@ -166,9 +168,10 @@ Add the following to your config.toml:
 
 Because externally-deployed Elasticsearch nodes will not have access to Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
 
-##### Backup to Local Filesystem
+##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
-To configure backups to use a local filesystem,
+To configure local filesystem backups of Chef Automate data stored in an
+externally-deployed Elasticsearch cluster:
 
 1. Ensure that the filesystems you intend to use for backups are mounted to the same path on all Elasticsearch master and data nodes.
 2. Configure the Elasticsearch `path.repo` setting on each node as described in the Elasticsearch documentation.
@@ -185,9 +188,10 @@ location = "fs"
 path = "/var/opt/chef-automate/backups"
 ```
 
-##### Backup to S3
+##### Backup Externally-Deployed Elasticsearch to S3
 
-To configure backups to use S3,
+To configure S3 backups of Chef Automate data stored in an externally-deployed
+Elasticsearch cluster:
 
 1. Install the [`repository-s3` plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3.html) on all nodes in your Elasticsearch cluster.
 2. If you wish to use IAM authentication to provide your Elasticsearch nodes access to the S3 bucket, you must apply the appropriate IAM policy to each host system in the cluster.
@@ -253,6 +257,8 @@ nodes = ["<pghostname1>:<port1>", "<pghostname2>:<port2>", "..."]
 [global.v1.external.postgresql.auth]
 scheme = "password"
 
+# Create these postgres users before starting the Automate deployment;
+# Automate assumes they already exist.
 [global.v1.external.postgresql.auth.password.superuser]
 username = "<admin username>"
 password = "<admin password>"

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -21,15 +21,14 @@ Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-fro
         curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate
     ```
 
-1. **Filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref
-"backup.md#backup-to-a-filesystem" >}}).
+1. **Filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 Ensure access for the backup type used:
 
-     1. To restore a network-attached filesystem backup, mount the shared backup directory to the same mount point configured at the time of the backup.
-     1. To restore a backup directory that is not a network-attached filesystem, copy the backup directory to the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}) at the time of the backup.
-     1. For restoring a single-file backup archive, copy your archive to the restore host and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}).
+     1. To restore [a network-attached filesystem backup]({{< ref "backup.md#backup-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
+     1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#backup-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
+     1. For restoring a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
 
-1. **(OPTIONAL)** To restore to a host with a different fully qualified domain name (FQDN) than that of the backup host, create a `patch.toml` file that specifies the new FQDN and provides it at restore time:
+1. If restoring to a host with a different fully qualified domain name (FQDN) than that of the backup host, then create a `patch.toml` file that specifies the new FQDN and provides it at restore time:
 
     ```toml
          [global.v1]
@@ -53,7 +52,7 @@ Ensure access for the backup type used:
 
 ## Restore From a Filesystem Backup
 
-Ensure to meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
+Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
 
 ### Restore in an Internet-Connected Environment
 
@@ -96,7 +95,7 @@ sudo chef-automate backup fix-repo-permissions <path>
 
 ## Restore From an S3 Backup
 
-Ensure to meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
+Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
 
 To restore from an S3 bucket backup, run:
 

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -21,12 +21,12 @@ Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-fro
         curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate
     ```
 
-1. **Filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
+1. To restore, **filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 Ensure access for the backup type used:
 
      1. To restore [a network-attached filesystem backup]({{< ref "backup.md#backup-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
      1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#backup-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
-     1. For restoring a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
+     1. To restore a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
 
 1. If restoring to a host with a different fully qualified domain name (FQDN) than that of the backup host, then create a `patch.toml` file that specifies the new FQDN and provides it at restore time:
 
@@ -66,7 +66,7 @@ chef-automate backup restore </path/to/backups/>BACKUP_ID [--patch-config </path
 Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
 Use the `--skip-preflight` option to restore to a host with a pre-existing Chef Automate installation.
 
-Incorrect directory permissions cause restore from a filesystem backup to fail.
+Restores from a filesystem backup may fail with incorrect directory permissions.
 Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell
@@ -86,7 +86,7 @@ chef-automate backup restore --airgap-bundle </path/to/bundle> </path/to/backups
 Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
 Use the `--skip-preflight` option to restore to a host with a pre-existing Chef Automate installation.
 
-Incorrect directory permissions cause restore from a filesystem backups to fail.
+Restores from a filesystem backup may fail with incorrect directory permissions.
 Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -1,0 +1,119 @@
++++
+title = "Restore"
+description = "Procedures for Restoring Chef Automate Data"
+date = 2018-03-26T15:27:52-07:00
+draft = false
+bref = ""
+toc = true
+[menu]
+  [menu.docs]
+    parent = "get_started"
+    weight = 70
++++
+
+Restore Chef Automate from a [fileystem backup]({{< ref "restore.md#restore-from-a-filesystem-backup" >}}) or an [s3 backup]({{< ref
+"restore.md#restore-from-an-s3-backup" >}}).
+
+## Prerequisites
+
+1. On the restore host, download and unzip the Chef Automate command-line tool:
+
+   ```shell
+        curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate
+    ```
+
+1. **Filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref
+"backup.md#backup-to-a-filesystem" >}}):
+
+     1. To restore a network-attached filesystem backup, mount the shared backup directory to the same mount point configured at the time of the backup.
+     1. To restore a backup directory that is not a network-attached filesystem, copy the backup directory to the location that was [configured]({{< ref
+"backup.md#backup-to-a-filesystem" >}}) at the time of the backup.
+     1. For restoring a single-file backup archive, copy your archive to the restore host and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}).
+
+1. **(different FQDN only)** To restore to a host whose FQDN differs from that of the host on which the backup was
+   taken, create a `patch.toml` file to provide at restore time that specifies the new FQDN:
+
+    ```toml
+         [global.v1]
+         fqdn = "<new-fqdn>"
+
+         # To provide a cert and key for the restore host, uncomment and fill
+         # these sections.
+         # [[global.v1.frontend_tls]]
+         # The TLS certificate for the load balancer frontend.
+         # cert = """-----BEGIN CERTIFICATE-----
+         # <certificate-for-new-fqdn>
+         # -----END CERTIFICATE-----
+         # """
+
+         # The TLS RSA key for the load balancer frontend.
+         # key = """-----BEGIN RSA PRIVATE KEY-----
+         # <key-for-new-fqdn>
+         # -----END RSA PRIVATE KEY-----
+         # """
+    ```
+
+## Restore From a Filesystem Backup
+See [prerequisites]({{< ref "restore.md#prerequisites" >}}).
+
+### Restore in an Internet-Connected Environment
+
+If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`) you must supply the backup directory. Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
+
+```shell
+chef-automate backup restore </path/to/backups/>BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
+```
+
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
+FQDN is different than that of the one on which the backup was taken. Use the `--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+
+Incorrect directory permissions cause restore from a filesystem backup to fail. Run the
+[`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
+
+```shell
+sudo chef-automate backup fix-repo-permissions <path>
+```
+
+### Restore in an Airgapped Environment
+
+To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation.
+If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
+
+```shell
+chef-automate backup restore --airgap-bundle </path/to/bundle> </path/to/backups/>BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
+```
+
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
+FQDN is different than that of the one on which the backup was taken. Use the `--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+
+Incorrect directory permissions cause restore from a filesystem backups to fail. Run the
+[`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
+
+```shell
+sudo chef-automate backup fix-repo-permissions <path>
+```
+
+
+## Restore From an S3 Backup
+See [prerequisites]({{< ref "restore.md#prerequisites" >}}).
+
+To restore from an S3 backup, run
+
+```shell
+chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
+```
+
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
+FQDN is different than that of the one on which the backup was taken. Use the
+`--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+
+## Troubleshooting
+Set the log level to `debug` before re-running a failed restore to output debug info to
+the Chef Automate log:
+
+```shell
+chef-automate debug set-log-level deployment-service debug
+```
+
+## References
+[`chef-automate backup restore` command reference]({{< ref "cli-chef-automate/#chef-automate-backup-restore" >}})

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -8,11 +8,10 @@ toc = true
 [menu]
   [menu.docs]
     parent = "get_started"
-    weight = 70
+    weight = 80
 +++
 
-Restore Chef Automate from a [fileystem backup]({{< ref "restore.md#restore-from-a-filesystem-backup" >}}) or an [s3 backup]({{< ref
-"restore.md#restore-from-an-s3-backup" >}}).
+Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-from-a-filesystem-backup" >}}) or an [Amazon S3 bucket backup]({{< ref "restore.md#restore-from-an-s3-backup" >}}).
 
 ## Prerequisites
 
@@ -23,15 +22,14 @@ Restore Chef Automate from a [fileystem backup]({{< ref "restore.md#restore-from
     ```
 
 1. **Filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref
-"backup.md#backup-to-a-filesystem" >}}):
+"backup.md#backup-to-a-filesystem" >}}).
+Ensure access for the backup type used:
 
      1. To restore a network-attached filesystem backup, mount the shared backup directory to the same mount point configured at the time of the backup.
-     1. To restore a backup directory that is not a network-attached filesystem, copy the backup directory to the location that was [configured]({{< ref
-"backup.md#backup-to-a-filesystem" >}}) at the time of the backup.
+     1. To restore a backup directory that is not a network-attached filesystem, copy the backup directory to the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}) at the time of the backup.
      1. For restoring a single-file backup archive, copy your archive to the restore host and extract it to the [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 
-1. **(different FQDN only)** To restore to a host whose FQDN differs from that of the host on which the backup was
-   taken, create a `patch.toml` file to provide at restore time that specifies the new FQDN:
+1. **(OPTIONAL)** To restore to a host with a different fully qualified domain name (FQDN) than that of the backup host, create a `patch.toml` file that specifies the new FQDN and provides it at restore time:
 
     ```toml
          [global.v1]
@@ -54,21 +52,23 @@ Restore Chef Automate from a [fileystem backup]({{< ref "restore.md#restore-from
     ```
 
 ## Restore From a Filesystem Backup
-See [prerequisites]({{< ref "restore.md#prerequisites" >}}).
+
+Ensure to meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
 
 ### Restore in an Internet-Connected Environment
 
-If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`) you must supply the backup directory. Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
+If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`), you must supply the backup directory.
+Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
 ```shell
 chef-automate backup restore </path/to/backups/>BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
-FQDN is different than that of the one on which the backup was taken. Use the `--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
+Use the `--skip-preflight` option to restore to a host with a pre-existing Chef Automate installation.
 
-Incorrect directory permissions cause restore from a filesystem backup to fail. Run the
-[`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
+Incorrect directory permissions cause restore from a filesystem backup to fail.
+Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell
 sudo chef-automate backup fix-repo-permissions <path>
@@ -77,43 +77,44 @@ sudo chef-automate backup fix-repo-permissions <path>
 ### Restore in an Airgapped Environment
 
 To restore a backup of an [airgapped installation]({{< relref "airgapped-installation.md" >}}), you must specify the [Airgap Installation Bundle]({{< relref "airgapped-installation.md#create-an-airgap-installation-bundle" >}}) used by the installation.
-If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory that is not default (`/var/opt/chef-automate/backups`) you must supply the backup directory; if you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
+If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory that is not the default `/var/opt/chef-automate/backups`, then you must supply the backup directory.
+If you do not provide a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
 ```shell
 chef-automate backup restore --airgap-bundle </path/to/bundle> </path/to/backups/>BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
-FQDN is different than that of the one on which the backup was taken. Use the `--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
+Use the `--skip-preflight` option to restore to a host with a pre-existing Chef Automate installation.
 
-Incorrect directory permissions cause restore from a filesystem backups to fail. Run the
-[`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
+Incorrect directory permissions cause restore from a filesystem backups to fail.
+Run the [`fix-repo-permissions` command]({{< ref "cli-chef-automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
 
 ```shell
 sudo chef-automate backup fix-repo-permissions <path>
 ```
 
-
 ## Restore From an S3 Backup
-See [prerequisites]({{< ref "restore.md#prerequisites" >}}).
 
-To restore from an S3 backup, run
+Ensure to meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
+
+To restore from an S3 bucket backup, run:
 
 ```shell
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID [--patch-config </path/to/patch.toml>] [--skip-preflight]
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host whose
-FQDN is different than that of the one on which the backup was taken. Use the
-`--skip-preflight` option to restore to a host on which a Chef Automate installation exists.
+Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
+Use the `--skip-preflight` option to restore to a host with a pre-existing Chef Automate installation.
 
 ## Troubleshooting
-Set the log level to `debug` before re-running a failed restore to output debug info to
-the Chef Automate log:
+
+Set the log level to `debug` before re-running a failed restore to output debug info to the Chef Automate log:
 
 ```shell
 chef-automate debug set-log-level deployment-service debug
 ```
 
 ## References
-[`chef-automate backup restore` command reference]({{< ref "cli-chef-automate/#chef-automate-backup-restore" >}})
+
+See the [`chef-automate backup restore` command reference]({{< ref "cli-chef-automate/#chef-automate-backup-restore" >}}).

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -21,14 +21,14 @@ Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-fro
         curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate
     ```
 
-1. To restore, **filesystem backups** require access for Chef Automate to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
+1. To restore from **filesystem backups**, Chef Automate requires access to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 Ensure access for the backup type used:
 
      1. To restore [a network-attached filesystem backup]({{< ref "backup.md#backup-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
      1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#backup-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
      1. To restore a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
 
-1. If restoring to a host with a different fully qualified domain name (FQDN) than that of the backup host, then create a `patch.toml` file that specifies the new FQDN and provides it at restore time:
+1. To restore a backup to a host with a different fully qualified domain name (FQDN) than the original backup host, create a `patch.toml` file that specifies the new FQDN and provide it at restore time:
 
     ```toml
          [global.v1]

--- a/tools/credscan/credscan.go
+++ b/tools/credscan/credscan.go
@@ -71,7 +71,7 @@ var a2Config = config{
 		// // TODO(ssd) 2019-01-22: The following files are files that need to be checked.
 		{regex: `components/automate-deployment/pkg/persistence/boltdb/internal/v1/testdata/boltdb-20180226095149.db`},
 		{regex: `components/automate-chef-io/content/docs/configuration.md`},
-		{regex: `components/automate-chef-io/content/docs/backup.md`},
+		{regex: `components/automate-chef-io/content/docs/restore.md`},
 		{regex: `components/automate-deployment/cmd/chef-server-ctl/secrets.go`},
 		{regex: `components/automate-deployment/pkg/a1stub/test_harness.go`},
 		{regex: `components/automate-deployment/pkg/a1upgrade/a1commands_test.go`},


### PR DESCRIPTION
Address assorted issues where users are either not finding information that is in the backup/restore docs, or expecting information to be there that is not.

1. Split the backup & restore page into a page for backup and a page for
restore. I have a wild theory, based on questions we were seeing, that people were getting tired of reading by the time they got to the restore section of the original single page doc. If someone has evidence for or against, I would be happy to hear it.
2. Signpost the external elasticsearch backup configuration docs as
being for backing up external elasticsearch, as distinct from backing up
all of Automate.
3. Add words around questions that come up frequently enough to seem
worth mentioning: the Automate backup mechanism creates a backup of all
data in all products deployed by Automate; how to manage backup
retention; `fix-repo-permissions`; how to set debug logging on backup operations.
4. Add links to the CLI docs. Again, based on questions, I don't think people are finding them, but I don't have proof one way or another.

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
