### PR TITLE
Policyfiles label change

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -46,7 +46,7 @@
           <app-tab tabTitle="Clients" #clients_tab  [active]="clientsTab">
             <app-clients *ngIf="clients_tab.active" [serverId]="serverId" [orgId]="orgId"></app-clients>
           </app-tab>
-          <app-tab tabTitle="Policy Files" #policyFiles_tab  [active]="policyFilesTab">
+          <app-tab tabTitle="Policyfiles" #policyFiles_tab  [active]="policyFilesTab">
             <app-policy-files *ngIf="policyFiles_tab.active" [serverId]="serverId" [orgId]="orgId"></app-policy-files>
           </app-tab>
           <app-tab tabTitle="Details" #details_tab [active]="false">


### PR DESCRIPTION
Signed-off-by: sachin-msys <sbacchav@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
Official spelling of `Policy Files` is actually `Policyfiles` so as per that convention changed tab label.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes: #4084 
### :+1: Definition of Done
Changed `Policyfiles` tab label in infra view ui
### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

Navigate to Infrastructure >>> Chef Servers >>> Click on one of server from list >>> Click on one of the Organization from the list >>> check the `Policyfiles` tab label.

### :white_check_mark: Checklist

- [ x ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ x ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![PolicyFiles_changes](https://user-images.githubusercontent.com/54940695/87800164-abf16000-c86b-11ea-8eba-6b8dd6de9cbb.png)
