### PR TITLE
Contain in div and add ellipsis css

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -18,7 +18,7 @@
         (click)="errorSelected.emit(item)"
         (keyup.enter)="errorSelected.emit(item)">
         <chef-td class="chart-list-item-label-cell">
-          {{ item.type }}: {{ item.message }}
+          <div>{{ item.type }}: {{ item.message }}</div>
         </chef-td>
         <chef-td class="chart-list-item-count-cell">
           <span>

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
@@ -58,6 +58,12 @@
 
   .chart-list-item-label-cell {
     flex-basis: 55%;
+
+    div {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
   }
 
   .chart-list-item-count-cell {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

### :chains: Related Resources
fixes: https://github.com/chef/automate/issues/3861

### :+1: Definition of Done
Long error messages in top errors section are single line only and apply an ellipses as seen in before and after images.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

navigate to https://a2-dev.test/desktop
View top 10 errors screen
when errors are NOT long, they should appear as full error message
When errors are too long for container, an ellipses is applied and message is shortened (if there are no pending long errors, you can see this apply to some errors by slowly narrowing your browser window)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Non Ellipsed:
![Non ellipsed](https://user-images.githubusercontent.com/16737484/84954048-883ecc80-b0a9-11ea-932d-3d2005d47d8a.png)

Ellipsis applied:
![ellipsis applied](https://user-images.githubusercontent.com/16737484/84954086-9bea3300-b0a9-11ea-88ad-f82d59733f11.png)

