### PR TITLE
[Desktop UI] Download filtered list of desktop data as JSON or CSV

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
@@ -93,7 +93,21 @@
     </div>
   </div>
 
-  <h4>Total: {{totalDesktops}}</h4>
+  <div class="node-list-options">
+    <h4>Total: {{totalDesktops}}</h4>
+    <div class="download-nodes">
+      <chef-button secondary (click)="toggleDownloadDropdown()" class='download-nodes-toggle'>
+        <span>Download</span>
+        <chef-icon>expand_more</chef-icon>
+      </chef-button>
+        <chef-dropdown class='download' [visible]="downloadOptsVisible">
+          <chef-click-outside omit="download-nodes-toggle" (clickOutside)="hideDownloadDropdown()">
+            <chef-button tertiary (click)="onDownloadOptPressed('json')">JSON</chef-button>
+            <chef-button tertiary (click)="onDownloadOptPressed('csv')">CSV</chef-button>
+          </chef-click-outside>
+        </chef-dropdown>
+    </div>
+  </div>
   <chef-table>
     <chef-thead>
       <chef-tr>

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.scss
@@ -85,6 +85,54 @@
   }
 }
 
+.node-list-options {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+
+  .download-nodes {
+    position: relative;
+    width: fit-content;
+
+    .download-nodes-toggle {
+      margin-bottom: 0;
+    }
+
+    .download {
+      margin: 0 8px;
+      position: absolute;
+      right: 0;
+      width: 114px;
+
+      chef-button {
+        margin: 0;
+        font-size: 14px;
+        text-align: center;
+        padding: 5px 0;
+        border-bottom: 1px solid $chef-grey;
+        width: 100%;
+        color: inherit;
+
+        button {
+          margin: 0;
+          padding: 0;
+        }
+
+        &:hover {
+          cursor: pointer;
+        }
+
+        &:last-child {
+          border-bottom: none;
+        }
+      }
+    }
+  }
+}
+
+
 chef-table {
   chef-icon {
     margin-right: $spacing-03;

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.ts
@@ -1,13 +1,22 @@
-import { Component, HostBinding, Input, Output, EventEmitter } from '@angular/core';
+import { Component, HostBinding, Input, Output, OnInit, EventEmitter } from '@angular/core';
+import { Store, createSelector } from '@ngrx/store';
+import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Desktop, TermFilter } from 'app/entities/desktop/desktop.model';
 import { FilterUpdate } from 'app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.model';
+import { finalize } from 'rxjs/operators';
+import * as moment from 'moment/moment';
+import { saveAs } from 'file-saver';
+import { DateTime } from 'app/helpers/datetime/datetime';
+import { ClientRunsRequests } from 'app/entities/client-runs/client-runs.requests';
+import { clientRunsState } from 'app/entities/client-runs/client-runs.selectors';
+import { NodeFilter } from 'app/entities/client-runs/client-runs.model';
 
 @Component({
   selector: 'app-insight',
   templateUrl: './insight.component.html',
   styleUrls: ['./insight.component.scss']
 })
-export class InsightComponent {
+export class InsightComponent implements OnInit {
 
   @Input() desktops: Desktop[];
   @Input() selectedDesktop: Desktop;
@@ -26,6 +35,23 @@ export class InsightComponent {
   @Output() desktopSelected: EventEmitter<Desktop> = new EventEmitter();
 
   public attributesMenuOpen = false;
+  public downloadOptsVisible = false;
+  public downloadInProgress = false;
+  public downloadFailed = false;
+
+  private nodeFilter: NodeFilter;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private requests: ClientRunsRequests
+  ) { }
+
+  ngOnInit() {
+    this.store.select(createSelector(clientRunsState, (state) => state.nodeFilter)).subscribe(
+      (nodeFilter: NodeFilter) => {
+        this.nodeFilter = nodeFilter;
+      });
+  }
 
   public close(): void {
     this.closed.emit();
@@ -49,5 +75,32 @@ export class InsightComponent {
 
   public updateFilters(event: FilterUpdate) {
     console.log(event);
+  }
+
+  toggleDownloadDropdown() {
+    this.downloadOptsVisible = !this.downloadOptsVisible;
+  }
+
+  hideDownloadDropdown() {
+    this.downloadOptsVisible = false;
+  }
+
+  onDownloadOptPressed(format) {
+    this.downloadOptsVisible = false;
+
+    const filename = `${moment().utc().format(DateTime.REPORT_DATE_TIME)}.${format}`;
+
+    const onComplete = () => this.downloadInProgress = false;
+    const onError = _e => this.downloadFailed = true;
+    const types = {'json': 'application/json', 'csv': 'text/csv'};
+    const onNext = data => {
+      const type = types[format];
+      const blob = new Blob([data], {type});
+      saveAs(blob, filename);
+    };
+
+    this.requests.downloadNodes(format, this.nodeFilter).pipe(
+      finalize(onComplete))
+      .subscribe(onNext, onError);
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Allow users to download the filtered desktop data in the current view in a JSON or CSV format.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/3503

### :+1: Definition of Done
Allow users to download the filtered desktop data in the current view in a JSON or CSV format.

### :athletic_shoe: How to Build and Test the Change
hab studio enter
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
load_desktop_reports

### :white_check_mark: Checklist
- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-06-16 at 12 52 40 PM](https://user-images.githubusercontent.com/4108100/84810053-6887a580-afd0-11ea-97cc-47a248121008.png)
![Screen Shot 2020-06-16 at 12 52 47 PM](https://user-images.githubusercontent.com/4108100/84810057-69203c00-afd0-11ea-9267-233d47492e43.png)
![Screen Shot 2020-06-16 at 12 53 03 PM](https://user-images.githubusercontent.com/4108100/84810060-6a516900-afd0-11ea-8653-5ff50fce1ac6.png)
![Screen Shot 2020-06-16 at 12 53 14 PM](https://user-images.githubusercontent.com/4108100/84810062-6ae9ff80-afd0-11ea-8531-4de273c473fe.png)
