### PR TITLE
Event Feed timeline project filtering

### DIFF
--- a/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 
 	"math/rand"
 	"strconv"
 
 	"github.com/chef/automate/api/interservice/event_feed"
+	authzConstants "github.com/chef/automate/components/authz-service/constants"
 	"github.com/chef/automate/components/event-feed-service/pkg/feed"
 	"github.com/chef/automate/components/event-feed-service/pkg/persistence"
 
@@ -224,6 +226,515 @@ func TestEventStringsFilterEventType(t *testing.T) {
 					}
 				}
 			})
+	}
+}
+
+func TestEventStringsProjectFilter(t *testing.T) {
+	var (
+		timezone  = "UTC"
+		startDate = time.Now().AddDate(0, 0, -3)
+		endDate   = time.Now()
+		request   = event_feed.FeedTimelineRequest{
+			Interval: 1,
+			Start:    startDate.Format("2006-01-02"),
+			End:      endDate.Format("2006-01-02"),
+			Timezone: timezone,
+		}
+	)
+
+	cases := []struct {
+		description string
+		entries     []feed.FeedEntry
+		ctx         context.Context
+		expected    map[string]int
+	}{
+		{
+			description: "No Actions with requesting projects",
+			entries:     []feed.FeedEntry{},
+			ctx:         contextWithProjects([]string{"project9"}),
+			expected:    map[string]int{},
+		},
+		{
+			description: "One Action with a project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two Actions with a project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "delete",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"policyfile": 1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Two Actions with only one's project matching requested projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Action project not matching request projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			ctx:      contextWithProjects([]string{"project3"}),
+			expected: map[string]int{},
+		},
+		{
+			description: "One Action has one project; request all projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Three Actions; request all projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project3"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "node",
+					Verb:               "create",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+				"node":       1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Action has no projects; request all projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.AllProjectsExternalID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Action has no projects; request unassigned projects allowed",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Action has a project; request only unassigned projects",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{},
+		},
+		{
+			description: "Two Actions have and don't have projects; request only unassigned projects",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"cookbook": 1,
+			},
+		},
+		{
+			description: "Action has a project; request unassigned and matching project allowed",
+			ctx:         contextWithProjects([]string{authzConstants.UnassignedProjectID, "project9"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Action has no projects; request has no projects",
+			ctx:         contextWithProjects([]string{}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two Actions have and don't have projects; request has no projects",
+			ctx:         contextWithProjects([]string{}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Action with one project matching one of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project9", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two actions with one project matching different one of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project9", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Action with one project not matching any of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{},
+		},
+		{
+			description: "Two Actions with one project not matching any of several requested projects allowed",
+			ctx:         contextWithProjects([]string{"project3", "project4", "project7", "project6"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project10"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{},
+		},
+		{
+			description: "Action with several projects where one matches a single requested project allowed",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two Actions with several projects where one matches a single requested project allowed",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project12", "project10", "project11", "project3"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Two Actions with several projects where only one action's project matches a single requested project allowed",
+			ctx:         contextWithProjects([]string{"project3"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project12", "project10", "project11", "project13"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Action with several projects where one matches one of several requested project allowed",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two Actions with several projects where one matches one of several requested project allowed",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "cookbook",
+					Verb:               "delete",
+					Projects:           []string{"project13", "project14", "project17", "project16"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+				"cookbook":   1,
+			},
+		},
+		{
+			description: "Action with several projects where none matches several requested project allowed",
+			ctx:         contextWithProjects([]string{"project14", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project4", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{},
+		},
+		{
+			description: "Action with several projects where two matches two of several requested project allowed",
+			ctx:         contextWithProjects([]string{"project3", "project10", "project12", "project13"}),
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "update",
+					Projects:           []string{"project3", "project10", "project7", "project6"},
+					ProducerObjectType: "chef_server",
+				},
+			},
+			expected: map[string]int{
+				"policyfile": 1,
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("Project filter: %s", test.description), func(t *testing.T) {
+			for index := range test.entries {
+				test.entries[index].ID = newUUID()
+				test.entries[index].Published = time.Now()
+				test.entries[index].ProducerName = "Fred"
+				test.entries[index].ProducerTags = []string{"mycompany", "engineering department", "compliance team"}
+				test.entries[index].FeedType = "event"
+				test.entries[index].EventType = event.ScanJobUpdatedEventName
+				test.entries[index].Tags = []string{"org_1", "compliance", "profile"}
+				test.entries[index].ActorID = "urn:mycompany:user:fred"
+				test.entries[index].ActorObjectType = "User"
+				test.entries[index].ActorName = "Fred"
+				test.entries[index].ObjectID = "urn:chef:compliance:scan-job"
+				test.entries[index].ObjectName = "Scan Job"
+				test.entries[index].TargetID = "urn:mycompany:environment:production"
+				test.entries[index].TargetObjectType = "Environment"
+				test.entries[index].TargetName = "Production"
+				test.entries[index].Created = time.Now().UTC()
+			}
+
+			for _, entry := range test.entries {
+				testSuite.feedBackend.CreateFeedEntry(&entry)
+			}
+
+			testSuite.RefreshIndices(persistence.IndexNameFeeds)
+			defer GetTestSuite().DeleteAllDocuments()
+
+			res, err := testSuite.feedClient.GetFeedTimeline(test.ctx, &request)
+			require.NoError(t, err)
+
+			itemsCount := map[string]int{}
+			// test response
+			for _, eventString := range res.ActionLines {
+
+				for _, item := range eventString.Slots {
+					if len(item.Counts) > 0 {
+						itemsCount[item.Counts[0].Category]++
+					}
+				}
+			}
+			for key, expectedValue := range test.expected {
+				value, ok := itemsCount[key]
+
+				assert.True(t, ok, "Event type '%s' was not found on string", key)
+				assert.Equal(t, expectedValue, value,
+					"Number of '%s' on string was %v should be %v", key, value, expectedValue)
+			}
+
+			for key := range itemsCount {
+				if key != "" {
+					_, ok := test.expected[key]
+					assert.True(t, ok, "Event type '%s' should not be on the string", key)
+				}
+			}
+		})
 	}
 }
 

--- a/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
+++ b/components/event-feed-service/pkg/integration_test/feed_timeline_test.go
@@ -249,13 +249,13 @@ func TestEventStringsProjectFilter(t *testing.T) {
 		expected    map[string]int
 	}{
 		{
-			description: "No Actions with requesting projects",
+			description: "No events with a request filting on a project",
 			entries:     []feed.FeedEntry{},
 			ctx:         contextWithProjects([]string{"project9"}),
 			expected:    map[string]int{},
 		},
 		{
-			description: "One Action with a project matching requested projects",
+			description: "One event with a project matching the request's project filters",
 			entries: []feed.FeedEntry{
 				{
 					ObjectObjectType:   "policyfile",
@@ -270,7 +270,21 @@ func TestEventStringsProjectFilter(t *testing.T) {
 			},
 		},
 		{
-			description: "Two Actions with a project matching requested projects",
+			description: "One non-chef-server event with no projects; request's has a project",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "profile",
+					Verb:               "update",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"profile": 1,
+			},
+		},
+		{
+			description: "Two events with the same project matching the request's project filter",
 			entries: []feed.FeedEntry{
 				{
 					ObjectObjectType:   "policyfile",
@@ -289,6 +303,47 @@ func TestEventStringsProjectFilter(t *testing.T) {
 			expected: map[string]int{
 				"policyfile": 1,
 				"cookbook":   1,
+			},
+		},
+		{
+			description: "Two events one chef-server and the other not; The chef-server event has a matching project to the request's projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "delete",
+					Projects:           []string{"project9"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "profile",
+					Verb:               "update",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"profile":    1,
+				"policyfile": 1,
+			},
+		},
+		{
+			description: "Two events one chef-server and the other not; The chef-server event has a non-matching project to the request's projects",
+			entries: []feed.FeedEntry{
+				{
+					ObjectObjectType:   "policyfile",
+					Verb:               "delete",
+					Projects:           []string{"non-matching-project"},
+					ProducerObjectType: "chef_server",
+				},
+				{
+					ObjectObjectType:   "profile",
+					Verb:               "update",
+					ProducerObjectType: "profile",
+				},
+			},
+			ctx: contextWithProjects([]string{"project9"}),
+			expected: map[string]int{
+				"profile": 1,
 			},
 		},
 		{

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -491,18 +491,13 @@ func (efs *ElasticFeedStore) indexExists(name string) (bool, error) {
 // interval - 24 must be divisible by this number
 // For example 1, 2, 3, 4, 6, 8, 12, and 24 are valid. Where
 // 5, 7, 9, 10, 11, and 13 are not valid values.
-func (efs ElasticFeedStore) GetActionLine(filters []string, startDate string, endDate string, timezone string, interval int, action string) (*feed.ActionLine, error) {
+func (efs ElasticFeedStore) GetActionLine(formattedFilters map[string][]string, startDate string, endDate string, timezone string, interval int, action string) (*feed.ActionLine, error) {
 	exists, err := efs.indexExists(IndexNameFeeds)
 	if err != nil {
 		return &feed.ActionLine{}, err
 	}
 	if !exists {
 		return &feed.ActionLine{}, feedErrors.NewBackendError("timeline index %s does not exist", IndexNameFeeds)
-	}
-
-	formattedFilters, err := feed.FormatFilters(filters)
-	if err != nil {
-		return &feed.ActionLine{}, err
 	}
 
 	var (

--- a/components/event-feed-service/pkg/persistence/store.go
+++ b/components/event-feed-service/pkg/persistence/store.go
@@ -29,7 +29,7 @@ type FeedStore interface {
 	CreateFeedEntry(entry *feed.FeedEntry) (bool, error)
 	GetFeed(query *feed.FeedQuery) ([]*feed.FeedEntry, int64, error)
 	GetFeedSummary(query *feed.FeedSummaryQuery) (map[string]int64, error)
-	GetActionLine(filters []string, startDate string, endDate string, timezone string, interval int, action string) (*feed.ActionLine, error)
+	GetActionLine(filters map[string][]string, startDate string, endDate string, timezone string, interval int, action string) (*feed.ActionLine, error)
 }
 
 func NewFeedStore(esClient *olivere.Client) FeedStore {

--- a/components/event-feed-service/pkg/server/server.go
+++ b/components/event-feed-service/pkg/server/server.go
@@ -124,7 +124,7 @@ func (eventFeedServer *EventFeedServer) GetFeedTimeline(ctx context.Context,
 
 	// Create three lines, one for each action
 	for i, action := range actionsMap {
-		actionLine, err := eventFeedServer.feedService.GetActionLine(request.Filters, request.Start,
+		actionLine, err := eventFeedServer.feedService.GetActionLine(ctx, request.Filters, request.Start,
 			request.End, request.Timezone, int(request.Interval), action)
 		if err != nil {
 			logctx.WithError(err).Warn("getting action line")


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding project filtering for the GetFeedTimeline endpoint for the event-feed-service. This is the last of the three endpoints that need project filtering. Project filtering is only used for chef-server events which are not added yet.

### :chains: Related Resources

#444 

### :athletic_shoe: How to Build and Test the Change
1. `build components/event-feed-service && start_all_services`
1. Add a project named "project9"
1. Add a project named "project3"
1. Add a chef-server event tagged with "project9" run `event_feed_add_event` 
1. Create a profile event by adding a profile from the "Available" section here https://a2-dev.test/compliance/compliance-profiles
1. Go to the event feed page and filter for project3 only. Ensure that only the profile "create" icon is on the event feed guitar string like below. 
![image](https://user-images.githubusercontent.com/1679247/87601108-3f2e6800-c6a9-11ea-8af9-ab7c7b179394.png)
1. Then filter for projects9 only. Ensure the both events are displayed on the guitar strings like below. 
![image](https://user-images.githubusercontent.com/1679247/87601205-73a22400-c6a9-11ea-846f-e25aa4869a0a.png)


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
