### PR TITLE
Add desktop filtering to desktop managment view

### DIFF
--- a/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.actions.ts
@@ -3,35 +3,71 @@ import { HttpErrorResponse } from '@angular/common/http';
 
 import { DailyCheckInCountCollection, NodeRunsDailyStatusCollection,
   TopErrorsCollection, CountedDurationCollection, Desktop, TermFilter,
-  PageSizeChangeEvent } from './desktop.model';
+  PageSizeChangeEvent, NodeMetadataCount } from './desktop.model';
 
 export enum DesktopActionTypes {
-  GET_DAILY_CHECK_IN_TIME_SERIES                     = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES',
-  GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS             = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::SUCCESS',
-  GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE             = 'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::FAILURE',
-  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES             = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES',
-  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_SUCCESS     = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::SUCCESS',
-  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE     = 'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::FAILURE',
-  GET_TOP_ERRORS_COLLECTION                          = 'DESKTOP::GET::TOP_ERRORS_COLLECTION',
-  GET_TOP_ERRORS_COLLECTION_SUCCESS                  = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::SUCCESS',
-  GET_TOP_ERRORS_COLLECTION_FAILURE                  = 'DESKTOP::GET::TOP_ERRORS_COLLECTION::FAILURE',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS                = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_SUCCESS        = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::SUCCESS',
-  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_FAILURE        = 'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::FAILURE',
-  GET_DESKTOPS                                       = 'DESKTOP::GET::DESKTOPS',
-  GET_DESKTOPS_SUCCESS                               = 'DESKTOP::GET::DESKTOPS::SUCCESS',
-  GET_DESKTOPS_FAILURE                               = 'DESKTOP::GET::DESKTOPS::FAILURE',
-  GET_DESKTOPS_TOTAL                                 = 'DESKTOP::GET::DESKTOPS_TOTAL',
-  GET_DESKTOPS_TOTAL_SUCCESS                         = 'DESKTOP::GET::DESKTOPS_TOTAL::SUCCESS',
-  GET_DESKTOPS_TOTAL_FAILURE                         = 'DESKTOP::GET::DESKTOPS_TOTAL::FAILURE',
-  SET_SELECTED_DESKTOP                               = 'DESKTOP::SET::DESKTOP',
-  SET_SELECTED_DAYS_AGO                              = 'DESKTOP::SET::DAYS_AGO',
-  UPDATE_DESKTOPS_FILTER_CURRENT_PAGE                = 'DESKTOP::UPDATE::DESKTOPS_FILTER_CURRENT_PAGE',
-  ADD_DESKTOPS_FILTER_TERM                           = 'DESKTOP::ADD::DESKTOPS_FILTER_TERM',
-  UPDATE_DESKTOPS_FILTER_TERMS                       = 'DESKTOP::UPDATE::DESKTOPS_FILTER_TERMS',
-  REMOVE_DESKTOPS_FILTER_TERM                        = 'DESKTOP::REMOVE::DESKTOPS_FILTER_TERM',
-  UPDATE_DESKTOPS_SORT_TERM                          = 'DESKTOP::UPDATE::DESKTOPS_SORT_TERM',
-  UPDATE_DESKTOPS_FILTER_PAGE_SIZE_AND_CURRENT_PAGE  = 'DESKTOP::UPDATE::DESKTOPS_FILTER_PAGE_SIZE_AND_CURRENT_PAGE'
+  GET_DAILY_CHECK_IN_TIME_SERIES =
+    'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES',
+  GET_DAILY_CHECK_IN_TIME_SERIES_SUCCESS =
+    'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::SUCCESS',
+  GET_DAILY_CHECK_IN_TIME_SERIES_FAILURE =
+    'DESKTOP::GET::DAILY_CHECK_IN_TIME_SERIES::FAILURE',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES =
+    'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_SUCCESS =
+    'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::SUCCESS',
+  GET_DAILY_NODE_RUNS_STATUS_TIME_SERIES_FAILURE =
+    'DESKTOP::GET::DAILY_NODE_RUNS_STATUS_TIME_SERIES::FAILURE',
+  GET_TOP_ERRORS_COLLECTION =
+    'DESKTOP::GET::TOP_ERRORS_COLLECTION',
+  GET_TOP_ERRORS_COLLECTION_SUCCESS =
+    'DESKTOP::GET::TOP_ERRORS_COLLECTION::SUCCESS',
+  GET_TOP_ERRORS_COLLECTION_FAILURE =
+    'DESKTOP::GET::TOP_ERRORS_COLLECTION::FAILURE',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS =
+    'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_SUCCESS =
+    'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::SUCCESS',
+  GET_UNKNOWN_DESKTOP_DURATION_COUNTS_FAILURE =
+    'DESKTOP::GET::UNKNOWN_DESKTOP_DURATION_COUNT::FAILURE',
+  GET_NODE_METADATA_COUNTS =
+    'DESKTOP::GET::NODE_METADATA_COUNTS',
+  GET_NODE_METADATA_COUNTS_SUCCESS =
+    'DESKTOP::GET::NODE_METADATA_COUNTS::SUCCESS',
+  GET_NODE_METADATA_COUNTS_FAILURE =
+    'DESKTOP::GET::NODE_METADATA_COUNTS::FAILURE',
+  UPDATE_DESKTOP_LIST_TITLE =
+    'DESKTOP::UPDATE::DESKTOP_LIST_TITLE',
+  GET_DESKTOPS =
+    'DESKTOP::GET::DESKTOPS',
+  GET_DESKTOPS_SUCCESS =
+    'DESKTOP::GET::DESKTOPS::SUCCESS',
+  GET_DESKTOPS_FAILURE =
+    'DESKTOP::GET::DESKTOPS::FAILURE',
+  GET_DESKTOPS_TOTAL =
+    'DESKTOP::GET::DESKTOPS_TOTAL',
+  GET_DESKTOPS_TOTAL_SUCCESS =
+    'DESKTOP::GET::DESKTOPS_TOTAL::SUCCESS',
+  GET_DESKTOPS_TOTAL_FAILURE =
+    'DESKTOP::GET::DESKTOPS_TOTAL::FAILURE',
+  SET_SELECTED_DESKTOP =
+    'DESKTOP::SET::DESKTOP',
+  SET_SELECTED_DAYS_AGO =
+    'DESKTOP::SET::DAYS_AGO',
+  UPDATE_DESKTOPS_FILTER_CURRENT_PAGE =
+    'DESKTOP::UPDATE::DESKTOPS_FILTER_CURRENT_PAGE',
+  ADD_DESKTOPS_FILTER_TERM =
+    'DESKTOP::ADD::DESKTOPS_FILTER_TERM',
+  UPDATE_DESKTOPS_FILTER_TERMS =
+    'DESKTOP::UPDATE::DESKTOPS_FILTER_TERMS',
+  REMOVE_DESKTOPS_FILTER_TERM =
+    'DESKTOP::REMOVE::DESKTOPS_FILTER_TERM',
+  UPDATE_DESKTOPS_SORT_TERM =
+    'DESKTOP::UPDATE::DESKTOPS_SORT_TERM',
+  UPDATE_DESKTOPS_DATE_TERM =
+    'DESKTOP::UPDATE::DESKTOPS_DATE_TERM',
+  UPDATE_DESKTOPS_FILTER_PAGE_SIZE_AND_CURRENT_PAGE =
+    'DESKTOP::UPDATE::DESKTOPS_FILTER_PAGE_SIZE_AND_CURRENT_PAGE'
 }
 
 export class SetSelectedDesktop implements Action {
@@ -101,6 +137,25 @@ export class GetUnknownDesktopDurationCountsFailure implements Action {
   constructor(public payload: HttpErrorResponse) { }
 }
 
+export class GetNodeMetadataCounts implements Action {
+  readonly type = DesktopActionTypes.GET_NODE_METADATA_COUNTS;
+}
+
+export class GetNodeMetadataCountsSuccess implements Action {
+  readonly type = DesktopActionTypes.GET_NODE_METADATA_COUNTS_SUCCESS;
+  constructor(public payload: NodeMetadataCount[]) { }
+}
+
+export class GetNodeMetadataCountsFailure implements Action {
+  readonly type = DesktopActionTypes.GET_NODE_METADATA_COUNTS_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export class UpdateDesktopListTitle implements Action {
+  readonly type = DesktopActionTypes.UPDATE_DESKTOP_LIST_TITLE;
+  constructor(public payload: string) { }
+}
+
 export class GetDesktops implements Action {
   readonly type = DesktopActionTypes.GET_DESKTOPS;
 }
@@ -154,6 +209,11 @@ export class UpdateDesktopSortTerm implements Action {
   constructor(public payload: { term: string }) { }
 }
 
+export class UpdateDesktopDateTerm implements Action {
+  readonly type = DesktopActionTypes.UPDATE_DESKTOPS_DATE_TERM;
+  constructor(public payload: { start?: Date, end?: Date }) { }
+}
+
 export class UpdateDesktopsFilterPageSizeAndCurrentPage implements Action {
   readonly type = DesktopActionTypes.UPDATE_DESKTOPS_FILTER_PAGE_SIZE_AND_CURRENT_PAGE;
   constructor(public payload: PageSizeChangeEvent) { }
@@ -174,6 +234,10 @@ export type DesktopActions =
   | GetUnknownDesktopDurationCounts
   | GetUnknownDesktopDurationCountsSuccess
   | GetUnknownDesktopDurationCountsFailure
+  | GetNodeMetadataCounts
+  | GetNodeMetadataCountsSuccess
+  | GetNodeMetadataCountsFailure
+  | UpdateDesktopListTitle
   | GetDesktops
   | GetDesktopsSuccess
   | GetDesktopsFailure
@@ -185,4 +249,5 @@ export type DesktopActions =
   | UpdateDesktopFilterTerm
   | RemoveDesktopFilterTerm
   | UpdateDesktopSortTerm
+  | UpdateDesktopDateTerm
   | UpdateDesktopsFilterPageSizeAndCurrentPage;

--- a/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.effects.ts
@@ -19,6 +19,9 @@ import {
   GetUnknownDesktopDurationCounts,
   GetUnknownDesktopDurationCountsSuccess,
   GetUnknownDesktopDurationCountsFailure,
+  GetNodeMetadataCounts,
+  GetNodeMetadataCountsSuccess,
+  GetNodeMetadataCountsFailure,
   GetDesktops,
   GetDesktopsSuccess,
   GetDesktopsFailure,
@@ -122,6 +125,16 @@ export class DesktopEffects {
         new GetUnknownDesktopDurationCountsSuccess(countedDurationCollection)),
         catchError((error) => of(new GetUnknownDesktopDurationCountsFailure(error)))))
     );
+
+  @Effect()
+  getNodeMetadataCounts$ = this.actions$.pipe(
+    ofType<GetNodeMetadataCounts>(DesktopActionTypes.GET_NODE_METADATA_COUNTS),
+    withLatestFrom(this.store$),
+    switchMap(([_action, storeState]) =>
+      this.requests.getNodeMetadataCounts(storeState.desktops.getDesktopsFilter).pipe(
+        map(nodeMetadataCounts => new GetNodeMetadataCountsSuccess(nodeMetadataCounts)),
+        catchError((error) => of(new GetNodeMetadataCountsFailure(error))))
+    ));
 
   @Effect()
   getUnknownDesktopDurationCountsFailure$ = this.actions$.pipe(

--- a/components/automate-ui/src/app/entities/desktop/desktop.model.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.model.ts
@@ -1,6 +1,8 @@
 export enum Terms {
   DesktopName = 'name',
   Platform = 'platform',
+  Domain = 'domain',
+  Status = 'status',
   CheckInTime = 'checkin',
   ErrorMessage = 'error_message',
   ErrorType = 'error_type'
@@ -81,7 +83,10 @@ export interface Desktop {
   checkin: Date;
   uptimeSeconds: number;
   platform: string;
+  platformFamily: string;
+  platformVersion: string;
   chefVersion: string;
+  domain: string;
 }
 
 export interface Filter {
@@ -90,6 +95,8 @@ export interface Filter {
   sortingField: string;
   sortingOrder: string;
   terms: TermFilter[];
+  start?: Date;
+  end?: Date;
 }
 
 export interface TermFilter {
@@ -100,4 +107,24 @@ export interface TermFilter {
 export interface PageSizeChangeEvent {
   pageSize: number;
   updatedPageNumber: number;
+}
+
+export enum NodeMetadataCountType {
+  Status = 'status',
+  Platform = 'platform',
+  Domain = 'domain',
+  Environment = 'environment'
+}
+
+export interface NodeMetadataCountValue {
+  value: string;
+  count: number;
+  disabled: boolean;
+  checked: boolean;
+}
+
+export interface NodeMetadataCount {
+  type: NodeMetadataCountType;
+  label: string;
+  values: NodeMetadataCountValue[];
 }

--- a/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.selectors.ts
@@ -44,6 +44,16 @@ export const unknownDesktopDurationCounts = createSelector(
   (state) => state.unknownDesktopDurationCounts
 );
 
+export const nodeMetadataCounts = createSelector(
+  desktopState,
+  (state) => state.nodeMetadataCounts
+);
+
+export const desktopListTitle = createSelector(
+  desktopState,
+  (state) => state.desktopListTitle
+);
+
 export const desktops = createSelector(
   desktopState,
   (state) => state.desktops

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -12,7 +12,7 @@
     </div>
     <app-chart-progress-bar size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>
   </div>
-  <chef-phat-radio deselectable>
+  <chef-phat-radio deselectable (change)="statusSelected.emit($event.target.value)" [value]="selectedStatus">
     <chef-option value='unknown' tabindex="0">
       <div class="title">Unknown</div>
       <div class="total">{{ unknownCount }}</div>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, OnChanges, SimpleChange } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, OnDestroy, OnChanges, Output, SimpleChange } from '@angular/core';
 import { Subject, timer } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { TimeFromNowPipe } from 'app/pipes/time-from-now.pipe';
@@ -16,6 +16,9 @@ export class DailyCheckInComponent implements OnInit, OnDestroy, OnChanges {
   @Input() unknownCount: number;
   @Input() checkedInCount: number;
   @Input() lastUpdated: Date;
+  @Input() selectedStatus: string;
+
+  @Output() statusSelected: EventEmitter<string> = new EventEmitter<string>();
 
   private isDestroyed = new Subject<boolean>();
   public lastUpdatedMessage = '-';

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.html
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.html
@@ -22,12 +22,15 @@
           <div class="dashboard-overview-row">
             <div class="dashboard-overview-col">
               <app-daily-check-in
+                *ngIf="last24HourCheckInCount$ | async as last24HourCheckInCount"
                 [unknownPercentage]="unknownPercentage$ | async"
                 [checkedInPercentage]="checkedInPercentage$ | async"
                 [totalCount]="totalCount$ | async"
                 [unknownCount]="unknownCount$ | async"
                 [lastUpdated]="checkInCountCollectedUpdated$ | async"
-                [checkedInCount]="checkedInCount$ | async">
+                [checkedInCount]="checkedInCount$ | async"
+                [selectedStatus]="selectedCheckInStatus"
+                (statusSelected)="onDailyStatusSelected($event, last24HourCheckInCount)">
               </app-daily-check-in>
             </div>
             <div class="dashboard-overview-col">
@@ -44,6 +47,7 @@
               <app-unknown-desktop-duration-counts
                 [countedDurationItems]="unknownDesktopCountedDurationItems$ | async"
                 [lastUpdated]="unknownDesktopCountedDurationUpdated$ | async"
+                [selectedDuration]="selectedDuration"
                 (durationSelected)="onDurationSelected($event)">
               </app-unknown-desktop-duration-counts>
             </div>
@@ -51,6 +55,7 @@
               <app-top-errors
                 [topErrorsItems]="topErrorsItems$ | async"
                 [lastUpdated]="topErrorsUpdated$ | async"
+                [selectedError]="selectedError"
                 (errorSelected)="onErrorSelected($event)">
               </app-top-errors>
             </div>
@@ -61,16 +66,19 @@
         *ngIf="desktopListVisible && !desktopDetailFullscreened"
         class="dashboard-list-column">
         <app-insight
+          [titleText]="desktopListTitle$ | async"
           [desktops]="desktops$ | async"
           [selectedDesktop]="selectedDesktop"
           [totalDesktops]="totalDesktopCount$ | async"
           [pageSize]="pageSize$ | async"
           [currentPage]="currentPage$ | async"
           [termFilters]="termFilters$ | async"
+          [nodeMetadataCounts]="nodeMetadataCounts$ | async"
           [fullscreened]="desktopListFullscreened"
           (pageChange)="onPageChange($event)"
           (pageSizeChange)="onPageSizeChange($event)"
-          (termFilterSelected)="onTermFilterSelected($event)"
+          (termFilterAdded)="onTermFilterAdded($event)"
+          (termFilterRemoved)="onTermFilterRemoved($event)"
           (desktopSelected)="onDesktopSelected($event)"
           (closed)="onDesktopListClose()"
           (fullscreenToggled)="onDesktopListFullscreen()"
@@ -83,6 +91,9 @@
         <app-desktop-detail
           [desktop]="selectedDesktop"
           [fullscreened]="desktopDetailFullscreened"
+          [checkInHistory]="checkInHistory$ | async"
+          [checkInNumDays]="checkInNumDays"
+          (checkInNumDaysChanged)="onCheckInNumDaysChanged($event)"
           (closed)="onDesktopDetailClose()"
           (fullscreenToggled)="onDesktopDetailFullscreen()">
         </app-desktop-detail>

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
@@ -4,6 +4,7 @@ import { Store } from '@ngrx/store';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { map, filter } from 'rxjs/operators';
 import { last, reverse } from 'lodash/fp';
+import * as moment from 'moment/moment';
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
 
 import {
@@ -12,19 +13,27 @@ import {
   SetSelectedDaysAgo,
   GetTopErrorsCollection,
   GetUnknownDesktopDurationCounts,
+  UpdateDesktopListTitle,
   GetDesktops,
   GetDesktopsTotal,
   UpdateDesktopFilterCurrentPage,
   UpdateDesktopFilterTerm,
+  GetNodeMetadataCounts,
+  AddDesktopFilterTerm,
   RemoveDesktopFilterTerm,
   UpdateDesktopSortTerm,
-  UpdateDesktopsFilterPageSizeAndCurrentPage
+  UpdateDesktopDateTerm,
+  UpdateDesktopsFilterPageSizeAndCurrentPage,
+  GetDailyNodeRunsStatusTimeSeries
 } from 'app/entities/desktop/desktop.actions';
 import {
   dailyCheckInCountCollection,
   getSelectedDaysAgo,
+  getDailyNodeRuns,
   topErrorsCollection,
   unknownDesktopDurationCounts,
+  nodeMetadataCounts,
+  desktopListTitle,
   desktops,
   desktopsTotal,
   desktopsCurrentPage,
@@ -34,7 +43,7 @@ import {
 import {
   DailyCheckInCount, DailyCheckInCountCollection, DayPercentage,
   TopErrorsItem, CountedDurationItem, Desktop, TermFilter, Terms,
-  PageSizeChangeEvent
+  NodeMetadataCount, DailyNodeRuns, PageSizeChangeEvent
 } from 'app/entities/desktop/desktop.model';
 
 @Component({
@@ -45,7 +54,7 @@ import {
 export class DashboardComponent implements OnInit {
 
   private checkInCountCollection$: Observable<DailyCheckInCountCollection>;
-  private last24HourCheckInCount$: Observable<DailyCheckInCount>;
+  public last24HourCheckInCount$: Observable<DailyCheckInCount>;
   public unknownPercentage$: Observable<number>;
   public checkedInPercentage$: Observable<number>;
   public totalCount$: Observable<number>;
@@ -53,21 +62,28 @@ export class DashboardComponent implements OnInit {
   public checkedInCount$: Observable<number>;
   public days$: Observable<DayPercentage[]>;
   public selectedDaysAgo$: Observable<number>;
+  public checkInHistory$: Observable<DailyNodeRuns>;
   public topErrorsItems$: Observable<TopErrorsItem[]>;
   public checkInCountCollectedUpdated$: Observable<Date>;
   public topErrorsUpdated$: Observable<Date>;
   public unknownDesktopCountedDurationItems$: Observable<CountedDurationItem[]>;
   public unknownDesktopCountedDurationUpdated$: Observable<Date>;
+  public nodeMetadataCounts$: Observable<NodeMetadataCount[]>;
+  public desktopListTitle$: Observable<string>;
   public desktops$: Observable<Desktop[]>;
   public totalDesktopCount$: Observable<number>;
   public currentPage$: Observable<number>;
   public pageSize$: Observable<number>;
   public termFilters$: Observable<TermFilter[]>;
+  public checkInNumDays = 15;
   public desktopListVisible = false;
   public desktopListFullscreened = false;
   public desktopDetailVisible = false;
   public desktopDetailFullscreened = false;
   public selectedDesktop: Desktop;
+  public selectedCheckInStatus: string;
+  public selectedDuration: string;
+  public selectedError: TopErrorsItem;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -80,6 +96,9 @@ export class DashboardComponent implements OnInit {
     this.store.dispatch(new GetUnknownDesktopDurationCounts());
     this.store.dispatch(new GetDesktops());
     this.store.dispatch(new GetDesktopsTotal());
+    this.store.dispatch(new GetNodeMetadataCounts());
+
+    this.nodeMetadataCounts$ = this.store.select(nodeMetadataCounts);
 
     this.termFilters$ = this.store.select(desktopsFilterTerms);
 
@@ -88,6 +107,7 @@ export class DashboardComponent implements OnInit {
     this.currentPage$ = this.store.select(desktopsCurrentPage);
     this.selectedDaysAgo$ = this.store.select(getSelectedDaysAgo);
 
+    this.desktopListTitle$ = this.store.select(desktopListTitle);
     this.desktops$ = this.store.select(desktops);
 
     this.totalDesktopCount$ = this.store.select(desktopsTotal);
@@ -161,6 +181,8 @@ export class DashboardComponent implements OnInit {
       map(counts => counts.updated)
     );
 
+    this.checkInHistory$ = this.store.select(getDailyNodeRuns);
+
     setTimeout(() => this.layoutFacade.hideSidebar());
   }
 
@@ -170,8 +192,14 @@ export class DashboardComponent implements OnInit {
 
   onDesktopListClose() {
     this.onDesktopDetailClose();
+    this.selectedCheckInStatus = '';
+    this.selectedDuration = undefined;
+    this.selectedError = undefined;
     this.desktopListFullscreened = false;
     this.desktopListVisible = false;
+    this.store.dispatch(new UpdateDesktopDateTerm({}));
+    this.store.dispatch(new UpdateDesktopFilterTerm({ terms: [] }));
+    this.store.dispatch(new UpdateDesktopDateTerm({}));
   }
 
   onDesktopListFullscreen() {
@@ -195,6 +223,45 @@ export class DashboardComponent implements OnInit {
     this.store.dispatch(new UpdateDesktopFilterCurrentPage({page: pageNumber}));
   }
 
+  public onDailyStatusSelected(status: string, last24HourCheckInCount: DailyCheckInCount) {
+    if (!status) { return this.onDesktopListClose(); }
+
+    let start: Date;
+    let end: Date;
+
+    switch (status) {
+      case ('checked-in'):
+        start = new Date(last24HourCheckInCount.start);
+        end = new Date(last24HourCheckInCount.end);
+        break;
+      case ('unknown'):
+        end = new Date(last24HourCheckInCount.start);
+        break;
+    }
+
+    this.store.dispatch(new UpdateDesktopListTitle(`Daily Check-in: ${status}`));
+    this.store.dispatch(new UpdateDesktopDateTerm({ start, end }));
+    this.store.dispatch(new UpdateDesktopFilterTerm({ terms: [] }));
+    this.store.dispatch(new GetNodeMetadataCounts());
+    this.store.dispatch(new GetDesktops());
+    this.selectedCheckInStatus = status;
+    this.selectedError = undefined;
+    this.selectedDuration = undefined;
+    this.desktopListVisible = true;
+  }
+
+  public onTermFilterAdded(term: TermFilter) {
+    this.store.dispatch(new AddDesktopFilterTerm({ term }));
+    this.store.dispatch(new GetNodeMetadataCounts());
+    this.store.dispatch(new GetDesktops());
+  }
+
+  public onTermFilterRemoved(term: TermFilter) {
+    this.store.dispatch(new RemoveDesktopFilterTerm({ term }));
+    this.store.dispatch(new GetNodeMetadataCounts());
+    this.store.dispatch(new GetDesktops());
+  }
+
   public onPageSizeChange(event: PageSizeChangeEvent) {
     this.store.dispatch(new UpdateDesktopsFilterPageSizeAndCurrentPage({
       pageSize: event.pageSize,
@@ -202,24 +269,56 @@ export class DashboardComponent implements OnInit {
     }));
   }
 
-  public onErrorSelected(errorItem: TopErrorsItem): void {
+  public onErrorSelected(error: TopErrorsItem): void {
+    if (!error) { return this.onDesktopListClose(); }
+
     const terms = [
-      { type: Terms.ErrorMessage, value: errorItem.message },
-      { type: Terms.ErrorType, value: errorItem.type }];
+      { type: Terms.ErrorType, value: error.type },
+      { type: Terms.ErrorMessage, value: error.message },
+      { type: Terms.Status, value: 'failure' }
+    ];
+    this.store.dispatch(new UpdateDesktopListTitle(`${error.type}: ${error.message}`));
+    this.store.dispatch(new UpdateDesktopDateTerm({}));
     this.store.dispatch(new UpdateDesktopFilterTerm({ terms }));
+    this.store.dispatch(new GetNodeMetadataCounts());
+    this.store.dispatch(new GetDesktops());
+    this.selectedError = error;
+    this.selectedDuration = undefined;
+    this.selectedCheckInStatus = '';
     this.desktopListVisible = true;
   }
 
-  public onDurationSelected(_durationItem: any): void {
-    this.store.dispatch(new UpdateDesktopFilterCurrentPage({ page: 1 }));
+  public onDurationSelected(duration: string): void {
+    if (!duration) { return this.onDesktopListClose(); }
+
+    const units = { 'M': 'month', 'w': 'week', 'd': 'day' };
+    const unit = units[duration[1]];
+    const amount = parseInt(duration[0], 10);
+    const end = moment().utc().subtract(amount, unit).toDate();
+    this.store.dispatch(new UpdateDesktopListTitle(`Last Check-in: ${amount} ${unit}${amount !== 1 ? 's' : ''} ago`));
+    this.store.dispatch(new UpdateDesktopDateTerm({ end }));
+    this.store.dispatch(new UpdateDesktopFilterTerm({ terms: [] }));
+    this.store.dispatch(new GetNodeMetadataCounts());
+    this.store.dispatch(new GetDesktops());
+    this.selectedDuration = duration;
+    this.selectedError = undefined;
+    this.selectedCheckInStatus = '';
     this.desktopListVisible = true;
   }
 
   public onDesktopSelected(desktop: Desktop) {
     this.selectedDesktop = desktop;
     this.store.dispatch(new SetSelectedDesktop({desktop}));
+    this.store.dispatch(
+      new GetDailyNodeRunsStatusTimeSeries(this.selectedDesktop.id, this.checkInNumDays));
     this.desktopDetailVisible = true;
     this.desktopListFullscreened = false;
+  }
+
+  public onCheckInNumDaysChanged(checkInNumDays: number) {
+    this.checkInNumDays = checkInNumDays;
+    this.store.dispatch(
+      new GetDailyNodeRunsStatusTimeSeries(this.selectedDesktop.id, this.checkInNumDays));
   }
 
   public onTermFilterSelected(term: TermFilter): void {

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -19,7 +19,7 @@
       <h3>Check-in History</h3>
       <div class="heading-actions">
         <chef-button secondary (click)="updateCheckInDays()">
-          <span>Last {{ (checkinNumDays === 15 ? 2 : 4) }} Weeks</span>
+          <span>Last {{ (checkInNumDays === twoWeekNumDays ? 2 : 4) }} Weeks</span>
           <chef-icon>expand_more</chef-icon>
         </chef-button>
         <chef-button secondary (click)="toggleDownloadDropdown()" class='download-dropdown-toggle'>
@@ -43,7 +43,7 @@
         </chef-tr>
       </chef-thead>
       <chef-tbody>
-        <chef-tr *ngFor="let history of checkInHistory; index as i">
+        <chef-tr *ngFor="let history of labeledCheckInHistory; index as i">
           <chef-td class="status-cell">
             <chef-icon [id]="'checkin-item-'+i+'text'" [ngClass]="history.status">
               {{ historyIcons[history.status] }}

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -156,7 +156,9 @@ h3 {
     }
 
     chef-icon {
-      &.converged, &.unchanged {
+      &.converged,
+      &.unchanged,
+      &.success {
         color: $status-success;
       }
 
@@ -273,11 +275,9 @@ h3 {
     border-left-color: $status-error;
   }
 
-  &.converged {
-    border-left-color: $status-success;
-  }
-
-  &.unchanged {
+  &.converged,
+  &.unchanged,
+  &.success {
     border-left-color: $status-success;
   }
 

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
@@ -1,7 +1,7 @@
 <div class="content-container">
   <div class="header">
     <div class="heading">
-      <h2 class="heading-title">Error: Chef::ExampleError1: Error 1 occurred</h2>
+      <h2 class="heading-title">{{ titleText }}</h2>
     </div>
     <div class="heading-actions">
       <chef-button secondary (click)="fullscreenToggled.emit()">
@@ -15,7 +15,7 @@
   </div>
   <div class="sub-header">
     <div class="selected-filters">
-      <chef-button secondary *ngFor="let term of termFilters">
+      <chef-button secondary *ngFor="let term of termFilters" (click)="termFilterRemoved.emit(term)">
         <chef-icon>close</chef-icon>
         <span>{{ term.value }}</span>
       </chef-button>
@@ -31,65 +31,20 @@
     ></app-insight-attributes-dropdown>
   </div>
   <div class="filters">
-    <div class="filter-group">
-      <div class="filter-group-heading">Top 3 Platforms</div>
-      <div class="filter-group-options">
-        <chef-pill>
-          <chef-checkbox>windows <chef-pill>10</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>ubuntu<chef-pill>60</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>linux<chef-pill>30</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-      </div>
-    </div>
-    <div class="filter-group">
-      <div class="filter-group-heading">Top 3 Version</div>
-      <div class="filter-group-options">
-        <chef-pill>
-          <chef-checkbox>10.01 <chef-pill>10</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>16.04<chef-pill>60</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>16.02<chef-pill>30</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-      </div>
-    </div>
-    <div class="filter-group">
-      <div class="filter-group-heading">Top 3 Domain</div>
-      <div class="filter-group-options">
-        <chef-pill>
-          <chef-checkbox>chef.io <chef-pill>10</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>habitat.sh<chef-pill>60</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-        <chef-pill>
-          <chef-checkbox>opscode.com<chef-pill>30</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-      </div>
-    </div>
-    <div class="filter-group">
-      <div class="filter-group-heading">Last Run</div>
-      <div class="filter-group-options">
-        <chef-pill>
-          <chef-checkbox>Error <chef-pill>10</chef-pill>
-          </chef-checkbox>
-        </chef-pill>
-      </div>
+    <div class="filter-group" *ngFor="let filterGroup of nodeMetadataCounts; trackBy:filterGroupTrackBy">
+      <ng-container *ngIf="filterGroup.values.length">
+        <div class="filter-group-heading">{{ filterGroup.label }}</div>
+        <div class="filter-group-options">
+          <chef-pill *ngFor="let filterGroupItem of filterGroup.values; trackBy:filterGroupValueTrackBy">
+            <chef-checkbox
+              (change)="termFilterOptionToggled({ type: filterGroup.type, value: filterGroupItem.value })"
+              [checked]="filterGroupItem.checked"
+              [disabled]="filterGroupItem.disabled">
+              {{ filterGroupItem.value }} <chef-pill>{{ filterGroupItem.count }}</chef-pill>
+            </chef-checkbox>
+          </chef-pill>
+        </div>
+      </ng-container>
     </div>
   </div>
 
@@ -132,9 +87,9 @@
           <chef-icon [ngClass]="desktop.status">{{ desktop.status | chefStatusIcon }}</chef-icon>
           {{ desktop.checkin | timeFromNow }}
         </chef-td>
-        <chef-td data-label="Platform">{{ desktop.platform }}</chef-td>
-        <chef-td data-label="Platform Version">10.08</chef-td>
-        <chef-td data-label="Domain">sales</chef-td>
+        <chef-td data-label="Platform">{{ desktop.platformFamily }}</chef-td>
+        <chef-td data-label="Platform Version">{{ desktop.platformVersion }}</chef-td>
+        <chef-td data-label="Domain">{{ desktop.domain }}</chef-td>
       </chef-tr>
     </chef-tbody>
   </chef-table>

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.scss
@@ -37,17 +37,19 @@
 .sub-header {
   display: flex;
   position: relative;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
 
   chef-button {
-    margin: 0;
+    margin: 0 0 $spacing-03 0;
   }
 }
 
 .selected-filters {
+  flex-basis: 70%;
+
   chef-button {
-    margin: 0 $spacing-03 0 0;
+    margin: 0 $spacing-03 $spacing-03 0;
   }
 }
 

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -14,9 +14,10 @@
       <chef-tr
         *ngFor="let item of topErrorsItems"
         class="chart-list-item"
+        [ngClass]="{'selected': item === selectedError}"
         tabindex="0"
-        (click)="errorSelected.emit(item)"
-        (keyup.enter)="errorSelected.emit(item)">
+        (click)="onErrorSelect(item)"
+        (keyup.enter)="onErrorSelect(item)">
         <chef-td class="chart-list-item-label-cell">
           <div>{{ item.type }}: {{ item.message }}</div>
         </chef-td>

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.scss
@@ -47,7 +47,8 @@
     margin-bottom: 0;
   }
 
-  &:hover {
+  &:hover,
+  &.selected {
     cursor: pointer;
 
     .chart-list-item-label-cell,

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
@@ -18,6 +18,7 @@ export class TopErrorsComponent  implements OnInit, OnDestroy, OnChanges  {
 
   @Input() topErrorsItems: TopErrorsItem[];
   @Input() lastUpdated: Date;
+  @Input() selectedError: TopErrorsItem;
   @Output() errorSelected: EventEmitter<TopErrorsItem> = new EventEmitter();
 
   private isDestroyed = new Subject<boolean>();
@@ -44,6 +45,10 @@ export class TopErrorsComponent  implements OnInit, OnDestroy, OnChanges  {
   ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  onErrorSelect(error: TopErrorsItem) {
+    this.errorSelected.emit(error !== this.selectedError ? error : undefined);
   }
 
   get topErrorsItemsMax() {

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
@@ -14,9 +14,10 @@
       <chef-tr
         *ngFor="let item of countedDurationItems"
         class="chart-list-item"
+        [ngClass]="{'selected': item.duration === selectedDuration}"
         tabindex="0"
-        (click)="durationSelected.emit(item)"
-        (keyup.enter)="durationSelected.emit(item)">
+        (click)="onDurationSelect(item.duration)"
+        (keyup.enter)="onDurationSelect(item.duration)">
         <chef-td class="chart-list-item-label-cell">
           {{ formatDuration(item.duration) }}
         </chef-td>

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.scss
@@ -47,7 +47,8 @@
     margin-bottom: 0;
   }
 
-  &:hover {
+  &:hover,
+  &.selected {
     cursor: pointer;
 
     .chart-list-item-label-cell,

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.ts
@@ -17,8 +17,9 @@ export class UnknownDesktopDurationCountsComponent  implements OnInit, OnDestroy
 
   @Input() countedDurationItems: CountedDurationItem[];
   @Input() lastUpdated: Date;
+  @Input() selectedDuration: string;
 
-  @Output() durationSelected: EventEmitter<any> = new EventEmitter();
+  @Output() durationSelected: EventEmitter<string> = new EventEmitter();
 
   private isDestroyed = new Subject<boolean>();
   public lastUpdatedMessage = '-';
@@ -48,6 +49,10 @@ export class UnknownDesktopDurationCountsComponent  implements OnInit, OnDestroy
 
   get countedDurationItemsMax() {
     return maxBy('count', this.countedDurationItems);
+  }
+
+  onDurationSelect(duration: string) {
+    this.durationSelected.emit(duration !== this.selectedDuration ? duration : undefined);
   }
 
   // Make this more general once we don't have hard coded durations.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This commit wires up the dashboard desktop filtering controls to the cfgmgmt API.

![c](https://user-images.githubusercontent.com/479121/85754132-13334e80-b6ca-11ea-85ac-576677819120.gif)

### :chains: Related Resources

https://github.com/chef/automate/issues/3639

### :+1: Definition of Done

- All desktop dashboard widgets properly link to desktop list subview.
- Filter/counts at top of desktop list subview display correct info and updates desktop list when toggled.

### :athletic_shoe: How to Build and Test the Change

- Start all services and UI
- Have some data to look at in the dashboard:
```
# From hab studio
for _ in {1..50}; do m=$((RANDOM % 4)); n=$((RANDOM % 4)); generate_chef_run_failure_example | jq --arg msg "Error $n occurred" --arg type "Chef::ExampleError$m" '.error.message = $msg | .error.class = $type' | send_chef_data_raw; done
```
- Navigate to `a2-dev.test/desktop`
