### PR TITLE
Automate-3576 right panel + bottom project banner issues

### DIFF
--- a/components/automate-ui/src/app/entities/layout/layout.facade.ts
+++ b/components/automate-ui/src/app/entities/layout/layout.facade.ts
@@ -102,6 +102,11 @@ export class LayoutFacadeService {
     return this.layout.license.display;
   }
 
+  hasUserNotifications(): boolean {
+    return this.layout.userNotifications.pendingEdits
+      || this.layout.userNotifications.updatesProcessing;
+  }
+
   ShowPageLoading(showLoading: boolean): void {
     setTimeout(() => this.store.dispatch(new ShowPageLoading(showLoading)));
   }

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.scss
@@ -101,10 +101,6 @@
 // Side Panel
 $event-group-border: 1px solid $chef-light-grey;
 
-chef-side-panel {
-  z-index: 100;
-}
-
 .event-group-list {
   margin: 0;
   padding: 0;

--- a/components/automate-ui/src/app/ui.component.html
+++ b/components/automate-ui/src/app/ui.component.html
@@ -24,7 +24,10 @@
   </div>
 
   <!-- App Content -->
-  <div id="app-content-wrapper" [attr.hasNotifications]="layoutFacade.hasGlobalNotifications() ? true : null" [ngStyle]="layoutFacade.getContentStyle()">
+  <div id="app-content-wrapper"
+    [attr.hasNotifications]="layoutFacade.hasGlobalNotifications() ? true : null"
+    [attr.hasUserNotifications]="layoutFacade.hasUserNotifications() ? true : null"
+    [ngStyle]="layoutFacade.getContentStyle()">
     <div id="main-content-wrapper">
       <div id="notifications-wrapper" class="sticky-notifications">
         <app-chef-notifications></app-chef-notifications>

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -13,6 +13,7 @@
 
   &[hasUserNotifications] {
     chef-side-panel {
+      // Adjust height when global notifications are visible.
       max-height: calc(100% - 120px);
     }
   }
@@ -25,6 +26,8 @@
 
   &[hasNotifications][hasUserNotifications] {
     chef-side-panel {
+      // Adjust height when global notifications
+      // and user notifications are visible.
       max-height: calc(100% - 162px);
     }
   }

--- a/components/automate-ui/src/styles.scss
+++ b/components/automate-ui/src/styles.scss
@@ -11,9 +11,21 @@
     top: 68px;
   }
 
+  &[hasUserNotifications] {
+    chef-side-panel {
+      max-height: calc(100% - 120px);
+    }
+  }
+
   &[hasNotifications] {
     chef-side-panel {
       top: 107px;
+    }
+  }
+
+  &[hasNotifications][hasUserNotifications] {
+    chef-side-panel {
+      max-height: calc(100% - 162px);
     }
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
when a project update is in progress it takes up a 54 px at the bottom of the screen. We've got a few right panel issues with this panel.

### :chains: Related Resources
https://app.zenhub.com/workspaces/ui-team-5cba23a3b14fdc05970c8f87/issues/chef/automate/3576

### :+1: Definition of Done
hides information, we should either add a scroll bar or some extra space to the bottom of those panels so folks can access all of the information.

### :athletic_shoe: How to Build and Test the Change
hab studio enter
export DEVPROXY_URL=localhost
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services
load compliance data
start a project update
navigate to compliance > reports > nodes > some node > scan history
notice you cannot scroll all the way to the bottom

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-06-22 at 12 12 18 PM](https://user-images.githubusercontent.com/4108100/85316051-b2193a00-b481-11ea-91dc-5c30ed2f9553.png)
![Screen Shot 2020-06-22 at 12 12 30 PM](https://user-images.githubusercontent.com/4108100/85316053-b34a6700-b481-11ea-8845-279a75183da6.png)
