### PR TITLE
Fix ontop backups for builder

### DIFF
--- a/components/automate-minio/habitat/config/secrets
+++ b/components/automate-minio/habitat/config/secrets
@@ -1,9 +1,0 @@
-{{~#if cfg.gateway.backup.s3.credentials.access_key}}
-export AWS_ACCESS_KEY_ID="{{cfg.gateway.backup.s3.credentials.access_key}}"
-{{~/if}}
-{{~#if cfg.gateway.backup.s3.credentials.secret_key}}
-export AWS_SECRET_ACCESS_KEY="{{cfg.gateway.backup.s3.credentials.secret_key}}"
-{{~/if}}
-{{~#if cfg.gateway.backup.s3.credentials.session_token}}
-export AWS_SESSION_TOKEN="{{cfg.gateway.backup.s3.credentials.session_token}}"
-{{~/if}}

--- a/components/automate-minio/habitat/hooks/run
+++ b/components/automate-minio/habitat/hooks/run
@@ -2,9 +2,6 @@
 
 exec 2>&1
 
-chmod 0600 "{{pkg.svc_config_path}}/secrets"
-source "{{pkg.svc_config_path}}/secrets"
-
 mkdir -p "{{pkg.svc_data_path}}/depot"
 
 # Minio requires TLS certs to be in a 'certs' subdirectory of the config-dir.

--- a/components/automate-minio/habitat/hooks/run
+++ b/components/automate-minio/habitat/hooks/run
@@ -33,6 +33,19 @@ export MINIO_BROWSER=off
 export SSL_CERT_FILE={{pkgPathFor "core/cacerts"}}/ssl/cert.pem
 export SSL_CERT_DIR={{pkgPathFor "core/cacerts"}}/ssl/certs
 
+# Minio uses the access key and secret key to encrypt its config.
+# We don't have any special config, so we want to make the safe to
+# regenerate.
+checksum_path="{{pkg.svc_var_path}}/creds.sha256"
+last_checksum=$(cat "${checksum_path}" || true)
+current_checksum=$(echo -n "${MINIO_ACCESS_KEY}:${MINIO_SECRET_KEY}" | sha256sum | cut -f1 -d ' ')
+
+if [[ "${last_checksum}" != "${current_checksum}" ]]; then
+    echo "minio credentials have changed: removing .minio.sys"
+    rm -r "{{pkg.svc_data_path}}/.minio.sys"
+    echo -n "${current_checksum}" > "${checksum_path}"
+fi
+
 #{{#if cfg.gateway.storage.s3.bucket.name~}}
 #exec minio gateway s3 {{cfg.gateway.storage.s3.bucket.endpoint}} \
   #--config-dir "{{pkg.svc_var_path}}/config" \

--- a/components/automate-minio/habitat/plan.sh
+++ b/components/automate-minio/habitat/plan.sh
@@ -8,6 +8,7 @@ pkg_deps=(
   core/bash
   core/curl
   core/cacerts
+  core/coreutils
   chef/automate-platform-tools
 )
 

--- a/integration/tests/backup_ontop.sh
+++ b/integration/tests/backup_ontop.sh
@@ -5,7 +5,38 @@ test_name="backup-ontop"
 test_backup_restore=true
 test_diagnostics_filters="~remove-this-tag-after-merge"
 
+install_automate() {
+    #shellcheck disable=SC2154
+    chef-automate deploy "$test_config_path" \
+        --hartifacts "$test_hartifacts_path" \
+        --override-origin "$HAB_ORIGIN" \
+        --upgrade-strategy "$test_upgrade_strategy" \
+        --product automate \
+        --product builder \
+        --accept-terms-and-mlsa \
+        --admin-password chefautomate \
+        --skip-preflight \
+        --debug
+}
+do_deploy() {
+    install_automate
+}
+
 do_prepare_restore() {
+    systemctl stop chef-automate
+    # Leave /hab/pkgs and /hab/cache
+    # Delete these sylinks
+    rm -rf /bin/knife
+    rm -rf /bin/chef-server-ctl
+    rm -rf /bin/chef-automate
+    rm -rf "/hab/bin"
+    rm -rf "/hab/sup"
+    rm -rf "/hab/svc"
+    rm -rf "/hab/user"
+    rm -rf "/hab/launcher"
+    copy_hartifacts "$test_hartifacts_path"
+
+    install_automate
     # Run the diagnostics command again. We'll verify that this does not pass
     #shellcheck disable=SC2154
     chef-automate diagnostics run $test_diagnostics_filters --lb-url "$test_loadbalancer_url" --skip-cleanup --save-file "/tmp/context2"


### PR DESCRIPTION
If you were to take a backup of builder, then on another machine, install automate + builder, and restore the backup, it would fail because we'd change the minio secret. Minio doesn't like this because it encrypts config with that secret now. We don't actually care about that config, so this PR detects that case and blows away the config