### PR TITLE
Updating the policy file term

### DIFF
--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
@@ -89,7 +89,7 @@ export class EventFeedComponent implements OnInit, OnDestroy {
         {name: 'node', title: 'Nodes', icon: 'storage'},
         {name: 'organization', title: 'Organizations', icon: 'layers'},
         {name: 'permission', title: 'Permissions', icon: 'lock_open'},
-        {name: 'policyfile', title: 'Policyfiles', icon: 'add_to_photos'},
+        {name: 'policy', title: 'Policyfiles', icon: 'add_to_photos'},
         {name: 'profile', title: 'Profiles', icon: 'library_books'},
         {name: 'role', title: 'Roles', icon: 'book'},
         {name: 'scanjobs', title: 'Scan Jobs', icon: 'wifi_tethering'},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixing event feed policy file filtering. In the UI the event type term for a policy file was incorrect. 

### :+1: Definition of Done
Filtering by policy file event type works in the UI. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui-devproxy && start_all_services && start_automate_ui_background && ui_logs`
1. After the UI finish loading, create a policy file event with these two commands. 
1. `rfc_time=$(date --rfc-3339=seconds  -d "$((RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/');`
1. `cat components/ingest-service/examples/actions/policy_update.json | jq --arg rfc_time "$rfc_time" '.recorded_at = $rfc_time' | send_chef_data_raw lb`, 
1. Go to https://a2-dev.test/dashboards/event-feed and filter by the policy file event type. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
