### PR TITLE
Infra proxy route consistency

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -249,23 +249,23 @@ const routes: Routes = [
               component: ChefServerDetailsComponent
             },
             {
-              path: ':id/organizations/:orgid',
+              path: ':id/organizations/:org-id',
               component: OrgDetailsComponent
             },
             {
-              path: ':id/organizations/:orgid/cookbooks/:cookbook_name',
+              path: ':id/organizations/:org-id/cookbooks/:cookbook-name',
               component: CookbookDetailsComponent
             },
             {
-              path: ':id/organizations/:orgid/roles/:name',
+              path: ':id/organizations/:org-id/roles/:name',
               component: InfraRoleDetailsComponent
             },
             {
-              path: ':id/organizations/:orgid/environments/:name',
+              path: ':id/organizations/:org-id/environments/:name',
               component: EnvironmentDetailsComponent
             },
             {
-              path: ':id/organizations/:orgid/data_bags/:name',
+              path: ':id/organizations/:org-id/data-bags/:name',
               component: DataBagsDetailsComponent
             }
           ]

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-details.selectors.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-details.selectors.ts
@@ -21,5 +21,5 @@ export const getStatus = createSelector(
 export const cookbookDetailsFromRoute = createSelector(
   cookbookDetailsEntities,
   routeParams,
-  (state, { cookbook_name }) => find({ cookbook_name }, state)
+  (state, { 'cookbook-name': cookbook_name }) => find({ cookbook_name }, state)
 );

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.selectors.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.selectors.ts
@@ -17,5 +17,5 @@ export const getStatus = createSelector(
 export const cookbookVersionsFromRoute = createSelector(
   cookbookVersionsEntities,
   routeParams,
-  (state, {cookbook_name}) => state[cookbook_name]
+  (state, {'cookbook-name': cookbook_name}) => state[cookbook_name]
 );

--- a/components/automate-ui/src/app/entities/orgs/org.selectors.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.selectors.ts
@@ -43,5 +43,5 @@ export const deleteStatus = createSelector(
 export const orgFromRoute = createSelector(
   orgEntities,
   routeParams,
-  (state, { 'org-id': orgid }) => state[orgid]
+  (state, { 'org-id': org_id }) => state[org_id]
 );

--- a/components/automate-ui/src/app/entities/orgs/org.selectors.ts
+++ b/components/automate-ui/src/app/entities/orgs/org.selectors.ts
@@ -43,5 +43,5 @@ export const deleteStatus = createSelector(
 export const orgFromRoute = createSelector(
   orgEntities,
   routeParams,
-  (state, { orgid }) => state[orgid]
+  (state, { 'org-id': orgid }) => state[orgid]
 );

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
@@ -84,7 +84,7 @@ describe('CookbookDetailsComponent', () => {
       state: {
         ...defaultRouterRouterState,
         url: `infrastructure/chef-servers/${serverId}/org/${orgId}/cookbooks/${cookbook_name}`,
-        params: { id: serverId, orgid: orgId, cookbook_name: cookbook_name }
+        params: { id: serverId, 'org-id': orgId, 'cookbook-name': cookbook_name }
       }
     }
   };

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.spec.ts
@@ -35,10 +35,10 @@ const declarations: any[] = [
   MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
   CookbookDetailsComponent
 ];
-const serverId = '6e98f609-586d-4816-a6de-e841e659b11d';
-const orgId = '6e98f609-586d-4816-a6de';
+const server_id = '6e98f609-586d-4816-a6de-e841e659b11d';
+const org_id = '6e98f609-586d-4816-a6de';
 const cookbook_name = 'aix';
-const currentVersion = '1.1.1';
+const current_version = '1.1.1';
 const readme_content = 'test content';
 const cookbookVersion: CookbookVersions = {
   name: 'aix',
@@ -83,8 +83,8 @@ describe('CookbookDetailsComponent', () => {
       ...defaultRouterState,
       state: {
         ...defaultRouterRouterState,
-        url: `infrastructure/chef-servers/${serverId}/org/${orgId}/cookbooks/${cookbook_name}`,
-        params: { id: serverId, 'org-id': orgId, 'cookbook-name': cookbook_name }
+        url: `infrastructure/chef-servers/${server_id}/org/${org_id}/cookbooks/${cookbook_name}`,
+        params: { id: server_id, 'org-id': org_id, 'cookbook-name': cookbook_name }
       }
     }
   };
@@ -142,7 +142,7 @@ describe('CookbookDetailsComponent', () => {
     store.dispatch(new GetCookbookDetailsSuccess(cookbookDetails));
     fixture.detectChanges();
     const fileUrl = encodeURIComponent(cookbookDetails.root_files[0].url);
-    const req = httpMock.expectOne(`${env.infra_proxy_url}/servers/${serverId}/orgs/${orgId}/cookbooks/${cookbook_name}/${currentVersion}/file-content?url=${fileUrl}`);
+    const req = httpMock.expectOne(`${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}/${current_version}/file-content?url=${fileUrl}`);
     expect(req.request.method).toBe('GET');
     httpMock.verify();
     req.flush(readme_content);
@@ -152,7 +152,7 @@ describe('CookbookDetailsComponent', () => {
   it('No remote HTTP call triggered when README file URL does not exist', () => {
     store.dispatch(new GetCookbookDetailsSuccess(cookbookDetails));
     fixture.detectChanges();
-    const req = httpMock.expectNone(`${env.infra_proxy_url}/servers/${serverId}/orgs/${orgId}/cookbooks/${cookbook_name}/${currentVersion}/file-content?url=`);
+    const req = httpMock.expectNone(`${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}/${current_version}/file-content?url=`);
     expect(req).toBeUndefined();
   });
 

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -85,8 +85,8 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('cookbook_name'), filter(identity))
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('cookbook-name'), filter(identity))
     ]).pipe(
       takeUntil(this.isDestroyed)
     ).subscribe(([server_id, org_id, cookbook_name]) => {

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -44,7 +44,7 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('name'), filter(identity))
     ]).pipe(
       takeUntil(this.isDestroyed)

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -72,7 +72,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('name'), filter(identity))
     ]).pipe(
       takeUntil(this.isDestroyed)

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -84,7 +84,7 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('name'), filter(identity))
     ]).pipe(
       takeUntil(this.isDestroyed)

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -82,7 +82,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-      this.store.select(routeParams).pipe(pluck('orgid'), filter(identity))
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))
     ]).pipe(
       takeUntil(this.isDestroyed)
     ).subscribe(([server_id, org_id]: string[]) => {


### PR DESCRIPTION
Signed-off-by: sachin-msys <sbacchav@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
To follow consistent route param pattern through out the application. Added some changes for infra proxy routes.


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes: #3924 

### :+1: Definition of Done
Infra proxy route inconsistency resolved. `orgid` is replaced with `org-id` and `cookbook_name`  is replaced with `cookbook-name`. 

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

navigate to https://a2-dev.test/infrastructure/chef-servers

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

