### PR TITLE
add ingest policy info to data collection docs

### DIFF
--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -21,7 +21,7 @@ There are two steps to getting data collection running in Chef Automate:
 
 1. You must first have an API token. You have two options:
 
-  * [Create a new API Token]({{< relref "api-tokens.md#creating-api-tokens" >}}) and add it to the Ingest policy.
+  * [Create a new API token]({{< relref "api-tokens.md#creating-api-tokens" >}}) and add the API token to the Ingest policy, preferably at time of creation.
   * Or you can [use your existing data collector token]({{< relref "#existing-data-collector-token-setup" >}}) if you are migrating from Chef Automate 1.
 
 1. Once you have an API token, you can either:

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -21,7 +21,7 @@ There are two steps to getting data collection running in Chef Automate:
 
 1. You must first have an API token. You have two options:
 
-  * [Create a new API Token]({{< relref "api-tokens.md#creating-api-tokens" >}}).
+  * [Create a new API Token]({{< relref "api-tokens.md#creating-api-tokens" >}}) and add it to the Ingest policy.
   * Or you can [use your existing data collector token]({{< relref "#existing-data-collector-token-setup" >}}) if you are migrating from Chef Automate 1.
 
 1. Once you have an API token, you can either:

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -72,7 +72,7 @@
             [resourcesUpdated]="policiesUpdatedEvent"
             [objectNounPlural]="'policies'"
             (onDropdownClosing)="onPolicyDropdownClosing($event)">
-            Assign the token to a policy to give the token permissions.
+            Add the token to a policy to give the token permissions.
           </app-resource-dropdown>
         </div>
         <div class="dropdown-margin" *ngIf="objectNoun !== 'project'">


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
recently, in a [community slack convo](https://chefcommunity.slack.com/archives/CAZSL536K/p1592595733202400) there were some questions around what policy to add the api token to in the data collection docs, this specifies that folks should use the ingest policy.

### :chains: Related Resources
zero.

### :+1: Definition of Done
docs still work but are more clear

### :athletic_shoe: How to Build and Test the Change
`make serve` from `components/automate-chef-io`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
zero.