### PR TITLE
Fix "See Also" links in chef-automate CLI page

### DIFF
--- a/components/automate-chef-io/layouts/_default/data-cli.html
+++ b/components/automate-chef-io/layouts/_default/data-cli.html
@@ -2,7 +2,7 @@
 <h1>{{ .Title }}</h1>
 <div class="prose">
 {{ range .Site.Data.docs.cli_chef_automate.commands }}
-{{ $id := replace .name " " "-" }}
+{{ $id := urlize .name }}
   <h2 id="{{ $id }}">{{ .name }}</h2>
   <p>{{ .description }}</p>
 
@@ -25,8 +25,11 @@
   <div class="grid-x">
     {{ range .see_also }}
     {{ $sa_bits := split . " - " }}
-    {{ $sa_id := replace (index $sa_bits 0) " " "-" }}
-    <div class="cell medium-3"><a href="#chef-automate-{{ $sa_id }}">{{ index $sa_bits 0 }}</a></div>
+    {{ $sa_id := urlize (index $sa_bits 0) }}
+    {{ if not (hasPrefix $sa_id "chef-automate") }}
+      {{ $sa_id = delimit (slice "chef-automate" $sa_id) "-" }}
+    {{ end }}
+    <div class="cell medium-3"><a href="#{{ $sa_id }}">{{ index $sa_bits 0 }}</a></div>
     <div class="cell medium-9">{{ index $sa_bits 1 }}</div>
     {{ end }}
   </div>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Fixes the "See Also" relative links in the data-cli.html template.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

`make serve`

Go to localhost:1313/docs/cli-chef-automate/

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
