### PR TITLE
4MB report size limit for A2-installed Chef Infra Server

### DIFF
--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -61,19 +61,20 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
-Add a stanza to a new patch.toml that bumps the max report size
+Add a stanza to a new patch.toml that bumps the maximum report size:
 
 ```toml
 [erchef.v1.sys.api]
-max_request_size = 4000000
+max_request_size = 2000000
+# Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
 ```
 
-Apply the config
+Apply the configuration:
 
 ```shell
 chef-automate config patch patch.toml
 ```
-    
+
 Then, [set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
@@ -87,14 +88,15 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server and bump the max report size:
+1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server and bump the maximum report size:
 
     ```toml
       [deployment.v1.svc]
       products=["automate", "infra-server"]
 
       [erchef.v1.sys.api]
-      max_request_size = 4000000      
+      max_request_size = 2000000
+      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Make any other configuration changes desired.
@@ -125,14 +127,15 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to disable Chef Automate data collection and bump the max report size:
+1. Add a stanza to the configuration file to disable Chef Automate data collection and bump the maximum report size:
 
     ```toml
        [erchef.v1.sys.data_collector]
        enabled = false
 
       [erchef.v1.sys.api]
-      max_request_size = 4000000      
+      max_request_size = 2000000
+      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Use the configuration file to deploy Chef Infra Server by running the following command:
@@ -156,7 +159,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Infra Server and bump the max report size:
+1. Add a stanza to the configuration file to deploy Chef Infra Server and bump the maximum report size:
 
     ```toml
        [deployment.v1.svc]
@@ -167,7 +170,8 @@ Installations require elevated privileges, so run the commands as the superuser 
        enabled = false
 
       [erchef.v1.sys.api]
-      max_request_size = 4000000      
+      max_request_size = 2000000
+      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Run the `chef-automate deploy` command with your configuration file (config.toml):
@@ -182,14 +186,15 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 Patch an existing Chef Automate installation to add Chef Infra Server:
 
-1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy and bump the max report size:
+1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy and bump the maximum report size:
 
     ```toml
        [deployment.v1.svc]
        products=["automate", "infra-server"]
 
       [erchef.v1.sys.api]
-      max_request_size = 4000000      
+      max_request_size = 2000000
+      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 2. Apply the patch to the Chef Automate installation:

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -61,6 +61,19 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
+Add a stanza to a new patch.toml that bumps the max report size
+
+```toml
+[erchef.v1.sys.api]
+max_request_size = 4000000
+```
+
+Apply the config
+
+```shell
+chef-automate config patch patch.toml
+```
+    
 Then, [set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
@@ -74,11 +87,14 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server:
+1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server and bump the max report size:
 
     ```toml
       [deployment.v1.svc]
       products=["automate", "infra-server"]
+
+      [erchef.v1.sys.api]
+      max_request_size = 4000000      
     ```
 
 1. Make any other configuration changes desired.
@@ -109,11 +125,14 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to disable Chef Automate data collection:
+1. Add a stanza to the configuration file to disable Chef Automate data collection and bump the max report size:
 
     ```toml
        [erchef.v1.sys.data_collector]
        enabled = false
+
+      [erchef.v1.sys.api]
+      max_request_size = 4000000      
     ```
 
 1. Use the configuration file to deploy Chef Infra Server by running the following command:
@@ -137,7 +156,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Infra Server:
+1. Add a stanza to the configuration file to deploy Chef Infra Server and bump the max report size:
 
     ```toml
        [deployment.v1.svc]
@@ -146,6 +165,9 @@ Installations require elevated privileges, so run the commands as the superuser 
        # Disable Automate data collection as Automate will not be deployed
        [erchef.v1.sys.data_collector]
        enabled = false
+
+      [erchef.v1.sys.api]
+      max_request_size = 4000000      
     ```
 
 1. Run the `chef-automate deploy` command with your configuration file (config.toml):
@@ -160,17 +182,20 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 Patch an existing Chef Automate installation to add Chef Infra Server:
 
-1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy:
+1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy and bump the max report size:
 
     ```toml
        [deployment.v1.svc]
        products=["automate", "infra-server"]
+
+      [erchef.v1.sys.api]
+      max_request_size = 4000000      
     ```
 
 2. Apply the patch to the Chef Automate installation:
 
     ```shell
-       sudo chef-automate config ./patch.toml
+       sudo chef-automate config patch ./patch.toml
     ```
 
    The command output shows the added Chef Infra Server services:


### PR DESCRIPTION
Signed-off-by: Sean Horn <sean_horn@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Update the standard installs that can be changed to reflect the 4MB GRPC limit.
This max report size applies to the allowable chef-client and Compliance profile reports proxied through a Chef Infra Server.

Proactively prevent 413/429 problems during report sending.

### :white_check_mark: Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
