### PR TITLE
Make periodic job enabledness reset with the Reset call

### DIFF
--- a/components/applications-service/integration_test/disconnected_services_job_test.go
+++ b/components/applications-service/integration_test/disconnected_services_job_test.go
@@ -101,7 +101,11 @@ func TestPeriodicDisconnectedServices(t *testing.T) {
 		runsThusFar := runners.MarkDisconnectedServicesExecutor.TotalRuns()
 		detectedJobRun := false
 		for i := 0; i <= 100; i++ {
-			if runners.MarkDisconnectedServicesExecutor.TotalRuns() > runsThusFar {
+			// Wait for the job to run twice. There is race condition potential with
+			// this test reconfiguring the job constantly and cereal concurrently
+			// starting tasks.
+			// We can be pretty sure things are good if the job runs twice.
+			if runners.MarkDisconnectedServicesExecutor.TotalRuns() > (runsThusFar + 1) {
 				detectedJobRun = true
 				break
 			}

--- a/components/applications-service/pkg/server/periodic.go
+++ b/components/applications-service/pkg/server/periodic.go
@@ -172,8 +172,15 @@ func (j *JobScheduler) ResetParams() error {
 		return err
 	}
 
+	if err := j.EnableDisconnectedServicesJob(ctx); err != nil {
+		return err
+	}
+
 	deleteConf := defaultDeleteDisconnectedServicesJobConfig()
 	if err := j.UpdateDeleteDisconnectedServicesJobConfig(ctx, deleteConf); err != nil {
+		return err
+	}
+	if err := j.EnableDeleteDisconnectedServicesJob(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

It appears the disconnected services job was sometimes disabled in a test and the "enabled-ness" was not reset, which caused a later test to fail. It probably should have been failing consistently but passed most of the time due to a race condition. So now we make the job run twice to be sure it's really working.
