### PR TITLE
Event-feed GetFeedSummary project filtering

### DIFF
--- a/components/event-feed-service/pkg/integration_test/feed_counts_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_counts_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chef/automate/components/event-feed-service/pkg/persistence"
 	"github.com/chef/automate/lib/grpc/grpctest"
 
+	authzConstants "github.com/chef/automate/components/authz-service/constants"
 	event "github.com/chef/automate/components/event-service/config"
 	"github.com/chef/automate/lib/stringutils"
 )
@@ -192,6 +193,672 @@ func TestFeedCountsCountOnlyFilteredUsers(t *testing.T) {
 
 	// Run all the cases!
 	runCases(t, cases)
+}
+
+func TestFeedCountsTypeCountsProjectFilter(t *testing.T) {
+	startDate := time.Now().UTC()
+	request := &event_feed.FeedSummaryRequest{
+		CountCategory: "event-type",
+		Start:         startDate.AddDate(0, 0, -11).Unix() * 1000,
+	}
+
+	cases := []struct {
+		description string
+		entries     []feed.FeedEntry
+		ctx         context.Context
+		expected    *event_feed.FeedSummaryResponse
+	}{
+		{
+			description: "No Events with requesting projects",
+			entries:     []feed.FeedEntry{},
+			ctx:         contextWithProjects([]string{"project9"}),
+			expected:    &event_feed.FeedSummaryResponse{},
+		},
+		{
+			description: "Return the only event; One event with a project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					Projects:           []string{"project9"},
+					ObjectObjectType:   "cookbook",
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return the only event; One non chef-server event with no projects; requesting one project",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "profile",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "profile",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return both events; Two events with a project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+					{
+						Category: "node",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return both events; Two events one chef-server and the other not; chef-server event has a project matching the requested project",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "profile",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+					{
+						Category: "profile",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return non chef-server event count; Two events one chef-server and the other not; chef-server event has a non-matching project to the requested project",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"not-matching-project"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "profile",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "profile",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return one of the events;Two Events with only one's project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return not counts; One event with a project not matching the request's projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project3"}),
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 0,
+				EntryCounts:  []*event_feed.EntryCount{},
+			},
+		},
+		{
+			description: "Return the only event; One event with one project; request is for all projects",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return all three events; Three events with different projects and one without any projects; request all projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project12"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "bag",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 3,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+					{
+						Category: "node",
+						Count:    1,
+					},
+					{
+						Category: "bag",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return the only event; One event with no projects; request for all projects",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return the only event; One event that has no projects; request unassigned projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Returns zero count; One event with a project; request only unassigned projects",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 0,
+				EntryCounts:  []*event_feed.EntryCount{},
+			},
+		},
+		{
+			description: "Returns one count; Two events have and don't have projects; requesting only unassigned projects",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "node",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return one count; One event with a project; request unassigned and a matching project allowed",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID, "project9"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return one event count; One event with no projects; request has no projects",
+			ctx:         contextWithProjects([]string{}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+
+		{
+			description: "Return both event counts;Two events have and don't have projects; request has no projects",
+			ctx:         contextWithProjects([]string{}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "node",
+						Count:    1,
+					},
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return one event count; One event with one project matching one of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project9", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return a count of both events; Two events with one project matching different projects of several requested",
+			ctx:         contextWithProjects([]string{"project3", "project9", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "node",
+						Count:    1,
+					},
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Returns zero counts; One event with one project not matching any of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 0,
+				EntryCounts:  []*event_feed.EntryCount{},
+			},
+		},
+		{
+			description: "Returns zero counts; Two events with neither having projects matching any of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project10"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 0,
+				EntryCounts:  []*event_feed.EntryCount{},
+			},
+		},
+
+		{
+			description: "Returns one count; One event with several projects where only one matches a single requested project",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Two events with both having several projects where one matches a single requested project",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project12", "project10", "project11", "project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "node",
+						Count:    1,
+					},
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Return the count for one; Two events with several projects where only one of the event's project matches a single requested project",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project12", "project10", "project11", "project13"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "One event with several projects where one matches one of several requested project",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Returns both events count; Two events with several projects where one matches one of several requested project",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Projects:           []string{"project13", "project14", "project17", "project16"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 2,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "node",
+						Count:    1,
+					},
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+		{
+			description: "Returns zero counts; One event with several projects where none matches several requested projects",
+			ctx:         contextWithProjects([]string{"project14", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "cookbook",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{},
+		},
+		{
+			description: "Returns one count; One event with several projects where two matches two of several requested project",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType: "cookbook",
+					Projects:         []string{"project3", "project10", "project7", "project6"},
+				},
+			},
+			expected: &event_feed.FeedSummaryResponse{
+				TotalEntries: 1,
+				EntryCounts: []*event_feed.EntryCount{
+					{
+						Category: "cookbook",
+						Count:    1,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("Project filter: %s", test.description), func(t *testing.T) {
+			for index := range test.entries {
+				test.entries[index].ID = newUUID()
+				test.entries[index].Published = time.Now()
+				test.entries[index].ProducerName = "Fred"
+				test.entries[index].ProducerTags = []string{"mycompany", "engineering department", "compliance team"}
+				test.entries[index].FeedType = "event"
+				test.entries[index].EventType = event.ScanJobUpdatedEventName
+				test.entries[index].Tags = []string{"org_1", "compliance", "profile"}
+				test.entries[index].ActorID = "urn:mycompany:user:fred"
+				test.entries[index].ActorObjectType = "User"
+				test.entries[index].ActorName = "Fred"
+				test.entries[index].Verb = "update"
+				test.entries[index].ObjectID = "urn:chef:compliance:scan-job"
+				test.entries[index].ObjectName = "Scan Job"
+				test.entries[index].TargetID = "urn:mycompany:environment:production"
+				test.entries[index].TargetObjectType = "Environment"
+				test.entries[index].TargetName = "Production"
+				test.entries[index].Created = time.Now().UTC()
+
+				testSuite.feedBackend.CreateFeedEntry(&test.entries[index])
+			}
+			testSuite.RefreshIndices(persistence.IndexNameFeeds)
+
+			defer testSuite.DeleteAllDocuments()
+
+			res, err := testSuite.feedClient.GetFeedSummary(test.ctx, request)
+			assert.NoError(t, err)
+
+			// test response
+			assert.Equal(t, test.expected.TotalEntries, res.TotalEntries)
+			t.Logf("counts %v", res.EntryCounts)
+			assert.ElementsMatch(t, test.expected.EntryCounts, res.EntryCounts)
+		})
+	}
 }
 
 func TestTaskCountsReturnOnlyEventsWithinDateRange(t *testing.T) {

--- a/components/event-feed-service/pkg/integration_test/feed_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_test.go
@@ -801,7 +801,6 @@ func TestEventFeedProjectFilter(t *testing.T) {
 
 			// collect IDs from events response
 			eventIDs := make([]string, res.TotalEntries)
-			t.Logf("number %d", res.TotalEntries)
 			for index, event := range res.FeedEntries {
 				eventIDs[index] = event.ID
 			}

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -352,32 +352,38 @@ func (efs ElasticFeedStore) getAggregationBucket(boolQuery *olivere.BoolQuery, i
 	searchSource := olivere.NewSearchSource().
 		Aggregation(searchTerm, agg)
 
-		// Search Elasticsearch body
-		// {
-		// 	"aggregations":{
-		// 		 "organization_name":{
-		// 				"aggregations":{
-		// 					 "counts":{
-		// 							"terms":{
-		// 								 "field":"[searchTerm]",
-		// 								 "size":1000
-		// 							}
-		// 					 }
-		// 				},
-		// 				"filter":{
-		// 					 "bool":{
-		// 							"must":{
-		// 								 "terms":{
-		// 										"exists":[
-		// 											 "true"
-		// 										]
-		// 								 }
-		// 							}
-		// 					 }
-		// 				}
-		// 		 }
-		// 	}
-		// }
+	source, err := searchSource.Source()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting source")
+	}
+
+	logQueryPartMin(indexName, source, "getAggregationBucket")
+	// Search Elasticsearch body
+	// {
+	// 	"aggregations":{
+	// 		 "organization_name":{
+	// 				"aggregations":{
+	// 					 "counts":{
+	// 							"terms":{
+	// 								 "field":"[searchTerm]",
+	// 								 "size":1000
+	// 							}
+	// 					 }
+	// 				},
+	// 				"filter":{
+	// 					 "bool":{
+	// 							"must":{
+	// 								 "terms":{
+	// 										"exists":[
+	// 											 "true"
+	// 										]
+	// 								 }
+	// 							}
+	// 					 }
+	// 				}
+	// 		 }
+	// 	}
+	// }
 	searchResult, err := efs.client.Search().
 		SearchSource(searchSource).
 		Index(indexName).

--- a/components/event-feed-service/pkg/server/feed.go
+++ b/components/event-feed-service/pkg/server/feed.go
@@ -27,7 +27,7 @@ func NewFeedService(feedStore persistence.FeedStore) *FeedService {
 	return &FeedService{store: feedStore}
 }
 
-func (f *FeedService) GetFeed(req *event_feed.FeedRequest, ctx context.Context) ([]*feed.FeedEntry, int64, error) {
+func (f *FeedService) GetFeed(ctx context.Context, req *event_feed.FeedRequest) ([]*feed.FeedEntry, int64, error) {
 
 	// Date Range
 	startTime, endTime, err := feed.ValidateMillisecondDateRange(req.Start, req.End)
@@ -74,13 +74,18 @@ func (f *FeedService) GetFeed(req *event_feed.FeedRequest, ctx context.Context) 
 	return resp, hits, nil
 }
 
-func (f *FeedService) GetFeedSummary(countCategory string, filters []string,
+func (f *FeedService) GetFeedSummary(ctx context.Context, countCategory string, filters []string,
 	start time.Time, end time.Time) (*feed.FeedSummary, error) {
 
 	// remove count category from the filters array
 	filters = stringutils.SliceReject(filters, countCategory)
 
 	mapFilters, err := feed.FormatFilters(filters)
+	if err != nil {
+		return nil, err
+	}
+
+	mapFilters, err = filterByProjects(ctx, mapFilters)
 	if err != nil {
 		return nil, err
 	}

--- a/components/event-feed-service/pkg/server/server.go
+++ b/components/event-feed-service/pkg/server/server.go
@@ -51,7 +51,7 @@ func (eventFeedServer *EventFeedServer) GetFeed(ctx context.Context,
 		"rpc":     "GetFeed",
 	})
 
-	if feedEntries, hits, err = eventFeedServer.feedService.GetFeed(request, ctx); err != nil {
+	if feedEntries, hits, err = eventFeedServer.feedService.GetFeed(ctx, request); err != nil {
 		logctx.WithError(err).Warn("getting feed")
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (eventFeedServer *EventFeedServer) GetFeedSummary(ctx context.Context,
 		return &event_feed.FeedSummaryResponse{}, e.GrpcErrorFromErr(codes.InvalidArgument, err)
 	}
 
-	fs, err := eventFeedServer.feedService.GetFeedSummary(request.CountCategory, request.Filters,
+	fs, err := eventFeedServer.feedService.GetFeedSummary(ctx, request.CountCategory, request.Filters,
 		startTime, endTime)
 	if err != nil {
 		logctx.WithError(err).Warn("getting feed summary")


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding project filtering for the GetFeedSummary endpoint for the event-feed-service. This is the second of the three endpoints remaining that need project filtering. Project filtering is only used for chef-server events which are not added yet.

### :chains: Related Resources
#444 

### :athletic_shoe: How to Build and Test the Change
1. `build components/event-feed-service && start_all_services`
1. Add a project named "project9"
1. Add a project named "project3"
1. Add a chef-server event tagged with "project9" run `event_feed_add_event` 
1. Create a profile event by adding a profile from the "Available" section here https://a2-dev.test/compliance/compliance-profiles
1. Go to the event feed page and filter for project3 only. Ensure that the "Total events" is 1 like below.
![image](https://user-images.githubusercontent.com/1679247/87596597-405d9600-c6a5-11ea-813c-0c158d63916b.png)
1. Then filter for projects9 only. Ensure the "Total events" is 2.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
