### PR TITLE
Adding the cookbook_artifact_version event type to the event feed

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -430,7 +430,7 @@ _component_auto_complete()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     opts="api config license"
-    opts="$opts $(ls /src/components/*/scripts/grpc.sh | cut -d/ -f4 | tr "\\n" " ")"
+    opts="$opts $(ls /src/components/ | cut -d/ -f4 | tr "\\n" " ")"
 
     if [[ ${cur} == * ]]; then
         COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/components/automate-ui/src/app/components/guitar-string-collection/guitar-string-item/guitar-string-item.component.ts
+++ b/components/automate-ui/src/app/components/guitar-string-collection/guitar-string-item/guitar-string-item.component.ts
@@ -36,6 +36,7 @@ export class GuitarStringItemComponent implements OnInit, OnChanges  {
       case 'node': return 'storage';
       case 'cookbook': return 'chrome_reader_mode';
       case 'version': return 'chrome_reader_mode';
+      case 'cookbook_artifact_version': return 'chrome_reader_mode';
       case 'item': return 'business_center';
       case 'bag': return 'business_center';
       case 'environment': return 'public';

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -107,6 +107,7 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
   getEventTypeLabel(event: ChefEvent): string {
     const labelMap = {
       version: 'cookbook',
+      cookbook_artifact_version: 'cookbook',
       item: 'data bag item',
       bag: 'data bag',
       scanjobs: 'scan job'

--- a/components/automate-ui/src/app/page-components/event-icon/event-icon.component.ts
+++ b/components/automate-ui/src/app/page-components/event-icon/event-icon.component.ts
@@ -20,6 +20,7 @@ export class EventIconComponent {
       case 'node': return 'storage';
       case 'cookbook': return 'chrome_reader_mode';
       case 'version': return 'chrome_reader_mode';
+      case 'cookbook_artifact_version': return 'chrome_reader_mode';
       case 'item': return 'business_center';
       case 'bag': return 'business_center';
       case 'environment': return 'public';

--- a/components/automate-ui/src/app/services/event-feed/event-feed.service.spec.ts
+++ b/components/automate-ui/src/app/services/event-feed/event-feed.service.spec.ts
@@ -40,8 +40,8 @@ describe('EventFeedService', () => {
       const end = moment('20190827-2359', 'YYYYMMDD-HHmm');
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         collapse: false,
@@ -55,8 +55,8 @@ describe('EventFeedService', () => {
 
       const httpFilters = httpParams.getAll('filter');
       expect(httpFilters.length).toEqual(3);
-      expect(httpFilters).toContain('entity_type:scan_job');
-      expect(httpFilters).toContain('entity_type:node');
+      expect(httpFilters).toContain('event-type:scan_job');
+      expect(httpFilters).toContain('event-type:node');
       expect(httpFilters).toContain('task:delete');
 
       expect(httpParams.get('page_size')).toEqual('77');
@@ -71,8 +71,8 @@ describe('EventFeedService', () => {
     it('full filter second page', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         collapse: false,
@@ -107,8 +107,8 @@ describe('EventFeedService', () => {
     it('collapse not set', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         task: 'delete',
@@ -125,8 +125,8 @@ describe('EventFeedService', () => {
     it('page not set', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         collapse: false,
@@ -147,8 +147,8 @@ describe('EventFeedService', () => {
       const end = moment('20190827-2359', 'YYYYMMDD-HHmm');
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         startDate: start,
@@ -161,8 +161,8 @@ describe('EventFeedService', () => {
 
       const httpFilters = httpParams.getAll('filter');
       expect(httpFilters.length).toEqual(2);
-      expect(httpFilters).toContain('entity_type:scan_job');
-      expect(httpFilters).toContain('entity_type:node');
+      expect(httpFilters).toContain('event-type:scan_job');
+      expect(httpFilters).toContain('event-type:node');
 
       expect(httpParams.get('hours_between')).toEqual('4');
 
@@ -173,8 +173,8 @@ describe('EventFeedService', () => {
     it('no start date', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         endDate: moment('20190827-2359', 'YYYYMMDD-HHmm')
@@ -188,8 +188,8 @@ describe('EventFeedService', () => {
     it('no end date', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         hoursBetween: 4,
         startDate: moment('20190822-0000', 'YYYYMMDD-HHmm')
@@ -214,7 +214,7 @@ describe('EventFeedService', () => {
     it('one search bar filter', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'}
+          {text: 'node', type: 'event-type'}
         ],
         startDate: moment('20190822-0000', 'YYYYMMDD-HHmm'),
         endDate: moment('20190827-2359', 'YYYYMMDD-HHmm'),
@@ -226,13 +226,13 @@ describe('EventFeedService', () => {
       const httpFilters = httpParams.getAll('filter');
 
       expect(httpFilters.length).toEqual(1);
-      expect(httpFilters).toContain('entity_type:node');
+      expect(httpFilters).toContain('event-type:node');
     });
 
     it('no hours between filter', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'}
+          {text: 'node', type: 'event-type'}
         ],
         startDate: moment('20190822-0000', 'YYYYMMDD-HHmm'),
         endDate: moment('20190827-2359', 'YYYYMMDD-HHmm')
@@ -250,8 +250,8 @@ describe('EventFeedService', () => {
       const end = moment('20190827-2359', 'YYYYMMDD-HHmm');
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         startDate: start,
         endDate: end
@@ -262,8 +262,8 @@ describe('EventFeedService', () => {
       const httpFilters = httpParams.getAll('filter');
 
       expect(httpFilters.length).toEqual(2);
-      expect(httpFilters).toContain('entity_type:scan_job');
-      expect(httpFilters).toContain('entity_type:node');
+      expect(httpFilters).toContain('event-type:scan_job');
+      expect(httpFilters).toContain('event-type:node');
       expect(httpParams.get('start')).toEqual(start.valueOf().toString());
       expect(httpParams.get('end')).toEqual(end.valueOf().toString());
     });
@@ -271,8 +271,8 @@ describe('EventFeedService', () => {
     it('no start date', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         endDate: moment('20190827-2359', 'YYYYMMDD-HHmm').utc()
       };
@@ -285,8 +285,8 @@ describe('EventFeedService', () => {
     it('no end date', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'},
-          {text: 'scan_job', type: 'entity_type'}
+          {text: 'node', type: 'event-type'},
+          {text: 'scan_job', type: 'event-type'}
         ],
         startDate: moment('20190822-0000', 'YYYYMMDD-HHmm').utc()
       };
@@ -310,7 +310,7 @@ describe('EventFeedService', () => {
     it('one search bar filter', () => {
       const filters: EventFeedFilter = {
         searchBar: [
-          {text: 'node', type: 'entity_type'}
+          {text: 'node', type: 'event-type'}
         ],
         startDate: moment('20190822-0000', 'YYYYMMDD-HHmm').utc(),
         endDate: moment('20190827-2359', 'YYYYMMDD-HHmm').utc()
@@ -321,15 +321,15 @@ describe('EventFeedService', () => {
       const httpFilters = httpParams.getAll('filter');
 
       expect(httpFilters.length).toEqual(1);
-      expect(httpFilters).toContain('entity_type:node');
+      expect(httpFilters).toContain('event-type:node');
     });
   });
 
   describe('addChildEventTypes', () => {
     it('no extra children filters', () => {
       const filters: Chicklet[] = [
-        {text: 'node', type: 'entity_type'},
-        {text: 'scan_job', type: 'entity_type'}
+        {text: 'node', type: 'event-type'},
+        {text: 'scan_job', type: 'event-type'}
       ];
 
       const filtersWithChildren = service.addChildEventTypes(filters);
@@ -339,40 +339,42 @@ describe('EventFeedService', () => {
 
     it('cookbook children filters added', () => {
       const filters: Chicklet[] = [
-        {text: 'cookbook', type: 'entity_type'}
-      ];
-
-      const filtersWithChildren = service.addChildEventTypes(filters);
-
-      expect(filtersWithChildren.length).toEqual(2);
-      expect(filtersWithChildren).toContain({text: 'cookbook', type: 'entity_type'});
-      expect(filtersWithChildren).toContain({text: 'version', type: 'entity_type'});
-    });
-
-    it('data bag children filters added', () => {
-      const filters: Chicklet[] = [
-        {text: 'bag', type: 'entity_type'}
-      ];
-
-      const filtersWithChildren = service.addChildEventTypes(filters);
-
-      expect(filtersWithChildren.length).toEqual(2);
-      expect(filtersWithChildren).toContain({text: 'bag', type: 'entity_type'});
-      expect(filtersWithChildren).toContain({text: 'item', type: 'entity_type'});
-    });
-
-    it('data bag children filters added with filter without children', () => {
-      const filters: Chicklet[] = [
-        {text: 'node', type: 'entity_type'},
-        {text: 'bag', type: 'entity_type'}
+        {text: 'cookbook', type: 'event-type'}
       ];
 
       const filtersWithChildren = service.addChildEventTypes(filters);
 
       expect(filtersWithChildren.length).toEqual(3);
-      expect(filtersWithChildren).toContain({text: 'bag', type: 'entity_type'});
-      expect(filtersWithChildren).toContain({text: 'item', type: 'entity_type'});
-      expect(filtersWithChildren).toContain({text: 'node', type: 'entity_type'});
+      expect(filtersWithChildren).toContain({text: 'cookbook', type: 'event-type'});
+      expect(filtersWithChildren).toContain({text: 'version', type: 'event-type'});
+      expect(filtersWithChildren).toContain(
+        {text: 'cookbook_artifact_version', type: 'event-type'});
+    });
+
+    it('data bag children filters added', () => {
+      const filters: Chicklet[] = [
+        {text: 'bag', type: 'event-type'}
+      ];
+
+      const filtersWithChildren = service.addChildEventTypes(filters);
+
+      expect(filtersWithChildren.length).toEqual(2);
+      expect(filtersWithChildren).toContain({text: 'bag', type: 'event-type'});
+      expect(filtersWithChildren).toContain({text: 'item', type: 'event-type'});
+    });
+
+    it('data bag children filters added with filter without children', () => {
+      const filters: Chicklet[] = [
+        {text: 'node', type: 'event-type'},
+        {text: 'bag', type: 'event-type'}
+      ];
+
+      const filtersWithChildren = service.addChildEventTypes(filters);
+
+      expect(filtersWithChildren.length).toEqual(3);
+      expect(filtersWithChildren).toContain({text: 'bag', type: 'event-type'});
+      expect(filtersWithChildren).toContain({text: 'item', type: 'event-type'});
+      expect(filtersWithChildren).toContain({text: 'node', type: 'event-type'});
     });
 
     it('empty filters', () => {

--- a/components/automate-ui/src/app/services/event-feed/event-feed.service.ts
+++ b/components/automate-ui/src/app/services/event-feed/event-feed.service.ts
@@ -25,11 +25,12 @@ import { environment } from '../../../environments/environment';
 import * as moment from 'moment/moment';
 const GATEWAY_URL = environment.gateway_url;
 const CONFIG_MGMT_URL = environment.config_mgmt_url;
-const ENTITY_TYPE_TAG = 'entity_type';
+const ENTITY_TYPE_TAG = 'event-type';
 const ENTITY_TYPE_DATA_BAG_ITEM_TAG = 'item';
 const ENTITY_TYPE_DATA_BAG_TAG = 'bag';
 const ENTITY_TYPE_COOKBOOK_TAG = 'cookbook';
 const ENTITY_TYPE_COOKBOOK_VERSION_TAG = 'version';
+const ENTITY_TYPE_ARTIFACT_COOKBOOK_VERSION_TAG = 'cookbook_artifact_version';
 
 @Injectable()
 export class EventFeedService {
@@ -161,7 +162,8 @@ export class EventFeedService {
     let searchParam: HttpParams = new HttpParams();
 
     if (filters.searchBar) {
-      searchParam = this.flattenSearchBar(filters.searchBar, searchParam);
+      const searchBarWithChildren = this.addChildEventTypes(filters.searchBar);
+      searchParam = this.flattenSearchBar(searchBarWithChildren, searchParam);
     }
 
     if (filters.startDate) {
@@ -182,7 +184,8 @@ export class EventFeedService {
     let searchParam: HttpParams = new HttpParams();
 
     if (filters.searchBar) {
-      searchParam = this.flattenSearchBar(filters.searchBar, searchParam);
+      const searchBarWithChildren = this.addChildEventTypes(filters.searchBar);
+      searchParam = this.flattenSearchBar(searchBarWithChildren, searchParam);
     }
 
     searchParam = searchParam.append('timezone', Intl.DateTimeFormat().resolvedOptions().timeZone);
@@ -228,6 +231,12 @@ export class EventFeedService {
     if (includes(ENTITY_TYPE_COOKBOOK_TAG, entityTypes) &&
       !includes(ENTITY_TYPE_COOKBOOK_VERSION_TAG, entityTypes)) {
       filters = concat(filters, {type: ENTITY_TYPE_TAG, text: ENTITY_TYPE_COOKBOOK_VERSION_TAG});
+    }
+
+    if (includes(ENTITY_TYPE_COOKBOOK_TAG, entityTypes) &&
+      !includes(ENTITY_TYPE_ARTIFACT_COOKBOOK_VERSION_TAG, entityTypes)) {
+      filters = concat(filters,
+        {type: ENTITY_TYPE_TAG, text: ENTITY_TYPE_ARTIFACT_COOKBOOK_VERSION_TAG});
     }
 
     return filters;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The event feed was not displaying or filtering all cookbook events correctly. Cookbook chef-server action comes in as three different types "cookbook", "cookbook_artifact_version", and "version". 

### :+1: Definition of Done
When we are filtering for cookbooks we want all three types to be returned. Also, the "cookbook_artifact_version" type should display the cookbook icon. 

### :athletic_shoe: How to Build and Test the Change
1. `build components/automate-ui-devproxy && start_all_services && start_automate_ui_background && ui_logs`
1. Add a few cookbook events with the below commands
1. `rfc_time=$(date --rfc-3339=seconds  -d "$((RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/');`
1. `cat components/ingest-service/examples/actions/version_cookbook_create.json | jq --arg rfc_time "$rfc_time" '.recorded_at = $rfc_time' | send_chef_data_raw lb`
1. `rfc_time=$(date --rfc-3339=seconds  -d "$((RANDOM % 144)) hour ago" | sed 's/ /T/' | sed 's/\+.*/Z/');`
1. `cat components/ingest-service/examples/actions/cookbookartifactversion_update.json | jq --arg rfc_time "$rfc_time" '.recorded_at = $rfc_time' | send_chef_data_raw lb`
1. `chef_load_actions 10`
1. Go to https://a2-dev.test/dashboards/event-feed?event-type=cookbook and ensure it looks like the image below. 
1. Ensure that there is an event with "Cookbook ed458ff53f19c306484cb1f23e6d76f937a32ad6 updated by delivery"
1. Ensure that there is an event with "Cookbook krasnow, version 0.1.0 created by mkrasnow"
1. Go back to master and see that the filtering does not work and the text and icons are incorrect. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/85805110-4690d000-b700-11ea-86a0-5fdf481d3b3d.png)
