### PR TITLE
api docs: add docs for event feed

### DIFF
--- a/components/automate-chef-io/data/docs/api-static/03-tags.swagger.json
+++ b/components/automate-chef-io/data/docs/api-static/03-tags.swagger.json
@@ -23,6 +23,12 @@
       ]
     },
     {
+      "name": "Event Feed",
+      "tags": [
+        "EventFeed"
+      ]
+    },
+    {
       "name": "Secrets",
       "tags": [
         "SecretsService"
@@ -73,6 +79,10 @@
     {
       "name": "NodesService",
       "x-displayName": "Managed Nodes"
+    },
+    {
+      "name": "EventFeed",
+      "x-displayName": "Event Feed"
     },
     {
       "name": "SecretsService",

--- a/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
@@ -13,8 +13,8 @@
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
-        "summary": "Get Counts Per Event Task Occurrence",
-        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Counts Per Event Task Occurrence",
+        "description": "Returns totals for update, create, and delete event tasks, which are the actions taken on the event.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -60,8 +60,8 @@
     },
     "/api/v0/event_type_counts": {
       "get": {
-        "summary": "Get Count of Event Type Occurrence",
-        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Count of Event Type Occurrence",
+        "description": "Returns totals for role, cookbook, and organization event types.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -108,7 +108,7 @@
     "/api/v0/eventfeed": {
       "get": {
         "summary": "List Events",
-        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "description": "Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -172,14 +172,14 @@
           },
           {
             "name": "cursor",
-            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
+            "description": "Used for pagination, to bookmark next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
-            "description": "Used to group similar events into one.",
+            "description": "Used to group similar events together.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -193,8 +193,8 @@
     },
     "/api/v0/eventstrings": {
       "get": {
-        "summary": "Get Summary Stats About Events",
-        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Summary Stats About Events",
+        "description": "Returns data that populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
           },
           {
             "name": "hours_between",
-            "description": "Interval for returned results (e.g. 1 hour buckets).",
+            "description": "Interval for returned results, for example: 1 hour buckets.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -262,23 +262,23 @@
         },
         "task": {
           "type": "string",
-          "description": "Type of task for the event (create, update, delete)."
+          "description": "Type of event task (create, update, delete)."
         },
         "start_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Start time of the event."
+          "description": "Event start time."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
           "type": "string",
-          "description": "Requestor type on the event record."
+          "description": "Event record requestor type."
         },
         "requestor_name": {
           "type": "string",
-          "description": "Requestor name on the event record."
+          "description": "Event record requestor name."
         },
         "service_hostname": {
           "type": "string",
@@ -328,7 +328,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the event."
+          "description": "Event name."
         },
         "count": {
           "type": "string",

--- a/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
+++ b/components/automate-chef-io/data/docs/api_chef_automate/event_feed/event_feed.swagger.json
@@ -13,6 +13,8 @@
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
+        "summary": "Get Counts Per Event Task Occurrence",
+        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -25,6 +27,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -35,6 +38,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -42,6 +46,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -55,6 +60,8 @@
     },
     "/api/v0/event_type_counts": {
       "get": {
+        "summary": "Get Count of Event Type Occurrence",
+        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -67,6 +74,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -77,6 +85,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -84,6 +93,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -97,6 +107,8 @@
     },
     "/api/v0/eventfeed": {
       "get": {
+        "summary": "List Events",
+        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -109,6 +121,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -119,6 +132,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -126,6 +140,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -133,6 +148,7 @@
           },
           {
             "name": "page_size",
+            "description": "Count of events to return per page.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -140,6 +156,7 @@
           },
           {
             "name": "after",
+            "description": "Used for pagination, to request results in ascending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -147,6 +164,7 @@
           },
           {
             "name": "before",
+            "description": "Used for pagination, to request results in descending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -154,12 +172,14 @@
           },
           {
             "name": "cursor",
+            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
+            "description": "Used to group similar events into one.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -173,6 +193,8 @@
     },
     "/api/v0/eventstrings": {
       "get": {
+        "summary": "Get Summary Stats About Events",
+        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -185,24 +207,28 @@
         "parameters": [
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "timezone",
+            "description": "User timezone to apply to request.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "hours_between",
+            "description": "Interval for returned results (e.g. 1 hour buckets).",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -210,6 +236,7 @@
           },
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -230,46 +257,58 @@
       "type": "object",
       "properties": {
         "event_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of event (cookbook, role, etc)."
         },
         "task": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of task for the event (create, update, delete)."
         },
         "start_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Start time of the event."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor type on the event record."
         },
         "requestor_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor name on the event record."
         },
         "service_hostname": {
-          "type": "string"
+          "type": "string",
+          "description": "Hostname from which the record was gathered."
         },
         "start_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "event_count": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "Used for grouping events together."
         },
         "parent_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "parent_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "end_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "title": "Used for grouping events together; equal to start_time if not grouped"
         },
         "end_id": {
-          "type": "string"
+          "type": "string",
+          "title": "Used for grouping events together; equal to start_id if not grouped"
         }
       }
     },
@@ -288,11 +327,13 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the event."
         },
         "count": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Count of events."
         }
       }
     },
@@ -301,13 +342,15 @@
       "properties": {
         "total": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         },
         "counts": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
-          }
+          },
+          "description": "Total count of events per type."
         }
       }
     },
@@ -353,11 +396,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
-          }
+          },
+          "description": "List of events."
         },
         "total_events": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         }
       }
     }

