### PR TITLE
Remove default initialization of radio button

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -42,11 +42,10 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
     fb: FormBuilder,
     private layoutFacade: LayoutFacadeService
   ) {
-    const initialStatus: TokenStatus = 'active';
     this.updateForm = fb.group({
       // Must stay in sync with error checks in api-token-details.component.html
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      status: [initialStatus],
+      status: [],
       projects: [[]]
     });
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Once you save a token as Inactive, you could not reactivate it. The system always thought "Active" was the saved state, so switching to Active actually _disables_ the "Save" button instead of _enabling_ it.
Cause: The default state of the radio button was being initialized to true, regardless of its actual value, thereby rendering the mechanism that recognizes a change ineffective.

### :chains: Related Resources
NA

### :+1: Definition of Done
You can reactivate an Inactive token in the UI.
<img width="301" alt="image" src="https://user-images.githubusercontent.com/6817500/85803758-c0bf5580-b6fc-11ea-9955-4cc24162dc00.png">


### :athletic_shoe: How to Build and Test the Change
Navigate to Settings >> Tokens >> (token) >> Details

Use a token that is inactive. If you do not have one, open the details, make it inactive, save, then go back to the token list, and re-open the details.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

