### PR TITLE
Fix error banner appearing for non-local users on login

### DIFF
--- a/components/automate-ui/src/app/entities/users/userself.effects.ts
+++ b/components/automate-ui/src/app/entities/users/userself.effects.ts
@@ -60,11 +60,6 @@ export class UserSelfEffects {
     }));
 
   @Effect()
-  setUserSelfId$ = this.actions$.pipe(
-    ofType(UserSelfActionTypes.SET_ID),
-    map(() => new GetUserSelf()));
-
-  @Effect()
   updatePasswordSelf$ = this.actions$.pipe(
     ofType<UpdatePasswordSelf>(UserSelfActionTypes.UPDATE_PASSWORD_SELF),
     mergeMap((action: UpdatePasswordSelf) =>

--- a/components/automate-ui/src/app/pages/signin/signin.component.spec.ts
+++ b/components/automate-ui/src/app/pages/signin/signin.component.spec.ts
@@ -156,7 +156,7 @@ describe('SigninComponent', () => {
         'kilgore@kilgore.trout',
         valid_id_token,
         ['authors'],
-        false);
+        true);
     });
   });
 

--- a/components/automate-ui/src/app/pages/signin/signin.component.ts
+++ b/components/automate-ui/src/app/pages/signin/signin.component.ts
@@ -48,8 +48,6 @@ export class SigninComponent implements OnInit {
   }
 
   setSession(): void {
-    const isLocalUser = this.id.federated_claims &&
-      this.id.federated_claims.connector_id === 'local';
     this.session.setSession(
       this.id.sub,
       this.id.name,
@@ -59,7 +57,7 @@ export class SigninComponent implements OnInit {
       this.id.email,
       this.idToken,
       this.id.groups,
-      isLocalUser);
+      this.session.isLocalUserFromId(this.id));
   }
 
   // pathFromState parses the URL path from state, and logs eventually occurring

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -1,19 +1,15 @@
 import { Injectable } from '@angular/core';
 import { HttpHeaders, HttpClient, HttpBackend, HttpErrorResponse } from '@angular/common/http';
-import { isNull, isNil } from 'lodash';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Observable, ReplaySubject, timer } from 'rxjs';
 import { map, mergeMap, filter } from 'rxjs/operators';
+import { isNull, isNil } from 'lodash';
 
-
-import { environment } from '../../../environments/environment';
-import { Jwt } from 'app/helpers/jwt/jwt';
-
-import {
-  SetUserSelfID
-} from 'app/entities/users/userself.actions';
+import { environment } from 'environments/environment';
+import { Jwt, IDToken } from 'app/helpers/jwt/jwt';
+import { SetUserSelfID } from 'app/entities/users/userself.actions';
 
 // Should never be on in production. Modify environment.ts locally
 // if you wish to bypass getting a session from dex.
@@ -126,7 +122,7 @@ export class ChefSessionService implements CanActivate {
       id.email,
       idToken,
       id.groups,
-      id.federated_claims.connector_id === 'local');
+      this.isLocalUserFromId(id));
   }
 
   // canActivate determines if any of the routes (except signin) can be activated
@@ -272,5 +268,10 @@ export class ChefSessionService implements CanActivate {
   setDefaultSession(): void {
     this.setSession('test_subject', 'Test User', 'testchefuser',
       'test_id_token', ['group1', 'group2', 'group3'], true);
+  }
+
+  isLocalUserFromId(id: IDToken): boolean {
+    return id.federated_claims &&
+      id.federated_claims.connector_id === 'local';
   }
 }

--- a/components/automate-ui/src/app/testing/mock-chef-session.service.ts
+++ b/components/automate-ui/src/app/testing/mock-chef-session.service.ts
@@ -1,3 +1,5 @@
+import { IDToken } from 'app/helpers/jwt/jwt';
+
 export class MockChefSessionService {
   fullname = 'Test Mock';
   username = 'testmock';
@@ -14,6 +16,10 @@ export class MockChefSessionService {
     return 'test_subject-welcome-modal-seen';
   }
   public fetchTelemetryPreference(): boolean {
+    return true;
+  }
+
+  public isLocalUserFromId(_id: IDToken): boolean {
     return true;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

#### How to reproduce:
Connect to a box with SAML (LDAP boxes would exhibit the problem, too).
Login with SAML (LDAP). Note that the dev environment is configured to use SAML so you could do this on your local machine.

Assuming you have appropriate permission to fetch users, previously you would have seen this error:
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/6817500/84857735-88de5100-b01e-11ea-96a4-cfc63bc7a72e.png">

Without permission from a policy, you would still see the same root error ("Could not get logged in user") but it would be greyed out and indicate no permissions:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6817500/84943930-f1b6df00-b099-11ea-9347-d2467d9e004b.png">


#### What was failing
ngrx dispatch to the `SetUserSelfID` action in ChefSessionService.

#### What changed to make it fail
PR 3725, merged 14 days ago, changed the flow slightly as to where `tryInitializeSession` was being called. The timing used to be such that the `SetUserSelfID` dispatch was not being run and with PR 3725 it was.

#### The fix
Looking into what `SetUserSelfID` was doing:
(a) set the ID into the ngrx store
(b) call GetUser on the back-end
As far as I could tell, (b) was unnecessary; that call will be done as needed on other pages.

### :+1: Definition of Done
No error banner for non-local users.

If you login with permissions, you get the standard logged in view with no error banner.

If you login with no permissions you simply get the "no permissions" page but no error banner:
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/6817500/84944805-3131fb00-b09b-11ea-9147-31db56e0399b.png">

### :athletic_shoe: How to Build and Test the Change
Logged in as Admin, go to Settings >> Policies >> Administrator >> Members >> Add Members >> Add Member Expression and enter `user:saml:*`.
Log out then log back in with your SAML id.

NB: This error would only occur between your logging in and arriving on your first page. It would not occur with just page refresh.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
