### PR TITLE
bumping habitat/builder-api pin due to new release

### DIFF
--- a/components/automate-builder-api/habitat/plan.sh
+++ b/components/automate-builder-api/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_deps=(
   core/bash
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # We need to pin here to get a build from unstable
-  "habitat/builder-api/8929/20200601115721"
+  "habitat/builder-api/8966/20200702163723"
 )
 
 pkg_binds=(


### PR DESCRIPTION
We released a new version of `habitat/builder-api` to the stable channel on 2020-07-07.
This change pins the version. No changes to `builder-api-proxy`.

Signed-off-by: Jeremy J. Miller <jm@chef.io>

