### PR TITLE
Jamie/page picker fix

### DIFF
--- a/components/automate-ui/src/app/components/page-picker/page-picker.component.html
+++ b/components/automate-ui/src/app/components/page-picker/page-picker.component.html
@@ -48,7 +48,7 @@
               </mat-select>
             </mat-form-field>
         </div>
-        <span>{{ itemStartCount }} - {{ itemEndCount | paginationTrueEnd: totalItems }} of {{ totalItems }} items</span>
+        <span>{{ itemStartCount }} - {{ itemEndCount | paginationTrueEnd: total }} of {{ total }} items</span>
       </div>
 
       <div class="column column--2">

--- a/components/automate-ui/src/app/components/page-picker/page-picker.component.spec.ts
+++ b/components/automate-ui/src/app/components/page-picker/page-picker.component.spec.ts
@@ -38,7 +38,7 @@ describe('PagePickerComponent', () => {
     beforeEach(() => {
       component.forDesktop = true;
       component.page = 1;
-      component.totalItems = 153;
+      component.total = 153;
       component.perPage = 10;
     });
 
@@ -94,7 +94,7 @@ describe('PagePickerComponent', () => {
           spyOn(component.pageSizeChanged, 'emit');
 
           component.itemStartCount = itemStartCount;
-          component.totalItems = totalItems;
+          component.total = totalItems;
           component.page = currentPageNumber;
           component.perPage = currentPageSize;
 

--- a/components/automate-ui/src/app/components/page-picker/page-picker.component.ts
+++ b/components/automate-ui/src/app/components/page-picker/page-picker.component.ts
@@ -10,7 +10,7 @@ import { PageSizeChangeEvent } from 'app/entities/desktop/desktop.model';
 })
 export class PagePickerComponent implements OnChanges {
 
-  @Input() totalItems: number;
+  @Input() total: number;
   @Input() perPage: number;
   @Input() page: number;
   @Input() maxPageItems = 10;
@@ -38,11 +38,11 @@ export class PagePickerComponent implements OnChanges {
   }
 
   private getItemEndCount() {
-    this.itemEndCount = this.page === this.last ? this.totalItems : this.page * this.perPage;
+    this.itemEndCount = this.page === this.last ? this.total : this.page * this.perPage;
   }
 
   private getAllPages() {
-    const pageCount = Math.ceil(this.totalItems / this.perPage);
+    const pageCount = Math.ceil(this.total / this.perPage);
     this.allPages = Array(pageCount).fill(0).map((_x, i) => i + 1);
   }
 
@@ -53,7 +53,7 @@ export class PagePickerComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    this.last = Math.ceil(this.totalItems / this.perPage) || 1;
+    this.last = Math.ceil(this.total / this.perPage) || 1;
     this.prev = (this.page === this.first) ? null : this.page - 1;
     this.next = (this.page === this.last) ? null : this.page + 1;
 

--- a/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
+++ b/components/automate-ui/src/app/modules/desktop/insight/insight.component.html
@@ -141,7 +141,7 @@
   <app-page-picker
     [forDesktop]="true"
     [fullScreened]="fullscreened"
-    [totalItems]="totalDesktops"
+    [total]="totalDesktops"
     [perPage]="pageSize"
     [page]="currentPage"
     (pageChanged)="onPageChange($event)"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In my last commits, I changed the name of one of the inputs on the page-picker.  This reverts the name change so all others will be in sync.

### :chains: Related Resources
https://github.com/chef/automate/pull/3812

### :+1: Definition of Done
All pagination is back to normal functionality

### :athletic_shoe: How to Build and Test the Change
 build components/automate-ui-devproxy && start_all_services
make serve

navigate to https://a2-dev.test/compliance/scan-jobs/nodes
check that pagination is as it should be when there are enough items to list.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
