### PR TITLE
Adding chef server and orgs from events

### DIFF
--- a/.studio/event-feed-service
+++ b/.studio/event-feed-service
@@ -36,7 +36,35 @@ document "generate_event_example" <<DOC
   Generate a exmaple event
 DOC
 function generate_event_example() {
-    echo '{"EventID": "f7b3ffa0-3f17-4bf3-8a01-8a15e17f6eeb", "Published": "2019-06-28T15:17:21Z", "Producer": { "ID": "", "ProducerName": "ProducerName", "ProducerType": "ProducerType", "Tags": []}, "Type": { "Name": "event type"}, "Actor": {"ID":"actor ID", "ObjectType": "actor ObjectType", "DisplayName": "actor DisplayName"}, "Object": {"ID":"object ID", "DisplayName": "object display name", "ObjectType": "object ObjectType"}, "Target": {"ID": "target ID", "ObjectType": "target ObjectType", "DisplayName": "target DisplayName"}}'
+    echo '{
+      "EventID": "f7b3ffa0-3f17-4bf3-8a01-8a15e17f6eeb", 
+      "Published": "2019-06-28T15:17:21Z", 
+      "Producer": { 
+        "ID": "", 
+        "ProducerName": "ProducerName", 
+        "ProducerType": "ProducerType", 
+        "Tags": []
+      }, 
+      "Type": { 
+        "Name": "event type"
+      }, 
+      "Actor": {
+        "ID":"actor ID", 
+        "ObjectType": "actor ObjectType", 
+        "DisplayName": "actor DisplayName"
+      }, 
+      "Object": {
+        "ID":"object ID", 
+        "DisplayName": 
+        "object display name", 
+        "ObjectType": "object ObjectType"
+      }, 
+      "Target": {
+        "ID": "target ID", 
+        "ObjectType": "target ObjectType", 
+        "DisplayName": "target DisplayName"
+      }
+    }'
 }
 
 document "generate_random_chef_server_event" <<DOC
@@ -56,7 +84,9 @@ function generate_random_chef_server_event() {
      .Object.ObjectType = "environment" |
      .Object.DisplayName = "acceptance-chef-products-automate-master" |
      .Object.ID = $uuid |
-     .Projects = ["project9"]')"
+     .Projects = ["project9"] |
+     .data.chef_organization = "1st Ranger Battalion" |
+     .data.chef_infra_server = "chef.example.com"')"
 
   echo $json
 }

--- a/components/event-feed-service/pkg/feed/feed.go
+++ b/components/event-feed-service/pkg/feed/feed.go
@@ -16,6 +16,14 @@ import (
 	"github.com/chef/automate/lib/stringutils"
 )
 
+var (
+	ProjectTag                = "projects"
+	ProducerTypeTag           = "producer_object_type"
+	ChefServerProducerTypeTag = "chef_server"
+	ChefServerFieldTag        = "chef_infra_server"
+	ChefOrganizationFieldTag  = "chef_organization"
+)
+
 type FeedSummary struct {
 	Counts map[string]int64
 }
@@ -142,6 +150,10 @@ func ConvertAPIKeyToBackendKey(parameter string) string {
 		return "verb"
 	case "requestor_name":
 		return "actor_name"
+	case "chef_server":
+		return ChefServerFieldTag
+	case "organization":
+		return ChefOrganizationFieldTag
 	default:
 		return parameter
 	}

