### PR TITLE
Fix click error that can occur in `chef-phat-radio`

### DIFF
--- a/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
+++ b/components/chef-ui-library/src/molecules/chef-phat-radio/chef-phat-radio.tsx
@@ -42,15 +42,19 @@ export class ChefPhatRadio {
 
   selected: HTMLChefOptionElement;
 
-  @Listen('click') handleClick(event) {
-    const option = event.target.closest('chef-option');
-    // If new click option is the same as current, we are deselecting
-    const isSameOption = this.value === option.value;
-
+  @Listen('click') handleClick(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    const option = target.closest('chef-option');
     if (option) {
-    this.value = this.deselectable && isSameOption ? '' : option.value;
-    this.change.emit();
-    this.input.emit();
+      this.selectOption(option);
+    }
+  }
+
+  @Listen('keypress') handleKeypress(event: KeyboardEvent) {
+    const target = event.target as HTMLElement;
+    const option = target.closest('chef-option');
+    if (option && event.key === 'Enter') {
+      this.selectOption(option);
     }
   }
 
@@ -67,11 +71,10 @@ export class ChefPhatRadio {
     }
     this.selected.selected = true;
 
-    // add keypress listeners to all the child options
+    // Set tabindex on options to make them keyboard focusable
     options.forEach(option => {
-        option.addEventListener('keypress', (event) => this.handleKeypress(event));
-        option.setAttribute('tabindex', '0');
-      });
+      option.setAttribute('tabindex', '0');
+    });
   }
 
   componentDidUpdate() {
@@ -95,10 +98,11 @@ export class ChefPhatRadio {
     return options;
   }
 
-  handleKeypress(event) {
-    if (event.key === 'Enter') {
-      this.handleClick(event);
-    }
+  selectOption(option: HTMLChefOptionElement) {
+    const isSameOption = this.value === option.value;
+    this.value = this.deselectable && isSameOption ? '' : option.value;
+    this.change.emit();
+    this.input.emit();
   }
 
 }


### PR DESCRIPTION
This commit fixes an issue where `chef-phat-radio` would throw an error if you clicked on the component, but not directly within a `chef-option` child, such as between the gutters surrounding the `chef-option` elements.

**Before**
![b](https://user-images.githubusercontent.com/479121/85319611-02db6380-b47f-11ea-8cca-03b76920286c.gif)

**After**
![a](https://user-images.githubusercontent.com/479121/85319623-05d65400-b47f-11ea-88d4-9f5a46237ee1.gif)
