### PR TITLE
Light up typescript check: strictDomLocalRefTypes

### DIFF
--- a/components/automate-ui/tsconfig.json
+++ b/components/automate-ui/tsconfig.json
@@ -29,7 +29,7 @@
     "strictNullInputTypes": true,
     "strictAttributeTypes": true,
     "strictSafeNavigationTypes": true,
-    "strictDomLocalRefTypes": false,
+    "strictDomLocalRefTypes": true,
     "strictOutputEventTypes": true,
     "strictDomEventTypes": false,
     "strictContextGenerics": true,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Follow-on to Angular 9 template type checking enablement, this throws the switch on one more check.
This was an easy win--no collateral to fix after turning it on!

### :chains: Related Resources
PR #3268 Turn on strict Angular checks
PR #3158 Light up an additional typescript template check

### :+1: Definition of Done
`ng build` reports no errors or warnings

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
