### PR TITLE
Revert "add a changelog to the repo using expeditor (#4053)"

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -8,11 +8,6 @@ slack:
 
 github:
   delete_branch_on_merge: true
-  changelog_file: "CHANGELOG.md"
-
-changelog:
-  categories:
-    - "bug 🐛": "Bug Fixes"
 
 # At the given time, trigger the following scheduled workloads
 # https://expeditor.chef.io/docs/getting-started/subscriptions/#scheduling-workloads
@@ -114,7 +109,6 @@ subscriptions:
   # These actions are taken, in order they are specified, anytime a Pull Request is merged.
   - workload: staged_workload_released:chef/automate:master:post_merge:*
     actions:
-      - built_in:update_changelog
       - bash:.expeditor/generate-automate-cli-docs.sh:
           post_commit: false
           only_if_modified:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,0 @@
-# Changelog
-
-<!-- latest_release -->
-<!-- latest_release -->


### PR DESCRIPTION


### :nut_and_bolt: Description: What code changed, and why?

This reverts commit 37598f60ef225d49b63415e4861a9b998b9082b9.
Having a VERSION file with semantic versioning is required even
for the basic changelog management workflow, so unfortunately we
will not be able to use as-is.
I will coordinate with releng to see if there is a workaround,
reverting to unblock.
