### PR TITLE
[automate-3918] Close modal if valid license is detected

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, EventEmitter, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import * as moment from 'moment/moment';
 
 import { LicenseFacadeService, LicenseApplyReason } from 'app/entities/license/license.facade';
@@ -51,12 +52,21 @@ export class LicenseApplyComponent implements AfterViewInit {
     public licenseFacade: LicenseFacadeService,
     private chefSessionService: ChefSessionService,
     fb: FormBuilder) {
+      // keep these subscriptions always present
+
       this.licenseFacade.licenseApplyReason$.subscribe((reason) => {
         this.licenseApplyReason = reason;
         if (this.licenseApplyReason === LicenseApplyReason.LICENSE_ABOUT_TO_EXPIRE) {
           this.modalLocked = false;
         }
       });
+      this.licenseFacade.fetchLicense$.pipe(
+        filter(state =>
+          this.modalVisible
+          && state.status === EntityStatus.loadingSuccess
+          && !moment().isAfter(state.license.licensed_period.end)))
+        .subscribe(() => this.closeModal());
+
       this.applyForm = fb.group({
         licenseKey: ['', [Validators.required]]
       });

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.ts
@@ -172,8 +172,13 @@ export class LicenseLockoutComponent implements AfterViewInit {
     } else if (licenseCurrentlyExpired) {
       // don't open, trigger event to apply license
       this.backToLicenseApply(LicenseApplyReason.LICENSE_EXPIRED);
-    } else if (!this.firstTriggerCompleted) {
-      this.licenseFacade.triggerWelcome();
+    } else { // license active and current!
+      if (this.modalVisible) {
+        this.closeModal();
+      }
+      if (!this.firstTriggerCompleted) {
+        this.licenseFacade.triggerWelcome();
+      }
     }
     // After this function has been run once, never want to trigger
     // the welcome modal again, so keep track of that here.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When a license is active and it reaches expiry (or is in any other way removed), all current users of the web-app will be asynchronously notified within 5 minutes that there is no valid license, popping up the license lockout modal. That's well and good, but only half the job.

Previously, if the admin then applies a new license, all other users with the license-lockout modal (or license-apply modal) showing will not see the new license status asynchronously (meaning the license-lockout modal or license-apply modal will **not** self-close). One had to manually refresh the browser to make that modal go away. Now, with this PR, either license modal will self-close within 5 minutes.

### :chains: Related Resources
NA

### :+1: Definition of Done
License modals self-close within 5 minutes of a valid license being applied.

### :athletic_shoe: How to Build and Test the Change
 - Reduce the polling interval of the license status. In license.effects.ts change `POLLING_INTERVAL_IN_SECONDS` to, for example, 10 seconds instead of 300 seconds (5 minutes).
 - Rebuild automate-ui.
 - Open Automate in your browser; you can be on any page in the app for the following.

In hab studio, find your current license:
```
chef-automate dev psql chef_license_control_service -- -c \
"select db_id, active from licenses;"
```
There should be one row showing active as `t`. (There may likely be only one row _total_.) Remember the corresponding `db_id` for that row so you can restore it later.

#### Scenario 1: License activates when NO license is present and license-lockout modal is open.
 
(a) Deactivate the license...
```
chef-automate dev psql chef_license_control_service -- -c \
"update licenses set active=null;"
```
(b) If you adjusted the polling interval above to 10 seconds, then within 10 seconds the license modal will appear:

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/6817500/85040242-73137d80-b13d-11ea-9e56-b996afd1b2e7.png">

(c) Next, restore your license to active by replacing `YOUR_SAVED_DBID` with the value from above.
```
chef-automate dev psql chef_license_control_service -- -c \
"update licenses set active=true where db_id=YOUR_SAVED_DBID;"
```
... and--the work from this PR will kick in--the license modal will disappear within 10 seconds.

#### Scenario 2: License activates when NO license is present and license-apply modal is open.

Repeat (a) and (b) above.

(b+) Select "Already have a license?" at the bottom of the modal to switch to the license-apply modal.

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/6817500/85043061-cb984a00-b140-11ea-96ef-597bfa999998.png">

Now repeat (c) above to restore your license and this license-apply modal should also disappear within 10 seconds. 

#### Scenario 3: License activates when EXPIRED license is present and license-apply modal is open.

(a) Obtain an expired license (e.g. from one of the acceptance servers) and apply that from the command line, for example:
```
chef-automate license apply -f license_token.jwt.expires.2019-12-31
```
(b) The license-apply modal appears again, this time with the expiry notice:
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/6817500/85043141-e4a0fb00-b140-11ea-9bc7-79f1b844518a.png">

Now repeat (c) above to restore your original license and this license-apply modal should also disappear within 10 seconds. 


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