--- a/components/automate-gateway/api/event_feed/event_feed.pb.go
+++ b/components/automate-gateway/api/event_feed/event_feed.pb.go
@@ -77,9 +77,7 @@ type EventFeedClient interface {
 	//
 	//List Events
 	//
-	//Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
-	//creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
-	//job creation.
+	//Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).
 	//Adding a filter makes a list of all events that meet the filter criteria.
 	//
 	//Example:
@@ -93,9 +91,9 @@ type EventFeedClient interface {
 	//```
 	GetEventFeed(ctx context.Context, in *request.EventFilter, opts ...grpc.CallOption) (*response.Events, error)
 	//
-	//Get Count of Event Type Occurrence
+	//List Count of Event Type Occurrence
 	//
-	//Event types are things like role, cookbook, organization, etc.
+	//Returns totals for role, cookbook, and organization event types.
 	//
 	//Example:
 	//```
@@ -108,9 +106,9 @@ type EventFeedClient interface {
 	//```
 	GetEventTypeCounts(ctx context.Context, in *request.EventCountsFilter, opts ...grpc.CallOption) (*response.EventCounts, error)
 	//
-	//Get Counts Per Event Task Occurrence
+	//List Counts Per Event Task Occurrence
 	//
-	//Event tasks are about the actions taken on the event, such as update, create, and delete.
+	//Returns totals for update, create, and delete event tasks, which are the actions taken on the event.
 	//
 	//Example:
 	//```
@@ -123,9 +121,9 @@ type EventFeedClient interface {
 	//```
 	GetEventTaskCounts(ctx context.Context, in *request.EventCountsFilter, opts ...grpc.CallOption) (*response.EventCounts, error)
 	//
-	//Get Summary Stats About Events
+	//List Summary Stats About Events
 	//
-	//This data populates the guitar strings visual on the top of the event feed.
+	//Returns data that populates the guitar strings visual on the top of the event feed.
 	//
 	//Example:
 	//```
@@ -188,9 +186,7 @@ type EventFeedServer interface {
 	//
 	//List Events
 	//
-	//Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
-	//creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
-	//job creation.
+	//Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).
 	//Adding a filter makes a list of all events that meet the filter criteria.
 	//
 	//Example:
@@ -204,9 +200,9 @@ type EventFeedServer interface {
 	//```
 	GetEventFeed(context.Context, *request.EventFilter) (*response.Events, error)
 	//
-	//Get Count of Event Type Occurrence
+	//List Count of Event Type Occurrence
 	//
-	//Event types are things like role, cookbook, organization, etc.
+	//Returns totals for role, cookbook, and organization event types.
 	//
 	//Example:
 	//```
@@ -219,9 +215,9 @@ type EventFeedServer interface {
 	//```
 	GetEventTypeCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
 	//
-	//Get Counts Per Event Task Occurrence
+	//List Counts Per Event Task Occurrence
 	//
-	//Event tasks are about the actions taken on the event, such as update, create, and delete.
+	//Returns totals for update, create, and delete event tasks, which are the actions taken on the event.
 	//
 	//Example:
 	//```
@@ -234,9 +230,9 @@ type EventFeedServer interface {
 	//```
 	GetEventTaskCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
 	//
-	//Get Summary Stats About Events
+	//List Summary Stats About Events
 	//
-	//This data populates the guitar strings visual on the top of the event feed.
+	//Returns data that populates the guitar strings visual on the top of the event feed.
 	//
 	//Example:
 	//```

--- a/components/automate-gateway/api/event_feed/event_feed.pb.go
+++ b/components/automate-gateway/api/event_feed/event_feed.pb.go
@@ -74,9 +74,68 @@ const _ = grpc.SupportPackageIsVersion6
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type EventFeedClient interface {
+	//
+	//List Events
+	//
+	//Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
+	//creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
+	//job creation.
+	//Adding a filter makes a list of all events that meet the filter criteria.
+	//
+	//Example:
+	//```
+	//eventfeed?collapse=true&filter=organization:The%2520Watchmen&page_size=100&start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventFeed(ctx context.Context, in *request.EventFilter, opts ...grpc.CallOption) (*response.Events, error)
+	//
+	//Get Count of Event Type Occurrence
+	//
+	//Event types are things like role, cookbook, organization, etc.
+	//
+	//Example:
+	//```
+	//event_type_counts?start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventTypeCounts(ctx context.Context, in *request.EventCountsFilter, opts ...grpc.CallOption) (*response.EventCounts, error)
+	//
+	//Get Counts Per Event Task Occurrence
+	//
+	//Event tasks are about the actions taken on the event, such as update, create, and delete.
+	//
+	//Example:
+	//```
+	//event_task_counts?start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventTaskCounts(ctx context.Context, in *request.EventCountsFilter, opts ...grpc.CallOption) (*response.EventCounts, error)
+	//
+	//Get Summary Stats About Events
+	//
+	//This data populates the guitar strings visual on the top of the event feed.
+	//
+	//Example:
+	//```
+	//eventstrings?timezone=America/Denver&hours_between=1&start=2020-06-19&end=2020-06-25
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventStringBuckets(ctx context.Context, in *request.EventStrings, opts ...grpc.CallOption) (*response.EventStrings, error)
 }
 
@@ -126,9 +185,68 @@ func (c *eventFeedClient) GetEventStringBuckets(ctx context.Context, in *request
 
 // EventFeedServer is the server API for EventFeed service.
 type EventFeedServer interface {
+	//
+	//List Events
+	//
+	//Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
+	//creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
+	//job creation.
+	//Adding a filter makes a list of all events that meet the filter criteria.
+	//
+	//Example:
+	//```
+	//eventfeed?collapse=true&filter=organization:The%2520Watchmen&page_size=100&start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventFeed(context.Context, *request.EventFilter) (*response.Events, error)
+	//
+	//Get Count of Event Type Occurrence
+	//
+	//Event types are things like role, cookbook, organization, etc.
+	//
+	//Example:
+	//```
+	//event_type_counts?start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventTypeCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
+	//
+	//Get Counts Per Event Task Occurrence
+	//
+	//Event tasks are about the actions taken on the event, such as update, create, and delete.
+	//
+	//Example:
+	//```
+	//event_task_counts?start=1592546400000&end=1593151199999
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventTaskCounts(context.Context, *request.EventCountsFilter) (*response.EventCounts, error)
+	//
+	//Get Summary Stats About Events
+	//
+	//This data populates the guitar strings visual on the top of the event feed.
+	//
+	//Example:
+	//```
+	//eventstrings?timezone=America/Denver&hours_between=1&start=2020-06-19&end=2020-06-25
+	//```
+	//
+	//Authorization Action:
+	//```
+	//event:events:list
+	//```
 	GetEventStringBuckets(context.Context, *request.EventStrings) (*response.EventStrings, error)
 }
 

--- a/components/automate-gateway/api/event_feed/event_feed.proto
+++ b/components/automate-gateway/api/event_feed/event_feed.proto
@@ -12,22 +12,84 @@ import "google/api/annotations.proto";
 import "components/automate-grpc/protoc-gen-policy/iam/annotations.proto";
 
 service EventFeed {
+  /*
+  List Events
+
+  Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
+  creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
+  job creation.
+  Adding a filter makes a list of all events that meet the filter criteria.
+
+  Example:
+  ```
+  eventfeed?collapse=true&filter=organization:The%2520Watchmen&page_size=100&start=1592546400000&end=1593151199999
+  ```
+
+	Authorization Action:
+	```
+	event:events:list
+	```
+	*/
   rpc GetEventFeed(event_feed.request.EventFilter) returns (event_feed.response.Events) {
     option (google.api.http).get =  "/api/v0/eventfeed";
-    // event feed includes compliance and cfg mgmt events
     option (chef.automate.api.iam.policy).resource = "event:events";
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
+  /*
+  Get Count of Event Type Occurrence
+  
+  Event types are things like role, cookbook, organization, etc.
+
+  Example:
+  ```
+  event_type_counts?start=1592546400000&end=1593151199999
+  ```
+
+	Authorization Action:
+	```
+	event:events:list
+	```
+	*/
   rpc GetEventTypeCounts(request.EventCountsFilter) returns (response.EventCounts) {
     option (google.api.http).get =  "/api/v0/event_type_counts";
     option (chef.automate.api.iam.policy).resource = "event:events";
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
+  /*
+  Get Counts Per Event Task Occurrence 
+  
+  Event tasks are about the actions taken on the event, such as update, create, and delete.
+
+  Example:
+  ```
+  event_task_counts?start=1592546400000&end=1593151199999
+  ```
+
+	Authorization Action:
+	```
+	event:events:list
+	```
+	*/
   rpc GetEventTaskCounts(request.EventCountsFilter) returns (response.EventCounts) {
     option (google.api.http).get =  "/api/v0/event_task_counts";
     option (chef.automate.api.iam.policy).resource = "event:events";
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
+  /*
+  Get Summary Stats About Events
+
+  This data populates the guitar strings visual on the top of the event feed.
+
+  Example:
+  ```
+  eventstrings?timezone=America/Denver&hours_between=1&start=2020-06-19&end=2020-06-25
+  ```
+
+	Authorization Action:
+	```
+	event:events:list
+	```
+	*/
   rpc GetEventStringBuckets(request.EventStrings) returns (response.EventStrings) {
     option (google.api.http).get = "/api/v0/eventstrings";
     option (chef.automate.api.iam.policy).resource = "event:events";

--- a/components/automate-gateway/api/event_feed/event_feed.proto
+++ b/components/automate-gateway/api/event_feed/event_feed.proto
@@ -15,9 +15,7 @@ service EventFeed {
   /*
   List Events
 
-  Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook
-  creation, policyfile updates, and node creation and Automate internal events like profile installs and scan
-  job creation.
+  Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).
   Adding a filter makes a list of all events that meet the filter criteria.
 
   Example:
@@ -36,9 +34,9 @@ service EventFeed {
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
   /*
-  Get Count of Event Type Occurrence
+  List Count of Event Type Occurrence
   
-  Event types are things like role, cookbook, organization, etc.
+  Returns totals for role, cookbook, and organization event types.
 
   Example:
   ```
@@ -56,9 +54,9 @@ service EventFeed {
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
   /*
-  Get Counts Per Event Task Occurrence 
+  List Counts Per Event Task Occurrence 
   
-  Event tasks are about the actions taken on the event, such as update, create, and delete.
+  Returns totals for update, create, and delete event tasks, which are the actions taken on the event.
 
   Example:
   ```
@@ -76,9 +74,9 @@ service EventFeed {
     option (chef.automate.api.iam.policy).action = "event:events:list";
   };
   /*
-  Get Summary Stats About Events
+  List Summary Stats About Events
 
-  This data populates the guitar strings visual on the top of the event feed.
+  Returns data that populates the guitar strings visual on the top of the event feed.
 
   Example:
   ```

--- a/components/automate-gateway/api/event_feed/event_feed.swagger.json
+++ b/components/automate-gateway/api/event_feed/event_feed.swagger.json
@@ -13,8 +13,8 @@
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
-        "summary": "Get Counts Per Event Task Occurrence",
-        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Counts Per Event Task Occurrence",
+        "description": "Returns totals for update, create, and delete event tasks, which are the actions taken on the event.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -60,8 +60,8 @@
     },
     "/api/v0/event_type_counts": {
       "get": {
-        "summary": "Get Count of Event Type Occurrence",
-        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Count of Event Type Occurrence",
+        "description": "Returns totals for role, cookbook, and organization event types.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -108,7 +108,7 @@
     "/api/v0/eventfeed": {
       "get": {
         "summary": "List Events",
-        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "description": "Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -172,14 +172,14 @@
           },
           {
             "name": "cursor",
-            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
+            "description": "Used for pagination, to bookmark next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
-            "description": "Used to group similar events into one.",
+            "description": "Used to group similar events together.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -193,8 +193,8 @@
     },
     "/api/v0/eventstrings": {
       "get": {
-        "summary": "Get Summary Stats About Events",
-        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "summary": "List Summary Stats About Events",
+        "description": "Returns data that populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -228,7 +228,7 @@
           },
           {
             "name": "hours_between",
-            "description": "Interval for returned results (e.g. 1 hour buckets).",
+            "description": "Interval for returned results, for example: 1 hour buckets.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -262,23 +262,23 @@
         },
         "task": {
           "type": "string",
-          "description": "Type of task for the event (create, update, delete)."
+          "description": "Type of event task (create, update, delete)."
         },
         "start_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Start time of the event."
+          "description": "Event start time."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
           "type": "string",
-          "description": "Requestor type on the event record."
+          "description": "Event record requestor type."
         },
         "requestor_name": {
           "type": "string",
-          "description": "Requestor name on the event record."
+          "description": "Event record requestor name."
         },
         "service_hostname": {
           "type": "string",
@@ -328,7 +328,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the event."
+          "description": "Event name."
         },
         "count": {
           "type": "string",

--- a/components/automate-gateway/api/event_feed/event_feed.swagger.json
+++ b/components/automate-gateway/api/event_feed/event_feed.swagger.json
@@ -13,6 +13,8 @@
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
+        "summary": "Get Counts Per Event Task Occurrence",
+        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n```\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -25,6 +27,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -35,6 +38,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -42,6 +46,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -55,6 +60,8 @@
     },
     "/api/v0/event_type_counts": {
       "get": {
+        "summary": "Get Count of Event Type Occurrence",
+        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n```\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -67,6 +74,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -77,6 +85,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -84,6 +93,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -97,6 +107,8 @@
     },
     "/api/v0/eventfeed": {
       "get": {
+        "summary": "List Events",
+        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -109,6 +121,7 @@
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -119,6 +132,7 @@
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -126,6 +140,7 @@
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -133,6 +148,7 @@
           },
           {
             "name": "page_size",
+            "description": "Count of events to return per page.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -140,6 +156,7 @@
           },
           {
             "name": "after",
+            "description": "Used for pagination, to request results in ascending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -147,6 +164,7 @@
           },
           {
             "name": "before",
+            "description": "Used for pagination, to request results in descending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -154,12 +172,14 @@
           },
           {
             "name": "cursor",
+            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
+            "description": "Used to group similar events into one.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -173,6 +193,8 @@
     },
     "/api/v0/eventstrings": {
       "get": {
+        "summary": "Get Summary Stats About Events",
+        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -185,24 +207,28 @@
         "parameters": [
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "timezone",
+            "description": "User timezone to apply to request.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "hours_between",
+            "description": "Interval for returned results (e.g. 1 hour buckets).",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -210,6 +236,7 @@
           },
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -230,46 +257,58 @@
       "type": "object",
       "properties": {
         "event_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of event (cookbook, role, etc)."
         },
         "task": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of task for the event (create, update, delete)."
         },
         "start_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Start time of the event."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor type on the event record."
         },
         "requestor_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor name on the event record."
         },
         "service_hostname": {
-          "type": "string"
+          "type": "string",
+          "description": "Hostname from which the record was gathered."
         },
         "start_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "event_count": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "Used for grouping events together."
         },
         "parent_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "parent_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "end_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "title": "Used for grouping events together; equal to start_time if not grouped"
         },
         "end_id": {
-          "type": "string"
+          "type": "string",
+          "title": "Used for grouping events together; equal to start_id if not grouped"
         }
       }
     },
@@ -288,11 +327,13 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the event."
         },
         "count": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Count of events."
         }
       }
     },
@@ -301,13 +342,15 @@
       "properties": {
         "total": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         },
         "counts": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
-          }
+          },
+          "description": "Total count of events per type."
         }
       }
     },
@@ -353,11 +396,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
-          }
+          },
+          "description": "List of events."
         },
         "total_events": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         }
       }
     }

--- a/components/automate-gateway/api/event_feed/request/event.pb.go
+++ b/components/automate-gateway/api/event_feed/request/event.pb.go
@@ -21,13 +21,21 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type EventFilter struct {
-	Filter               []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
-	Start                int64    `protobuf:"varint,2,opt,name=start,proto3" json:"start,omitempty"`
-	End                  int64    `protobuf:"varint,3,opt,name=end,proto3" json:"end,omitempty"`
-	PageSize             int32    `protobuf:"varint,4,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	After                int64    `protobuf:"varint,5,opt,name=after,proto3" json:"after,omitempty"`
-	Before               int64    `protobuf:"varint,6,opt,name=before,proto3" json:"before,omitempty"`
-	Cursor               string   `protobuf:"bytes,7,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	// Filters to be applied to the request.
+	Filter []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
+	// Earliest events to return.
+	Start int64 `protobuf:"varint,2,opt,name=start,proto3" json:"start,omitempty"`
+	// Latest events to return.
+	End int64 `protobuf:"varint,3,opt,name=end,proto3" json:"end,omitempty"`
+	// Count of events to return per page.
+	PageSize int32 `protobuf:"varint,4,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Used for pagination, to request results in ascending order.
+	After int64 `protobuf:"varint,5,opt,name=after,proto3" json:"after,omitempty"`
+	// Used for pagination, to request results in descending order.
+	Before int64 `protobuf:"varint,6,opt,name=before,proto3" json:"before,omitempty"`
+	// Used for pagination, to bookmark the place from which to grab the next set of results.
+	Cursor string `protobuf:"bytes,7,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	// Used to group similar events into one.
 	Collapse             bool     `protobuf:"varint,8,opt,name=collapse,proto3" json:"collapse,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -116,8 +124,11 @@ func (m *EventFilter) GetCollapse() bool {
 }
 
 type EventCountsFilter struct {
-	Filter               []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
-	Start                int64    `protobuf:"varint,2,opt,name=start,proto3" json:"start,omitempty"`
+	// Filters to be applied to the request.
+	Filter []string `protobuf:"bytes,1,rep,name=filter,proto3" json:"filter,omitempty"`
+	// Earliest events to return.
+	Start int64 `protobuf:"varint,2,opt,name=start,proto3" json:"start,omitempty"`
+	// Latest events to return.
 	End                  int64    `protobuf:"varint,3,opt,name=end,proto3" json:"end,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/components/automate-gateway/api/event_feed/request/event.pb.go
+++ b/components/automate-gateway/api/event_feed/request/event.pb.go
@@ -33,9 +33,9 @@ type EventFilter struct {
 	After int64 `protobuf:"varint,5,opt,name=after,proto3" json:"after,omitempty"`
 	// Used for pagination, to request results in descending order.
 	Before int64 `protobuf:"varint,6,opt,name=before,proto3" json:"before,omitempty"`
-	// Used for pagination, to bookmark the place from which to grab the next set of results.
+	// Used for pagination, to bookmark next set of results.
 	Cursor string `protobuf:"bytes,7,opt,name=cursor,proto3" json:"cursor,omitempty"`
-	// Used to group similar events into one.
+	// Used to group similar events together.
 	Collapse             bool     `protobuf:"varint,8,opt,name=collapse,proto3" json:"collapse,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/components/automate-gateway/api/event_feed/request/event.proto
+++ b/components/automate-gateway/api/event_feed/request/event.proto
@@ -4,18 +4,29 @@ package chef.automate.api.event_feed.request;
 option go_package = "github.com/chef/automate/components/automate-gateway/api/event_feed/request";
 
 message EventFilter {
+  // Filters to be applied to the request.
   repeated string filter = 1;
+  // Earliest events to return.
   int64 start = 2;
+  // Latest events to return.
   int64 end = 3;
+  // Count of events to return per page.
   int32 page_size = 4;
+  // Used for pagination, to request results in ascending order.
   int64 after = 5;
+  // Used for pagination, to request results in descending order.
   int64 before = 6;
+  // Used for pagination, to bookmark the place from which to grab the next set of results.
   string cursor = 7;
+  // Used to group similar events into one.
   bool collapse = 8;
 }
 
 message EventCountsFilter {
+  // Filters to be applied to the request.
   repeated string filter = 1;
+  // Earliest events to return.
   int64 start = 2;
+  // Latest events to return.
   int64 end = 3;
 }

--- a/components/automate-gateway/api/event_feed/request/event.proto
+++ b/components/automate-gateway/api/event_feed/request/event.proto
@@ -16,9 +16,9 @@ message EventFilter {
   int64 after = 5;
   // Used for pagination, to request results in descending order.
   int64 before = 6;
-  // Used for pagination, to bookmark the place from which to grab the next set of results.
+  // Used for pagination, to bookmark next set of results.
   string cursor = 7;
-  // Used to group similar events into one.
+  // Used to group similar events together.
   bool collapse = 8;
 }
 

--- a/components/automate-gateway/api/event_feed/request/eventstrings.pb.go
+++ b/components/automate-gateway/api/event_feed/request/eventstrings.pb.go
@@ -27,7 +27,7 @@ type EventStrings struct {
 	End string `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
 	// User timezone to apply to request.
 	Timezone string `protobuf:"bytes,3,opt,name=timezone,proto3" json:"timezone,omitempty"`
-	// Interval for returned results (e.g. 1 hour buckets).
+	// Interval for returned results, for example: 1 hour buckets.
 	HoursBetween int32 `protobuf:"varint,4,opt,name=hours_between,json=hoursBetween,proto3" json:"hours_between,omitempty"`
 	// Filters to be applied to the request.
 	Filter               []string `protobuf:"bytes,5,rep,name=filter,proto3" json:"filter,omitempty"`

--- a/components/automate-gateway/api/event_feed/request/eventstrings.pb.go
+++ b/components/automate-gateway/api/event_feed/request/eventstrings.pb.go
@@ -21,10 +21,15 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type EventStrings struct {
-	Start                string   `protobuf:"bytes,1,opt,name=start,proto3" json:"start,omitempty"`
-	End                  string   `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
-	Timezone             string   `protobuf:"bytes,3,opt,name=timezone,proto3" json:"timezone,omitempty"`
-	HoursBetween         int32    `protobuf:"varint,4,opt,name=hours_between,json=hoursBetween,proto3" json:"hours_between,omitempty"`
+	// Earliest events to return.
+	Start string `protobuf:"bytes,1,opt,name=start,proto3" json:"start,omitempty"`
+	// Latest events to return.
+	End string `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
+	// User timezone to apply to request.
+	Timezone string `protobuf:"bytes,3,opt,name=timezone,proto3" json:"timezone,omitempty"`
+	// Interval for returned results (e.g. 1 hour buckets).
+	HoursBetween int32 `protobuf:"varint,4,opt,name=hours_between,json=hoursBetween,proto3" json:"hours_between,omitempty"`
+	// Filters to be applied to the request.
 	Filter               []string `protobuf:"bytes,5,rep,name=filter,proto3" json:"filter,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/components/automate-gateway/api/event_feed/request/eventstrings.proto
+++ b/components/automate-gateway/api/event_feed/request/eventstrings.proto
@@ -4,10 +4,15 @@ package chef.automate.api.event_feed.request;
 option go_package = "github.com/chef/automate/components/automate-gateway/api/event_feed/request";
 
 message EventStrings {
+    // Earliest events to return.
     string start = 1;
+    // Latest events to return.
     string end = 2;
+    // User timezone to apply to request.
     string timezone = 3;
+    // Interval for returned results (e.g. 1 hour buckets).
     int32 hours_between = 4;
+    // Filters to be applied to the request.
     repeated string filter = 5;
 }
 

--- a/components/automate-gateway/api/event_feed/request/eventstrings.proto
+++ b/components/automate-gateway/api/event_feed/request/eventstrings.proto
@@ -10,7 +10,7 @@ message EventStrings {
     string end = 2;
     // User timezone to apply to request.
     string timezone = 3;
-    // Interval for returned results (e.g. 1 hour buckets).
+    // Interval for returned results, for example: 1 hour buckets.
     int32 hours_between = 4;
     // Filters to be applied to the request.
     repeated string filter = 5;

--- a/components/automate-gateway/api/event_feed/response/event.pb.go
+++ b/components/automate-gateway/api/event_feed/response/event.pb.go
@@ -22,7 +22,9 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Events struct {
-	Events               []*Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	// List of events.
+	Events []*Event `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	// Total count of events.
 	TotalEvents          int64    `protobuf:"varint,2,opt,name=total_events,json=totalEvents,proto3" json:"total_events,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -69,22 +71,34 @@ func (m *Events) GetTotalEvents() int64 {
 }
 
 type Event struct {
-	EventType            string               `protobuf:"bytes,1,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
-	Task                 string               `protobuf:"bytes,2,opt,name=task,proto3" json:"task,omitempty"`
-	StartTime            *timestamp.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	EntityName           string               `protobuf:"bytes,4,opt,name=entity_name,json=entityName,proto3" json:"entity_name,omitempty"`
-	RequestorType        string               `protobuf:"bytes,5,opt,name=requestor_type,json=requestorType,proto3" json:"requestor_type,omitempty"`
-	RequestorName        string               `protobuf:"bytes,6,opt,name=requestor_name,json=requestorName,proto3" json:"requestor_name,omitempty"`
-	ServiceHostname      string               `protobuf:"bytes,7,opt,name=service_hostname,json=serviceHostname,proto3" json:"service_hostname,omitempty"`
-	StartId              string               `protobuf:"bytes,8,opt,name=start_id,json=startId,proto3" json:"start_id,omitempty"`
-	EventCount           int32                `protobuf:"varint,9,opt,name=event_count,json=eventCount,proto3" json:"event_count,omitempty"`
-	ParentName           string               `protobuf:"bytes,16,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
-	ParentType           string               `protobuf:"bytes,17,opt,name=parent_type,json=parentType,proto3" json:"parent_type,omitempty"`
-	EndTime              *timestamp.Timestamp `protobuf:"bytes,18,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
-	EndId                string               `protobuf:"bytes,19,opt,name=end_id,json=endId,proto3" json:"end_id,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
-	XXX_unrecognized     []byte               `json:"-"`
-	XXX_sizecache        int32                `json:"-"`
+	// Type of event (cookbook, role, etc).
+	EventType string `protobuf:"bytes,1,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
+	// Type of task for the event (create, update, delete).
+	Task string `protobuf:"bytes,2,opt,name=task,proto3" json:"task,omitempty"`
+	// Start time of the event.
+	StartTime  *timestamp.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	EntityName string               `protobuf:"bytes,4,opt,name=entity_name,json=entityName,proto3" json:"entity_name,omitempty"`
+	// Requestor type on the event record.
+	RequestorType string `protobuf:"bytes,5,opt,name=requestor_type,json=requestorType,proto3" json:"requestor_type,omitempty"`
+	// Requestor name on the event record.
+	RequestorName string `protobuf:"bytes,6,opt,name=requestor_name,json=requestorName,proto3" json:"requestor_name,omitempty"`
+	// Hostname from which the record was gathered.
+	ServiceHostname string `protobuf:"bytes,7,opt,name=service_hostname,json=serviceHostname,proto3" json:"service_hostname,omitempty"`
+	// Used for grouping events together.
+	StartId string `protobuf:"bytes,8,opt,name=start_id,json=startId,proto3" json:"start_id,omitempty"`
+	// Used for grouping events together.
+	EventCount int32 `protobuf:"varint,9,opt,name=event_count,json=eventCount,proto3" json:"event_count,omitempty"`
+	// Used for grouping events together.
+	ParentName string `protobuf:"bytes,16,opt,name=parent_name,json=parentName,proto3" json:"parent_name,omitempty"`
+	// Used for grouping events together.
+	ParentType string `protobuf:"bytes,17,opt,name=parent_type,json=parentType,proto3" json:"parent_type,omitempty"`
+	// Used for grouping events together; equal to start_time if not grouped
+	EndTime *timestamp.Timestamp `protobuf:"bytes,18,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	// Used for grouping events together; equal to start_id if not grouped
+	EndId                string   `protobuf:"bytes,19,opt,name=end_id,json=endId,proto3" json:"end_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *Event) Reset()         { *m = Event{} }
@@ -204,7 +218,9 @@ func (m *Event) GetEndId() string {
 }
 
 type EventCounts struct {
-	Total                int64         `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
+	// Total count of events.
+	Total int64 `protobuf:"varint,1,opt,name=total,proto3" json:"total,omitempty"`
+	// Total count of events per type.
 	Counts               []*EventCount `protobuf:"bytes,2,rep,name=counts,proto3" json:"counts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
@@ -251,7 +267,9 @@ func (m *EventCounts) GetCounts() []*EventCount {
 }
 
 type EventCount struct {
-	Name                 string   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Name of the event.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Count of events.
 	Count                int64    `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`

--- a/components/automate-gateway/api/event_feed/response/event.pb.go
+++ b/components/automate-gateway/api/event_feed/response/event.pb.go
@@ -73,14 +73,14 @@ func (m *Events) GetTotalEvents() int64 {
 type Event struct {
 	// Type of event (cookbook, role, etc).
 	EventType string `protobuf:"bytes,1,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`
-	// Type of task for the event (create, update, delete).
+	// Type of event task (create, update, delete).
 	Task string `protobuf:"bytes,2,opt,name=task,proto3" json:"task,omitempty"`
-	// Start time of the event.
+	// Event start time.
 	StartTime  *timestamp.Timestamp `protobuf:"bytes,3,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
 	EntityName string               `protobuf:"bytes,4,opt,name=entity_name,json=entityName,proto3" json:"entity_name,omitempty"`
-	// Requestor type on the event record.
+	// Event record requestor type.
 	RequestorType string `protobuf:"bytes,5,opt,name=requestor_type,json=requestorType,proto3" json:"requestor_type,omitempty"`
-	// Requestor name on the event record.
+	// Event record requestor name.
 	RequestorName string `protobuf:"bytes,6,opt,name=requestor_name,json=requestorName,proto3" json:"requestor_name,omitempty"`
 	// Hostname from which the record was gathered.
 	ServiceHostname string `protobuf:"bytes,7,opt,name=service_hostname,json=serviceHostname,proto3" json:"service_hostname,omitempty"`
@@ -267,7 +267,7 @@ func (m *EventCounts) GetCounts() []*EventCount {
 }
 
 type EventCount struct {
-	// Name of the event.
+	// Event name.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Count of events.
 	Count                int64    `protobuf:"varint,2,opt,name=count,proto3" json:"count,omitempty"`

--- a/components/automate-gateway/api/event_feed/response/event.proto
+++ b/components/automate-gateway/api/event_feed/response/event.proto
@@ -6,32 +6,50 @@ option go_package = "github.com/chef/automate/components/automate-gateway/api/ev
 import "google/protobuf/timestamp.proto";
 
 message Events {
+  // List of events.
   repeated Event events = 1;
+  // Total count of events.
   int64 total_events = 2;
 }
 
 message Event {
+  // Type of event (cookbook, role, etc).
   string event_type = 1;
+  // Type of task for the event (create, update, delete).
   string task = 2;
+  // Start time of the event.
   google.protobuf.Timestamp start_time = 3;
   string entity_name = 4;
+  // Requestor type on the event record.
   string requestor_type = 5;
+  // Requestor name on the event record.
   string requestor_name = 6;
+  // Hostname from which the record was gathered.
   string service_hostname = 7;
+  // Used for grouping events together.
   string start_id = 8;
-  int32 event_count = 9;        // To group events of the same type, task and requestor
+  // Used for grouping events together.
+  int32 event_count = 9;
+  // Used for grouping events together.
   string parent_name = 16;
+  // Used for grouping events together.
   string parent_type = 17;
-  google.protobuf.Timestamp end_time = 18; // Equal to start_time if not grouped
-  string end_id = 19; // Equal to start_id if not grouped
+  // Used for grouping events together; equal to start_time if not grouped
+  google.protobuf.Timestamp end_time = 18; 
+  // Used for grouping events together; equal to start_id if not grouped
+  string end_id = 19;
 }
 
 message EventCounts {
+  // Total count of events.
   int64 total = 1;
+  // Total count of events per type.
   repeated EventCount counts = 2;
 }
 
 message EventCount {
+  // Name of the event.
   string name = 1;
+  // Count of events.
   int64 count = 2;
 }

--- a/components/automate-gateway/api/event_feed/response/event.proto
+++ b/components/automate-gateway/api/event_feed/response/event.proto
@@ -15,14 +15,14 @@ message Events {
 message Event {
   // Type of event (cookbook, role, etc).
   string event_type = 1;
-  // Type of task for the event (create, update, delete).
+  // Type of event task (create, update, delete).
   string task = 2;
-  // Start time of the event.
+  // Event start time.
   google.protobuf.Timestamp start_time = 3;
   string entity_name = 4;
-  // Requestor type on the event record.
+  // Event record requestor type.
   string requestor_type = 5;
-  // Requestor name on the event record.
+  // Event record requestor name.
   string requestor_name = 6;
   // Hostname from which the record was gathered.
   string service_hostname = 7;
@@ -48,7 +48,7 @@ message EventCounts {
 }
 
 message EventCount {
-  // Name of the event.
+  // Event name.
   string name = 1;
   // Count of events.
   int64 count = 2;

--- a/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
+++ b/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
@@ -16,8 +16,8 @@ func init() {
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
-        "summary": "Get Counts Per Event Task Occurrence",
-        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "summary": "List Counts Per Event Task Occurrence",
+        "description": "Returns totals for update, create, and delete event tasks, which are the actions taken on the event.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -63,8 +63,8 @@ func init() {
     },
     "/api/v0/event_type_counts": {
       "get": {
-        "summary": "Get Count of Event Type Occurrence",
-        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "summary": "List Count of Event Type Occurrence",
+        "description": "Returns totals for role, cookbook, and organization event types.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -111,7 +111,7 @@ func init() {
     "/api/v0/eventfeed": {
       "get": {
         "summary": "List Events",
-        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "description": "Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -175,14 +175,14 @@ func init() {
           },
           {
             "name": "cursor",
-            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
+            "description": "Used for pagination, to bookmark next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
-            "description": "Used to group similar events into one.",
+            "description": "Used to group similar events together.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -196,8 +196,8 @@ func init() {
     },
     "/api/v0/eventstrings": {
       "get": {
-        "summary": "Get Summary Stats About Events",
-        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "summary": "List Summary Stats About Events",
+        "description": "Returns data that populates the guitar strings visual on the top of the event feed.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -231,7 +231,7 @@ func init() {
           },
           {
             "name": "hours_between",
-            "description": "Interval for returned results (e.g. 1 hour buckets).",
+            "description": "Interval for returned results, for example: 1 hour buckets.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -265,23 +265,23 @@ func init() {
         },
         "task": {
           "type": "string",
-          "description": "Type of task for the event (create, update, delete)."
+          "description": "Type of event task (create, update, delete)."
         },
         "start_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Start time of the event."
+          "description": "Event start time."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
           "type": "string",
-          "description": "Requestor type on the event record."
+          "description": "Event record requestor type."
         },
         "requestor_name": {
           "type": "string",
-          "description": "Requestor name on the event record."
+          "description": "Event record requestor name."
         },
         "service_hostname": {
           "type": "string",
@@ -331,7 +331,7 @@ func init() {
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the event."
+          "description": "Event name."
         },
         "count": {
           "type": "string",

--- a/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
+++ b/components/automate-gateway/api/event_feed_event_feed.pb.swagger.go
@@ -16,6 +16,8 @@ func init() {
   "paths": {
     "/api/v0/event_task_counts": {
       "get": {
+        "summary": "Get Counts Per Event Task Occurrence",
+        "description": "Event tasks are about the actions taken on the event, such as update, create, and delete.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_task_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventTaskCounts",
         "responses": {
           "200": {
@@ -28,6 +30,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -38,6 +41,7 @@ func init() {
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -45,6 +49,7 @@ func init() {
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -58,6 +63,8 @@ func init() {
     },
     "/api/v0/event_type_counts": {
       "get": {
+        "summary": "Get Count of Event Type Occurrence",
+        "description": "Event types are things like role, cookbook, organization, etc.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\nevent_type_counts?start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventTypeCounts",
         "responses": {
           "200": {
@@ -70,6 +77,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -80,6 +88,7 @@ func init() {
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -87,6 +96,7 @@ func init() {
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -100,6 +110,8 @@ func init() {
     },
     "/api/v0/eventfeed": {
       "get": {
+        "summary": "List Events",
+        "description": "Returns a list of events that have been recorded in Chef Automate, such as Infra Server events like cookbook\ncreation, policyfile updates, and node creation and Automate internal events like profile installs and scan\njob creation.\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventfeed?collapse=true\u0026filter=organization:The%2520Watchmen\u0026page_size=100\u0026start=1592546400000\u0026end=1593151199999\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventFeed",
         "responses": {
           "200": {
@@ -112,6 +124,7 @@ func init() {
         "parameters": [
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -122,6 +135,7 @@ func init() {
           },
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -129,6 +143,7 @@ func init() {
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -136,6 +151,7 @@ func init() {
           },
           {
             "name": "page_size",
+            "description": "Count of events to return per page.",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -143,6 +159,7 @@ func init() {
           },
           {
             "name": "after",
+            "description": "Used for pagination, to request results in ascending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -150,6 +167,7 @@ func init() {
           },
           {
             "name": "before",
+            "description": "Used for pagination, to request results in descending order.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -157,12 +175,14 @@ func init() {
           },
           {
             "name": "cursor",
+            "description": "Used for pagination, to bookmark the place from which to grab the next set of results.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "collapse",
+            "description": "Used to group similar events into one.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -176,6 +196,8 @@ func init() {
     },
     "/api/v0/eventstrings": {
       "get": {
+        "summary": "Get Summary Stats About Events",
+        "description": "This data populates the guitar strings visual on the top of the event feed.\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\neventstrings?timezone=America/Denver\u0026hours_between=1\u0026start=2020-06-19\u0026end=2020-06-25\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nevent:events:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "GetEventStringBuckets",
         "responses": {
           "200": {
@@ -188,24 +210,28 @@ func init() {
         "parameters": [
           {
             "name": "start",
+            "description": "Earliest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "end",
+            "description": "Latest events to return.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "timezone",
+            "description": "User timezone to apply to request.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
             "name": "hours_between",
+            "description": "Interval for returned results (e.g. 1 hour buckets).",
             "in": "query",
             "required": false,
             "type": "integer",
@@ -213,6 +239,7 @@ func init() {
           },
           {
             "name": "filter",
+            "description": "Filters to be applied to the request.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -233,46 +260,58 @@ func init() {
       "type": "object",
       "properties": {
         "event_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of event (cookbook, role, etc)."
         },
         "task": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of task for the event (create, update, delete)."
         },
         "start_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Start time of the event."
         },
         "entity_name": {
           "type": "string"
         },
         "requestor_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor type on the event record."
         },
         "requestor_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Requestor name on the event record."
         },
         "service_hostname": {
-          "type": "string"
+          "type": "string",
+          "description": "Hostname from which the record was gathered."
         },
         "start_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "event_count": {
           "type": "integer",
-          "format": "int32"
+          "format": "int32",
+          "description": "Used for grouping events together."
         },
         "parent_name": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "parent_type": {
-          "type": "string"
+          "type": "string",
+          "description": "Used for grouping events together."
         },
         "end_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "title": "Used for grouping events together; equal to start_time if not grouped"
         },
         "end_id": {
-          "type": "string"
+          "type": "string",
+          "title": "Used for grouping events together; equal to start_id if not grouped"
         }
       }
     },
@@ -291,11 +330,13 @@ func init() {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the event."
         },
         "count": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Count of events."
         }
       }
     },
@@ -304,13 +345,15 @@ func init() {
       "properties": {
         "total": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         },
         "counts": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
-          }
+          },
+          "description": "Total count of events per type."
         }
       }
     },
@@ -356,11 +399,13 @@ func init() {
           "type": "array",
           "items": {
             "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
-          }
+          },
+          "description": "List of events."
         },
         "total_events": {
           "type": "string",
-          "format": "int64"
+          "format": "int64",
+          "description": "Total count of events."
         }
       }
     }


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

Adding api docs for event feed bits.

### :chains: Related Resources
n/a

### :+1: Definition of Done
event feed api calls are documented

### :athletic_shoe: How to Build and Test the Change
```
cd components/automate-chef-io
make serve
http://localhost:1313/docs/api/#operation/GetEventFeed
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
