### PR TITLE
Desktop UI Download individual desktop historical data as JSON or CSV…

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -28,8 +28,8 @@
         </chef-button>
           <chef-dropdown class='download' [visible]="downloadDropdownVisible">
             <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeDownloadDropdown()">
-              <div (click)="onDownloadCheckInHistory('json')">JSON</div>
-              <div (click)="onDownloadCheckInHistory('csv')">CSV</div>
+              <chef-button tertiary (click)="onDownloadCheckInHistory('json')">JSON</chef-button>
+              <chef-button tertiary (click)="onDownloadCheckInHistory('csv')">CSV</chef-button>
             </chef-click-outside>
           </chef-dropdown>
       </div>

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -22,10 +22,16 @@
           <span>Last {{ (checkinNumDays === 15 ? 2 : 4) }} Weeks</span>
           <chef-icon>expand_more</chef-icon>
         </chef-button>
-        <chef-button secondary>
+        <chef-button secondary (click)="toggleDownloadDropdown()" class='download-dropdown-toggle'>
           <span>Download</span>
           <chef-icon>expand_more</chef-icon>
         </chef-button>
+          <chef-dropdown class='download' [visible]="downloadDropdownVisible">
+            <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeDownloadDropdown()">
+              <div (click)="onDownloadCheckInHistory('json')">JSON</div>
+              <div (click)="onDownloadCheckInHistory('csv')">CSV</div>
+            </chef-click-outside>
+          </chef-dropdown>
       </div>
     </div>
     <chef-table class="checkin-history-table grid">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -42,11 +42,19 @@
     right: 0;
     width: 114px;
 
-    div {
+    chef-button {
+      margin: 0;
       font-size: 14px;
       text-align: center;
       padding: 5px 0;
       border-bottom: 1px solid $chef-grey;
+      width: 100%;
+      color: inherit;
+
+      button {
+        margin: 0;
+        padding: 0;
+      }
 
       &:hover {
         cursor: pointer;

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -34,6 +34,31 @@
   }
 }
 
+.heading-actions {
+  position: relative;
+
+  .download {
+    position: absolute;
+    right: 0;
+    width: 114px;
+
+    div {
+      font-size: 14px;
+      text-align: center;
+      padding: 5px 0;
+      border-bottom: 1px solid $chef-grey;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+}
+
 h3 {
   margin-bottom: $spacing-05;
 }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -1,12 +1,16 @@
 import { Component, OnInit, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { Desktop, DailyNodeRunsStatus } from 'app/entities/desktop/desktop.model';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, finalize } from 'rxjs/operators';
+import * as moment from 'moment/moment';
+import { saveAs } from 'file-saver';
 import { DateTime } from 'app/helpers/datetime/datetime';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Subject } from 'rxjs';
 import { GetDailyNodeRunsStatusTimeSeries } from 'app/entities/desktop/desktop.actions';
 import { getDailyNodeRuns } from 'app/entities/desktop/desktop.selectors';
+import { NodeRunsService } from '../../../services/node-details/node-runs.service';
+import { RunHistoryStore } from '../../../services/run-history-store/run-history.store';
 
 @Component({
   selector: 'app-desktop-detail',
@@ -27,6 +31,7 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   public checkinTableType = 'grid';
   public checkinGridFlexType = 'wrap';
   public checkinNumDays = 15;
+  public downloadDropdownVisible = false;
   // These are Material Icon names from https://material.io/resources/icons/
   public historyIcons = {
     converged: 'check_box',
@@ -39,7 +44,9 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   private isDestroyed = new Subject<boolean>();
 
   constructor(
-    private store: Store<NgrxStateAtom>
+    private store: Store<NgrxStateAtom>,
+    private nodeHistoryStore: RunHistoryStore,
+    private nodeRunsService: NodeRunsService
   ) {
     this.store.select(getDailyNodeRuns).pipe(
       takeUntil(this.isDestroyed)
@@ -64,6 +71,32 @@ export class DesktopDetailComponent implements OnInit, OnDestroy {
   updateCheckInDays() {
     this.checkinNumDays = (this.checkinNumDays === 15 ? 29 : 15);
     this.getCheckInHistory();
+  }
+
+  onDownloadCheckInHistory(format) {
+    this.closeDownloadDropdown();
+    const filename = `${moment.utc().format(DateTime.REPORT_DATE_TIME)}.${format}`;
+
+    const onComplete = () => console.warn('completed downloading report');
+    const onError = _e => console.error('error downloading report');
+    const types = {'json': 'application/json', 'csv': 'text/csv'};
+    const onNext = data => {
+      const type = types[format];
+      const blob = new Blob([data], {type});
+      saveAs(blob, filename);
+    };
+
+    this.nodeRunsService.downloadRuns(format, this.nodeHistoryStore.filter.getValue()).pipe(
+      finalize(onComplete))
+      .subscribe(onNext, onError);
+  }
+
+  toggleDownloadDropdown() {
+    this.downloadDropdownVisible = !this.downloadDropdownVisible;
+  }
+
+  closeDownloadDropdown() {
+    this.downloadDropdownVisible = false;
   }
 
   addCheckInLabels(checkInHistory: DailyNodeRunsStatus[]): DailyNodeRunsStatus[] {


### PR DESCRIPTION
 ### :nut_and_bolt: Description: What code changed, and why?
Allow users to download the individual desktop historical data, including all the run happened in the selected time span and the attributes data, in a JSON or CSV format

### :chains: Related Resources
https://github.com/chef/automate/issues/3545#issuecomment-640870011

### :+1: Definition of Done
Users can download the individual desktop historical data, including all the run happened in the selected time span and the attributes data, in a JSON or CSV format

### :athletic_shoe: How to Build and Test the Change
hab studio enter
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
load_desktop_reports

### :white_check_mark: Checklist

- [x ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-06-16 at 9 48 40 AM](https://user-images.githubusercontent.com/4108100/84790270-c909e900-afb6-11ea-804b-200638087921.png)
![Screen Shot 2020-06-16 at 9 48 47 AM](https://user-images.githubusercontent.com/4108100/84790272-ca3b1600-afb6-11ea-8659-88e2249bb897.png)
![Screen Shot 2020-06-16 at 9 48 59 AM](https://user-images.githubusercontent.com/4108100/84790274-cad3ac80-afb6-11ea-8604-05bb1e1f3761.png)
![Screen Shot 2020-06-16 at 9 49 09 AM](https://user-images.githubusercontent.com/4108100/84790277-cb6c4300-afb6-11ea-8439-68c78d12c3e0.png)
![Screen Shot 2020-06-16 at 9 49 16 AM](https://user-images.githubusercontent.com/4108100/84790278-cb6c4300-afb6-11ea-8617-7f8127774d40.png)
