### PR TITLE
Send an event to the notifications-service when there are no failed r…

### DIFF
--- a/components/notifications-client/builder/ccr.go
+++ b/components/notifications-client/builder/ccr.go
@@ -23,7 +23,7 @@ func ChefClientConverge(url string, run *chef.Run) (*Event, error) {
 	if run.Status == "failure" {
 		failed_resource := getFailedResources(run.GetResources())
 		if failed_resource == nil {
-			log.Warn("Could not find failed resource in chef run")
+			log.Info("Could not find failed resource in chef run")
 			failed_resource = &chef.Resource{}
 		}
 

--- a/components/notifications-client/builder/ccr.go
+++ b/components/notifications-client/builder/ccr.go
@@ -10,6 +10,7 @@ import (
 
 	chef "github.com/chef/automate/api/external/ingest/request"
 	. "github.com/chef/automate/components/notifications-client/api"
+	log "github.com/sirupsen/logrus"
 )
 
 // ChefClientConverge builds a chef converge event that can be sent to the notifier
@@ -22,7 +23,8 @@ func ChefClientConverge(url string, run *chef.Run) (*Event, error) {
 	if run.Status == "failure" {
 		failed_resource := getFailedResources(run.GetResources())
 		if failed_resource == nil {
-			return nil, errors.New("Could not find failed resource in chef run")
+			log.Warn("Could not find failed resource in chef run")
+			failed_resource = &chef.Resource{}
 		}
 
 		err := run.GetError()

--- a/components/notifications-service/server/test/formatters/servicenow_test.exs
+++ b/components/notifications-service/server/test/formatters/servicenow_test.exs
@@ -92,5 +92,93 @@ defmodule Notifications.Formatters.ServiceNow.Test do
 
       assert expected == ServiceNow.format(notification)
     end
+
+    test "that a populated CCR notification with no failed resources creates the correct webhook payload" do
+      exception_backtrace = [
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:240:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:321:in `block in run'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:320:in `each'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:320:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/provider.rb:155:in `process_resource_requirements'",
+            "/Users/aleff/projects/chef/lib/chef/provider.rb:133:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/resource.rb:591:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:69:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `block (2 levels) in converge'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `each'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `block in converge'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/resource_list.rb:94:in `block in execute_each_resource'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/resource_list.rb:92:in `execute_each_resource'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:96:in `converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:669:in `block in converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:664:in `catch'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:664:in `converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:703:in `converge_and_save'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:283:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:286:in `block in fork_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:274:in `fork'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:274:in `fork_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:239:in `block in run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/local_mode.rb:44:in `with_server_connectivity'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:227:in `run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:456:in `sleep_then_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:443:in `block in interval_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:442:in `loop'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:442:in `interval_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:426:in `run_application'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:59:in `run'",
+            "/Users/aleff/projects/chef/bin/chef-client:26:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/chef-client:22:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/chef-client:22:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/bundle:22:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/bundle:22:in `<main>'"
+          ]
+
+      notification = %Notifications.CCRFailure{
+        run_id: "",
+        node_name: "insights.chef.co",
+        node_url: "chef-server.insights.co",
+        run_url: "https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606",
+        cookbook: "",
+        recipe: "",
+        time: %Notifications.TimeInfo{start_time: "2016-06-28T20:05:29.000000Z", end_time: "2016-06-28T20:05:30.000000Z"},
+        timestamp: "2016-06-28T20:05:31.000000Z",
+        exception: %Notifications.ExceptionInfo{class: "RuntimeError",
+          title: "",
+          msg: "",
+          backtrace: exception_backtrace}}
+
+      expected =
+        %{automate_failure_url: "https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606",
+          automate_fqdn: "http://localhost",
+          cookbook: "",
+          end_time_utc: "2016-06-28T20:05:30.000000Z",
+          exception_message: "",
+          exception_title: "",
+          failure_snippet: "Chef client run failure on [chef-server.insights.co] insights.chef.co : https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606\n\n \n",
+          node_name: "insights.chef.co", start_time_utc: "2016-06-28T20:05:29.000000Z",
+          type: "converge_failure",
+          timestamp_utc: "2016-06-28T20:05:31.000000Z",
+          exception_backtrace: exception_backtrace
+        }
+
+      assert expected == ServiceNow.format(notification)
+    end
   end
 end

--- a/components/notifications-service/server/test/formatters/webhook_test.exs
+++ b/components/notifications-service/server/test/formatters/webhook_test.exs
@@ -89,5 +89,91 @@ defmodule Notifications.Formatters.Webhook.Test do
 
       assert expected == Webhook.format(notification)
     end
+
+    test "that a populated CCR notification with no failed resources creates the correct webhook paylaod" do
+      exception_backtrace = [
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:240:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:321:in `block in run'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:320:in `each'",
+            "/Users/aleff/projects/chef/lib/chef/mixin/why_run.rb:320:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/provider.rb:155:in `process_resource_requirements'",
+            "/Users/aleff/projects/chef/lib/chef/provider.rb:133:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/resource.rb:591:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:69:in `run_action'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `block (2 levels) in converge'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `each'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:97:in `block in converge'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/resource_list.rb:94:in `block in execute_each_resource'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'",
+            "/Users/aleff/projects/chef/lib/chef/resource_collection/resource_list.rb:92:in `execute_each_resource'",
+            "/Users/aleff/projects/chef/lib/chef/runner.rb:96:in `converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:669:in `block in converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:664:in `catch'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:664:in `converge'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:703:in `converge_and_save'",
+            "/Users/aleff/projects/chef/lib/chef/client.rb:283:in `run'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:286:in `block in fork_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:274:in `fork'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:274:in `fork_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:239:in `block in run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/local_mode.rb:44:in `with_server_connectivity'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:227:in `run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:456:in `sleep_then_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:443:in `block in interval_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:442:in `loop'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:442:in `interval_run_chef_client'",
+            "/Users/aleff/projects/chef/lib/chef/application/client.rb:426:in `run_application'",
+            "/Users/aleff/projects/chef/lib/chef/application.rb:59:in `run'",
+            "/Users/aleff/projects/chef/bin/chef-client:26:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/chef-client:22:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/chef-client:22:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/bundle:22:in `load'",
+            "/Users/aleff/.chefdk/gem/ruby/2.1.0/bin/bundle:22:in `<main>'"
+          ]
+
+      notification = %Notifications.CCRFailure{
+        run_id: "",
+        node_name: "insights.chef.co",
+        node_url: "chef-server.insights.co",
+        run_url: "https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606",
+        cookbook: "",
+        recipe: "",
+        time: %Notifications.TimeInfo{start_time: "2016-06-28T20:05:29.000000Z", end_time: "2016-06-28T20:05:30.000000Z"},
+        exception: %Notifications.ExceptionInfo{class: "RuntimeError",
+          title: "",
+          msg: "",
+          backtrace: exception_backtrace}}
+
+      expected =
+        %{automate_failure_url: "https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606",
+          automate_fqdn: "http://localhost",
+          end_time_utc: "2016-06-28T20:05:30.000000Z",
+          exception_message: "",
+          exception_title: "",
+          failure_snippet: "Chef client run failure on [chef-server.insights.co] insights.chef.co : https://localhost/nodes/0271e125-97dd-498a-b026-8448ee60aafe/runs/ba6acb91-1eaa-4c84-8d68-f19ee641e606\n\n \n",
+          node_name: "insights.chef.co", start_time_utc: "2016-06-28T20:05:29.000000Z",
+          type: "converge_failure",
+          exception_backtrace: exception_backtrace
+        }
+
+      assert expected == Webhook.format(notification)
+    end
+
   end
 end


### PR DESCRIPTION
…esources in a failed client run

Signed-off-by: Martin Scott <mscott@chef.io>

See #4039 

### :nut_and_bolt: Description: What code changed, and why?

Send an event to the notifications-service for a failed client run that does not have a failed resource. 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

Build and deploy the automate-gateway

Set up a notification for slack, webhook and servicenow (can be same destination as webhook).
Perform a client run for a cookbook that does not compile. This is fairly easy to do, just type some random words into a cookbook and it will not compile. 

Verify notifications are received.
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated? -unit tests for webhook and servicenow added. All notification types tested manually
- [ ] Docs added/updated? NA
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
