### PR TITLE
Adding missing 'e' to the On-prem setup

### DIFF
--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -264,7 +264,7 @@ cd on-prem-builder
 The Chef Automate installer uses a self-signed certificate. Copy the SSL public key certificate chain from Chef Automate into `/hab/cache/ssl` with this command:
 
 ```shell
-cp /hab/svc/automate-load-balancer/data/{{< example_fqdn "automate" >}}.cert /hab/cache/ssl/{{< example_fqdn "automate" >}}.crt
+cp /hab/svc/automate-load-balancer/data/{{< example_fqdn "automate" >}}.cert /hab/cache/ssl/{{< example_fqdn "automate" >}}.cert
 ```
 
 ### Download Seed List Packages from the Public Chef Habitat Builder


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When copying the cert file the extention was misspelled to "/hab/cache/ssl/{{< example_fqdn "automate" >}}.crt". 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
