### PR TITLE
Update builder pins to version released on 2020.06.16

### DIFF
--- a/components/automate-builder-api-proxy/habitat/plan.sh
+++ b/components/automate-builder-api-proxy/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api-proxy/8865/20200421224604"
+  "habitat/builder-api-proxy/8929/20200601120044"
 )
 
 pkg_build_deps=(

--- a/components/automate-builder-api/habitat/plan.sh
+++ b/components/automate-builder-api/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/bash
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api/8885/20200504153856"
+  "habitat/builder-api/8929/20200601115721"
 )
 
 pkg_binds=(


### PR DESCRIPTION
This updates the version pins for `builder-api` and `builder-api-proxy` to the versions released on 2020.06.16
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>
