### PR TITLE
Fixing Event Feed chef server filter bug

### DIFF
--- a/components/config-mgmt-service/integration_test/event_feed_test.go
+++ b/components/config-mgmt-service/integration_test/event_feed_test.go
@@ -663,9 +663,25 @@ func TestEventFeedFilterChefServers(t *testing.T) {
 			expected: expectedEvents,
 		},
 		{
-			description: "should return only 'chef_1' chef server events",
+			description: "should return only 'chef_1' chef server events. Using 'source_fqdn' alias",
 			request: request.EventFilter{
 				Filter:   []string{"source_fqdn:chef_1"},
+				PageSize: pageSize,
+			},
+			expected: expectedEvents[0:5],
+		},
+		{
+			description: "should return only 'chef_1' chef server events. Using 'chef_server' alias",
+			request: request.EventFilter{
+				Filter:   []string{"chef_server:chef_1"},
+				PageSize: pageSize,
+			},
+			expected: expectedEvents[0:5],
+		},
+		{
+			description: "should return only 'chef_1' chef server events. Using 'service_hostname' alias",
+			request: request.EventFilter{
+				Filter:   []string{"service_hostname:chef_1"},
 				PageSize: pageSize,
 			},
 			expected: expectedEvents[0:5],

--- a/components/config-mgmt-service/params/parameters.go
+++ b/components/config-mgmt-service/params/parameters.go
@@ -137,7 +137,7 @@ func ConvertParamToActionBackend(parameter string) string {
 	switch parameter {
 	case "organization":
 		return backend.ActionOrganization
-	case "source_fqdn":
+	case "source_fqdn", "chef_server":
 		return backend.ActionSourceFQDN
 	case "event-type":
 		return backend.EntityTypeName


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixing event feed chef-server filtering. The problem was that the UI was using the term 'chef_server' but the only valid terms were ''source_fqdn' or 'service_hostname'. The solution was to add 'chef_server' as an alias. 

### :+1: Definition of Done
Filtering the event feed with a chef-server works. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/config-mgmt-service && start_all_servcies`
1. `chef_load_nodes 100`
1. `chef_load_actions 100`
1. Go to https://a2-dev.test/dashboards/event-feed and add a chef-server filter. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
