### PR TITLE
Disable xpack in deprecated ES backup test

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -801,6 +801,15 @@ steps:
         linux:
           privileged: true
 
+  - label: "[integration] deprecated backup w external es"
+    command: integration/run_test integration/tests/deprecated_backup_external_es.sh
+    timeout_in_minutes: 25
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+
   - label: "iam reset admin access"
     command:
       - integration/run_test integration/tests/iam_reset_admin_access.sh

--- a/integration/helpers/setup.sh
+++ b/integration/helpers/setup.sh
@@ -69,6 +69,9 @@ http.port: 59200
 transport.tcp.port: "59300-59400"
 path.repo: "/var/opt/chef-automate/backups"
 discovery.zen.minimum_master_nodes: 1
+
+xpack.security.enabled: false
+xpack.ml.enabled: false
 EOF
 
   local backup_type="$1"


### PR DESCRIPTION
We strip xpack from ES. We cannot connect to an ES cluster
with xpack enabled, which is the deprecated way of way of
using external ES.
