### PR TITLE
Build ES package in our plan.sh

### DIFF
--- a/components/automate-elasticsearch/habitat/config/elasticsearch.yml
+++ b/components/automate-elasticsearch/habitat/config/elasticsearch.yml
@@ -77,6 +77,8 @@ gateway.recover_after_time: {{cfg.gateway.recover_after_time}}
 
 action.destructive_requires_name: {{cfg.action.destructive_requires_name}}
 
+xpack.ml.enabled: false
+
 {{#if cfg.plugins.cloud_aws_signer ~}}
 cloud.aws.signer: {{cfg.plugins.cloud_aws_signer}}
 {{/if ~}}

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -5,14 +5,19 @@ pkg_name="automate-elasticsearch"
 pkg_description="Wrapper package for core/elasticsearch"
 pkg_origin="chef"
 pkg_version="6.8.3"
-vendor_origin="core"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
+pkg_source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz"
+pkg_shasum=824078e421c9f7e5ab9c875e4019d9ebfe3ada99db286b54dec090f97d1cbe25
+
 pkg_build_deps=(
-  "${vendor_origin}/elasticsearch/${pkg_version}"
+  core/patchelf
 )
 pkg_deps=(
+  core/busybox-static
+  core/zlib
+  core/wget
   chef/mlsa
   core/glibc
   core/coreutils-static
@@ -41,6 +46,7 @@ pkg_binds=(
 pkg_exposes=(http-port transport-port)
 
 do_download() {
+  do_default_download
   download_file "https://artifacts.elastic.co/downloads/elasticsearch-plugins/repository-s3/repository-s3-${pkg_version}.zip" "repository-s3.zip" "3dc05d6c20e683596ddabfcc3f63c9d4e9680da75bff1c904566b5508584a6d6"
 }
 
@@ -49,9 +55,37 @@ do_build() {
 }
 
 do_install() {
-  cp -a "$(pkg_path_for ${vendor_origin}/elasticsearch)/es/"* "${pkg_prefix}/es/"
+  cd "$HAB_CACHE_SRC_PATH/elasticsearch-${pkg_version}"
+  install -vDm644 README.textile "${pkg_prefix}/README.textile"
+  install -vDm644 LICENSE.txt "${pkg_prefix}/LICENSE.txt"
+  install -vDm644 NOTICE.txt "${pkg_prefix}/NOTICE.txt"
+
+  # Elasticsearch is greedy when grabbing config files from /bin/..
+  # so we need to put the untemplated config dir out of reach
+  mkdir -p "${pkg_prefix}/es"
+  cp -a ./* "${pkg_prefix}/es"
+
+  # jvm.options needs to live relative to the binary.
+  # mkdir -p "$pkg_prefix/es/config"
+  # install -vDm644 config/jvm.options "$pkg_prefix/es/config/jvm.options"
+
+  # Delete unused binaries to save space
+  rm "${pkg_prefix}/es/bin/"*.bat "${pkg_prefix}/es/bin/"*.exe
+
+  LD_RUN_PATH=$LD_RUN_PATH:${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/lib
+  export LD_RUN_PATH
+
+  _es_ml_bins=( "autoconfig" "autodetect" "categorize" "controller" "normalize" )
+  for bin in "${_es_ml_bins[@]}"; do
+    build_line "patch ${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/bin/${bin}"
+    patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" \
+      "${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/bin/${bin}"
+
+    find "${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/lib" -type f -name "*.so" \
+      -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+  done
+
   "${pkg_prefix}/es/bin/elasticsearch-plugin" install -b "file://${HAB_CACHE_SRC_PATH}/repository-s3.zip"
-  rm -rf "${pkg_prefix}/es/modules/x-pack-"*
 }
 
 do_strip() {

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -73,15 +73,14 @@ do_install() {
   LD_RUN_PATH=$LD_RUN_PATH:${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/lib
   export LD_RUN_PATH
 
-  _es_ml_bins=( "autoconfig" "autodetect" "categorize" "controller" "normalize" )
-  for bin in "${_es_ml_bins[@]}"; do
+  for bin in autoconfig autodetect categorize controller normalize; do
     build_line "patch ${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/bin/${bin}"
     patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" \
       "${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/bin/${bin}"
-
-    find "${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/lib" -type f -name "*.so" \
-      -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
   done
+
+  find "${pkg_prefix}/es/modules/x-pack-ml/platform/linux-x86_64/lib" -type f -name "*.so" \
+      -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
 
   "${pkg_prefix}/es/bin/elasticsearch-plugin" install -b "file://${HAB_CACHE_SRC_PATH}/repository-s3.zip"
 }

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -15,15 +15,13 @@ pkg_build_deps=(
   core/patchelf
 )
 pkg_deps=(
-  core/busybox-static
-  core/zlib
-  core/wget
-  chef/mlsa
-  core/glibc
   core/coreutils-static
+  core/busybox-static
+  core/glibc
+  core/zlib
+
+  chef/mlsa
   core/curl # health_check
-  core/unzip
-  core/grep
   chef/automate-openjdk
   chef/automate-platform-tools
 )


### PR DESCRIPTION
We were bringing in core/elasticsearch and it had binaries that were
pointing at the wrong versiosn of things. This was fixed by removing
xpack in #4051, however doing that breaks the deprecated elasticsearch
clustering.

This PR undoes #4051 and instead creates a ES package with working
binaries.
