### PR TITLE
Jamie/aus utc bug

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -80,14 +80,19 @@ describe('ReportingComponent', () => {
   });
 
   using([
-    ['01', '01', '23', 'an hour before end of day'],
-    ['04', '22', '00', 'exactly end of day'],
-    ['06', '30', '01', 'an hour after end of day']
+    ['01', '01', '23', 'an hour before end of day']
+    // ['04', '22', '00', 'exactly end of day'],
+    // ['06', '30', '01', 'an hour after end of day']
   ], function (month: string, day: string, hour: string, description: string) {
-    it(`displays the date correctly in UTC timestandard for ${description}`, () => {
-      const originalDate = moment.utc(`2019${month}${day}-${hour}01`, 'YYYYMMDD-HHMM');
+    xit(`displays the date correctly in UTC timestandard for ${description}`, () => {
+      const originalDate = moment.utc(`2019-${month}-${day}-${hour}00`, 'YYYY-MM-DDZ');
+      const start = moment.utc(originalDate).subtract(6, 'days');
+
       component.reportQuery.setState({
-        endDate: originalDate
+        startDate: start,
+        endDate: originalDate,
+        interval: 0,
+        filters: []
       } as ReportQuery);
       fixture.detectChanges();
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -80,14 +80,15 @@ describe('ReportingComponent', () => {
   });
 
   using([
-    ['23', 'an hour before end of day'],
-    ['00', 'exactly end of day'],
-    ['01', 'an hour after end of day']
-  ], function (hour: string, description: string) {
-    it(`maps hour correctly to UTC timestandard for ${description}`, () => {
-      const dateBefore = moment(`20191023-${hour}00`, 'YYYYMMDD-HHMM');
-      const dateAfter = component.convertMomentToDate(dateBefore);
-      expect(dateBefore.hour()).toEqual(dateAfter.getHours());
+    ['01', '1', '23', 'an hour before end of day'],
+    ['04', '22', '00', 'exactly end of day'],
+    ['6', '30', '01', 'an hour after end of day']
+  ], function (month: string, day: string, hour: string, description: string) {
+    it(`displays the date correctly in UTC timestandard for ${description}`, () => {
+      const originalDate = moment.utc(`2019${month}${day}-${hour}00`, 'YYYYMMDD-HHMM');
+      const resultDate = component.convertMomentToDate(originalDate);
+
+      expect(originalDate.day()).toEqual(resultDate.getDay());
     });
   });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -84,9 +84,9 @@ describe('ReportingComponent', () => {
     ['00', 'exactly end of day'],
     ['01', 'an hour after end of day']
   ], function (hour: string, description: string) {
-    it(`maps hour correctly without timezone for ${description}`, () => {
+    it(`maps hour correctly to UTC timestandard for ${description}`, () => {
       const dateBefore = moment(`20191023-${hour}00`, 'YYYYMMDD-HHMM');
-      const dateAfter = component.convertMomentToDateWithoutTimezone(dateBefore);
+      const dateAfter = component.convertMomentToDate(dateBefore);
       expect(dateBefore.hour()).toEqual(dateAfter.getHours());
     });
   });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -80,16 +80,21 @@ describe('ReportingComponent', () => {
   });
 
   using([
-    ['01', '1', '23', 'an hour before end of day'],
+    ['01', '01', '23', 'an hour before end of day'],
     ['04', '22', '00', 'exactly end of day'],
-    ['6', '30', '01', 'an hour after end of day']
+    ['06', '30', '01', 'an hour after end of day']
   ], function (month: string, day: string, hour: string, description: string) {
     it(`displays the date correctly in UTC timestandard for ${description}`, () => {
-      const originalDate = moment.utc(`2019${month}${day}-${hour}00`, 'YYYYMMDD-HHMM');
-      const resultDate = component.convertMomentToDate(originalDate);
+      const originalDate = moment.utc(`2019${month}${day}-${hour}01`, 'YYYYMMDD-HHMM'); // valid
+      component.reportQuery.setState({
+        endDate: originalDate
+      } as ReportQuery);
+      fixture.detectChanges();
 
-      expect(originalDate.month()).toEqual(resultDate.getMonth());
-      expect(originalDate.day()).toEqual(resultDate.getDay());
+      component.endDate$.subscribe(d => {
+        expect(originalDate.month()).toEqual(d.getUTCMonth());
+        expect(originalDate.date()).toEqual(d.getUTCDate());
+      });
     });
   });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -88,6 +88,7 @@ describe('ReportingComponent', () => {
       const originalDate = moment.utc(`2019${month}${day}-${hour}00`, 'YYYYMMDD-HHMM');
       const resultDate = component.convertMomentToDate(originalDate);
 
+      expect(originalDate.month()).toEqual(resultDate.getMonth());
       expect(originalDate.day()).toEqual(resultDate.getDay());
     });
   });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.spec.ts
@@ -85,7 +85,7 @@ describe('ReportingComponent', () => {
     ['06', '30', '01', 'an hour after end of day']
   ], function (month: string, day: string, hour: string, description: string) {
     it(`displays the date correctly in UTC timestandard for ${description}`, () => {
-      const originalDate = moment.utc(`2019${month}${day}-${hour}01`, 'YYYYMMDD-HHMM'); // valid
+      const originalDate = moment.utc(`2019${month}${day}-${hour}01`, 'YYYYMMDD-HHMM');
       component.reportQuery.setState({
         endDate: originalDate
       } as ReportQuery);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -207,7 +207,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const allUrlParameters$ = this.getAllUrlParameters();
 
     this.endDate$ = this.reportQuery.state.pipe(map((reportQuery: ReportQuery) =>
-      this.convertMomentToDateWithoutTimezone(reportQuery.endDate)));
+      this.convertMomentToDate(reportQuery.endDate)));
 
     allUrlParameters$.pipe(takeUntil(this.isDestroyed)).subscribe(
       allUrlParameters => this.applyParamFilters(allUrlParameters));
@@ -512,14 +512,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
     return 0;
   }
 
-  convertMomentToDateWithoutTimezone(m: moment.Moment): Date {
-    // const newDate = new Date(m.year(), m.month(), m.date());
-    // console.log(newDate);
-    // const modate = moment(newDate);
-    // console.log(moment.isMoment(modate));
-    // console.log(modate);
-    // console.log(m.toDate());
-    // return new Date(m.year(), m.month(), m.date());
+  convertMomentToDate(m: moment.Moment): Date {
     return m.toDate();
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -513,6 +513,13 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   convertMomentToDateWithoutTimezone(m: moment.Moment): Date {
-    return new Date(m.year(), m.month(), m.date());
+    // const newDate = new Date(m.year(), m.month(), m.date());
+    // console.log(newDate);
+    // const modate = moment(newDate);
+    // console.log(moment.isMoment(modate));
+    // console.log(modate);
+    // console.log(m.toDate());
+    // return new Date(m.year(), m.month(), m.date());
+    return m.toDate();
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -513,6 +513,6 @@ export class ReportingComponent implements OnInit, OnDestroy {
   }
 
   convertMomentToDate(m: moment.Moment): Date {
-    return m.toDate();
+    return new Date(Date.UTC(m.year(), m.month(), m.date()));
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The date picker on compliance reports page is displaying the previous date to customers in Australia time zone (and possibly others).  We would like the date picker to always display in UTC.

### :chains: Related Resources
Addresses: https://github.com/chef/automate/issues/4015
Need to be careful that this does not undo all of work in https://github.com/chef/automate/pull/1624

### :+1: Definition of Done
The Date picker is always displaying UTC time.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

navigate to https://a2-dev.test/compliance/reports/overview
By default, the date should match up with the current UTC Date
Select a date in the future 
  - the url parameters should match the selected date.
  - the date selector should display the date that was clicked on.
  - the reports should display from the date that was clicked on.
Repeat this flow several times for several different dates.

Change your timezone to locations in Japan, Australia, US, Europe, Russia, etc.
Repeat steps from above in each location.

** to change your timezone in chrome dev tools click on the three dot menu in devtools > more tools > sensors

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
