### PR TITLE
Increase default max report size for infra server

### DIFF
--- a/api/config/erchef/config_request.go
+++ b/api/config/erchef/config_request.go
@@ -43,7 +43,7 @@ func DefaultConfigRequest() *ConfigRequest {
 
 	c.V1.Sys.Api.AuthSkew = w.Int32(900)
 	c.V1.Sys.Api.BulkFetchBatchSize = w.Int32(5)
-	c.V1.Sys.Api.MaxRequestSize = w.Int32(2000000)
+	c.V1.Sys.Api.MaxRequestSize = w.Int32(4000000)
 	c.V1.Sys.Api.BaseResourceUrl = w.String("host_header")
 	c.V1.Sys.Api.StrictSearchResultAcls = w.Bool(false)
 

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -61,20 +61,6 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
-Add a stanza to a new patch.toml that bumps the maximum report size:
-
-```toml
-[erchef.v1.sys.api]
-max_request_size = 2000000
-# Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
-```
-
-Apply the configuration:
-
-```shell
-chef-automate config patch patch.toml
-```
-
 Then, [set up `knife`]({{< relref "infra-server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
@@ -93,10 +79,6 @@ Installations require elevated privileges, so run the commands as the superuser 
     ```toml
       [deployment.v1.svc]
       products=["automate", "infra-server"]
-
-      [erchef.v1.sys.api]
-      max_request_size = 2000000
-      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Make any other configuration changes desired.
@@ -132,10 +114,6 @@ Installations require elevated privileges, so run the commands as the superuser 
     ```toml
        [erchef.v1.sys.data_collector]
        enabled = false
-
-      [erchef.v1.sys.api]
-      max_request_size = 2000000
-      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Use the configuration file to deploy Chef Infra Server by running the following command:
@@ -168,10 +146,6 @@ Installations require elevated privileges, so run the commands as the superuser 
        # Disable Automate data collection as Automate will not be deployed
        [erchef.v1.sys.data_collector]
        enabled = false
-
-      [erchef.v1.sys.api]
-      max_request_size = 2000000
-      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 1. Run the `chef-automate deploy` command with your configuration file (config.toml):
@@ -191,10 +165,6 @@ Patch an existing Chef Automate installation to add Chef Infra Server:
     ```toml
        [deployment.v1.svc]
        products=["automate", "infra-server"]
-
-      [erchef.v1.sys.api]
-      max_request_size = 2000000
-      # Default: 2000000 (2mb), increase to 4000000 (4mb) as needed.
     ```
 
 2. Apply the patch to the Chef Automate installation:

--- a/components/automate-cs-oc-erchef/habitat/default.toml
+++ b/components/automate-cs-oc-erchef/habitat/default.toml
@@ -16,7 +16,7 @@ max_error_logs_per_second = 1000
 
 [api]
 auth_skew=900
-max_request_size=1000000
+max_request_size=4000000
 bulk_fetch_batch_size=5
 base_resource_url="host_header"
 strict_search_result_acls=false


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Set the default max report size for chef-client and compliance profile reports proxied through an infra server to match the 4MB GRPC limit.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
