### PR TITLE
[automate-ui] Fix reducer signatures

### DIFF
--- a/components/automate-ui/src/app/entities/automate-settings/automate-settings.reducer.ts
+++ b/components/automate-ui/src/app/entities/automate-settings/automate-settings.reducer.ts
@@ -38,12 +38,13 @@ export function automateSettingsEntityReducer(
     case AutomateSettingsActionTypes.GET_SETTINGS_SUCCESS:
       return pipe(
         set('status', EntityStatus.loadingSuccess),
-        set('jobSchedulerStatus', action.payload.jobSchedulerStatus))(state);
+        set('jobSchedulerStatus', action.payload.jobSchedulerStatus))
+        (state) as AutomateSettingsEntityState;
 
     case AutomateSettingsActionTypes.GET_SETTINGS_FAILURE:
       return pipe(
         set('status', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as AutomateSettingsEntityState;
 
     case AutomateSettingsActionTypes.CONFIGURE_SETTINGS:
       return set('changeConfiguration.status', EntityStatus.loading, state);
@@ -51,12 +52,13 @@ export function automateSettingsEntityReducer(
     case AutomateSettingsActionTypes.CONFIGURE_SETTINGS_SUCCESS:
       return pipe(
         set('changeConfiguration.status', EntityStatus.loadingSuccess),
-        set('changeConfiguration.errorResp', null))(state);
+        set('changeConfiguration.errorResp', null))(state) as AutomateSettingsEntityState;
 
     case AutomateSettingsActionTypes.CONFIGURE_SETTINGS_FAILURE:
       return pipe(
         set('changeConfiguration.status', EntityStatus.loadingFailure),
-        set('changeConfiguration.errorResp', action.payload))(state);
+        set('changeConfiguration.errorResp', action.payload))
+        (state) as AutomateSettingsEntityState;
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/automate-settings/automate-settings.reducer.ts
+++ b/components/automate-ui/src/app/entities/automate-settings/automate-settings.reducer.ts
@@ -28,7 +28,7 @@ export const AutomateSettingsEntityInitialState: AutomateSettingsEntityState = {
 
 export function automateSettingsEntityReducer(
       state: AutomateSettingsEntityState = AutomateSettingsEntityInitialState,
-      action: AutomateSettingsActions) {
+      action: AutomateSettingsActions): AutomateSettingsEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/client-runs/client-runs.reducer.ts
+++ b/components/automate-ui/src/app/entities/client-runs/client-runs.reducer.ts
@@ -60,12 +60,12 @@ export function clientRunsEntityReducer(
     case ClientRunsActionTypes.GET_NODES_SUCCESS:
       return pipe(
         set('status', EntityStatus.loadingSuccess),
-        set('nodes', action.payload.nodes))(state);
+        set('nodes', action.payload.nodes))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODES_FAILURE:
       return pipe(
         set('status', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODES_COUNT:
       return set('countStatus', EntityStatus.loading, state);
@@ -73,12 +73,12 @@ export function clientRunsEntityReducer(
     case ClientRunsActionTypes.GET_NODES_COUNT_SUCCESS:
       return pipe(
         set('countStatus', EntityStatus.loadingSuccess),
-        set('nodeCount', action.payload.nodeCount))(state);
+        set('nodeCount', action.payload.nodeCount))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODES_COUNT_FAILURE:
       return pipe(
         set('countStatus', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_WORKFLOW_ENABLED:
       return set('workflowStatus', EntityStatus.loading, state);
@@ -86,28 +86,28 @@ export function clientRunsEntityReducer(
     case ClientRunsActionTypes.GET_WORKFLOW_ENABLED_SUCCESS:
       return pipe(
         set('workflowStatus', EntityStatus.loadingSuccess),
-        set('workflowEnabled', action.payload.workflowEnabled))(state);
+        set('workflowEnabled', action.payload.workflowEnabled))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_WORKFLOW_ENABLED_FAILURE:
       return pipe(
         set('workflowStatus', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODE_SUGGESTIONS:
       return pipe(
         set('nodeSuggestionsStatus', EntityStatus.loading),
-        set('nodeSuggestions', []))(state);
+        set('nodeSuggestions', []))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODE_SUGGESTIONS_SUCCESS:
       return pipe(
         set('nodeSuggestionsStatus', EntityStatus.loadingSuccess),
-        set('nodeSuggestions', action.payload.nodeSuggestions))(state);
+        set('nodeSuggestions', action.payload.nodeSuggestions))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.GET_NODE_SUGGESTIONS_FAILURE:
       return pipe(
         set('nodeSuggestions', []),
         set('nodeSuggestionsStatus', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.DELETE_NODES:
       return set('nodeDeleteStatus', EntityStatus.loading, state);
@@ -118,7 +118,7 @@ export function clientRunsEntityReducer(
     case ClientRunsActionTypes.DELETE_NODES_FAILURE:
       return pipe(
         set('nodeDeleteStatus', EntityStatus.loadingFailure),
-        set('errorResp', action.payload))(state);
+        set('errorResp', action.payload))(state) as ClientRunsEntityState;
 
     case ClientRunsActionTypes.UPDATE_NODES_FILTER: {
       const {filters: filters} = action.payload;

--- a/components/automate-ui/src/app/entities/client-runs/client-runs.reducer.ts
+++ b/components/automate-ui/src/app/entities/client-runs/client-runs.reducer.ts
@@ -50,7 +50,7 @@ export const ClientRunsEntityInitialState: ClientRunsEntityState = {
 
 export function clientRunsEntityReducer(
       state: ClientRunsEntityState = ClientRunsEntityInitialState,
-      action: ClientRunsActions) {
+      action: ClientRunsActions): ClientRunsEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
@@ -76,7 +76,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
     case DesktopActionTypes.GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS:
       return pipe(
         set('getDailyCheckInTimeSeriesStatus', EntityStatus.loadingSuccess),
-        set('dailyCheckInCountCollection', action.payload))(state);
+        set('dailyCheckInCountCollection', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE:
       return set('getDailyCheckInTimeSeriesStatus', EntityStatus.loadingFailure, state);
@@ -85,12 +85,12 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
       return pipe(
         set('dailyNodeRuns.status', EntityStatus.loading),
         set('dailyNodeRuns.nodeId', action.nodeId),
-        set('dailyNodeRuns.daysAgo', action.daysAgo))(state);
+        set('dailyNodeRuns.daysAgo', action.daysAgo))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_SUCCESS:
       return pipe(
         set('dailyNodeRuns.status', EntityStatus.loadingSuccess),
-        set('dailyNodeRuns.durations', action.payload))(state);
+        set('dailyNodeRuns.durations', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE:
       return set('dailyNodeRuns.status', EntityStatus.loadingFailure, state);
@@ -101,7 +101,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
     case DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_SUCCESS:
       return pipe(
         set('getTopErrorCollectionStatus', EntityStatus.loadingSuccess),
-        set('topErrorCollection', action.payload))(state);
+        set('topErrorCollection', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_TOP_ERRORS_COLLECTION_FAILURE:
       return set('getTopErrorCollectionStatus', EntityStatus.loadingFailure, state);
@@ -112,7 +112,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
     case DesktopActionTypes.GET_UNKNOWN_DESKTOP_DURATION_COUNTS_SUCCESS:
       return pipe(
         set('getUnknownDesktopDurationCountsStatus', EntityStatus.loadingSuccess),
-        set('unknownDesktopDurationCounts', action.payload))(state);
+        set('unknownDesktopDurationCounts', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_UNKNOWN_DESKTOP_DURATION_COUNTS_FAILURE:
       return set('getUnknownDesktopDurationCountsStatus', EntityStatus.loadingFailure, state);
@@ -123,7 +123,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
     case DesktopActionTypes.GET_DESKTOPS_SUCCESS:
       return pipe(
         set('getDesktopsStatus', EntityStatus.loadingSuccess),
-        set('desktops', action.payload))(state);
+        set('desktops', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_DESKTOPS_FAILURE:
       return set('getDesktopsStatus', EntityStatus.loadingFailure, state);
@@ -134,7 +134,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
     case DesktopActionTypes.GET_DESKTOPS_TOTAL_SUCCESS:
       return pipe(
         set('getDesktopsTotalStatus', EntityStatus.loadingSuccess),
-        set('desktopsTotal', action.payload))(state);
+        set('desktopsTotal', action.payload))(state) as DesktopEntityState;
 
     case DesktopActionTypes.GET_DESKTOPS_TOTAL_FAILURE:
       return set('getDesktopsTotalStatus', EntityStatus.loadingFailure, state);
@@ -147,13 +147,13 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
         set('getDesktopsFilter.terms',
           concat(state.getDesktopsFilter.terms, [action.payload.term])),
         set('getDesktopsFilter.currentPage', 1)
-      )(state);
+      )(state) as DesktopEntityState;
 
     case DesktopActionTypes.UPDATE_DESKTOPS_FILTER_TERMS:
       return pipe(
         set('getDesktopsFilter.terms', action.payload.terms ),
         set('getDesktopsFilter.currentPage', 1)
-      )(state);
+      )(state) as DesktopEntityState;
 
     case DesktopActionTypes.REMOVE_DESKTOPS_FILTER_TERM:
       return pipe(
@@ -162,7 +162,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
             term.type === action.payload.term.type,
             state.getDesktopsFilter.terms)),
         set('getDesktopsFilter.currentPage', 1)
-      )(state);
+      )(state) as DesktopEntityState;
 
     case DesktopActionTypes.UPDATE_DESKTOPS_SORT_TERM:
       let order = SortOrder.Ascending;
@@ -175,7 +175,7 @@ export function desktopEntityReducer(state: DesktopEntityState = desktopEntityIn
       return pipe(
         set('getDesktopsFilter.sortingField', action.payload.term),
         set('getDesktopsFilter.sortingOrder', order)
-      )(state);
+      )(state) as DesktopEntityState;
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.reducer.ts
@@ -61,7 +61,7 @@ export const desktopEntityInitialState: DesktopEntityState = {
 };
 
 export function desktopEntityReducer(state: DesktopEntityState = desktopEntityInitialState,
-  action: DesktopActions) {
+  action: DesktopActions): DesktopEntityState {
 
   switch (action.type) {
     case DesktopActionTypes.SET_SELECTED_DESKTOP:

--- a/components/automate-ui/src/app/entities/jobs/job.reducer.ts
+++ b/components/automate-ui/src/app/entities/jobs/job.reducer.ts
@@ -16,7 +16,7 @@ export const JobEntityInitialState: JobEntityState = jobEntityAdapter.getInitial
 });
 
 export function jobEntityReducer(state: JobEntityState = JobEntityInitialState,
-                                 action: JobActions) {
+                                 action: JobActions): JobEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/managers/manager.reducer.ts
+++ b/components/automate-ui/src/app/entities/managers/manager.reducer.ts
@@ -35,7 +35,7 @@ export const ManagerEntityInitialState: ManagerEntityState = managerEntityAdapte
 });
 
 export function managerEntityReducer(state: ManagerEntityState = ManagerEntityInitialState,
-                                     action: ManagerActions) {
+                                     action: ManagerActions): ManagerEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
+++ b/components/automate-ui/src/app/entities/nodes/nodes.reducer.ts
@@ -52,7 +52,7 @@ export const NodesEntityInitialState: NodesEntityState = nodesEntityAdapter.getI
 });
 
 export function nodesEntityReducer(state: NodesEntityState = NodesEntityInitialState,
-  action: NodesActions) {
+  action: NodesActions): NodesEntityState {
 
   switch (action.type) {
     case NodesActionTypes.LIST_NODES: {

--- a/components/automate-ui/src/app/entities/profiles/profile.reducer.ts
+++ b/components/automate-ui/src/app/entities/profiles/profile.reducer.ts
@@ -16,7 +16,7 @@ export const ProfileEntityInitialState: ProfileEntityState = profileEntityAdapte
 });
 
 export function profileEntityReducer(state: ProfileEntityState = ProfileEntityInitialState,
-                                     action: ProfileActions) {
+                                     action: ProfileActions): ProfileEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/roles/role.reducer.ts
+++ b/components/automate-ui/src/app/entities/roles/role.reducer.ts
@@ -20,7 +20,7 @@ export const RoleEntityInitialState: RoleEntityState = roleEntityAdapter.getInit
 });
 
 export function roleEntityReducer(state: RoleEntityState = RoleEntityInitialState,
-  action: RoleActions) {
+  action: RoleActions): RoleEntityState {
 
   switch (action.type) {
     case RoleActionTypes.GET_ALL:

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -64,7 +64,7 @@ export const ServiceGroupEntityInitialState: ServiceGroupsEntityState = {
 
 export function serviceGroupsEntityReducer(
   state: ServiceGroupsEntityState = ServiceGroupEntityInitialState,
-  action: ServiceGroupsActions) {
+  action: ServiceGroupsActions): ServiceGroupsEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
+++ b/components/automate-ui/src/app/entities/service-groups/service-groups.reducer.ts
@@ -71,17 +71,17 @@ export function serviceGroupsEntityReducer(
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS:
       return pipe(
         set('status', EntityStatus.loading),
-        set('list', {}))(state);
+        set('list', {}))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_SUCCESS:
       return pipe(
         set('status', EntityStatus.loadingSuccess),
-        set('list', action.payload.service_groups))(state);
+        set('list', action.payload.service_groups))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_FAILURE:
       return pipe(
         set('status', EntityStatus.loadingFailure),
-        set('error', action.payload))(state);
+        set('error', action.payload))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.UPDATE_SERVICE_GROUPS_FILTER: {
       const {filters: filters} = action.payload;
@@ -94,12 +94,12 @@ export function serviceGroupsEntityReducer(
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_COUNTS_SUCCESS:
       return pipe(
         set('status', EntityStatus.loadingSuccess),
-        set('healthSummary', action.payload))(state);
+        set('healthSummary', action.payload))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_COUNTS_FAILURE:
       return pipe(
         set('status', EntityStatus.loadingFailure),
-        set('error', action.payload))(state);
+        set('error', action.payload))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.UPDATE_SELECTED_SERVICE_GROUP:
       return set('selectedGroup.services.filters', action.payload, state);
@@ -107,34 +107,36 @@ export function serviceGroupsEntityReducer(
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP:
       return pipe(
         set('selectedGroup.services.status', EntityStatus.loading),
-        set('selectedGroup.services.list', []))(state);
+        set('selectedGroup.services.list', []))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP_SUCCESS:
       return pipe(
         set('selectedGroup.name', action.payload.group),
         set('selectedGroup.services.healthSummary', action.payload.services_health_counts),
-        set('selectedGroup.services.list', action.payload.services))(state);
+        set('selectedGroup.services.list', action.payload.services))
+        (state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICES_BY_SERVICE_GROUP_FAILURE:
       return pipe(
         set('selectedGroup.services.status', EntityStatus.loadingFailure),
-        set('selectedGroup.services.error', action.payload))(state);
+        set('selectedGroup.services.error', action.payload))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_SUGGESTIONS:
       return pipe(
         set('suggestions.status', EntityStatus.loading),
-        set('suggestions.values', []))(state);
+        set('suggestions.values', []))(state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_SUGGESTIONS_SUCCESS:
       return pipe(
         set('suggestions.status', EntityStatus.loadingSuccess),
-        set('suggestions.values', action.payload.serviceGroupsSuggestions))(state);
+        set('suggestions.values', action.payload.serviceGroupsSuggestions))
+        (state) as ServiceGroupsEntityState;
 
     case ServiceGroupsActionTypes.GET_SERVICE_GROUPS_SUGGESTIONS_FAILURE:
       return pipe(
         set('suggestions.values', []),
         set('suggestions.status', EntityStatus.loadingFailure),
-        set('error', action.payload))(state);
+        set('error', action.payload))(state) as ServiceGroupsEntityState;
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/users/user.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/user.reducer.ts
@@ -25,7 +25,7 @@ export const UserEntityInitialState: UserEntityState = userEntityAdapter.getInit
 });
 
 export function userEntityReducer(state: UserEntityState = UserEntityInitialState,
-  action: UserActions) {
+  action: UserActions): UserEntityState {
 
   switch (action.type) {
 

--- a/components/automate-ui/src/app/entities/users/userself.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/userself.reducer.ts
@@ -19,7 +19,7 @@ export const UserSelfEntityInitialState: UserSelfEntityState = {
 };
 
 export function userSelfEntityReducer(state: UserSelfEntityState = UserSelfEntityInitialState,
-  action: UserSelfActions) {
+  action: UserSelfActions): UserSelfEntityState {
 
   switch (action.type) {
     case UserSelfActionTypes.SET_ID:

--- a/components/automate-ui/src/app/entities/users/userself.reducer.ts
+++ b/components/automate-ui/src/app/entities/users/userself.reducer.ts
@@ -35,7 +35,7 @@ export function userSelfEntityReducer(state: UserSelfEntityState = UserSelfEntit
       return pipe(
         set('getStatus', EntityStatus.loadingSuccess),
         set('userSelf', action.payload)
-      )(state);
+      )(state) as UserSelfEntityState;
 
     case UserSelfActionTypes.GET_FAILURE:
       return set('getStatus', EntityStatus.loadingFailure, state);
@@ -47,7 +47,7 @@ export function userSelfEntityReducer(state: UserSelfEntityState = UserSelfEntit
       return pipe(
         set('updateStatus', EntityStatus.loadingSuccess),
         set('userSelf', action.payload)
-      )(state);
+      )(state) as UserSelfEntityState;
 
     case UserSelfActionTypes.UPDATE_PASSWORD_SELF_FAILURE:
       return set('updateStatus', EntityStatus.loadingFailure, state);
@@ -59,7 +59,7 @@ export function userSelfEntityReducer(state: UserSelfEntityState = UserSelfEntit
       return pipe(
         set('updateStatus', EntityStatus.loadingSuccess),
         set('userSelf', action.payload)
-      )(state);
+      )(state) as UserSelfEntityState;
 
     case UserSelfActionTypes.UPDATE_NAME_SELF_FAILURE:
       return set('updateStatus', EntityStatus.loadingFailure, state);

--- a/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/user/user-details/user-details.component.spec.ts
@@ -28,6 +28,7 @@ import {
   GetUserSelfSuccess
 } from 'app/entities/users/userself.actions';
 import { UserDetailsComponent } from './user-details.component';
+import { EntityStatus } from 'app/entities/entities';
 
 describe('UserDetailsComponent', () => {
   let component: UserDetailsComponent;
@@ -49,7 +50,14 @@ describe('UserDetailsComponent', () => {
       },
       users: UserEntityInitialState,
       userSelf: {
-        userSelfId: 'alice'
+        userSelfId: 'alice',
+        getStatus: EntityStatus.loading,
+        updateStatus: EntityStatus.loading,
+        userSelf: {
+          id: 'any',
+          name: 'any',
+          membership_id: 'any'
+        }
       }
     };
 
@@ -203,7 +211,14 @@ describe('UserDetailsComponent', () => {
       },
       users: UserEntityInitialState,
       userSelf: {
-        userSelfId: 'bob'
+        userSelfId: 'bob',
+        getStatus: EntityStatus.loading,
+        updateStatus: EntityStatus.loading,
+        userSelf: {
+          id: 'any',
+          name: 'any',
+          membership_id: 'any'
+        }
       }
     };
 

--- a/components/automate-ui/src/app/pages/integrations/add/integration-add.reducer.ts
+++ b/components/automate-ui/src/app/pages/integrations/add/integration-add.reducer.ts
@@ -17,8 +17,9 @@ export const IntegrationsAddInitialState: IntegrationsAddState = {
   status: Status.notCreated
 };
 
-export function integrationsAddReducer(state: IntegrationsAddState = IntegrationsAddInitialState,
-                                       action: ManagerActions | RouterAction<any>) {
+export function integrationsAddReducer(
+  state: IntegrationsAddState = IntegrationsAddInitialState,
+  action: ManagerActions | RouterAction<any>): IntegrationsAddState {
   switch (action.type) {
     case ManagerActionTypes.CREATE:
       return set('status', Status.saving, state);

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.reducer.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.reducer.ts
@@ -43,7 +43,7 @@ export function integrationsDetailReducer(
       return pipe(
         set('manager', manager),
         set('managerLoadingStatus', Status.success)
-      )(state);
+      )(state) as IntegrationsDetailState;
 
     case ManagerActionTypes.GET_NODES:
       return set('managerNodesLoadingStatus', Status.loading, state);
@@ -54,7 +54,7 @@ export function integrationsDetailReducer(
         set('managerNodes', nodes),
         set('managerNodesTotal', total),
         set('managerNodesLoadingStatus', Status.success)
-      )(state);
+      )(state) as IntegrationsDetailState;
 
     case ManagerActionTypes.NAV_DETAIL:
       const { page, per_page } = action.payload;
@@ -63,7 +63,7 @@ export function integrationsDetailReducer(
         set('managerNodesPage', page),
         set('managerNodesPerPage', per_page),
         set('managerNodesLoadingStatus', Status.notLoaded)
-      )(state);
+      )(state) as IntegrationsDetailState;
 
     default:
       return state;

--- a/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.reducer.ts
+++ b/components/automate-ui/src/app/pages/integrations/detail/integrations-detail.reducer.ts
@@ -32,7 +32,7 @@ export const IntegrationsDetailInitialState: IntegrationsDetailState = {
 
 export function integrationsDetailReducer(
   state: IntegrationsDetailState = IntegrationsDetailInitialState,
-  action: ManagerActions) {
+  action: ManagerActions): IntegrationsDetailState {
 
   switch (action.type) {
     case ManagerActionTypes.GET:

--- a/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.reducer.ts
+++ b/components/automate-ui/src/app/pages/integrations/edit/integrations-edit.reducer.ts
@@ -18,7 +18,7 @@ export const IntegrationsEditInitialState: IntegrationsEditState = {
 };
 
 export function integrationsEditReducer(state: IntegrationsEditState = IntegrationsEditInitialState,
-                                        action: ManagerActions) {
+                                        action: ManagerActions): IntegrationsEditState {
   switch (action.type) {
     case ManagerActionTypes.UPDATE:
       return set('status', Status.updating, state);

--- a/components/automate-ui/src/app/pages/job-add/job-add.reducer.ts
+++ b/components/automate-ui/src/app/pages/job-add/job-add.reducer.ts
@@ -19,7 +19,7 @@ export const JobAddInitialState: JobAddState = {
 };
 
 export function jobAddReducer(state: JobAddState = JobAddInitialState,
-                              action: JobActions | RouterAction<any>) {
+                              action: JobActions | RouterAction<any>): JobAddState {
   switch (action.type) {
     case JobActionTypes.JOB_CREATE:
       return set('status', Status.saving, state);

--- a/components/automate-ui/src/app/pages/job-edit/job-edit.reducer.ts
+++ b/components/automate-ui/src/app/pages/job-edit/job-edit.reducer.ts
@@ -19,7 +19,7 @@ export const JobEditInitialState: JobEditState = {
 };
 
 export function jobEditReducer(state: JobEditState = JobEditInitialState,
-                               action: JobActions | RouterAction<any>) {
+                               action: JobActions | RouterAction<any>): JobEditState {
   switch (action.type) {
     case JobActionTypes.JOB_UPDATE:
       return set('status', Status.saving, state);

--- a/components/automate-ui/src/app/pages/job-list/job-list.reducer.ts
+++ b/components/automate-ui/src/app/pages/job-list/job-list.reducer.ts
@@ -33,7 +33,7 @@ export const JobListInitialState: JobListState = {
 };
 
 export function jobListReducer(state: JobListState = JobListInitialState,
-                               action: JobListActions) {
+                               action: JobListActions): JobListState {
   switch (action.type) {
 
     case JobListActionTypes.SORT_JOBS:
@@ -41,7 +41,6 @@ export function jobListReducer(state: JobListState = JobListInitialState,
 
     default:
       return state;
-
   }
 
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

While reviewing PR #3812, I noticed an unexpected construct--explicitly typing a constant as `any`:
```
const newState: any = desktopEntityReducer(initialState, action);
```

That led me down this not terribly deep rabbit hole to discover--and fix--all the reducers that do not declare a return type. A nice side effect is that this revealed a couple tests that were not properly defining the ngrx state for testing purposes. Looking at it from another perspective, though, it revealed that almost all the existing tests were fine.

### :chains: Related Resources
NA

### :+1: Definition of Done
All reducer functions are explicitly typed to return their respective states.

### :athletic_shoe: How to Build and Test the Change
Nothing to see, I fear. As long as tests pass, we should be good.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
