### PR TITLE
fix the router link from scan jobs list to single job scans list

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/jobs-list/jobs-list.component.html
@@ -39,7 +39,7 @@
         {{ job.name }}
       </chef-td>
       <chef-td  *ngIf="!isJobReport(job)">
-        <a [routerLink]="['/api/v0/compliance', 'scan-jobs', 'jobs', job.id, 'scans']">{{ job.name }}</a>
+        <a [routerLink]="['/compliance', 'scan-jobs', 'jobs', job.id, 'scans']">{{ job.name }}</a>
       </chef-td>
       <chef-td >{{ displayNodeCount(job.node_count | number, job.recurrence) }}</chef-td>
       <chef-td >{{ timeFromNow(job.end_time) }}</chef-td>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
the link to job scans for a recurring scanjob was broken.
this fixes it.

Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :+1: Definition of Done
can go to a list of scans for a single recurring job

### :athletic_shoe: How to Build and Test the Change
rebuild ui
create recurring scan job
go to scans list

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-06-18 at 13 24 17](https://user-images.githubusercontent.com/10341541/85063207-09a86480-b167-11ea-9631-6a611856252a.png)
