### PR TITLE
Remove xpack plugins from elasticsearch

### DIFF
--- a/components/automate-elasticsearch/habitat/config/elasticsearch.yml
+++ b/components/automate-elasticsearch/habitat/config/elasticsearch.yml
@@ -77,8 +77,6 @@ gateway.recover_after_time: {{cfg.gateway.recover_after_time}}
 
 action.destructive_requires_name: {{cfg.action.destructive_requires_name}}
 
-xpack.ml.enabled: false
-
 {{#if cfg.plugins.cloud_aws_signer ~}}
 cloud.aws.signer: {{cfg.plugins.cloud_aws_signer}}
 {{/if ~}}

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -51,6 +51,7 @@ do_build() {
 do_install() {
   cp -a "$(pkg_path_for ${vendor_origin}/elasticsearch)/es/"* "${pkg_prefix}/es/"
   "${pkg_prefix}/es/bin/elasticsearch-plugin" install -b "file://${HAB_CACHE_SRC_PATH}/repository-s3.zip"
+  rm -rf "${pkg_prefix}/es/modules/x-pack-"*
 }
 
 do_strip() {


### PR DESCRIPTION
We ship elasticsearch with xpack. While we disable it, it still seems to
run some of the binaries (maybe enough to know that its disabled?). We
can just remove the plugins entirely.

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>