--- a/components/event-feed-service/pkg/feed/feed.go
+++ b/components/event-feed-service/pkg/feed/feed.go
@@ -111,6 +111,8 @@ type FeedEntry struct {
 	TargetObjectType   string    `json:"target_object_type"`
 	Created            time.Time `json:"created"`
 	Projects           []string  `json:"projects"`
+	ChefOrganization   string    `json:"chef_organization"`
+	ChefInfraServer    string    `json:"chef_infra_server"`
 }
 
 func (f *FeedEntry) ToJSON() ([]byte, error) {

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -246,7 +246,7 @@ func newBoolQueryFromFilters(filters map[string][]string) *olivere.BoolQuery {
 		if field == ProjectTag {
 			// do not project filter on non-chef-server events
 			notChefServerEvent := olivere.NewBoolQuery()
-			notChefServerEvent.MustNot(olivere.NewTermQuery(ProducerTypeTag, ChefServerProducerIDTag))
+			notChefServerEvent.MustNot(olivere.NewTermQuery(ProducerTypeTag, ChefServerProducerTypeTag))
 			filterQuery = filterQuery.Should(notChefServerEvent)
 
 			if stringutils.SliceContains(values, authzConstants.UnassignedProjectID) {

--- a/components/event-feed-service/pkg/persistence/feed-elastic.go
+++ b/components/event-feed-service/pkg/persistence/feed-elastic.go
@@ -243,10 +243,10 @@ func newBoolQueryFromFilters(filters map[string][]string) *olivere.BoolQuery {
 		}
 		filterQuery := olivere.NewBoolQuery()
 		refinedValues := make([]string, 0, 0)
-		if field == ProjectTag {
+		if field == feed.ProjectTag {
 			// do not project filter on non-chef-server events
 			notChefServerEvent := olivere.NewBoolQuery()
-			notChefServerEvent.MustNot(olivere.NewTermQuery(ProducerTypeTag, ChefServerProducerTypeTag))
+			notChefServerEvent.MustNot(olivere.NewTermQuery(feed.ProducerTypeTag, feed.ChefServerProducerTypeTag))
 			filterQuery = filterQuery.Should(notChefServerEvent)
 
 			if stringutils.SliceContains(values, authzConstants.UnassignedProjectID) {

--- a/components/event-feed-service/pkg/persistence/store.go
+++ b/components/event-feed-service/pkg/persistence/store.go
@@ -10,9 +10,11 @@ import (
 )
 
 var (
-	ProjectTag              = "projects"
-	ProducerTypeTag         = "producer_object_type"
-	ChefServerProducerIDTag = "chef_server"
+	ProjectTag                = "projects"
+	ProducerTypeTag           = "producer_object_type"
+	ChefServerProducerTypeTag = "chef_server"
+	ChefServerFieldTag        = "chef_infra_server"
+	ChefOrganizationFieldTag  = "chef_organization"
 )
 
 type FeedStore interface {

--- a/components/event-feed-service/pkg/persistence/store.go
+++ b/components/event-feed-service/pkg/persistence/store.go
@@ -9,14 +9,6 @@ import (
 	project_update_lib "github.com/chef/automate/lib/authz"
 )
 
-var (
-	ProjectTag                = "projects"
-	ProducerTypeTag           = "producer_object_type"
-	ChefServerProducerTypeTag = "chef_server"
-	ChefServerFieldTag        = "chef_infra_server"
-	ChefOrganizationFieldTag  = "chef_organization"
-)
-
 type FeedStore interface {
 	// @param (context, indexName)
 	DeleteIndex(ctx context.Context, index string) error

--- a/components/event-feed-service/pkg/server/feed.go
+++ b/components/event-feed-service/pkg/server/feed.go
@@ -169,19 +169,19 @@ func (f *FeedService) HandleEvent(req *api.EventMsg) (*api.EventResponse, error)
 
 func getChefInfraServer(req *api.EventMsg) string {
 	if req.Data != nil && req.Data.Fields != nil {
-		return req.Data.Fields[persistence.ChefServerFieldTag].GetStringValue()
+		return req.Data.Fields[feed.ChefServerFieldTag].GetStringValue()
 	}
 	return ""
 }
 
 func getChefOrganization(req *api.EventMsg) string {
 	if req.Data != nil && req.Data.Fields != nil {
-		return req.Data.Fields[persistence.ChefOrganizationFieldTag].GetStringValue()
+		return req.Data.Fields[feed.ChefOrganizationFieldTag].GetStringValue()
 	}
 	return ""
 }
 func isEventFromChefServer(req *api.EventMsg) bool {
-	return req.Producer.ProducerType == persistence.ChefServerProducerTypeTag
+	return req.Producer.ProducerType == feed.ChefServerProducerTypeTag
 }
 
 func filterByProjects(ctx context.Context, filters map[string][]string) (map[string][]string, error) {
@@ -193,6 +193,6 @@ func filterByProjects(ctx context.Context, filters map[string][]string) (map[str
 		return filters, nil
 	}
 
-	filters[persistence.ProjectTag] = projectsFilter
+	filters[feed.ProjectTag] = projectsFilter
 	return filters, nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding Chef Infra Server and Chef Infra Server Organization fields to the event-feed-service. This allows these fields to be set from an event. This also allows these fields to be filtered on.  

### :chains: Related Resources

#444

### :athletic_shoe: How to Build and Test the Change
1. `build components/event_feed_service && start_all_services`
1. Add an event with Chef Infra Server "chef.example.com" and Chef Organization "1st Ranger Battalion" with `event_feed_add_event`
1. Add a profile event by going to https://a2-dev.test/compliance/compliance-profiles and adding one of the available profiles. 
1. Go to https://a2-dev.test/dashboards/event-feed and ensure there are two events. 
1. To test the Chef server filter go to https://a2-dev.test/dashboards/event-feed?chef_server=chef.example.com. Ensure only the environment event is shown not the profile event.
1. To test the Chef organization filter go to https://a2-dev.test/dashboards/event-feed?organization=1st%20Ranger%20Battalion. Ensure only the environment event is shown not the profile event.

Note: Suggestions will not show the "chef.example.com" or "1st Ranger Battalion" because suggestions are pulled from Infra nodes and not events. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
