### PR TITLE
only announce acceptance promotion in a2-release-coordinate

### DIFF
--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -11,5 +11,4 @@ The list of changes can be found here: https://github.com/chef/automate/compare/
 Please take your time to fill out the release notes by *EOD WEDNESDAY*: https://github.com/chef/automate/wiki/Pending-Release-Notes
 EOF
 
-post_slack_message "a2-team" "$message"
 post_slack_message "a2-release-coordinate" "$message"


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

only announce acceptance promotion in a2-release-coordinate