### PR TITLE
Revert "verbose logging `npm install` in license_scout.sh (#4097)"

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -26,7 +26,7 @@ trap upload_dep_manifest EXIT
 
 echo "--- Installing Chef UI Library dependencies"
 pushd components/chef-ui-library
-  npm install --verbose
+  npm install
   npm run build
 popd
 

--- a/components/automate-deployment/README.md
+++ b/components/automate-deployment/README.md
@@ -114,4 +114,3 @@ without the mock interfaces used by self-test. To facilitate this the
 `a1migration` directory has a docker-based test environment suited for
 that purpose.  See the README in that directory for more details.
 
-


### PR DESCRIPTION
This reverts commit e8684cce1a1d02e95ea9429896f9793d56a37b53.

We think we know what the problem is. Don't need the extra
logging anymore

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>
