### PR TITLE
Cookbook details content tab

### DIFF
--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-details.model.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-details.model.ts
@@ -46,3 +46,12 @@ export interface RootFiles {
     specificity: string;
 }
 
+export interface SubMenu {
+    name: string;
+    url: string;
+}
+
+export interface Menu {
+    menu: string;
+    subMenu: SubMenu[];
+}

--- a/components/automate-ui/src/app/helpers/infra-proxy/collapsible-list-mapper.ts
+++ b/components/automate-ui/src/app/helpers/infra-proxy/collapsible-list-mapper.ts
@@ -1,7 +1,7 @@
-import { Menu } from './../../entities/cookbooks/cookbook-details.model';
+import { Menu, CookbookDetails } from 'app/entities/cookbooks/cookbook-details.model';
 
 export class CollapsibleListMapper {
-    public static transform(resp, keys): Menu[] {
+    public static transform( resp: CookbookDetails, keys: string[] ): Menu[] {
         return keys.map(key => {
             return {
                 menu: key,

--- a/components/automate-ui/src/app/helpers/infra-proxy/collapsible-list-mapper.ts
+++ b/components/automate-ui/src/app/helpers/infra-proxy/collapsible-list-mapper.ts
@@ -1,0 +1,15 @@
+import { Menu } from './../../entities/cookbooks/cookbook-details.model';
+
+export class CollapsibleListMapper {
+    public static transform(resp, keys): Menu[] {
+        return keys.map(key => {
+            return {
+                menu: key,
+                subMenu: resp[key].map(data => {
+                    return { name: data.name, url: data.url };
+                })
+            };
+        });
+
+    }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -5,25 +5,44 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Cookbooks</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Cookbooks
+        </chef-breadcrumb>
         {{ cookbookName }}
       </chef-breadcrumbs>
       <chef-page-header>
         <chef-heading>{{ cookbookName }}</chef-heading>
         <div class="version-dropdown">
           <label for="version">Version</label>
-          <chef-select id="version" *ngIf="cookbook"
-            (change)="handleCookbookVersionChange($event)">
+          <chef-select id="version" *ngIf="cookbook" (change)="handleCookbookVersionChange($event)">
             <chef-option *ngFor="let version of cookbook.versions" [value]="version">{{ version }}</chef-option>
           </chef-select>
         </div>
-        <chef-tab-selector [value]="tabValue">
+        <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
           <chef-option value='details' data-cy="details-tab">Details</chef-option>
+          <chef-option value='content' data-cy="content-tab">Content</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      <section class="page-body">
+      <section class="page-body" *ngIf="tabValue === 'details'">
         <chef-loading-spinner *ngIf="cookbookDetailsLoading" size="50"></chef-loading-spinner>
         <chef-markdown *ngIf="readFileContent" [text]="readFileContent.content"></chef-markdown>
+      </section>
+      <section class="page-body" *ngIf="tabValue === 'content'">
+        <div class="details-row">
+          <div class="item-column">
+            <ul class="list">
+              <li *ngFor="let item of accordian; let i = index;">
+                <span (click)="clickEvent($event)" [ngClass]="{'extend-list': i === 0}">
+                  {{ item.menu | titlecase  }}
+                </span>
+                <ul class="sub-list" [ngClass]="{'show': i === 0}">
+                  <li *ngFor="let content of item.submenu; let j = index;" [ngClass]="{'active-sub-list': j === 0}">{{ content.name }}</li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+          <div class="item-details-column">
+          </div>
+        </div>
       </section>
     </main>
   </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -18,14 +18,10 @@
           </chef-select>
         </div>
         <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">
-          <chef-option value='details' data-cy="details-tab">Details</chef-option>
           <chef-option value='content' data-cy="content-tab">Content</chef-option>
+          <chef-option value='details' data-cy="details-tab">Details</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      <section class="page-body" *ngIf="tabValue === 'details'">
-        <chef-loading-spinner *ngIf="cookbookDetailsLoading" size="50"></chef-loading-spinner>
-        <chef-markdown *ngIf="readFileContent" [text]="readFileContent.content"></chef-markdown>
-      </section>
       <section class="page-body" *ngIf="tabValue === 'content'">
         <chef-loading-spinner *ngIf="contentTabLoading" size="50"></chef-loading-spinner>
         <div class="details-row" *ngIf="!contentTabLoading">
@@ -34,13 +30,13 @@
               <li *ngFor="let item of menuList; let i = index;">
                 <span (click)="listClickEvent($event)" 
                 [ngClass]="{'extend-list': i === 0}">
-                  {{ item.menu | titlecase  }}
+                  {{ item.menu | titlecase  }} ({{ item.subMenu.length }})
                 </span>
                 <ul class="sub-list" [ngClass]="{'show': i === 0}">
                   <li *ngFor="let content of item.subMenu; let j = index;" 
                   [ngClass]="{'active-sub-list': j === 0 && i === 0}" 
                   (click)="subListClickEvent($event, content)">
-                    {{ content.name }}</li>
+                    {{ content.name }}<chef-icon>fiber_manual_record</chef-icon></li>
                 </ul>
               </li>
             </ul>
@@ -48,13 +44,17 @@
           <div class="item-details-column">
             <chef-loading-spinner *ngIf="contentLoading" size="50"></chef-loading-spinner>
             <div *ngIf="!contentLoading">
-              <div class="item-heading">{{ activeContentName }}</div>
+              <h2 class="item-heading">{{ activeContentName }}</h2>
               <div class="item-content">
                 <chef-snippet [code]="urlContent?.content"></chef-snippet>
               </div>
             </div>
           </div>
         </div>
+      </section>
+      <section class="page-body" *ngIf="tabValue === 'details'">
+        <chef-loading-spinner *ngIf="cookbookDetailsLoading" size="50"></chef-loading-spinner>
+        <chef-markdown *ngIf="readFileContent" [text]="readFileContent.content"></chef-markdown>
       </section>
     </main>
   </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -27,20 +27,32 @@
         <chef-markdown *ngIf="readFileContent" [text]="readFileContent.content"></chef-markdown>
       </section>
       <section class="page-body" *ngIf="tabValue === 'content'">
-        <div class="details-row">
+        <chef-loading-spinner *ngIf="contentTabLoading" size="50"></chef-loading-spinner>
+        <div class="details-row" *ngIf="!contentTabLoading">
           <div class="item-column">
-            <ul class="list">
-              <li *ngFor="let item of accordian; let i = index;">
-                <span (click)="clickEvent($event)" [ngClass]="{'extend-list': i === 0}">
+            <ul class="list" *ngIf="menuList.length">
+              <li *ngFor="let item of menuList; let i = index;">
+                <span (click)="listClickEvent($event)" 
+                [ngClass]="{'extend-list': i === 0}">
                   {{ item.menu | titlecase  }}
                 </span>
                 <ul class="sub-list" [ngClass]="{'show': i === 0}">
-                  <li *ngFor="let content of item.submenu; let j = index;" [ngClass]="{'active-sub-list': j === 0}">{{ content.name }}</li>
+                  <li *ngFor="let content of item.subMenu; let j = index;" 
+                  [ngClass]="{'active-sub-list': j === 0 && i === 0}" 
+                  (click)="subListClickEvent($event, content)">
+                    {{ content.name }}</li>
                 </ul>
               </li>
             </ul>
           </div>
           <div class="item-details-column">
+            <chef-loading-spinner *ngIf="contentLoading" size="50"></chef-loading-spinner>
+            <div *ngIf="!contentLoading">
+              <div class="item-heading">{{ activeContentName }}</div>
+              <div class="item-content">
+                <chef-snippet [code]="urlContent?.content"></chef-snippet>
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
@@ -38,21 +38,24 @@ chef-loading-spinner {
     padding-inline-start: 20px;
   }
 
-  .list>li {
+  .list > li {
     margin-bottom: 5px;
+    color: $chef-primary-bright;
   }
 
-  .list>li>span {
+  .list > li > span {
     cursor: pointer;
   }
 
-  .list>li>span:before {
-    content: "+";
+  .list > li > span:before {
+    font-family: 'Material Icons';
+    content: "folder";
     padding-right: 5px;
   }
 
-  .list>li>span.extend-list:before {
-    content: "-";
+  .list > li > span.extend-list:before {
+    font-family: 'Material Icons';
+    content: "folder_open";
     padding-right: 6px;
   }
 
@@ -64,15 +67,24 @@ chef-loading-spinner {
     display: block;
   }
 
-  .sub-list>li {
+  .sub-list > li {
     margin: 5px;
-    color: $chef-primary-light;
+    color: $chef-primary-dark;
     cursor: pointer;
+
+    chef-icon {
+      display: none;
+      float: right;
+      margin-top: 4px;
+    }
   }
 
-  .sub-list>li.active-sub-list {
-    color: $chef-primary-dark;
+  .sub-list > li.active-sub-list {
     font-weight: 900;
+
+    chef-icon {
+      display: block;
+    }
   }
 
   .details-row {
@@ -99,7 +111,8 @@ chef-loading-spinner {
 
       .item-heading {
         margin-bottom: 1em;
-        font-weight: 900;
+        font-size: 18px;
+        font-weight: 600;
       }
 
       chef-snippet {
@@ -107,7 +120,6 @@ chef-loading-spinner {
           background-color: $chef-lightest-grey;
         }
       }
-
     }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
@@ -31,4 +31,75 @@ chef-loading-spinner {
     margin: 100px auto;
     width: 100px;
   }
+
+  ul {
+    list-style: none;
+    padding-inline-start: 20px;
+  }
+
+  .list>li {
+    margin-bottom: 5px;
+  }
+
+  .list>li>span {
+    cursor: pointer;
+  }
+
+  .list>li>span:before {
+    content: "+";
+    padding-right: 5px;
+  }
+
+  .list>li>span.extend-list:before {
+    content: "-";
+    padding-right: 6px;
+  }
+
+  .sub-list {
+    display: none;
+  }
+
+  .show {
+    display: block;
+  }
+
+  .sub-list>li {
+    margin: 5px;
+    color: $chef-primary-light;
+    cursor: pointer;
+  }
+
+  .sub-list>li.active-sub-list {
+    color: $chef-primary-dark;
+    font-weight: 900;
+  }
+
+  .details-row {
+    display: flex;
+
+    .item-column {
+      flex-basis: 25%;
+      height: fit-content;
+      margin-right: 1em;
+      padding: 1em;
+      border: 1px solid $chef-light-grey;
+      background-color: $chef-white;
+      border-radius: $global-radius;
+    }
+
+    .item-details-column {
+      chef-loading-spinner {
+        display: flex;
+        margin: auto auto;
+        width: 100%;
+        position: relative;
+      }
+
+      flex-basis: 75%;
+      padding: 1em;
+      border: 1px solid $chef-light-grey;
+      background-color: $chef-white;
+      border-radius: $global-radius;
+    }
+  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
@@ -33,6 +33,7 @@ chef-loading-spinner {
   }
 
   ul {
+    margin: 0;
     list-style: none;
     padding-inline-start: 20px;
   }
@@ -88,18 +89,25 @@ chef-loading-spinner {
     }
 
     .item-details-column {
-      chef-loading-spinner {
-        display: flex;
-        margin: auto auto;
-        width: 100%;
-        position: relative;
-      }
-
       flex-basis: 75%;
-      padding: 1em;
+      height: fit-content;
+      overflow: auto;
+      padding: 1em 1em;
       border: 1px solid $chef-light-grey;
       background-color: $chef-white;
       border-radius: $global-radius;
+
+      .item-heading {
+        margin-bottom: 1em;
+        font-weight: 900;
+      }
+
+      chef-snippet {
+        ::ng-deep pre {
+          background-color: $chef-lightest-grey;
+        }
+      }
+
     }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.scss
@@ -80,7 +80,7 @@ chef-loading-spinner {
   }
 
   .sub-list > li.active-sub-list {
-    font-weight: 900;
+    font-weight: 600;
 
     chef-icon {
       display: block;
@@ -111,7 +111,7 @@ chef-loading-spinner {
 
       .item-heading {
         margin-bottom: 1em;
-        font-size: 18px;
+        font-size: 16px;
         font-weight: 600;
       }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
@@ -122,8 +122,8 @@ describe('CookbookDetailsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('defaults to showing details section', () => {
-    expect(component.tabValue).toBe('details');
+  it('defaults to showing content section', () => {
+    expect(component.tabValue).toBe('content');
   });
 
   it('Check cookbook version success', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Store } from '@ngrx/store';
-import { environment as env } from 'environments/environment';
 import { Subject, combineLatest } from 'rxjs';
 import { first, filter, takeUntil, pluck } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
+
+import { environment as env } from 'environments/environment';
 import { CollapsibleListMapper } from 'app/helpers/infra-proxy/collapsible-list-mapper';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { EntityStatus } from 'app/entities/entities';
@@ -24,7 +25,7 @@ import {
   getStatus as getAllCookbooksDetailsStatus
 } from 'app/entities/cookbooks/cookbook-details.selectors';
 import { GetCookbookDetails } from 'app/entities/cookbooks/cookbook-details.actions';
-export type CookbookDetailsTab = 'details' | 'content';
+export type CookbookDetailsTab = 'content' | 'details';
 
 @Component({
   selector: 'app-cookbook-details',
@@ -40,7 +41,7 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
   public currentVersion: string;
   public cookbookName: string;
   public cookbookDetails: CookbookDetails;
-  public tabValue: CookbookDetailsTab = 'details';
+  public tabValue: CookbookDetailsTab = 'content';
   public readFile: RootFiles;
   public readFileUrl: string;
   public readFileContent;
@@ -79,7 +80,7 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
       .subscribe((url: string) => {
         this.url = url;
         const [, fragment] = url.split('#');
-        this.tabValue = (fragment === 'content') ? 'content' : 'details';
+        this.tabValue = (fragment === 'details') ? 'details' : 'content';
       });
 
     combineLatest([
@@ -134,9 +135,12 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
       .subscribe(([_getCookbooksSt, cookbookDetailsState]) => {
         this.cookbookDetails = cookbookDetailsState;
         this.menuList = CollapsibleListMapper.transform(cookbookDetailsState, this.listItem);
-        this.defaultContent = this.menuList[0].subMenu[0];
-        if (this.defaultContent) {
-          this.getContent(this.defaultContent);
+        if (this.menuList.length) {
+          // to check submenu exist and show defualt item detials
+          if ( this.menuList[0].subMenu.length ) {
+            this.defaultContent = this.menuList[0].subMenu[0];
+            this.getContent(this.defaultContent);
+          }
         }
         this.readFile = cookbookDetailsState?.root_files.find(data => data.name === 'README.md');
         if (this.readFile) {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Store } from '@ngrx/store';
+import { Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngrx/store';
 import { environment as env } from 'environments/environment';
 import { Subject, combineLatest } from 'rxjs';
 import { first, filter, takeUntil, pluck } from 'rxjs/operators';
@@ -40,9 +41,17 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
   public readFileContent;
   public cookbookDetailsLoading = false;
   public cookbookVersionsLoading = true;
+  public status = false;
+
+  // tslint:disable-next-line: max-line-length
+  public accordian = [ { menu: 'attribute', submenu: [{name: 'aix'}, {name: 'aix1'}, {name: 'aix2'}, {name: 'aix3'}, {name: 'aix4'}, {name: 'aix5'}, {name: 'aix6'}] },
+  // tslint:disable-next-line: max-line-length
+  { menu: 'Definations', submenu: [{name: 'aix'}, {name: 'aix1'}, {name: 'aix2'}, {name: 'aix3'}, {name: 'aix4'}, {name: 'aix5'}, {name: 'aix6'}] }];
+
   constructor(
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService,
+    private router: Router,
     private http: HttpClient
   ) { }
 
@@ -131,6 +140,21 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
       cookbook_name: this.cookbook.name,
       cookbook_version: event.target.value
     }));
+  }
+
+  clickEvent(event) {
+    if (event.target.classList.contains('extend-list')) {
+      event.target.classList.remove('extend-list');
+      event.target.parentNode.querySelector('ul').classList.remove('show');
+    } else {
+      event.target.classList.add('extend-list');
+      event.target.parentNode.querySelector('ul').classList.add('show');
+    }
+  }
+
+  onSelectedTab(event: { target: { value: CookbookDetailsTab } }) {
+    this.tabValue = event.target.value;
+    this.router.navigate([this.url.split('#')[0]], { fragment: event.target.value });
   }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -136,7 +136,7 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
         this.cookbookDetails = cookbookDetailsState;
         this.menuList = CollapsibleListMapper.transform(cookbookDetailsState, this.listItem);
         if (this.menuList.length) {
-          // to check submenu exist and show defualt item detials
+          // check submenu exists and show default item details
           if ( this.menuList[0].subMenu.length ) {
             this.defaultContent = this.menuList[0].subMenu[0];
             this.getContent(this.defaultContent);


### PR DESCRIPTION
Signed-off-by: sachin-msys <sbacchav@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
Introduced Content tab on cookbook details page view.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Mock up : https://www.sketch.com/s/f20922a3-b546-4ef0-8031-6f7f02394ea9/a/rvvbkP
Fixes: #3735 
### :+1: Definition of Done
In Cookbook details page of infra view we have introduced content tab where content details are shown using collapsible tree UI
### :athletic_shoe: How to Build and Test the Change

1. build components/automate-ui
2. To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
3. Go to Infrastructure tab >> Chef Servers its under Chef-Server feature flag.
4. Click on `Server list` >> `Organisation list` >> `Cookbooks` >> then click on any of the data bag list item >> `Content` 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![content-tab](https://user-images.githubusercontent.com/54940695/85858028-832ffa80-b7d8-11ea-8cd0-d3827fc923be.png)


