### PR TITLE
Updated toggle sort in Notification table.

### DIFF
--- a/components/automate-ui/src/app/pages/notifications/notifications.component.ts
+++ b/components/automate-ui/src/app/pages/notifications/notifications.component.ts
@@ -35,6 +35,7 @@ export class NotificationsComponent implements OnInit {
   pageSize = 10;
   sortField: string;
   sortDir: FieldDirection;
+  direction = 'none';
   permissionDenied = false; // not currently used
   // This is exposed here to allow the component HTML access to ServiceActionType
   serviceActionType = ServiceActionType;
@@ -72,13 +73,28 @@ export class NotificationsComponent implements OnInit {
   toggleSort(field: string) {
     if (field === this.sortField) {
       // when sorting is inverted for the currently sorted column
-      this.sortDir[field] = this.sortDir[field] === 'asc' ? 'desc' : 'asc';
+      switch (this.direction) {
+        case 'none':
+          this.direction = this.sortDir[field] = 'asc';
+          break;
+        case 'asc':
+          this.direction = this.sortDir[field] = 'desc';
+          break;
+        case 'desc':
+        default:
+          this.direction = this.sortDir[field] = 'none';
+      }
     } else {
       // when sorting a different column than the currently sorted one
       this.resetSortDir();
     }
+    if (this.sortDir[field] === 'none') {
+      this.resetSortDir();
+      this.toggleSort('name');
+    } else {
     this.sortField = field;
     this.updateSort(field, this.sortDir[field]);
+    }
   }
 
   sortIcon(field: string): string {
@@ -108,6 +124,7 @@ export class NotificationsComponent implements OnInit {
   }
 
   private updateSort(field: string, direction: string) {
+    this.direction = direction;
     this.rules$ = this.rules$.pipe(map(rules => {
       let sortedRules: NotificationRule[] = [];
       if (field === 'name') {

--- a/components/automate-ui/src/app/types/types.ts
+++ b/components/automate-ui/src/app/types/types.ts
@@ -7,7 +7,7 @@ export type HealthStatus = 'ok' | 'critical' | 'warning' | 'unknown';
 export type RollupServiceStatus = HealthStatus | 'total';
 export type RollupState = Status | 'total';
 export type RollupCompliance = Compliance | 'total';
-export type SortDirection = 'asc' | 'desc' | 'ASC' | 'DESC';
+export type SortDirection = 'asc' | 'desc' | 'ASC' | 'DESC' | 'none';
 
 
 export enum LoadingStatus {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Before it being used as up/down, which then sets the toggles arrows out of sync with the actual sort direction. So Updated the code and added default case scenario in Notification list table.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/3837
### :+1: Definition of Done
Updated The toggle arrows to stay in sync with the sort direction.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```

1. git fetch origin Amol/chef_sort_toggle
2. build components/automate-ui [Above steps for reference.]
3. Go to Settings tab >> Notification Tab.
4. Click on `Notification list` >> Create Notification >> Add notifications
5. Click on Sort arrows for 3 scenario : asc/des/default.
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![arrow-issue-resolved](https://user-images.githubusercontent.com/10369422/85692008-a7191080-b6f2-11ea-912e-c6b2c51a8d0c.gif)
