### PR TITLE
Fixed Environment detail page UI to show cookbook constraints

### DIFF
--- a/components/automate-ui/src/app/entities/environments/environment.model.ts
+++ b/components/automate-ui/src/app/entities/environments/environment.model.ts
@@ -13,7 +13,12 @@ export interface Environment {
 
 export interface CookbookVersion {
   name: string;
-  version: string;
+}
+
+export interface CookbookVersionDisplay {
+  name?: string;
+  operator?: string;
+  versionNumber?: string;
 }
 
 export class EnvironmentAttributes {

--- a/components/automate-ui/src/app/entities/environments/environment.model.ts
+++ b/components/automate-ui/src/app/entities/environments/environment.model.ts
@@ -16,9 +16,9 @@ export interface CookbookVersion {
 }
 
 export interface CookbookVersionDisplay {
-  name?: string;
-  operator?: string;
-  versionNumber?: string;
+  name: string;
+  operator: string;
+  versionNumber: string;
 }
 
 export class EnvironmentAttributes {

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -43,10 +43,10 @@
                 </chef-tr>
               </chef-thead>
               <chef-tbody>
-                <chef-tr *ngFor= "let version of cookbookVersions | keyvalue">
-                  <chef-td  >{{ version.key }}</chef-td>
-                  <chef-td  >{{ version.value.split(" ")[0] }}</chef-td>
-                  <chef-td  >{{ version.value.split(" ")[1] }}</chef-td>
+                <chef-tr *ngFor= "let version of cookbookVersions">
+                  <chef-td  >{{ version.name }}</chef-td>
+                  <chef-td  >{{ version.operator }}</chef-td>
+                  <chef-td  >{{ version.versionNumber }}</chef-td>
                 </chef-tr>
               </chef-tbody>
             </chef-table>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -44,9 +44,9 @@
               </chef-thead>
               <chef-tbody>
                 <chef-tr *ngFor= "let version of cookbookVersions">
-                  <chef-td  >{{ version.name }}</chef-td>
-                  <chef-td  >{{ version.operator }}</chef-td>
-                  <chef-td  >{{ version.versionNumber }}</chef-td>
+                  <chef-td>{{ version.name }}</chef-td>
+                  <chef-td>{{ version.operator }}</chef-td>
+                  <chef-td>{{ version.versionNumber }}</chef-td>
                 </chef-tr>
               </chef-tbody>
             </chef-table>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -37,12 +37,16 @@
             <chef-table>
               <chef-thead>
                 <chef-tr>
+                  <chef-th>Cookbook</chef-th>
+                  <chef-th>Operator</chef-th>
                   <chef-th>Version</chef-th>
                 </chef-tr>
               </chef-thead>
               <chef-tbody>
-                <chef-tr *ngFor= "let version of cookbookVersions">
-                  <chef-td  >{{ version }}</chef-td>
+                <chef-tr *ngFor= "let version of cookbookVersions | keyvalue">
+                  <chef-td  >{{ version.key }}</chef-td>
+                  <chef-td  >{{ version.value.split(" ")[0] }}</chef-td>
+                  <chef-td  >{{ version.value.split(" ")[1] }}</chef-td>
                 </chef-tr>
               </chef-tbody>
             </chef-table>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -12,7 +12,8 @@ import { GetEnvironment } from 'app/entities/environments/environment.action';
 import {
   Environment,
   CookbookVersion,
-  EnvironmentAttributes
+  EnvironmentAttributes,
+  CookbookVersionDisplay
 } from 'app/entities/environments/environment.model';
 import { JsonTreeTableComponent as JsonTreeTable } from './../json-tree-table/json-tree-table.component';
 
@@ -26,7 +27,7 @@ export type EnvironmentTabName = 'cookbookConstraints' | 'attributes';
 
 export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
   public environment: Environment;
-  public cookbookVersions: CookbookVersion[];
+  public cookbookVersions: CookbookVersionDisplay[];
   public tabValue: EnvironmentTabName = 'cookbookConstraints';
   public url: string;
   public conflictErrorEvent = new EventEmitter<boolean>();
@@ -91,7 +92,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(environment => {
       this.show = true;
       this.environment = environment;
-      this.cookbookVersions = environment.cookbook_versions;
+      this.cookbookVersions = this.toDisplay(environment.cookbook_versions);
       if (Object.keys(environment.cookbook_versions).length > 0) {
         this.hasCookbookConstraints = true;
       }
@@ -124,6 +125,13 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
         return {};
       }
     }
+  }
+
+  toDisplay(cookbookVersions: CookbookVersion[]): CookbookVersionDisplay[] {
+    return Object.keys(cookbookVersions).map(function (key) {
+      const value = cookbookVersions[key].split(' ');
+      return {name: key, operator: value[0], versionNumber: value[1]};
+    });
   }
 
   onSelectedTab(event: { target: { value: EnvironmentTabName } }) {

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -91,8 +91,8 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(environment => {
       this.show = true;
       this.environment = environment;
-      this.cookbookVersions = environment.cookbook_versions.filter(Boolean);
-      if (this.cookbookVersions.length > 0) {
+      this.cookbookVersions = environment.cookbook_versions;
+      if (Object.keys(environment.cookbook_versions).length > 0) {
         this.hasCookbookConstraints = true;
       }
       this.attributes = new EnvironmentAttributes(this.environment);


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
on the environment details page cookbook constraint tab data is not showing I have fixed the UI for this.
### :chains: Related Resources
https://github.com/chef/automate/issues/4003
### :+1: Definition of Done
I have added some changes to fix this page UI to show the cookbook constraint tab where we can show the list of cookbooks with name, operator and version.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab

To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
Go to Infrastructure tab >> Chef Servers it's under Chef-Server feature flag.
Click on Server list >> Organisation list >> environments Tab >> then click on any of the environments list items
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![environment-details](https://user-images.githubusercontent.com/12297653/86120105-55f18e00-baf1-11ea-8900-c26bb6760b1b.png)
