### PR TITLE
Automate CDS adding unit test to buildkite

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -550,6 +550,21 @@ steps:
           # a1-buildkite has erlang 18 pre-installed
           image: chefes/a1-buildkite
 
+  - label: "[unit] automate-cds"
+    command:
+      - hab studio run "source .studiorc && go_component_unit automate-cds && go_component_static_tests automate-cds"
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - HAB_STUDIO_SUP=false
+            - HAB_NONINTERACTIVE=true
+
   - wait
 
   - label: "automate-ui"

--- a/components/automate-cds/server/root.go
+++ b/components/automate-cds/server/root.go
@@ -93,7 +93,7 @@ func (s *Server) InstallContentItem(ctx context.Context,
 	contentItem, found, err := s.client.GetContentItem(request.Id)
 	if err != nil {
 		return &response.InstallContentItem{}, status.Errorf(codes.Internal,
-			"Could not connect to Content Delivery Service error: %s", err.Error)
+			"Could not connect to Content Delivery Service error: %s", err.Error())
 	}
 	if !found {
 		return &response.InstallContentItem{}, status.Errorf(codes.InvalidArgument,
@@ -114,7 +114,7 @@ func (s *Server) InstallContentItem(ctx context.Context,
 		err = s.installProfile(ctx, contentItem, request.RequestUser)
 		if err != nil {
 			return &response.InstallContentItem{}, status.Errorf(codes.Internal,
-				"Error Installing Profile: %s", err.Error)
+				"Error Installing Profile: %s", err.Error())
 		}
 	} else {
 		return &response.InstallContentItem{}, status.Errorf(codes.InvalidArgument,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding the automate-cds service's unit and static tests to buildkite.

### :chains: Related Resources

https://github.com/chef/automate/issues/3913

### :athletic_shoe: How to Build and Test the Change

Check that the unit tests are in buildkite. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


![buildkite](https://user-images.githubusercontent.com/1679247/86641752-3abecc80-bf90-11ea-94e5-556bad6a474c.png)
