### PR TITLE
Add way to skip hab user/group creation

### DIFF
--- a/components/automate-deployment/pkg/target/local_target.go
+++ b/components/automate-deployment/pkg/target/local_target.go
@@ -223,8 +223,10 @@ func (t *LocalTarget) SetupSupervisor(ctx context.Context, config *dc.ConfigRequ
 		}
 	}
 
-	if err := t.EnsureHabUser(writer); err != nil {
-		return err
+	if os.Getenv("CHEF_AUTOMATE_SKIP_HAB_USER") != "true" {
+		if err := t.EnsureHabUser(writer); err != nil {
+			return err
+		}
 	}
 
 	if os.Getenv("CHEF_AUTOMATE_SKIP_SYSTEMD") != "true" {


### PR DESCRIPTION
Our current code assumes hab user and group are local and does not work
if those existed in say ldap.

Your way of making it work is exporting the
`CHEF_AUTOMATE_SKIP_HAB_USER` environment variable.

```
CHEF_AUTOMATE_SKIP_HAB_USER=true chef-automate deploy
```

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>