### PR TITLE
fix tag filter matching logic to recognize null val

### DIFF
--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -601,11 +601,12 @@ func convertControl(profileControlsMap map[string]*reportingapi.Control, reportC
 	for _, tag := range reportControlMin.StringTags {
 		if len(tag.Values) == 0 {
 			jsonTags[tag.Key] = &reportingapi.TagValues{Values: []string{"null"}}
-		}
-		vals := make([]string, 0)
-		for _, val := range tag.Values {
-			vals = append(vals, val)
-			jsonTags[tag.Key] = &reportingapi.TagValues{Values: vals}
+		} else {
+			vals := make([]string, 0)
+			for _, val := range tag.Values {
+				vals = append(vals, val)
+				jsonTags[tag.Key] = &reportingapi.TagValues{Values: vals}
+			}
 		}
 	}
 
@@ -634,7 +635,7 @@ func doesControlTagMatchFilter(filters map[string][]string,
 			trimmed := strings.TrimPrefix(filterKey, "control_tag:")
 			if tagVal, ok := jsonTags[trimmed]; ok {
 				for _, val := range filterVals {
-					if contains(tagVal.Values, val) || val == "null" {
+					if contains(tagVal.Values, val) || nullArrMatchEmptyString(tagVal.Values, val) {
 						return true
 					}
 				}
@@ -646,6 +647,15 @@ func doesControlTagMatchFilter(filters map[string][]string,
 		return false
 	}
 	return true
+}
+
+func nullArrMatchEmptyString(vals []string, val string) bool {
+	if len(vals) == 1 && vals[0] == "null" {
+		if val == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func contains(a []string, x string) bool {

--- a/components/compliance-service/reporting/relaxting/reports_test.go
+++ b/components/compliance-service/reporting/relaxting/reports_test.go
@@ -160,3 +160,49 @@ func TestConvertControlFiltersByTagOnlyMatch(t *testing.T) {
 		},
 	}, convertedControl)
 }
+
+func TestDoesControlTagMatchFilter(t *testing.T) {
+	// json tags set one
+	tags1 := map[string]*reportingapi.TagValues{}
+	tags1["test"] = &reportingapi.TagValues{
+		Values: []string{"one", "two"},
+	}
+	// json tags set two
+	tags2 := map[string]*reportingapi.TagValues{}
+	tags2["shoe"] = &reportingapi.TagValues{
+		Values: []string{"blue"},
+	}
+	tags2["sock"] = &reportingapi.TagValues{
+		Values: []string{"yellow", "pink"},
+	}
+	// json tags set three
+	tags3 := map[string]*reportingapi.TagValues{}
+	tags3["key_only"] = &reportingapi.TagValues{
+		Values: []string{"null"},
+	}
+
+	filterSock := map[string][]string{}
+	filterSock["control_tag:sock"] = []string{"yellow"}
+
+	filterShoe := map[string][]string{}
+	filterShoe["control_tag:shoe"] = []string{"blue"}
+
+	filterNull := map[string][]string{}
+	filterNull["control_tag:key_only"] = []string{"null"}
+
+	// test matching filter
+	assert.Equal(t, true, doesControlTagMatchFilter(filterSock, tags2))
+	assert.Equal(t, true, doesControlTagMatchFilter(filterShoe, tags2))
+
+	// test no match filter
+	assert.Equal(t, false, doesControlTagMatchFilter(filterSock, tags3))
+	assert.Equal(t, false, doesControlTagMatchFilter(filterNull, tags2))
+
+	// test null match
+	assert.Equal(t, true, doesControlTagMatchFilter(filterNull, tags3))
+
+	// test multiple control tag filters
+	multFilters := filterSock
+	multFilters["control_tag:shoe"] = []string{"blue"}
+	assert.Equal(t, true, doesControlTagMatchFilter(multFilters, tags2))
+}


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
from the customer: "When using the 'Control Tag' filter in the Compliance tab of Automate, no output is generated when exporting to .csv."
https://getchef.zendesk.com/agent/tickets/25517

After some investigation I realized this was the case only for tags that used the "no value" option (or empty string) for the values. We were incorrectly matching when the values were empty and since no matches were found, only returning profile/node info from the report and no controls.

This fixes that issue by resolving the matching of null value for the tag key in es with the record of the empty string value for the tag val in the api

### :chains: Related Resources
https://getchef.zendesk.com/agent/tickets/25517
https://github.com/chef/customer-bugs/issues/205

### :+1: Definition of Done
filtering the reports by a tag with only key (no value) correctly filters the reports and returns matching controls 

### :athletic_shoe: How to Build and Test the Change
rebuild compliance
load_compliance_reports
filter by a key that has no value (web is a good one for this)
download reports
check they have the correct info

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
