### PR TITLE
send reports to notifications after we have glued them back together

### DIFF
--- a/components/compliance-service/ingest/pipeline/processor/profile.go
+++ b/components/compliance-service/ingest/pipeline/processor/profile.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/chef/automate/components/compliance-service/ingest/events/compliance"
+
 	"github.com/chef/automate/components/compliance-service/ingest/ingestic"
 	"github.com/chef/automate/components/compliance-service/ingest/pipeline/message"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
@@ -140,6 +141,7 @@ func complianceProfile(in <-chan message.Compliance, client *ingestic.ESClient) 
 
 			logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid}).Debug("Processed Compliance Profile")
 			message.Propagate(out, &msg)
+
 		}
 		close(out)
 	}()


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
notifications service was receiving reports with values missing, such
as impact. we realized hte reason for this is that when we added logic to allow
for smaller, more compact reports to be ingested, we forgot to move the call
to notifications client further down the process to after we glue all
the information back together again.

### :chains: Related Resources
https://github.com/chef/automate/issues/3994

### :+1: Definition of Done
running a scan job with critical control failures triggers the critical control failure notification

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
set up a notification in automate for inspec control failures
get a vanilla vm going
run a scan job on it (use linux sec baseline), see the notification

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
