### PR TITLE
Add docs api swagger file

### DIFF
--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -10,10 +10,12 @@ git checkout -b "$branch"
 
 pushd /go/src/github.com/chef/automate/components/automate-chef-io
   make sync_swagger_files
+  make generate_swagger
 popd
 
 if [[ $(git status --porcelain) ]]; then
   git add components/automate-chef-io/data/docs/api_chef_automate
+  git add components/automate-chef-io/static/api-docs/all-apis.swagger.json
 
   git commit --message "Sync swagger files for Automate docs." --message "This pull request was triggered automatically via Expeditor." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 

--- a/components/automate-chef-io/.gitignore
+++ b/components/automate-chef-io/.gitignore
@@ -7,5 +7,4 @@ package.json
 
 public/
 themes/
-static/api-docs
 static/redoc.standalone.js

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -48,7 +48,7 @@ generate_swagger: $(SWAGGER_RESULT_FILE)
 		jq -es 'if . == [] then null else .[] | .paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) ) end' \
 		> $(SWAGGER_RESULT_FILE)
 
-serve: sync $(REDOC_FILE)
+serve: sync generate_swagger $(REDOC_FILE)
 	hugo server --buildDrafts --noHTTPCache
 
 lint: themes/chef

--- a/components/automate-chef-io/Makefile
+++ b/components/automate-chef-io/Makefile
@@ -48,13 +48,13 @@ generate_swagger: $(SWAGGER_RESULT_FILE)
 		jq -es 'if . == [] then null else .[] | .paths = (.paths | with_entries( select( all( .value[].tags[]; . != "hidden") ) ) ) end' \
 		> $(SWAGGER_RESULT_FILE)
 
-serve: sync generate_swagger $(REDOC_FILE)
+serve: sync $(REDOC_FILE)
 	hugo server --buildDrafts --noHTTPCache
 
 lint: themes/chef
 	hugo -D
 
-build: themes/chef generate_swagger $(REDOC_FILE)
+build: themes/chef $(REDOC_FILE)
 	hugo
 
 # Consult scripts/spellcheck.sh in the root Automate directory for notes on using cspell.

--- a/components/automate-chef-io/static/api-docs/all-apis.swagger.json
+++ b/components/automate-chef-io/static/api-docs/all-apis.swagger.json
@@ -1,0 +1,16747 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "# Authentication\nThe Chef Automate API typically uses an API token passed in the header of your API request.\n\nTo create admin token can and set it as an environment variable use the following command:\n\n```\nexport TOKEN=`chef-automate iam token create <TOKEN-NAME> --admin`\n```\n\nAn admin token has unlimited access the entire Chef Automate API.\n\nPass the token as part of the API call. For example:\n\n```\ncurl -s -H \"api-token: $TOKEN\" https://automate.example.com/apis/iam/v2/policies -v\n```\n\nTo create api tokens with limited permissions, use your admin token to create a standard token. You can then write a policy that exactly defines the API access for the standard token.\n\nIn this example, the `curl` command creates the new token and the `export` command saves it as an environment variable with the name \"TOKEN2\".\n\n```\ncurl -s -H \"api-token: $TOKEN\" -d '{\"name\":\"New Token\", \"id\":\"new-token\"}' https://automate.example.com/apis/iam/v2/tokens\n  {\n    \"token\": {\n      \"id\": \"new-token\",\n      \"name\": \"New Token\",\n      \"value\": \"bww8EEpr39_eYMnQ2zybtrP9uzk=\",\n      \"active\": true,\n      \"created_at\": \"2020-02-26T19:36:07Z\",\n      \"updated_at\": \"2020-02-26T19:36:07Z\",\n      \"projects\": []\n    }\n  }\n\nexport TOKEN2=bww8EEpr39_eYMnQ2zybtrP9uzk=\n```\n\nThe Chef Automate documentation covers policies, authentication, and authorization in greater detail.\n* **[API Tokens](https://automate.chef.io/docs/api-tokens/)** explains authentication in Chef Automate.\n* **[Authorization Overview](https://automate.chef.io/docs/iam-v2-overview)** explains authorization in Chef Automate.\n",
+    "title": "Chef Automate API Documentation",
+    "termsOfService": "https://www.chef.io/terms-and-conditions-of-use/",
+    "contact": {
+      "url": "https://www.chef.io/support/",
+      "email": "support@chef.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://github.com/chef/automate/blob/master/LICENSE"
+    },
+    "version": "version not set",
+    "x-logo": {
+      "altText": "Chef logo",
+      "url": "/images/chef-automate-logo.svg"
+    }
+  },
+  "host": "automate.chef.io",
+  "paths": {
+    "/api/beta/cfgmgmt/rollouts/create": {
+      "post": {
+        "description": "Creates a Rollout record. A rollout represents the process of nodes acquiring\nthe latest policy revision pushed to a policy group.\n\nAuthorization Action:\n```\ningest:unifiedEvents:create\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "CreateRollout",
+        "operationId": "CreateRollout",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.CreateRollout"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/cfgmgmt/rollouts/find": {
+      "get": {
+        "description": "Returns the rollout for the given Chef Server/org, policy group, policy name, and policy revision\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "GetRolloutForChefRun",
+        "operationId": "GetRolloutForChefRun",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "policy_name",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "policy_group",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "policy_revision_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/cfgmgmt/rollouts/list": {
+      "get": {
+        "description": "Gives a list of rollouts\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "GetRollouts",
+        "operationId": "GetRollouts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to apply to the request for the rollouts list.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollouts"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/cfgmgmt/rollouts/progress_by_node_segment": {
+      "get": {
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "operationId": "ListNodeSegmentsWithRolloutProgress",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to apply to the request for the node segments list.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeSegmentsWithRolloutProgress"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/cfgmgmt/rollouts/rollout/{rollout_id}": {
+      "get": {
+        "description": "Returns the rollout with the given Id\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "GetRolloutById",
+        "operationId": "GetRolloutById",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "rollout_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/cfgmgmt/rollouts/test_create": {
+      "post": {
+        "description": "CreateRolloutTest is a no-op endpoint that has the same auth requirements as\nCreateRollout. It can be used to verify end-to-end config/connectivity for\nclients\n\nAuthorization Action:\n```\ningest:unifiedEvents:create\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "CreateRolloutTest",
+        "operationId": "CreateRolloutTest",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.CreateRolloutTest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CreateRolloutTest"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/content/credentials": {
+      "post": {
+        "description": "Submit a Chef Cloud Credentials to enable content\n\nAuthorization Action:\n```\ncontent:credentials:add\n```",
+        "tags": [
+          "Cds"
+        ],
+        "summary": "SubmitCredentials",
+        "operationId": "SubmitCredentials",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.request.Credentials"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.response.Credentials"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/content/enabled": {
+      "get": {
+        "description": "Check if the content is enable for this Automate instance. \n\nAuthorization Action:\n```\ncontent:credentials:enabled\n```",
+        "tags": [
+          "Cds"
+        ],
+        "summary": "IsContentEnabled",
+        "operationId": "IsContentEnabled",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.response.ContentEnabled"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/content/install": {
+      "post": {
+        "description": "Installs a content item from its ID\n\nAuthorization Action:\n```\ncontent:items:install\n```",
+        "tags": [
+          "Cds"
+        ],
+        "summary": "InstallContentItem",
+        "operationId": "InstallContentItem",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.request.InstallContentItem"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.response.InstallContentItem"
+            }
+          }
+        }
+      }
+    },
+    "/api/beta/content/items": {
+      "get": {
+        "description": "Returns a list of metadata for each CDS content. Provides a description and current \nstate of each content item.\n\nAuthorization Action:\n```\ncontent:items:list\n```",
+        "tags": [
+          "Cds"
+        ],
+        "summary": "ListContentItems",
+        "operationId": "ListContentItems",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cds.response.ContentItems"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/delete_disconnected_services": {
+      "post": {
+        "description": "Removes services marked as disconnected based on the `threshold_seconds` setting.\nThis function is not used by the API or CLI and is here for testing purposes.\nThe functionality is currently covered by a periodically running job that can be configured using `UpdateDeleteDisconnectedServicesConfig`.\n\nAuthorization Action:\n```\napplications:serviceGroups:delete\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "Remove Disconnected Services",
+        "operationId": "DeleteDisconnectedServices",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.DisconnectedServicesReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/delete_services_by_id": {
+      "post": {
+        "description": "Authorization Action:\n```\napplications:serviceGroups:delete\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "Delete the services with the given IDs",
+        "operationId": "DeleteServicesByID",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.DeleteServicesByIDReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/disconnected_services": {
+      "get": {
+        "description": "Marks services as disconnected based on the `threshold_seconds` setting.\nThis function is not used by the API or CLI and is here for testing purposes.\nThe functionality is currently covered by a periodically running job that can be configured\nby utilizing the `UpdateDisconnectedServicesConfig` endpoint.\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "Mark Services as Disconnected",
+        "operationId": "GetDisconnectedServices",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Threshold for marking services disconnected in seconds.",
+            "name": "threshold_seconds",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/service-groups": {
+      "get": {
+        "description": "Lists service groups with name, health information, and application, environment, package, release metadata.\nAccepts pagination, sorting, search, and status filters.\n\nExample:\n```\napplications/service-groups?sorting.field=percent_ok&sorting.order=ASC&pagination.page=1&pagination.size=25\n```\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "List Service Groups",
+        "operationId": "GetServiceGroups",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Applies search and status filters, in the format of `fieldname:value` or `status:value`.\n\nValid filter fieldnames are:\n* `origin`: origin component of the service's package identifier\n* `service`: the name component of the service's package identifier\n* `version`: the version number component of the service's package identifier\n* `buildstamp`: the build timestamp (also called \"release\") of the service's package identifier\n* `channel`: the package channel to which the service subscribes for updates\n* `application`: the application field of the service's event-stream metadata\n* `environment`: the environment field of the service's event-stream metadata\n* `site`: the site field of the service's event-stream metadata\n* `group`: the suffix of the service group name\n\n`status` filters refine the service group results by a service's\n most recent connected/disconnected state or healthcheck result.\n\n Valid status filter parameters are:\n* `status:disconnected`: returns service groups with at least one service in a disconnected state\n* `status:critical`: returns service groups with a with at least one service in a \"critical\" healthcheck result\n* `status:unknown`: returns service groups with at least one service with an \"unknown\" healthcheck result\n* `status:warning`: returns service groups with at least one service with a \"warning\" healthcheck result\n* `status:ok`: returns service groups with at least one service with an \"ok\" health check result",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page number of the results to return.",
+            "name": "pagination.page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Amount of results to include per page.",
+            "name": "pagination.size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Field to sort the list results on.",
+            "name": "sorting.field",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "default": "ASC",
+            "description": "Order the results should be returned in.",
+            "name": "sorting.order",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServiceGroups"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/service-groups/{service_group_id}": {
+      "get": {
+        "description": "List the services for a service group with health status and service metadata.\nUses the service group ID generated by Chef Automate instead of the Chef Habitat- provided ID.\nSupports pagination and filtering.\n\nExample:\n```\napplications/service-groups/1dfff679054c60a10c51d059b6dbf81a765c46f8d3e8ce0752b22ffe8d4d9716?pagination.page=1&pagination.size=25\n```\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "List Services for a Service Group",
+        "operationId": "GetServicesBySG",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Service group ID.",
+            "name": "service_group_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page number of the results to return.",
+            "name": "pagination.page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Amount of results to include per page.",
+            "name": "pagination.size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Field to sort the list results on.",
+            "name": "sorting.field",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "default": "ASC",
+            "description": "Order the results should be returned in.",
+            "name": "sorting.order",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Applies filters, in the format of `fieldname:value`.\nSee documentation for ServicesReq for valid filter parameters.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesBySGRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/service_groups_health_counts": {
+      "get": {
+        "description": "Lists the total service group health reports by critical, warning, ok and unknown responses. Supports search and status filtering.\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "List Service Groups Health Counts",
+        "operationId": "GetServiceGroupsHealthCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Applies search filters, in the format of `fieldname:value`.\nSee the documentation for ServiceGroupsReq for valid filter parameters.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/services": {
+      "get": {
+        "description": "Lists service health status and service metadata for services.\nSupports pagination and search and status filtering. For a list of services for a specific service-group see \"List Services for a Service Group\" (GetServicesBySG endpoint).\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "List Services",
+        "operationId": "GetServices",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Applies search filters, in the format of `fieldname:value`.\n\nValid filter fieldnames are:\n* `origin`: origin component of the service's package identifier\n* `service`: the name component of the service's package identifier\n* `version`: the version number component of the service's package identifier\n* `buildstamp`: the build timestamp (also called \"release\") of the service's package identifier\n* `channel`: the package channel to which the service subscribes for updates\n* `application`: the application field of the service's event-stream metadata\n* `environment`: the environment field of the service's event-stream metadata\n* `site`: the site field of the service's event-stream metadata\n* `group`: the suffix of the service group name\n\n`status` filters refine service results by a service's\n current state or most recent healthcheck result.\n Disconnected services keep their last healthcheck result\n until their reports are removed by Chef Automate.\n When you apply a healthcheck filter, the report includes\n all recently disconnected services.\n Valid status filter parameters are:\n* `status:disconnected`: returns services in a disconnected state\n* `status:critical`: returns services with a \"critical\" healthcheck result\n* `status:unknown`: returns services with an \"unknown\" healthcheck result\n* `status:warning`: returns services with a \"warning\" healthcheck result\n* `status:ok`: returns services with an  \"ok\" health check result",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page number of the results to return.",
+            "name": "pagination.page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Amount of results to include per page.",
+            "name": "pagination.size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Field to sort the list results on.",
+            "name": "sorting.field",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "default": "ASC",
+            "description": "Order the results should be returned in.",
+            "name": "sorting.order",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/services-distinct-values": {
+      "get": {
+        "description": "Lists all of the possible filter values for a given valid field.\nLimit the returned values by providing at one or more characters in the `query_fragment` parameter.\nSupports wildcard (* and ?)\n\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "List Filter Values",
+        "operationId": "GetServicesDistinctValues",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Field name of service values.",
+            "name": "field_name",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Query value, supports wildcards (* and ?).",
+            "name": "query_fragment",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Applies filters, in the format of `fieldname:value`.\nSee documentation for ServicesReq for valid filter parameters.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesDistinctValuesRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/applications/stats": {
+      "get": {
+        "description": "Shows a summary of service-groups, services, deployments, and supervisors.\nUsed for telemetry.\nDoes not support filtering.\n\nAuthorization Action:\n```\napplications:serviceGroups:list\n```",
+        "tags": [
+          "service_groups"
+        ],
+        "summary": "Show Summary",
+        "operationId": "GetServicesStats",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.ServicesStatsRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/errors": {
+      "get": {
+        "description": "Returns a list of the most common errors reported for infra nodes' most recent Chef Infra Client runs.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Errors",
+        "operationId": "GetErrors",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of results to return.\nIf set to zero, the default size of 10 will be used. Set to a negative\nvalue for unlimited results.",
+            "name": "size",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters in the request select the nodes from which the errors are\ncollected. The same filters may be specified for this request as for other\nNodes requests, with the exception of 'status' which is not valid for this\nrequest.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Errors"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/node_metadata_counts": {
+      "get": {
+        "description": "For each type of field requested this returns distinct values the amount of each. For example, \nif the 'platform' field is requested 'windows' 10, 'redhat' 5, and 'ubuntu' 8 could be returned. \nThe number next to each represents the number of nodes with that type of platform.\n\nExample:\nrequest\n```\ncfgmgmt/node_metadata_counts?type=platform&type=status\n```\nresponse\n```\n{\n\"types\": [\n{\n\"values\": [\n{\n\"value\": \"mac_os_x 10.11.5\",\n\"count\": 28\n},\n{\n\"value\": \"linux 8.9\",\n\"count\": 1\n},\n{\n\"value\": \"macos 8.9\",\n\"count\": 1\n},\n{\n\"value\": \"windows 8.9\",\n\"count\": 1\n}\n],\n\"type\": \"platform\"\n},\n{\n\"value\": [\n{\n\"value\": \"missing\",\n\"count\": 29\n},\n{\n\"value\": \"failure\",\n\"count\": 2\n}\n],\n\"type\": \"status\"\n}\n]\n}\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "GetNodeMetadataCounts",
+        "operationId": "GetNodeMetadataCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Types of node fields to collect value counts for.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to apply to the counts returned.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Earliest most recent check-in node information to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest most recent check-in node information to return.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeMetadataCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/node_runs_daily_status_time_series": {
+      "get": {
+        "description": "Provides the status of runs for each 24-hour duration. For multiple runs in one 24-hour duration, \nthe most recent failed run will be returned. If there are no failed runs the most recent successful \nrun will be returned. If no runs are found in the 24-hour duration, the status will be \"missing\" \nand no run information will be returned.\n\nExample:\nrequest\n```\ncfgmgmt/node_runs_daily_status_time_series?node_id=507bd518-5c18-4c2d-a445-60fe7dde9961&days_ago=3\n```\nresponse\n```\n{\n\"durations\": [\n{\n\"start\": \"2020-04-25T19:00:00Z\",\n\"end\": \"2020-04-26T18:59:59Z\",\n\"status\": \"missing\",\n\"run_id\": \"\"\n},\n{\n\"start\": \"2020-04-26T19:00:00Z\",\n\"end\": \"2020-04-27T18:59:59Z\",\n\"status\": \"missing\",\n\"run_id\": \"\"\n},\n{\n\"start\": \"2020-04-27T19:00:00Z\",\n\"end\": \"2020-04-28T18:59:59Z\",\n\"status\": \"failure\",\n\"run_id\": \"b7904f41-68b5-44ec-9da6-cf2481ff8600\"\n}\n]\n}\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "GetNodeRunsDailyStatusTimeSeries",
+        "operationId": "GetNodeRunsDailyStatusTimeSeries",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Node ID of the runs.",
+            "name": "node_id",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of past days.",
+            "name": "days_ago",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeRunsDailyStatusTimeSeries"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/nodes": {
+      "get": {
+        "description": "Returns a list of infra nodes that have checked in to Automate.\nAdding a filter makes a list of all nodes that meet the filter criteria.\nFilters for the same field are ORd together, while filters across different fields are ANDed together.\nSupports pagination, filtering (with wildcard support), and sorting.\nLimited to 10k results.\n\nExample:\n```\ncfgmgmt/nodes?pagination.page=1&pagination.size=100&sorting.field=name&sorting.order=ASC&filter=name:mySO*&filter=platform:ubun*\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Checked-in Nodes",
+        "operationId": "GetNodes",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to apply to the request for nodes list.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page number of the results to return.",
+            "name": "pagination.page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Amount of results to include per page.",
+            "name": "pagination.size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Field to sort the list results on.",
+            "name": "sorting.field",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string",
+            "default": "ASC",
+            "description": "Order the results should be returned in.",
+            "name": "sorting.order",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Earliest most recent check-in node information to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest most recent check-in node information to return.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/nodes/export": {
+      "post": {
+        "description": "Stream nodes in JSON (default) or CSV format.\n\nSupports filtering and sorting, but not pagination.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the value `0` to sort descending.\nInclude the value `1` to sort ascending.\n Example: \n\n ```'{\"output_type\":\"csv\",\"sorting\":{\"order\": 1, \"field\": \"name\"},\"filters\":[{\"status\":\"success\",\"environment\":\"prod\", \"organization:chef\"}]}'```",
+        "produces": [
+          "application/json",
+          "text/csv"
+        ],
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "NodeExport",
+        "operationId": "NodeExport",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.NodeExport"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.ExportData"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/nodes/{node_id}/attribute": {
+      "get": {
+        "description": "Returns the latest reported attributes for the provided node ID.\n\nAuthorization Action:\n```\ninfra:nodes:get\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "Show Attributes",
+        "operationId": "GetAttributes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef guid for the requested node.",
+            "name": "node_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeAttribute"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/nodes/{node_id}/runs": {
+      "get": {
+        "description": "Returns a list of run metadata (id, start and end time, and status) for the provided node ID.\nSupports pagination.\nAccepts a `start` parameter to denote start date for the list and a filter of type `status`.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Run Details",
+        "operationId": "GetRuns",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef guid for the node.",
+            "name": "node_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to apply to the request for runs list.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Page number of the results to return.",
+            "name": "pagination.page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Amount of results to include per page.",
+            "name": "pagination.size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Earliest (in history) run information to return for the runs list.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest (in history) run information to return for the runs list.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/nodes/{node_id}/runs/{run_id}": {
+      "get": {
+        "description": "Returns the infra run report for the provided node ID and run ID.\n\nAuthorization Action:\n```\ninfra:nodes:get\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "Show Node Run",
+        "operationId": "GetNodeRun",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef guid for the requested node.",
+            "name": "node_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Run id for the node.",
+            "name": "run_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "End time on the node's run.",
+            "name": "end_time",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Run"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/organizations": {
+      "get": {
+        "description": "Returns a list of all organizations associated with nodes that have checked in to Automate.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Organizations",
+        "operationId": "GetOrganizations",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/policy_revision/{revision_id}": {
+      "get": {
+        "description": "Returns Policy Names with a list of cookbook names and associated policy identifiers based on a policy revision ID. \nPolicy revision IDs are sent with an infra run report and identifies which instance of a policy the node used for this run.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Policy Cookbooks",
+        "operationId": "GetPolicyCookbooks",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Revision id for the policy.",
+            "name": "revision_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.PolicyCookbooks"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/reports/export": {
+      "post": {
+        "description": "Stream node run reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `output_type` parameter in the request to receive CSV formatted data.\nInclude the value `json` for the `output_type` parameter in the request to receive JSON formatted data.\nInclude the node ID for the `node_id` for the reports to receive.\nInclude the number of seconds since the Unix Epoch for the `start` and `end` fields.\n Example: \n\n ```'{\"output_type\":\"csv\"node_id\":\"80e73cf5-32eb-3556-ac99-6597274a8522\",\"start\":{\"seconds\":1585336095},\"end\":{\"seconds\":1585337095},\"filters\":[{\"status\":\"success\"}]}'```",
+        "produces": [
+          "application/json",
+          "text/csv"
+        ],
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "ReportExport",
+        "operationId": "ReportExport",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.ReportExport"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.ExportData"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/source_fqdns": {
+      "get": {
+        "description": "Returns a list of all Chef Infra Servers associated with nodes that have checked in to Automate.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Associated Chef Infra Servers",
+        "operationId": "GetSourceFqdns",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/stats/checkin_counts_timeseries": {
+      "get": {
+        "description": "Returns a daily time series of unique node check-ins for the number of days requested.\nIf `days ago` value is empty, API will return the default 1 day ago results.\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Node Checkins",
+        "operationId": "GetCheckInCountsTimeSeries",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "List of filters to be applied to the time series.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of past days to create the time series.",
+            "name": "days_ago",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CheckInCountsTimeSeries"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/stats/missing_node_duration_counts": {
+      "get": {
+        "description": "Returns a count of missing nodes for the provided durations.\n\nExample:\n```\ncfgmgmt/stats/missing_node_duration_counts?durations=3d&durations=1w&durations=2w&durations=1M&durations=3M\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Missing Nodes Count",
+        "operationId": "GetMissingNodeDurationCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "A valid duration is any number zero or greater with one of these characters 'h', 'd', 'w', or 'M'. \n'h' is hours\n'd' is days\n'w' is weeks\n'M' is months\nWill contain one or many.",
+            "name": "durations",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.MissingNodeDurationCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/stats/node_counts": {
+      "get": {
+        "description": "Returns totals for failed, success, missing, and overall total infra nodes that have reported into Automate.\nSupports filtering.\n\nExample:\n```\ncfgmgmt/stats/node_counts?filter=name:mySO*&filter=platform:ubun*\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Node Status Counts",
+        "operationId": "GetNodesCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "List of filters to be applied to the node count results.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Earliest node check-in.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest node check-in.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodesCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/stats/run_counts": {
+      "get": {
+        "description": "Returns totals for failed and successful runs given a `node_id`.\n\nExample:\n```\ncfgmgmt/stats/run_counts?node_id=821fff07-abc9-4160-96b1-83d68ae5cfdd&start=2019-11-02\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Run Status Totals",
+        "operationId": "GetRunsCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "List of filters to be applied to the run count results.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Earliest (in history) run information to return for the run counts.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest (in history) run information to return for the run counts.",
+            "name": "end",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Node id associated with the run.",
+            "name": "node_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunsCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/cfgmgmt/suggestions": {
+      "get": {
+        "description": "Returns possible filter values given a valid `type` parameter. All values returned until two or more characters are provided for the `text` parameter.\nSupports wildcard (* and ?).\n\nExample:\n```\ncfgmgmt/suggestions?type=environment&text=_d\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "ConfigMgmt"
+        ],
+        "summary": "List Filter Suggestions",
+        "operationId": "GetSuggestions",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Field for which suggestions are being returned.",
+            "name": "type",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Text to search on for the type value.",
+            "name": "text",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to be applied to the results.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/market/read/{name}/version/{version}": {
+      "get": {
+        "description": "Show the details of an un-installed profile using the profile name and version.\nin the UI, these are the profiles under the \"Available\" tab.\nThese profiles are created and maintained by Chef, shipped with Chef Automate.\n\n\nAuthorization Action:\n```\ncompliance:marketProfiles:get\n```",
+        "tags": [
+          "ProfilesService"
+        ],
+        "summary": "Show an available profile",
+        "operationId": "ReadFromMarket",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Name of the profile.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Version of the profile.",
+            "name": "version",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Automate user associated with the profile.",
+            "name": "owner",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/profiles/metasearch": {
+      "post": {
+        "description": "The endpoint takes an array of compliance profile sha256 IDs and returns the ones that the backend\ndoesn't have metadata (profile title, copyright, controls title, code, tags, etc) for.\nThis is useful when deciding if a compliance report can be sent for ingestion without the associated profile metadata.\n\nAuthorization Action:\n```\ncompliance:profiles:list\n```",
+        "tags": [
+          "ProfilesService"
+        ],
+        "summary": "Check if one or multiple profiles exist in the metadata database.",
+        "operationId": "MetaSearch",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Sha256"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Missing"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/profiles/read/{owner}/{name}/version/{version}": {
+      "get": {
+        "description": "Show the details of an installed profile given the profile name, owner (Automate user associated with the profile), and version.\n\n\nAuthorization Action:\n```\ncompliance:profiles:get\n```",
+        "tags": [
+          "ProfilesService"
+        ],
+        "summary": "Show an installed profile",
+        "operationId": "ReadMixin19",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Automate user associated with the profile.",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of the profile.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Version of the profile.",
+            "name": "version",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/profiles/search": {
+      "post": {
+        "description": "Lists all profiles available for the Automate instance.\nEmpty params return all \"market\" profiles.\nSpecifying the `owner` field returns all profiles installed for the specified user.\n\nSupports pagination, sorting, and filtering (wildcard supported).\n\nSupported sort fields: title, name (default: title)\nSupported filter fields: name, version, title\n\nExample:\n```\n{\n\"filters\":[\n{\"type\": \"title\", \"values\": [ \"Dev*\"]}\n],\n\"page\": 1,\n\"per_page\": 3,\n\"owner\": \"admin\"\n}\n```\n\n\nAuthorization Action:\n```\ncompliance:profiles:list\n```",
+        "tags": [
+          "ProfilesService"
+        ],
+        "summary": "List all available profiles",
+        "operationId": "ListMixin19",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profiles"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/profiles/{owner}/{name}/version/{version}": {
+      "delete": {
+        "description": "Delete an installed profile given the profile name, owner (Automate user associated with the profile), and version.\nNote: this action \"uninstalls\" the profile. This has no impact on the market profiles.\n\n\nAuthorization Action:\n```\ncompliance:profiles:delete\n```",
+        "tags": [
+          "ProfilesService"
+        ],
+        "summary": "Delete an installed profile",
+        "operationId": "DeleteMixin19",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Automate user associated with the profile.",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of the profile.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Version of the profile.",
+            "name": "version",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/controls": {
+      "post": {
+        "description": "Lists controls from the last run, with optional filtering.\nSupports filtering, but not pagination or sorting.\nLimited to 100 results by default.\n\nAuthorization Action:\n```\ncompliance:controlItems:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Controls",
+        "operationId": "ListControlItems",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItemRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItems"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/export": {
+      "post": {
+        "description": "Stream reports in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\n Example: \n\n ```'{\"type\":\"csv\",\"filters\":[{\"type\":\"start_time\",\"values\":[\"2019-09-16T00:00:00Z\"]},{\"type\":\"end_time\",\"values\":[\"2019-09-18T23:59:59Z\"]}, {\"type\":\"environment\",\"values\":[\"_default\"]}]}'```",
+        "produces": [
+          "application/json",
+          "text/csv"
+        ],
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "Export reports",
+        "operationId": "Export",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.ExportData"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/node/export": {
+      "post": {
+        "description": "Stream historical reports for a single node in JSON (default) or CSV format.\n\nSupports filtering, but not pagination or sorting.\nRequires one `node_id` filter.\n\nInclude the value `csv` for the `type` parameter in the request to receive CSV formatted data.\nIncluding more than one value for `profile_id`, `profile_name`, or `node_id` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nLimited to 9999 results.\n\nExample: \n\n ```'{\"type\":\"csv\",\"filters\":[{\"type\":\"start_time\",\"values\":[\"2019-09-16T00:00:00Z\"]},{\"type\":\"end_time\",\"values\":[\"2019-09-18T23:59:59Z\"]}, {\"type\":\"node_id\",\"values\":[\"9b9f4e51-b049-4b10-9555-10578916e149\"]}]}'```",
+        "produces": [
+          "application/json",
+          "text/csv"
+        ],
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "Export node reports",
+        "operationId": "Node Export",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.ExportData"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/nodes/id/{id}": {
+      "get": {
+        "description": "Show a specific node by ID.\nSupports filtering by profile or control.\nDoes not support pagination or sorting.\n\nAuthorization Action:\n```\ncompliance:reportNodes:get\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "Show Node by ID",
+        "operationId": "ReadNode",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/nodes/search": {
+      "post": {
+        "description": "List all nodes, with optional filtering, pagination, and sorting.\nLimited to 10k results.\n\n| Sort parameter | Sort value |\n| --- | --- |\n| environment | environment.lower |\n| latest_report.controls.failed.critical | controls_sums.failed.critical |\n| latest_report.controls.failed.total | controls_sums.failed.total |\n| latest_report.end_time (default) | end_time |\n| latest_report.status | status |\n| name | node_name.lower |\n| platform | platform.full |\n| status | status |\n\nExample:\n```\n{\n\"filters\":[\n{\"type\":\"environment\",\"values\":[\"dev*\"]},\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]}\n],\n\"page\":1,\"per_page\":100,\n\"sort\":\"environment\",\"order\":\"ASC\"\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportNodes:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Nodes",
+        "operationId": "ListNodes",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Nodes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/profiles": {
+      "post": {
+        "description": "List all profiles in use, with optional filtering.\nSupports pagination, filtering, and sorting.\nValid sort fields: name, title\n\nAuthorization Action:\n```\ncompliance:reportProfiles:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Profiles",
+        "operationId": "ListProfiles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMins"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/report-ids": {
+      "post": {
+        "description": "List all IDs for the latest report for each node, with optional filtering.\nSupports filtering, but not pagination or sorting.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\nNot limited to 10k results.\n\nAuthorization Action:\n```\ncompliance:reportids:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Report IDs",
+        "operationId": "ListReportIds",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ReportIds"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/reports": {
+      "post": {
+        "description": "Makes a list of reports. Adding a filter makes a list of all node reports that meet the filter criteria.\nSupports pagination, filtering, and sorting.\nLimited to 10k results.\n\nValid sort fields: latest_report.controls.failed.critical, latest_report.controls.failed.total, latest_report.end_time, latest_report.status, node_name\n\nExample:\n```\n{\"filters\":\n[\n{\"type\":\"start_time\",\"values\":[\"2019-09-09T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-09-11T23:59:59Z\"]}\n],\n\"page\":1, \"per_page\": 3,\n\"sort\": \"latest_report.status\", \"order\": \"ASC\"\n}\n```\n\nAuthorization Action:\n```\ncompliance:reports:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Reports",
+        "operationId": "ListReports",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Reports"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/reports/id/{id}": {
+      "post": {
+        "description": "Show a specific report by ID. Supports filtering, but not pagination or sorting.\nIncluding more than one value for `profile_id`, or `profile_name` is not allowed.\nIncluding values for both `profile_id` and `profile_name` in one request is not allowed.\n\nAuthorization Action:\n```\ncompliance:reports:get\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "Show Report by ID",
+        "operationId": "ReadReport",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/stats/failures": {
+      "post": {
+        "description": "Returns the top failures for the specified object. A types filter is required for this api.\nSupported values are `platform`, `environment`, `control`, and `profile`.\nBy default, the top ten failed objects for the specified type are returned.\nSupports filtering and respects `size` parameter.\n\nExample:\n```\n{\n\"filters\":[\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]},\n{\"type\":\"types\",\"values\":[\"platform\",\"environment\"]}\n]\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportFailures:get\n```",
+        "tags": [
+          "StatsService"
+        ],
+        "summary": "Read Failures",
+        "operationId": "ReadFailures",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Failures"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/stats/profiles": {
+      "post": {
+        "description": "Returns statistics and summary information for profiles executed as part of the compliance reports. \nIf called without specifying a profile ID (`id`), the API will return stats on all the profiles.\nIf the `id` field is provided (profile ID) as part of the query object, the `type` field must also be specified. Options are `controls` or `summary`.\nSupports filtering.\n\n```\n{\n\"type\":\"controls\",\n\"id\":\"09adcbb3b9b3233d5de63cd98a5ba3e155b3aaeb66b5abed379f5fb1ff143988\",\n\"filters\":[\n{\"type\":\"environment\",\"values\":[\"dev*\"]},\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]}\n]\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportProfiles:get\n```",
+        "tags": [
+          "StatsService"
+        ],
+        "summary": "Read Profiles",
+        "operationId": "ReadProfiles",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Profile"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/stats/summary": {
+      "post": {
+        "description": "Returns summary statistics for compliance reports. \nGeneral report summary information is the default. \nAdding a `type` value of `nodes` or `controls` will return summary statistics for that object.\nSupports filtering.\n\nExample:\n```\n{\n\"type\":\"nodes\",\n\"filters\":[\n{\"type\":\"environment\",\"values\":[\"dev*\"]},\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]}\n]\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportSummary:get\n```",
+        "tags": [
+          "StatsService"
+        ],
+        "summary": "Read Summary",
+        "operationId": "ReadSummary",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Summary"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/stats/trend": {
+      "post": {
+        "description": "Returns trendgraph statistics for compliance reports. \nThe `type` field is required for this api call. Options are `nodes` or `controls`.\nRequires minimum `interval` field of 3600 and defined start time and end time filters.\nSupports filtering.\n\nExample:\n```\n{\n\"type\":\"nodes\",\n\"interval\":86400,\n\"filters\":[\n{\"type\":\"environment\",\"values\":[\"dev*\"]},\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]}\n]\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportTrend:get\n```",
+        "tags": [
+          "StatsService"
+        ],
+        "summary": "Read Trend",
+        "operationId": "ReadTrend",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trends"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/reporting/suggestions": {
+      "post": {
+        "description": "Get suggestions for compliance reporting resources based on matching text substrings.\nSupports filtering, but not pagination or sorting.\n`type` parameter is required. It must be one of the parameters from the following table.\n\n| Suggestion type parameter | Suggestion type value |\n| --- | --- |\n| chef_server | source_fqdn |\n| chef_tags | chef_tags |\n| control | profiles.controls.title |\n| control_tag_key | profiles.controls.string_tags.key |\n| control_tag_value | profiles.controls.string_tags.values |\n| environment | environment |\n| inspec_version | version |\n| node | node_name |\n| organization | organization_name |\n| platform | platform.name |\n| platform_with_version | platform.full |\n| policy_group | policy_group |\n| policy_name | policy_name |\n| profile | profiles.title |\n| profile_with_version | profiles.full |\n| recipe | recipes |\n| role | roles |\n\nExample:\n```\n{\n\"type\":\"environment\",\n\"text\":\"aws*\",\n\"filters\":[\n{\"type\":\"start_time\",\"values\":[\"2019-10-26T00:00:00Z\"]},\n{\"type\":\"end_time\",\"values\":[\"2019-11-05T23:59:59Z\"]}\n]\n}\n```\n\nAuthorization Action:\n```\ncompliance:reportSuggestions:list\n```",
+        "tags": [
+          "ReportingService"
+        ],
+        "summary": "List Reporting Suggestions",
+        "operationId": "ListSuggestions",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SuggestionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestions"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/scanner/jobs": {
+      "post": {
+        "description": "Creates a scan job. A scan job executes Chef InSpec against the specified nodes.\nRequires a user-specified name. Type should be `detect` (checks if the node is reachable and reports the\nplatform information for the nodes) or `exec` (executes a set of profiles against the nodes).\nNodes to scan may be specified by including an array of node IDs to scan or a node manager ID along with some optional\nfiltering information.\nExec jobs require at least one profile to be used as part of the Chef InSpec scan.\nOptional recurrence schedules enable regularly scheduled (repeating) scans.\n\nExample:\n```\n{  \n\"name\": \"my testjob\",\n\"tags\": [],\n\"type\": \"exec\",\n\"nodes\": [\"i07uc612-7e97-43f2-9b19-256abh785820\"],\n\"profiles\": [\"https://github.com/dev-sec/linux-baseline/archive/master.tar.gz\", \"compliance://admin/ssh-baseline#2.2.0\"],\n\"retries\": 1,\n\"node_selectors\":[\n{\n\"manager_id\":\"e69dc612-7e67-43f2-9b19-256afd385820\",\n\"filters\":[{\"key\":\"name\",\"values\":[\"ins*\"],\"exclude\":false}]\n}\n],\n\"recurrence\":\"DTSTART=20191231T045100Z;FREQ=DAILY;INTERVAL=1\"\n}\n```\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:create\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "Create a scan job",
+        "operationId": "CreateMixin20",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Id"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/scanner/jobs/id/{id}": {
+      "get": {
+        "description": "Read the details of a scan job given an ID.\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:get\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "Read a scan job",
+        "operationId": "ReadMixin20",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID (UUID) assigned to object.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of object.",
+            "name": "name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "PUT operation to update the details for a scan job, such as the name, profiles, node set, or recurrence schedule.\nPlease note that this is a PUT operation, so all scan job details included in the create function\nshould be included in the PUT message to update.\t\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:update\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "Update a job",
+        "operationId": "UpdateMixin20",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID (UUID) of the scan job.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a scan job given an ID. Note this does not delete the report(s) generated by the scan job.\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:delete\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "Delete a scan job",
+        "operationId": "DeleteMixin20",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID (UUID) assigned to object.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of object.",
+            "name": "name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/scanner/jobs/rerun/id/{id}": {
+      "get": {
+        "description": "Does not create a new job in the database. Reads the job info given the job ID\nand runs a scan. The latest job information is then updated to reflect this latest run.\t\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:rerun\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "Rerun a scan job",
+        "operationId": "RerunMixin20",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID (UUID) assigned to object.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of object.",
+            "name": "name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.RerunResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/compliance/scanner/jobs/search": {
+      "post": {
+        "description": "Returns a list of scan jobs matching the query.\nSupports filtering, sorting, and pagination.\nValid filtering fields: job_type, parent_job, status\nValid sorting fields: name, type, status, start_time, end_time\n\nExample:\n```\n{\n\"filters\":[\n{\"key\":\"job_type\",\"values\":[\"exec\"]},\n{\"key\":\"parent_job\",\"values\":[\"\"]}\n],\n\"page\":1,\n\"per_page\":100,\n\"sort\":\"end_time\",\n\"order\":\"DESC\"\n} \n```\n\nAuthorization Action:\n\n```\ncompliance:scannerJobs:list\n```",
+        "tags": [
+          "JobsService"
+        ],
+        "summary": "List of scan jobs",
+        "operationId": "ListMixin20",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Jobs"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/compliance/config": {
+      "put": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "SetComplianceConfig configures the compliance data lifecycle scheduler and jobs",
+        "operationId": "SetComplianceConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetComplianceConfigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetComplianceConfigResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/compliance/run": {
+      "post": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "RunCompliance runs the compliance data lifecycle jobs",
+        "operationId": "RunCompliance",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunComplianceRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunComplianceResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/compliance/status": {
+      "get": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "GetComplianceStatus returns the compliance job scheduler status",
+        "operationId": "GetComplianceStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetComplianceStatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/config": {
+      "put": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "SetConfig provides a singular endpoint for configuring all data lifecycle jobs",
+        "operationId": "SetConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetConfigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetConfigResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/event-feed/config": {
+      "put": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "SetEventFeedConfig configures the event feed data lifecycle scheduler and jobs",
+        "operationId": "SetEventFeedConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetEventFeedConfigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetEventFeedConfigResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/event-feed/run": {
+      "post": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "RunEventFeed runs the event feed data lifecycle jobs",
+        "operationId": "RunEventFeed",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunEventFeedRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunEventFeedResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/event-feed/status": {
+      "get": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "GetEventFeedStatus returns the event feed job scheduler status",
+        "operationId": "GetEventFeedStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetEventFeedStatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/infra/config": {
+      "put": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "SetInfraConfig configures the infra data lifecycle scheduler and jobs",
+        "operationId": "SetInfraConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetInfraConfigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetInfraConfigResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/infra/run": {
+      "post": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "RunInfra runs the infra data lifecycle jobs",
+        "operationId": "RunInfra",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunInfraRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunInfraResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/infra/status": {
+      "get": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "GetInfraStatus returns the infra job scheduler status",
+        "operationId": "GetInfraStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetInfraStatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/run": {
+      "post": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "Run runs all data lifecycle actions across all data lifecycle jobs",
+        "operationId": "Run",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/services/config": {
+      "put": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "operationId": "SetServicesConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetServicesConfigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetServicesConfigResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/services/run": {
+      "post": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "operationId": "RunServices",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunServicesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.RunServicesResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/services/status": {
+      "get": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "Services",
+        "operationId": "GetServicesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetServicesStatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/data-lifecycle/status": {
+      "get": {
+        "tags": [
+          "DataLifecycle"
+        ],
+        "summary": "GetStatus returns the aggregate status across all data lifecycle jobs",
+        "operationId": "GetStatusMixin22",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetStatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/datafeed/destination": {
+      "post": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "AddDestination",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.AddDestinationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/datafeed/destination/{id}": {
+      "get": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "GetDestination",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "int64",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "DeleteDestination",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "int64",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.DeleteDestinationResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "UpdateDestination",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.UpdateDestinationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/datafeed/destinations": {
+      "post": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "ListDestinations",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.ListDestinationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/datafeed/destinations/test": {
+      "post": {
+        "tags": [
+          "DatafeedService"
+        ],
+        "operationId": "TestDestination",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.URLValidationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.datafeed.TestDestinationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/deployment/service_versions": {
+      "get": {
+        "tags": [
+          "Deployment"
+        ],
+        "operationId": "ServiceVersions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersionsResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/event_task_counts": {
+      "get": {
+        "description": "Returns totals for update, create, and delete event tasks, which are the actions taken on the event.\n\nExample:\n```\nevent_task_counts?start=1592546400000&end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "tags": [
+          "EventFeed"
+        ],
+        "summary": "List Counts Per Event Task Occurrence",
+        "operationId": "GetEventTaskCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to be applied to the request.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Earliest events to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Latest events to return.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/event_type_counts": {
+      "get": {
+        "description": "Returns totals for role, cookbook, and organization event types.\n\nExample:\n```\nevent_type_counts?start=1592546400000&end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "tags": [
+          "EventFeed"
+        ],
+        "summary": "List Count of Event Type Occurrence",
+        "operationId": "GetEventTypeCounts",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to be applied to the request.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Earliest events to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Latest events to return.",
+            "name": "end",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCounts"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/eventfeed": {
+      "get": {
+        "description": "Returns a list of recorded events in Chef Automate, such as Infra Server events (cookbook creation, policyfile updates, and node creation) and Chef Automate internal events (profile installs and scan job creation).\nAdding a filter makes a list of all events that meet the filter criteria.\n\nExample:\n```\neventfeed?collapse=true&filter=organization:The%2520Watchmen&page_size=100&start=1592546400000&end=1593151199999\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "tags": [
+          "EventFeed"
+        ],
+        "summary": "List Events",
+        "operationId": "GetEventFeed",
+        "parameters": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to be applied to the request.",
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Earliest events to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Latest events to return.",
+            "name": "end",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Count of events to return per page.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Used for pagination, to request results in ascending order.",
+            "name": "after",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "int64",
+            "description": "Used for pagination, to request results in descending order.",
+            "name": "before",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Used for pagination, to bookmark next set of results.",
+            "name": "cursor",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "format": "boolean",
+            "description": "Used to group similar events together.",
+            "name": "collapse",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.Events"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/events/data-collector": {
+      "get": {
+        "tags": [
+          "LegacyDataCollector"
+        ],
+        "summary": "This is used by chef-server, it requests a GET /data-collector/v0 to check\nAutomate's status.\nWe proxy /data-collector/v0 to /api/v0/events/data-collector, so this is\nwhere we need to respond.\nSince this is for legacy-support only, we don't bother much about having\ngoogle.protobuf.Empty as argument.",
+        "operationId": "Status",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.legacy.StatusResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/eventstrings": {
+      "get": {
+        "description": "Returns data that populates the guitar strings visual on the top of the event feed.\n\nExample:\n```\neventstrings?timezone=America/Denver&hours_between=1&start=2020-06-19&end=2020-06-25\n```\n\nAuthorization Action:\n```\nevent:events:list\n```",
+        "tags": [
+          "EventFeed"
+        ],
+        "summary": "List Summary Stats About Events",
+        "operationId": "GetEventStringBuckets",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Earliest events to return.",
+            "name": "start",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Latest events to return.",
+            "name": "end",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "User timezone to apply to request.",
+            "name": "timezone",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "format": "int32",
+            "description": "Interval for returned results, for example: 1 hour buckets.",
+            "name": "hours_between",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Filters to be applied to the request.",
+            "name": "filter",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.event_feed.response.EventStrings"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/gateway/health": {
+      "get": {
+        "tags": [
+          "Gateway"
+        ],
+        "operationId": "GetHealth",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.Health"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/gateway/version": {
+      "get": {
+        "tags": [
+          "Gateway"
+        ],
+        "operationId": "GetVersionMixin53",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.Version"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetServers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.GetServers"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateServer",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateServer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CreateServer"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{id}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetServer",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.GetServer"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "UpdateServer",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.UpdateServer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.UpdateServer"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteServer",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DeleteServer"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetOrgs",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.GetOrgs"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateOrg",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateOrg"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CreateOrg"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{id}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetOrg",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.GetOrg"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "UpdateOrg",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.UpdateOrg"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.UpdateOrg"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteOrg",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DeleteOrg"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{id}/reset-key": {
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "ResetOrgAdminKey",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.ResetOrgAdminKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.ResetOrgAdminKey"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/affected-nodes/{chef_type}/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetAffectedNodes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef object type (e.g. 'cookbooks', 'roles', 'chef_environment').",
+            "name": "chef_type",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef object name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef object version.",
+            "name": "version",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.AffectedNodes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/clients": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetClients",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Clients"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/clients/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetClient",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Client name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Client"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/cookbooks": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetCookbooks",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the Server",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the Org.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Cookbooks"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/cookbooks/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetCookbookVersions",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the Server.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the Org.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of the cookbook.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookVersions"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/cookbooks/{name}/{version}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetCookbook",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the Server.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the Org.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of the cookbook.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Version of the cookbook.",
+            "name": "version",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Cookbook"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/cookbooks/{name}/{version}/file-content": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetCookbookFileContent",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the server.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the org.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Name of the cookbook.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Version of the cookbook.",
+            "name": "version",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Cookbook data file URL.",
+            "name": "url",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookFileContent"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/data_bags": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetDataBags",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag name.",
+            "name": "name",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DataBags"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateDataBag",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateDataBag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CreateDataBag"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/data_bags/{name}": {
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateDataBagItem",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateDataBagItem"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CreateDataBagItem"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteDataBag",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag item name.",
+            "name": "item",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DataBag"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/data_bags/{name}/{item_id}": {
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "UpdateDataBagItem",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag item ID.",
+            "name": "item_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.UpdateDataBagItem"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.UpdateDataBagItem"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/data_bags/{name}/{item}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetDataBagItem",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Data bag item name.",
+            "name": "item",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DataBag"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/environments": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetEnvironments",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Environments"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateEnvironment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateEnvironment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Environment"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/environments/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetEnvironment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Environment name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Environment"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "UpdateEnvironment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Environment name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.UpdateEnvironment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Environment"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteEnvironment",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Environment name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Environment"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/nodes/{name}": {
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteNode",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Node name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DeleteNode"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/policyfiles": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetPolicyfiles",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef Organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Policyfiles"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/policyfiles/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetPolicyfile",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef Organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Policyfile name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Policyfile revision ID.",
+            "name": "revision_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Policyfile"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/roles": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetRoles",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Roles"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "CreateRoleMixin50",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.CreateRole"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Role"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/roles/{name}": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetRoleMixin50",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Role name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Role"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "UpdateRoleMixin50",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Role name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.request.UpdateRole"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Role"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "DeleteRoleMixin50",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Role name.",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Role"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/infra/version": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "GetVersionMixin50",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/events/chef/action": {
+      "post": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "ProcessChefAction",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Action"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefActionResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/events/chef/liveness": {
+      "post": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "ProcessLivenessPing",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Liveness"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessLivenessResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/events/chef/node-multiple-deletes": {
+      "post": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "ProcessMultipleNodeDeletes",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.MultipleNodeDeleteRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/events/chef/nodedelete": {
+      "post": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "ProcessNodeDelete",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Delete"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessNodeDeleteResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/events/chef/run": {
+      "post": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "ProcessChefRun",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.Run"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ProcessChefRunResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/ingest/version": {
+      "get": {
+        "tags": [
+          "ChefIngester"
+        ],
+        "operationId": "GetVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/license/apply": {
+      "post": {
+        "tags": [
+          "License"
+        ],
+        "operationId": "ApplyLicense",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.license.ApplyLicenseResp"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/license/request": {
+      "post": {
+        "tags": [
+          "License"
+        ],
+        "operationId": "RequestLicense",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.license.RequestLicenseResp"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/license/status": {
+      "get": {
+        "tags": [
+          "License"
+        ],
+        "operationId": "GetStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers": {
+      "post": {
+        "description": "Creates a node manager given a name, credential id *or* credential data, and type.\n\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:create\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Create a Node Manager",
+        "operationId": "CreateMixin12",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{id}": {
+      "get": {
+        "description": "List the details of a node manager.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:get\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "View a Node Manager",
+        "operationId": "ReadMixin12",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update a node manager's metadata, such as its name, associated credential id, or data.\nThis is a PUT operation and it overwrites ALL of the existing node manager metadata. Include all fields, because a PUT operation overwrites any missing fields to empty (\"\").\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:update\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Update a Node Manager",
+        "operationId": "UpdateMixin12",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the nodemanager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete a single node manager. This deletes the node manager itself and\nreassigns its associated nodes to the Automate node manager.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:delete\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Delete a Node Manager",
+        "operationId": "DeleteMixin12",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{id}/with-node-state/stopped": {
+      "delete": {
+        "description": "Delete a node manager and update its associated nodes to `stopped`.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:delete\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Delete a Node Manager and Stop Nodes",
+        "operationId": "DeleteWithNodeStateStopped",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{id}/with-node-state/terminated": {
+      "delete": {
+        "description": "Delete a node manager and update its associated nodes to `terminated`.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:delete\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Delete a Node Manager and Terminate Nodes",
+        "operationId": "DeleteWithNodeStateTerminated",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{id}/with-nodes": {
+      "delete": {
+        "description": "Delete a node manager and all of its associated nodes.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:delete\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Delete a Node Manager and Delete Nodes",
+        "operationId": "DeleteWithNodes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Ids"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{node_manager_id}/search-fields": {
+      "post": {
+        "description": "Searches the available values for a given field across all nodes associated with the nodemanager id.\n\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:list\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Search Node Fields",
+        "operationId": "SearchNodeFields",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Node manager ID.",
+            "name": "node_manager_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.FieldQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Fields"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/id/{node_manager_id}/search-nodes": {
+      "post": {
+        "description": "Searches the available nodes for a single node manager by id.\n\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:list\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Search nodes",
+        "operationId": "SearchNodes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Node manager ID.",
+            "name": "node_manager_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Nodes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/rerun/id/{id}": {
+      "post": {
+        "description": "Attempts to reach the API for the given nodemanager id to validate the\ncredentials associated with the nodemanager.\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:rerun\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "Connect",
+        "operationId": "Connect",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "UUID for the node manager.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.ConnectResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodemanagers/search": {
+      "post": {
+        "description": "Returns a list of node managers.\nSupports filtering, sorting, and pagination.\n\nValid filtering fields: manager_type\n\n\nAuthorization Action:\n\n```\ninfra:nodeManagers:list\n```",
+        "tags": [
+          "NodeManagerService"
+        ],
+        "summary": "List all Node Managers",
+        "operationId": "ListMixin12",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManagers"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes": {
+      "post": {
+        "description": "Creates a node and adds it to the Chef Automate node manager.\nRequires a FQDN or IP address, a user-specified name, and a ssh or winrm credential reference.\nUseful for creating nodes for the purpose of running compliance scan jobs.\n\nExample:\n```\n{\n\"name\": \"my-vagrant-node\",\n\"manager\":\"automate\",\n\"target_config\": {\n\"backend\":\"ssh\",\n\"host\":\"localhost\",\n\"secrets\":[\"b75195e5-a173-4502-9f59-d949adfe2c38\"],\n\"port\": 22\n},\n\"tags\": [\n{ \"key\":\"test-node\", \"value\":\"is amazing\" }\n]\n}\n```\n\nAuthorization Action:\n```\ninfra:nodes:create\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Create a Node",
+        "operationId": "Create",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Id"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/bulk-create": {
+      "post": {
+        "description": "Creates multiple nodes from a list of node data.\n`hosts` field is required. Multiple hosts may be defined in this field.\n\nExample:\n```\n{\n\"name_prefix\": \"000-my-ssh-node\",\n\"manager\":\"automate\",\n\"target_config\": {\n\"backend\":\"ssh\",\n\"hosts\":[\"localhost\",\"127.0.0.1\"],\n\"secrets\":[\"b75195e5-a173-4502-9f59-d949adfe2c38\"],\n\"port\": 22\n},\n\"tags\": [\n{ \"key\":\"test-node\", \"value\":\"is-amazing\" },\n]\n}\n```\n\nAuthorization Action:\n```\ninfra:nodes:create\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Bulk Create Nodes",
+        "operationId": "BulkCreate",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/delete": {
+      "post": {
+        "description": "Deletes a set of nodes that match a filter.\nAvailable filters: account_id, last_contact, manager_id, manager_type, name, platform_name,\nplatform_release, region, source_id, state, statechange_timerange, status,\nlast_run_timerange, last_scan_timerange, last_run_status, last_scan_status,\nlast_run_penultimate_status, last_scan_penultimate_status\n\nExample:\n```\n{\"filters\": [{\"key\": \"name\", \"values\": [\"vj*\"]}]}'\n```\n\nAuthorization Action:\n```\ninfra:nodes:delete\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Bulk Delete Nodes by Filter",
+        "operationId": "BulkDelete",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/delete/ids": {
+      "post": {
+        "description": "Deletes a set of nodes given a list of IDs.\nInvalid IDs will be ignored.\n\nAuthorization Action:\n```\ninfra:nodes:delete\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Bulk Delete Nodes by ID",
+        "operationId": "BulkDeleteById",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Ids"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.BulkDeleteResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/id/{id}": {
+      "get": {
+        "description": "Returns the details for a node given the node ID.\n\nAuthorization Action:\n```\ninfra:nodes:get\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Show Node Details",
+        "operationId": "Read",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "This PUT operation overwrites ALL node details and requires the complete set of node details,\nconsisting of a FQDN or IP address, a user-specified name, and the ID for an ssh or winrm credential.\nSubstitute the desired values for the existing node details in the PUT message.\n\nAuthorization Action:\n```\ninfra:nodes:update\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Update Node",
+        "operationId": "Update",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID).",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      },
+      "delete": {
+        "description": "Deletes the node with the node ID.\n\nAuthorization Action:\n```\ninfra:nodes:delete\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "Delete a Node",
+        "operationId": "Delete",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/rerun/id/{id}": {
+      "get": {
+        "description": "Use this to run an `inspec detect` job on the node, which updates the status to reflect that the node is reachable or unreachable.\n\nAuthorization Action:\n```\ninfra:nodes:rerun\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "List Node Status",
+        "operationId": "Rerun",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.RerunResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/nodes/search": {
+      "post": {
+        "description": "Makes a list of nodes.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of nodes to only those that match the filter or filters.\nSupported filters:\naccount_id, last_contact, manager_id, manager_type, name, platform_name,\nplatform_release, region, source_id, state, statechange_timerange, status,\nlast_run_timerange, last_scan_timerange, last_run_status, last_scan_status,\nlast_run_penultimate_status, last_scan_penultimate_status\n\nExample:\n```\n{\n\"filters\":[\n{\"key\": \"last_scan_status\", \"values\": [\"FAILED\"]},\n{\"key\": \"last_scan_penultimate_status\", \"values\": [\"PASSED\"]},\n{\"key\": \"name\", \"values\": [\"MyNode*\"]}\n],\n\"page\":1, \"per_page\":100,\n\"sort\":\"status\", \"order\":\"ASC\"\n}\n```\n\nAuthorization Action:\n```\ninfra:nodes:list\n```",
+        "tags": [
+          "NodesService"
+        ],
+        "summary": "List and Filter Nodes",
+        "operationId": "List",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.nodes.v1.Nodes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/notifications/rules": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "ListRules",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleListResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "AddRule",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleAddResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/notifications/rules/{id}": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "GetRuleMixin52",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleGetResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "UpdateRuleMixin52",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleUpdateResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "DeleteRuleMixin52",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.RuleDeleteResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/notifications/version": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "Version",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.VersionResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/notifications/webhook": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "ValidateWebhook",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.notifications.URLValidationResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/nodes/delete-nodes/config": {
+      "post": {
+        "tags": [
+          "JobScheduler"
+        ],
+        "operationId": "ConfigureDeleteNodesScheduler",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/nodes/missing-nodes-deletion/config": {
+      "post": {
+        "tags": [
+          "JobScheduler"
+        ],
+        "operationId": "ConfigureMissingNodesForDeletionScheduler",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/nodes/missing-nodes/config": {
+      "post": {
+        "tags": [
+          "JobScheduler"
+        ],
+        "operationId": "ConfigureNodesMissingScheduler",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.request.SchedulerConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.ConfigureNodesMissingScheduler"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/nodes/status": {
+      "get": {
+        "tags": [
+          "JobScheduler"
+        ],
+        "operationId": "GetStatusJobScheduler",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.ingest.response.JobSchedulerStatus"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/service_groups/delete_disconnected_services/config": {
+      "get": {
+        "description": "Displays configuration for the task that deletes services marked as disconnected\nafter 'threshold'. Threshold is a string that follows Elasticsearch's date math expressions.\nThis job is disabled if running is set to false.\n\nAuthorization Action:\n```\nretention:serviceGroups:get\n```",
+        "tags": [
+          "retention"
+        ],
+        "summary": "Show 'Remove Disconnected Services' Configuration",
+        "operationId": "GetDeleteDisconnectedServicesConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Updates configuration information for the task that deletes services marked as disconnected\nafter 'threshold'. Threshold is a string that follows Elasticsearch's date math expressions.\nThis job can be disabled by setting `\"running\": false`.\n\nThe frequency of the job's execution can be modified by changing the\n'recurrence'. This setting is a string\n[as defined in section 4.3.10 of RFC 2445](https://www.ietf.org/rfc/rfc2445.txt).\nBy default, the task runs every 60 seconds. It is not recommended to change\nthe recurrence.\n\nExample:\n```\nservice_groups/delete_disconnected_services/config\" -d\n'{\n\"threshold\": \"1d\",\n\"running\":true,\n\"recurrence\": \"FREQ=SECONDLY;DTSTART=20200612T182166Z;INTERVAL=60\"\n}'\n```\n\nAuthorization Action:\n```\nretention:serviceGroups:update\n```",
+        "tags": [
+          "retention"
+        ],
+        "summary": "Change 'Remove Disconnected Services' Configuration",
+        "operationId": "UpdateDeleteDisconnectedServicesConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/service_groups/delete_disconnected_services/run": {
+      "post": {
+        "tags": [
+          "retention"
+        ],
+        "operationId": "RunDeleteDisconnectedServicesJob",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.RunDeleteDisconnectedServicesJobReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.RunDeleteDisconnectedServicesJobResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/service_groups/disconnected_services/config": {
+      "get": {
+        "description": "Returns the configuration for the task that marks services as disconnected. The `threshold` setting defines the period of time between the last report from a node and the moment when Chef Automate marks it as disconnected. `Threshold` is a string that follows Elasticsearch's date math expressions.\nThis task is always enabled, cannot be disabled. Because this task runs continuously, the response does not return information about its status.\n\nAuthorization Action:\n```\nretention:serviceGroups:get\n```",
+        "tags": [
+          "retention"
+        ],
+        "summary": "Show 'Disconnected Services' configuration",
+        "operationId": "GetDisconnectedServicesConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Changes the configuration for the task that marks services as disconnected.\n\nThe periodic task to check for disconnected services can be enabled or\ndisabled by setting the 'running' setting to `true` or `false`, respectively.\nWhen disabled, no services will be marked disconnected, regardless of the\ntime that has elapsed since the last health check. It is not recommened to\ndisable the job.\n\nThe frequency of the job's execution can be modified by changing the\n'recurrence'. This setting is a string\n[as defined in section 4.3.10 of RFC 2445](https://www.ietf.org/rfc/rfc2445.txt).\nBy default, the task runs every 60 seconds. It is not recommended to change\nthe recurrence.\n\nWhen enabled, services are marked disconnected when the time elapsed since\nAutomate last received a health check exceeds 'threshold'. Threshold is a\nstring that follows Elasticsearch's date math expressions.\n\n\nExample:\n```\n/retention/service_groups/disconnected_services/config\n'{\n\"threshold\": \"15m\",\n\"running\": true,\n\"recurrence\": \"FREQ=SECONDLY;DTSTART=20200612T182166Z;INTERVAL=60\"\n}'\n```\n\nAuthorization Action:\n```\nretention:serviceGroups:update\n```",
+        "tags": [
+          "retention"
+        ],
+        "summary": "Change 'Disconnected Services' Configuration",
+        "operationId": "UpdateDisconnectedServicesConfig",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.PeriodicMandatoryJobConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.UpdateDisconnectedServicesConfigRes"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/retention/service_groups/disconnected_services/run": {
+      "post": {
+        "description": "Authorization Action:\n```\nretention:serviceGroups:update\n```",
+        "tags": [
+          "retention"
+        ],
+        "summary": "Runs the job to mark services as disconnected immediately.",
+        "operationId": "RunDisconnectedServicesJob",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.RunDisconnectedServicesJobReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.applications.RunDisconnectedServicesJobResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/secrets": {
+      "post": {
+        "description": "Creates a secret. Requires values for name, type, and data.\n\nSupported types: ssh, winrm, sudo, aws, azure, gcp, service_now\nSupported keys by type: \nssh: username, password, key\nwinrm: username, password\nsudo: username, password\nservice_now: username, password\naws: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN\nazure: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID\ngcp: GOOGLE_CREDENTIALS_JSON\n\nExample:\n```\n{\n\"name\": \"my ssh secret\",\n\"type\": \"ssh\",\n\"data\": [\n{ \"key\": \"username\", \"value\": \"vagrant\" },\n{ \"key\": \"password\", \"value\": \"vagrant\"} \n]\n}\n```\n\nAuthorization Action:\n```\nsecrets:secrets:create\n```",
+        "tags": [
+          "SecretsService"
+        ],
+        "summary": "Create a secret",
+        "operationId": "CreateMixin13",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Id"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/secrets/id/{id}": {
+      "get": {
+        "description": "Reads a secret given the ID of the secret.\nNote that the secret information (password and key values) will not be returned by the API, as a safety measure.\n\nAuthorization Action:\n```\nsecrets:secrets:get\n```",
+        "tags": [
+          "SecretsService"
+        ],
+        "summary": "Read a secret",
+        "operationId": "ReadMixin13",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID).",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Deletes a secret given the ID of the secret.\nNote that any nodes that were using the secret will no longer be associated with the deleted secret.\n\nAuthorization Action:\n```\nsecrets:secrets:delete\n```",
+        "tags": [
+          "SecretsService"
+        ],
+        "summary": "Delete a secret",
+        "operationId": "DeleteMixin13",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID).",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.DeleteResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates a secret. \nThis is a PATCH operation, meaning the details sent in will override/replace those stored in the DB.\nSecret information that is not in the body of the request will persist.\n\nExample:\n```\ngiven a credential with a username and password, a user could update the password by passing in the following body, \nand the name of the secret as well as the username for the secret be unchanged:\n\n{\n\"id\": \"525c013a-2ab3-4e6f-9005-51bc620e9157\",\n\"data\": [\n{ \"key\": \"password\", \"value\": \"new-value\"} \n]\n}\n```\n\nAuthorization Action:\n```\nsecrets:secrets:update\n```",
+        "tags": [
+          "SecretsService"
+        ],
+        "summary": "Update a secret",
+        "operationId": "UpdateMixin13",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique node ID (UUID).",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.UpdateResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/secrets/search": {
+      "post": {
+        "description": "Makes a list of secrets.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of secrets to only those that match the filter or filters.\nSupported filters: type\nSupported sort types: name, type, last modified\n\nExample:\n```\n{\n\"sort\": \"type\",\n\"order\": \"ASC\",\n\"filters\": [\n{ \"key\": \"type\", \"values\": [\"ssh\",\"winrm\",\"sudo\"] }\n],\n\"page\":1,\n\"per_page\":100\n}\n```\n\nAuthorization Action:\n```\nsecrets:secrets:list\n```",
+        "tags": [
+          "SecretsService"
+        ],
+        "summary": "List and filter secrets",
+        "operationId": "ListMixin13",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.secrets.Secrets"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/telemetry/config": {
+      "get": {
+        "tags": [
+          "Telemetry"
+        ],
+        "operationId": "GetTelemetryConfiguration",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.telemetry.TelemetryResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v0/version": {
+      "get": {
+        "tags": [
+          "Deployment"
+        ],
+        "operationId": "GetVersionMixin46",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.deployment.Version"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/apply-rules": {
+      "get": {
+        "description": "Returns details about a project update operation.\n\nYou can poll this endpoint during a project update to monitor progress.\nQuerying this endpoint when there is no update in progress will return details\nabout the completion status of the most recent update.\n\nAuthorization Action:\n```\niam:rules:status\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Get the status of a project update",
+        "operationId": "ApplyRulesStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ApplyRulesStatusResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Any changes to a project's rules are staged first. They do not take effect until\nall projects are updated.\n\nUpdating all projects begins an operation that applies all pending rule edits\nand then moves ingested resources into the correct projects according to those latest changes.\n\nWith a large amount of historical compliance data, rule application can take a considerable amount of time.\nIt’s best to batch up rule changes and apply them all at once.\n\nAuthorization Action:\n```\niam:rules:apply\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Start project update",
+        "operationId": "ApplyRulesStart",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ApplyRulesStartResp"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Cancels an ongoing project update.\n\nWarning! This action leaves the system in an unknown state that only another\nsuccessful project update can rectify.\n\nThis command exists really just for one scenario: you started a project update\nbut shortly thereafter discovered that you had one more change to include in the\nbatch of updates to be done.\n\nAuthorization Action:\n```\niam:rules:cancel\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Cancel project update",
+        "operationId": "ApplyRulesCancel",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ApplyRulesCancelResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/introspect": {
+      "get": {
+        "tags": [
+          "Authorization"
+        ],
+        "operationId": "IntrospectAll",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.IntrospectResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Authorization"
+        ],
+        "operationId": "Introspect",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.IntrospectReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.IntrospectResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/introspect_some": {
+      "post": {
+        "tags": [
+          "Authorization"
+        ],
+        "operationId": "IntrospectSome",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.IntrospectSomeReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.IntrospectResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/policies": {
+      "get": {
+        "description": "Lists all policies.\n\nAuthorization Action:\n```\niam:policies:list\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Lists all policies",
+        "operationId": "ListPolicies",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListPoliciesResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a custom IAM policy used to control permissions in Automate.\nA policy is composed of one or more statements that grant permissions to a set of members.\nEach statement contains a role as well as a list of projects.\n\nThe role defines a set of actions that the statement is scoped to.\nThe project list defines the set of resources that the statement is scoped to.\nPass `\"projects\": [\"*\"]` to scope a statement to every project.\n\nA policy's *top-level* projects list defines which projects the policy belongs to (for filtering policies by their projects),\nwhereas the *statement-level* projects list defines which projects the statement applies to.\n\nThe example creates a new policy not associated with any project (because the top-level `projects` property is empty) that grants the `viewer` role\non a few projects for all LDAP teams and a custom role `qa` on a specific project.\n\nAuthorization Action:\n```\niam:policies:create\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Creates a custom policy",
+        "operationId": "CreatePolicy",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreatePolicyReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreatePolicyResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Viewer Policy\",\"id\": \"custom-viewer-policy\",\"members\": [\"team:ldap:*\"], \"statements\": [{\"role\": \"viewer\",\"projects\": [\"project1\", \"project2\"], \"effect\": \"ALLOW\"},{\"role\": \"qa\",\"projects\": [\"acceptanceProject\"], \"effect\": \"ALLOW\"}],\"projects\": []}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/policies/{id}": {
+      "get": {
+        "description": "Returns the details for a policy.\n\nAuthorization Action:\n```\niam:policies:get\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Gets a policy",
+        "operationId": "GetPolicy",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetPolicyResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "This operation overwrites all fields excepting ID,\nincluding those omitted from the request, so be sure to specify all properties.\nProperties that you do not include are reset to empty values.\nThe only exception is the policy ID, which is immutable; it can only be set at creation time.\n\nWhile you can use this endpoint to update members on a policy, if that is the only\nproperty you wish to modify you might find it more convenient to use one of these endpoints instead:\nAdd policy members, Remove policy members, or Replace policy members.\n\nAuthorization Action:\n```\niam:policies:update\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Updates a custom policy",
+        "operationId": "UpdatePolicy",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID. Cannot be changed.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdatePolicyReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdatePolicyResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Updated Viewer Policy\", \"members\": [\"user:ldap:newuser\", \"team:ldap:newteam\"], \"statements\": [{\"role\": \"viewer\",\"projects\":[\"project1\", \"project2\"], \"effect\": \"ALLOW\"},{\"role\": \"qa\",\"projects\": [\"acceptanceProject\"], \"effect\": \"ALLOW\"}],\"projects\": []}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a specified custom policy. You cannot delete Chef-managed policies.\n\nAuthorization Action:\n```\niam:policies:delete\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Deletes a custom policy",
+        "operationId": "DeletePolicy",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeletePolicyResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/policies/{id}/members": {
+      "get": {
+        "description": "Lists all members of a specific policy.\n\nAuthorization Action:\n```\niam:policyMembers:get\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Lists policy members",
+        "operationId": "ListPolicyMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListPolicyMembersResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Replaces the entire member list of a specific policy with a new list.\nYou may use this endpoint to update members of either Custom or Chef-managed policies.\n\nEnsure each element of the members array is in the correct\n[Member Expression](https://automate.chef.io/docs/iam-v2-guide/#member-expressions) format.\n\nAuthorization Action:\n```\niam:policyMembers:update\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Replaces policy members",
+        "operationId": "ReplacePolicyMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ReplacePolicyMembersReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ReplacePolicyMembersResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"members\": [\"team:local:viewers\", \"user:local:test\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/policies/{id}/members:add": {
+      "post": {
+        "description": "Adds members to the member list of a specific policy.\nYou may use this endpoint to update members of either Custom or Chef-managed policies.\n\nEnsure each element of the members array is in the correct\n[Member Expression](https://automate.chef.io/docs/iam-v2-guide/#member-expressions) format.\n\nAuthorization Action:\n```\niam:policyMembers:create\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Adds policy members",
+        "operationId": "AddPolicyMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.AddPolicyMembersReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.AddPolicyMembersResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"members\": [\"team:local:viewers\", \"user:local:test\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/policies/{id}/members:remove": {
+      "post": {
+        "description": "Removes members from the member list of a specific policy. Silently ignores\nmembers that are not already part of the member list.\nYou may use this endpoint to update members of either Custom or Chef-managed policies.\n\nEnsure each element of the members array is in the correct\n[Member Expression](https://automate.chef.io/docs/iam-v2-guide/#member-expressions) format.\n\nThe removed members will still exist within Chef Automate, but are no longer associated with this policy.\n\nAuthorization Action:\n```\niam:policyMembers:delete\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Removes policy members",
+        "operationId": "RemovePolicyMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the policy.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.RemovePolicyMembersReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.RemovePolicyMembersResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"members\": [\"team:local:viewers\", \"user:local:test\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/policy_version": {
+      "get": {
+        "description": "Returns the major and minor version of IAM that your automate installation is running.\n\nAuthorization Action:\n```\niam:policies:get\n```",
+        "tags": [
+          "policies"
+        ],
+        "summary": "Gets IAM version",
+        "operationId": "GetPolicyVersion",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetPolicyVersionResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/projects": {
+      "get": {
+        "description": "Lists all projects.\n\nAuthorization Action:\n```\niam:projects:list\n```",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Lists all projects",
+        "operationId": "ListProjects",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListProjectsResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new project to be used in the policies that control permissions in Automate.\n\nA project defines the scope of resources in a policy statement. Resources can be in more than one project.\n\nWhen a project is created, the system also creates three policies associated with the new project,\none for each of the following roles: editor, viewer, and project owner.\nYou can optionally pass the `skip_policies` flag set to `true` to skip the creation of these policies.\n\nAuthorization Action:\n```\niam:projects:create\n```",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Creates a project",
+        "operationId": "CreateProject",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateProjectReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateProjectResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Custom Project\", \"id\": \"custom-project\", \"skip_policies\": true}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/projects/{id}": {
+      "get": {
+        "description": "Returns the details for a project.\n\nAuthorization Action:\n```\niam:projects:get\n```",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Gets a project",
+        "operationId": "GetProject",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the project.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetProjectResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Updates the name of an existing project.\n\nAuthorization Action:\n```\niam:projects:update\n```",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Updates a project",
+        "operationId": "UpdateProject",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID. Cannot be changed.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateProjectReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateProjectResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Custom Updated Project Name\"}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a project from any resources tagged with it.\n\nAlso deletes this project from any project list in any policy statements.\nIf the resulting project list for a given statement is empty, it is deleted.\nIf the resulting policy has no statements, it is also deleted.\n\nAuthorization Action:\n```\niam:projects:delete\n```",
+        "tags": [
+          "projects"
+        ],
+        "summary": "Deletes a project",
+        "operationId": "DeleteProject",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the project.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteProjectResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/projects/{id}/rules": {
+      "get": {
+        "description": "Lists all of the project rules of a specific project.\n\nAuthorization Action:\n```\niam:projects:get\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "List a project's rules",
+        "operationId": "ListRulesForProject",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the project.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListRulesForProjectResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/projects/{project_id}/rules": {
+      "post": {
+        "description": "Creates a new project rule to move ingested resources into projects.\n\nA project rule contains conditions that determine if an ingested resource should be moved into the rule’s project.\n\nEach condition specifies one or more values to match for a particular attribute on an ingested resource.\n\nThe choice of attributes depends on the rule type.\nFor NODE type, specify any of the available attributes.\nFor EVENT type, specify either CHEF_ORGANIZATION or CHEF_SERVER.\n\nThe choice of operator depends on how many values you provide.\nIf you wish to match one among a group of values, set the operator to MEMBER_OF.\nFor a single value, use EQUALS.\n\nAuthorization Action:\n```\niam:projects:update\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Create a project rule",
+        "operationId": "CreateRule",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID of the project this rule belongs to. Cannot be changed.",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateRuleReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateRuleResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"id\": \"example-rule\", \"project-id\": \"example-project\", \"name\": \"My Example Rule\", \"type\": \"NODE\", \"conditions\": [{\"attribute\": \"CHEF_SERVER\", \"operator\": \"MEMBER_OF\", \"values\": [\"example.co\", \"example.io\"]}]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/projects/{project_id}/rules/{id}": {
+      "get": {
+        "description": "Returns the details for a project rule.\n\nAuthorization Action:\n```\niam:projects:get\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Get a project rule",
+        "operationId": "GetRule",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the project the rule belongs to.",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the project rule.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetRuleResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Updates the name and conditions of an existing project rule.\nNew conditions can be added. Existing conditions can be updated or removed.\n\nThis operation overwrites all fields excluding ID and Type,\nincluding those omitted from the request, so be sure to specify all properties.\nProperties that you do not include are reset to empty values.\n\nThe resulting change to the project's resources does not take effect immediately.\nUpdates to project rules must be applied to ingested resources by a project update.\n\nAuthorization Action:\n```\niam:projects:update\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Update a project rule",
+        "operationId": "UpdateRule",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID of the project this rule belongs to. Cannot be changed.",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique ID. Cannot be changed.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateRuleReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateRuleResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"id\": \"example-rule\", \"project-id\": \"example-project\", \"name\": \"My Updated Rule\", \"type\": \"NODE\", \"conditions\": [{\"attribute\": \"CHEF_SERVER\", \"operator\": \"EQUALS\", \"values\": [\"example.co\"]}]}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "The resulting change to the project's resources does not take effect immediately.\nUpdates to project rules must be applied to ingested resources by a project update.\n\nAuthorization Action:\n```\niam:projects:update\n```",
+        "tags": [
+          "rules"
+        ],
+        "summary": "Delete a project rule",
+        "operationId": "DeleteRule",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the project the rule belongs to.",
+            "name": "project_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "ID of the project rule.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteRuleResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/roles": {
+      "get": {
+        "description": "Lists all *Chef-managed* and *Custom* roles.\n\nAuthorization Action:\n```\niam:roles:list\n```",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Lists all roles",
+        "operationId": "ListRoles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListRolesResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new role to be used in the policies that control permissions in Automate.\n\nA role defines the scope of actions in a policy statement.\n\nAuthorization Action:\n```\niam:roles:create\n```",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Creates a custom role",
+        "operationId": "CreateRole",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateRoleReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateRoleResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"id\": \"custom-role\", \"name\": \"My Custom Secret Manager Role\", \"actions\": [\"secrets:*\", \"iam:projects:list\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/roles/{id}": {
+      "get": {
+        "description": "Returns the details for a role.\n\nAuthorization Action:\n```\niam:roles:get\n```",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Gets a role",
+        "operationId": "GetRole",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the role.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetRoleResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "This operation overwrites all fields excepting ID,\nincluding those omitted from the request, so be sure to specify all properties.\nProperties that you do not include are reset to empty values.\n\nAuthorization Action:\n```\niam:roles:update\n```",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Updates a custom role",
+        "operationId": "UpdateRole",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID. Cannot be changed.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateRoleReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateRoleResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Updated Custom Secret Manager Role\", \"actions\": [\"secrets:*\", \"iam:projects:list\"]}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a specified custom role (you cannot delete Chef-managed roles) and remove it from any statements that may have been using it.\nIf such a statement has no other associated actions, the statement is deleted as well.\nSimilarly, if that statement removal results in a policy with no other statements,\nthat policy is removed as well.\n\nAuthorization Action:\n```\niam:roles:delete\n```",
+        "tags": [
+          "roles"
+        ],
+        "summary": "Deletes a custom role",
+        "operationId": "DeleteRole",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the role.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteRoleResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/self/{id}": {
+      "put": {
+        "description": "Updates a local user's own name or password.\nIf changing the password, both \"password\" and \"previous_password\" are required.\n\nAuthorization Action:\n```\niam:usersSelf:update\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "Update self (as user)",
+        "operationId": "UpdateSelf",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the user. Cannot be changed. Used to sign in.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateSelfReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateSelfResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My New Name\", \"password\": \"aNewSafePassword\", \"previous_password\": \"aPreviousSafePassword\"}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/teams": {
+      "get": {
+        "description": "Lists all local teams.\n\nAuthorization Action:\n```\niam:teams:list\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Lists all local teams",
+        "operationId": "ListTeams",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListTeamsResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a local team that is used to group local users as members of IAM policies.\n\nAuthorization Action:\n```\niam:teams:create\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Creates a local team",
+        "operationId": "CreateTeam",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateTeamReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateTeamResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"id\": \"test-id\", \"name\": \"My Test Team\", \"projects\": [\"project1\", \"project2\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/teams/{id}": {
+      "get": {
+        "description": "Returns the details for a team.\n\nAuthorization Action:\n```\niam:teams:get\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Get a team",
+        "operationId": "GetTeam",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetTeamResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Updates a local team.\n\nAuthorization Action:\n```\niam:teams:update\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Updates a local team",
+        "operationId": "UpdateTeam",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateTeamReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateTeamResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"My Update Test Team\", \"projects\": [\"project1\", \"projectnew\"]}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a local team and removes it from any policies.\n\nAuthorization Action:\n```\niam:teams:delete\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Deletes a local team",
+        "operationId": "DeleteTeam",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteTeamResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/teams/{id}/users": {
+      "get": {
+        "description": "Lists all users of a local team. Users are listed by their membership_id.\n\nAuthorization Action:\n```\niam:teamUsers:list\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Gets local team membership",
+        "operationId": "GetTeamMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetTeamMembershipResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/teams/{id}/users:add": {
+      "post": {
+        "description": "Adds a list of users to a local team. Users are added by their membership_id.\nThe request currently does not validate that membership_id maps to a real user.\n\nThe membership_id for users can be found via GET /apis/apis/iam/v2/users/<user_id>.\n\nAuthorization Action:\n```\niam:teamUsers:create\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Adds local team membership",
+        "operationId": "AddTeamMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.AddTeamMembersReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.AddTeamMembersResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{membership_ids: [\"527ed96f-2ecb-4f8f-abd7-0bf6511459ac\", \"987c8475-5747-4f9b-a766-c337f73965ae\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/teams/{id}/users:remove": {
+      "post": {
+        "description": "Removes a list of users from a local team. Users are removed by their membership_id.\nThe request currently does not validate that membership_id maps to a real user.\n\nThe membership_id for users can be found via GET /apis/apis/iam/v2/users/<user_id>.\n\nAuthorization Action:\n```\niam:teamUsers:delete\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Removes local team membership",
+        "operationId": "RemoveTeamMembers",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.RemoveTeamMembersReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.RemoveTeamMembersResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{membership_ids: [\"527ed96f-2ecb-4f8f-abd7-0bf6511459ac\", \"987c8475-5747-4f9b-a766-c337f73965ae\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/tokens": {
+      "get": {
+        "description": "Lists all tokens, both admin and non-admin.\n\nAuthorization Action:\n```\niam:tokens:list\n```",
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Lists all tokens",
+        "operationId": "ListTokens",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListTokensResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a token.\nActive defaults to true when not specified.\nValue is auto-generated when not specified.\n\nNote that this creates *non-admin* tokens that may then be assigned permissions via policies just like users or teams (unless you have already created policies that encompass all tokens using `tokens:*``).\n\nYou cannot create admin tokens via the REST API.\nAdmin tokens can only be created by specifying the `--admin` flag to this chef-automate sub-command:\n```\nchef-automate iam token create <your-token-name> --admin`\n```\n\nAuthorization Action:\n```\niam:tokens:create\n```",
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Creates a token",
+        "operationId": "CreateToken",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateTokenReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateTokenResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"token 1\", \"id\": \"token-1\", \"active\": true, \"projects\": [\"east-region\", \"west-region\"]}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/tokens/{id}": {
+      "get": {
+        "description": "Returns the details for a token.\n\nAuthorization Action:\n```\niam:tokens:get\n```",
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Gets a token",
+        "operationId": "GetToken",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the token.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetTokenResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "This operation overwrites all fields excepting ID, timestamps, and value,\nincluding those omitted from the request, so be sure to specify all properties.\nProperties that you do not include are reset to empty values.\n\nAuthorization Action:\n```\niam:tokens:update\n```",
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Updates a token",
+        "operationId": "UpdateToken",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique ID. Cannot be changed.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateTokenReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateTokenResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"updated token name\", \"active\": true, \"projects\": [\"east-region\", \"south-region\"]}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a token and remove it from any policies.\n\nAuthorization Action:\n```\niam:tokens:delete\n```",
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Deletes a token",
+        "operationId": "DeleteToken",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the token.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteTokenResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/users": {
+      "get": {
+        "description": "Lists all local users.\n\nAuthorization Action:\n```\niam:users:list\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "List all users",
+        "operationId": "ListUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.ListUsersResp"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a local user that can sign in to Automate and be a member of IAM teams\nand IAM policies.\n\nAuthorization Action:\n```\niam:users:create\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "Create a user",
+        "operationId": "CreateUser",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateUserReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.CreateUserResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"Display Name\", \"id\": \"username001rulez\", \"password\": \"aSafePassword\"}"
+          }
+        ]
+      }
+    },
+    "/apis/iam/v2/users/{id}": {
+      "get": {
+        "description": "Returns the details for a local user.\n\nAuthorization Action:\n```\niam:users:get\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "Get a user",
+        "operationId": "GetUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the user.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetUserResp"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Updates a local user's name or password.\n\nAuthorization Action:\n```\niam:users:update\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "Update a user",
+        "operationId": "UpdateUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the user. Cannot be changed. Used to sign in.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateUserReq"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.UpdateUserResp"
+            }
+          }
+        },
+        "x-code-samples": [
+          {
+            "lang": "JSON",
+            "source": "{\"name\": \"New Name\", \"password\": \"aSafePassword\"}"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a local user.\n\nAuthorization Action:\n```\niam:users:delete\n```",
+        "tags": [
+          "users"
+        ],
+        "summary": "Delete a user",
+        "operationId": "DeleteUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID of the user.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.DeleteUserResp"
+            }
+          }
+        }
+      }
+    },
+    "/apis/iam/v2/users/{membership_id}/teams": {
+      "get": {
+        "description": "Lists all local teams for a specific user. You must use their membership_id in the request URL.\n\nAuthorization Action:\n```\niam:userTeams:get\n```",
+        "tags": [
+          "teams"
+        ],
+        "summary": "Gets team membership for a user",
+        "operationId": "GetTeamsForMember",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "membership_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.iam.v2.GetTeamsForMemberResp"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "chef.automate.api.Health": {
+      "description": "The automate-gateway service health is constructed with:\n* Status:\n           => ok:             Everything is alright\n           => initialization: The service is in its initialization process\n           => warning:        Something might be wrong?\n           => critical:       Something is wrong!\n\n@afiune: Here we can add more health information to the response",
+      "type": "object",
+      "title": "Health message",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.Version": {
+      "description": "The service version constructed with:\n* Service name\n* Built time\n* Semantic version\n* Git SHA",
+      "type": "object",
+      "title": "Version message",
+      "properties": {
+        "built": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.applications.DeleteServicesByIDReq": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "List of the database IDs of the services to be deleted.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.applications.DisconnectedServicesReq": {
+      "description": "Request message for GetDisconnectedServices.",
+      "type": "object",
+      "properties": {
+        "threshold_seconds": {
+          "description": "Threshold for marking services disconnected in seconds.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.applications.HealthCheckResult": {
+      "type": "object",
+      "title": "HealthCheckResult aggregates the stdout output, stderr output and process\nexit status of a habitat health check",
+      "properties": {
+        "exit_status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "stderr": {
+          "type": "string"
+        },
+        "stdout": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.applications.HealthCounts": {
+      "description": "Combined count values from the health status and disconnected status reports.",
+      "type": "object",
+      "properties": {
+        "critical": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "disconnected": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ok": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "unknown": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "warning": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.applications.HealthStatus": {
+      "description": "The HealthStatus enumerable matches the Chef Habitat implementation for health-check status:\n=> https://www.habitat.sh/docs/reference/#health-check\nFor a health status within a service group.\n*critical* means that one or more services are in critical condition.\n*warning* means that one or more services have a warning, but none are in critical condition.\n*unknown* means that one or more services have not responded, but all of the remaining nodes responded to the health check as \"OK\".\n*OK* means that all of the services are OK and all have responded to the health check.\n*none* means that there is no health check information.",
+      "type": "string",
+      "default": "OK",
+      "enum": [
+        "OK",
+        "WARNING",
+        "CRITICAL",
+        "UNKNOWN",
+        "NONE"
+      ]
+    },
+    "chef.automate.api.applications.PeriodicJobConfig": {
+      "description": "Periodic job configuration.",
+      "type": "object",
+      "properties": {
+        "job_info": {
+          "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobInfo"
+        },
+        "recurrence": {
+          "description": "A recurrence rule that determines how often, at what interval, and when to\ninitially start a scheduled job.\n\nIf the field is omitted from the request or is set to an emtpy string, no\nchange will be made to the current value. Otherwise, the value should match\nthe  [recurrence rule format defined in section 4.3.10 of RFC 2445](https://www.ietf.org/rfc/rfc2445.txt).\n\nIt is not recommended to change this value from the default setting of a\n60 second interval. This configuration option is provided only for\nconsistency with other data lifecyle APIs.",
+          "type": "string"
+        },
+        "running": {
+          "description": "Enable/disable the job. `false` is disabled, `true` is enabled.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "threshold": {
+          "description": "The `threshold` setting used by periodic jobs for evaluating services.\nThreshold is a string that follows Elasticsearch's date math expressions. For more information, see the simpledatemath package under `lib/`.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.applications.PeriodicJobInfo": {
+      "description": "PeriodicJobInfo gives information about the last and next scheduled\nexecutions of a periodic job.",
+      "type": "object",
+      "properties": {
+        "last_elapsed": {
+          "type": "string"
+        },
+        "last_ended_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_enqueued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "next_due_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.api.applications.PeriodicMandatoryJobConfig": {
+      "description": "Configuration for a periodic job. Initially Jobs using this message type\nwere designed such that they could not be disabled, but that has been\nchanged to make the various data lifecycle APIs consistent with each other.\nThus, there is a `running` field which will disable the job if set to false.\nThat is not recommended.",
+      "type": "object",
+      "properties": {
+        "job_info": {
+          "description": "Information about the last and next scheduled executions of the job. This\nis only used in a response context.",
+          "$ref": "#/definitions/chef.automate.api.applications.PeriodicJobInfo"
+        },
+        "recurrence": {
+          "description": "A recurrence rule that determines how often, at what interval, and when to\ninitially start a scheduled job.\n\nIf the field is omitted from the request or is set to an emtpy string, no\nchange will be made to the current value. Otherwise, the value should match\nthe  [recurrence rule format defined in section 4.3.10 of RFC 2445](https://www.ietf.org/rfc/rfc2445.txt).\n\nIt is not recommended to change this value from the default setting of a\n60 second interval. This configuration option is provided only for\nconsistency with other data lifecyle APIs.",
+          "type": "string"
+        },
+        "running": {
+          "description": "Enable/disable the job. `false` is disabled, `true` is enabled. It is not\nrecommended to disable this job.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "threshold": {
+          "description": "The `threshold` setting used by periodic jobs for evaluating services.\nThreshold is a string that follows Elasticsearch's date math expressions. For more information, see the simpledatemath package under `lib/`.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.applications.RunDeleteDisconnectedServicesJobReq": {
+      "type": "object"
+    },
+    "chef.automate.api.applications.RunDeleteDisconnectedServicesJobResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.applications.RunDisconnectedServicesJobReq": {
+      "type": "object"
+    },
+    "chef.automate.api.applications.RunDisconnectedServicesJobResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.applications.Service": {
+      "type": "object",
+      "properties": {
+        "application": {
+          "description": "Application name.",
+          "type": "string"
+        },
+        "channel": {
+          "description": "Chef Habitat channel that the service is subscribed to.",
+          "type": "string"
+        },
+        "current_health_since": {
+          "description": "Time interval of current health status from last status change until now.",
+          "type": "string"
+        },
+        "disconnected": {
+          "description": "Service connection information.\nBased on time since last healthcheck received and disconnected service configuration.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "environment": {
+          "description": "Environment name.",
+          "type": "string"
+        },
+        "fqdn": {
+          "description": "FQDN reported by a Chef Habitat Supervisor.",
+          "type": "string"
+        },
+        "group": {
+          "description": "Service group name.",
+          "type": "string"
+        },
+        "health_check": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
+        },
+        "health_check_result": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCheckResult"
+        },
+        "health_updated_at": {
+          "description": "Timestamp since health status change.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "string",
+          "title": "Internal ID"
+        },
+        "last_event_occurred_at": {
+          "description": "Timestamp of last received health check message.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_event_since": {
+          "description": "Interval since last event received until now.",
+          "type": "string"
+        },
+        "previous_health_check": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
+        },
+        "release": {
+          "description": "Combination of the service version and release in a single string.\nExample: 0.1.0/8743278934278923.",
+          "type": "string"
+        },
+        "site": {
+          "description": "Site reported by Chef Habitat service, a user defined flag.",
+          "type": "string"
+        },
+        "supervisor_id": {
+          "description": "The Chef Habitat Supervisor ID.",
+          "type": "string"
+        },
+        "update_strategy": {
+          "description": "Update strategy that the service employs.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.applications.ServiceGroup": {
+      "description": "A service group message is the representation of an individual service group that\nis internally generated by aggregating all of its services.",
+      "type": "object",
+      "properties": {
+        "application": {
+          "description": "Application name for the service group.",
+          "type": "string"
+        },
+        "disconnected_count": {
+          "description": "Count of disconnected services within this service group.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "environment": {
+          "description": "Environment name for the service group.",
+          "type": "string"
+        },
+        "health_percentage": {
+          "description": "Percentage of services reporting OK status.\nThe health_percentage can be a number between 0-100.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "description": "Service group ID. This is a value constructed by Chef Automate and is not reported by Chef Habitat.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of service group.",
+          "type": "string"
+        },
+        "package": {
+          "description": "Combination of the origin and package name in a single string.\nExample: core/redis.",
+          "type": "string"
+        },
+        "release": {
+          "description": "Combination of the version and release in a single string.\nExample: 0.1.0/8743278934278923.",
+          "type": "string"
+        },
+        "services_health_counts": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
+        },
+        "status": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthStatus"
+        }
+      }
+    },
+    "chef.automate.api.applications.ServiceGroups": {
+      "description": "List of service groups.",
+      "type": "object",
+      "properties": {
+        "service_groups": {
+          "description": "List of service groups.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.applications.ServiceGroup"
+          }
+        }
+      }
+    },
+    "chef.automate.api.applications.ServicesBySGRes": {
+      "description": "Response message for GetServicesBySG.",
+      "type": "object",
+      "properties": {
+        "group": {
+          "description": "Service group name.",
+          "type": "string"
+        },
+        "services": {
+          "description": "List of services.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
+          }
+        },
+        "services_health_counts": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.applications.HealthCounts"
+        }
+      }
+    },
+    "chef.automate.api.applications.ServicesDistinctValuesRes": {
+      "description": "Response message for GetServicesDistinctValues.",
+      "type": "object",
+      "properties": {
+        "values": {
+          "description": "List of distinct values fitting query_fragment and filters.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.applications.ServicesRes": {
+      "description": "Response message for GetServices.",
+      "type": "object",
+      "properties": {
+        "services": {
+          "description": "List of services.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.applications.Service"
+          }
+        }
+      }
+    },
+    "chef.automate.api.applications.ServicesStatsRes": {
+      "description": "Response message for ServicesStats.",
+      "type": "object",
+      "properties": {
+        "total_deployments": {
+          "description": "Total number of deployments reporting to Chef Automate.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_service_groups": {
+          "description": "Total number of service groups reporting to Chef Automate.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_services": {
+          "description": "Total number of services reporting to Chef Automate, counts both connected and disconnected services.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_supervisors": {
+          "description": "Total number of supervisors reporting to Chef Automate.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.applications.UpdateDeleteDisconnectedServicesConfigRes": {
+      "type": "object"
+    },
+    "chef.automate.api.applications.UpdateDisconnectedServicesConfigRes": {
+      "type": "object"
+    },
+    "chef.automate.api.cds.request.Credentials": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string"
+        },
+        "client_secret": {
+          "type": "string"
+        },
+        "tenant_specific_url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cds.request.InstallContentItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "request_user": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cds.response.ContentEnabled": {
+      "type": "object",
+      "properties": {
+        "is_content_enabled": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.cds.response.ContentItem": {
+      "type": "object",
+      "properties": {
+        "can_be_installed": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "filename": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cds.response.ContentItems": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cds.response.ContentItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cds.response.Credentials": {
+      "type": "object"
+    },
+    "chef.automate.api.cds.response.InstallContentItem": {
+      "type": "object"
+    },
+    "chef.automate.api.cfgmgmt.request.CreateRollout": {
+      "description": "CreateRollout is a request to create a new Rollout. All\nfields have the same meaning as with the response Rollout\ntype.",
+      "type": "object",
+      "properties": {
+        "ci_job_id": {
+          "type": "string"
+        },
+        "ci_job_url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "policy_domain_url": {
+          "type": "string"
+        },
+        "policy_domain_username": {
+          "type": "string"
+        },
+        "policy_name": {
+          "type": "string"
+        },
+        "policy_node_group": {
+          "type": "string"
+        },
+        "policy_revision_id": {
+          "type": "string"
+        },
+        "policy_scm_commit": {
+          "type": "string"
+        },
+        "policy_scm_url": {
+          "type": "string"
+        },
+        "policy_scm_web_url": {
+          "type": "string"
+        },
+        "scm_author_email": {
+          "type": "string"
+        },
+        "scm_author_name": {
+          "type": "string"
+        },
+        "scm_type": {
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.SCMType"
+        },
+        "scm_web_type": {
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.request.SCMWebType"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.request.CreateRolloutTest": {
+      "type": "object"
+    },
+    "chef.automate.api.cfgmgmt.request.NodeExport": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "description": "Filters to apply to the request for nodes list. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output_type": {
+          "description": "File type, either JSON or CSV.",
+          "type": "string",
+          "default": "json",
+          "enum": [
+            "json",
+            "csv"
+          ]
+        },
+        "sorting": {
+          "description": "sorting parameters to apply to the returned node list. Defaults to Asc and 'name'",
+          "$ref": "#/definitions/chef.automate.api.common.query.Sorting"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.request.ReportExport": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "description": "Latest (in history) run information to return for the runs list. Not required.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "filter": {
+          "description": "Filters to apply to the request for nodes list. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "node_id": {
+          "description": "The node ID of the reports. Required.",
+          "type": "string"
+        },
+        "output_type": {
+          "description": "File type, either JSON or CSV.",
+          "type": "string",
+          "default": "json",
+          "enum": [
+            "json",
+            "csv"
+          ]
+        },
+        "start": {
+          "description": "Earliest (in history) run information to return for the runs list. Not required.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.request.SCMType": {
+      "type": "string",
+      "default": "UNKNOWN_SCM",
+      "enum": [
+        "UNKNOWN_SCM",
+        "GIT"
+      ]
+    },
+    "chef.automate.api.cfgmgmt.request.SCMWebType": {
+      "type": "string",
+      "default": "UNKNOWN_SCM_WEB",
+      "enum": [
+        "UNKNOWN_SCM_WEB",
+        "GITHUB"
+      ]
+    },
+    "chef.automate.api.cfgmgmt.response.CheckInCounts": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "end": {
+          "type": "string"
+        },
+        "start": {
+          "type": "string"
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.CheckInCountsTimeSeries": {
+      "type": "object",
+      "properties": {
+        "counts": {
+          "type": "array",
+          "title": "List of daily checkin counts",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CheckInCounts"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.ChefError": {
+      "type": "object",
+      "properties": {
+        "backtrace": {
+          "description": "Stacktrace for the failure.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "class": {
+          "description": "Class for the error.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description for the error.",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Description"
+        },
+        "message": {
+          "description": "Error message for the failed run.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.CookbookLock": {
+      "type": "object",
+      "properties": {
+        "cookbook": {
+          "description": "Cookbook name.",
+          "type": "string"
+        },
+        "policy_identifier": {
+          "description": "Policy identifier for the cookbook lock.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.CountedDuration": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "title": "The number of nodes for this duration"
+        },
+        "duration": {
+          "type": "string",
+          "title": "Duration of the count. Example '3d'"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.CreateRolloutTest": {
+      "type": "object"
+    },
+    "chef.automate.api.cfgmgmt.response.CurrentRolloutProgress": {
+      "type": "object",
+      "properties": {
+        "build_link": {
+          "type": "string"
+        },
+        "latest_run_errored_count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "latest_run_successful_count": {
+          "description": "I'm assuming it's easy to get the status when we get the counts.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "node_count": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Nodes that have run the code being rolled out thus far"
+        },
+        "rollout": {
+          "description": "Rollout is the full rollout object, but we can change this to be a subset only.",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+        },
+        "source_link": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Deprecation": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "description": "Location of the deprecated code.",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message for the deprecation.",
+          "type": "string"
+        },
+        "url": {
+          "description": "Url reference for the deprecation.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Description": {
+      "type": "object",
+      "properties": {
+        "sections": {
+          "description": "More information about the error.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "title": {
+          "description": "Title for the error description.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.ErrorCount": {
+      "type": "object",
+      "title": "ErrorCount gives the number of occurrences (count) of the error specified by\nthe type and message among the nodes included by the request parameters",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "error_message": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Errors": {
+      "description": "Errors contains a list of the most common Chef Infra error type/message\ncombinations among nodes in the active project as filtered according to the\nrequest.",
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ErrorCount"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.ExpandedRunList": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Id of the run list collection.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "Intentionally blank.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.MissingNodeDurationCounts": {
+      "type": "object",
+      "properties": {
+        "counted_durations": {
+          "type": "array",
+          "title": "List of counted durations",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CountedDuration"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodeAttribute": {
+      "type": "object",
+      "properties": {
+        "all_value_count": {
+          "description": "Total count of attributes on the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "automatic": {
+          "description": "Stringified json of the automatic attributes for the node.",
+          "type": "string"
+        },
+        "automatic_value_count": {
+          "description": "Count of automatic attributes on the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "chef_environment": {
+          "description": "The environment for the node.",
+          "type": "string"
+        },
+        "default": {
+          "description": "Stringified json of the default attributes for the node.",
+          "type": "string"
+        },
+        "default_value_count": {
+          "description": "Count of default attributes on the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "description": "Name of the node.",
+          "type": "string"
+        },
+        "node_id": {
+          "description": "The chef_guid associated with the node.",
+          "type": "string"
+        },
+        "normal": {
+          "description": "Stringified json of the normal attributes for the node.",
+          "type": "string"
+        },
+        "normal_value_count": {
+          "description": "Count of normal attributes on the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "override": {
+          "description": "Stringified json of the override attributes for the node.",
+          "type": "string"
+        },
+        "override_value_count": {
+          "description": "Count of override attributes on the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "run_list": {
+          "description": "Run list for the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodeMetadataCounts": {
+      "type": "object",
+      "properties": {
+        "types": {
+          "type": "array",
+          "title": "Field Types for a node with value counts",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.TypeCount"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodeRunsDailyStatusTimeSeries": {
+      "type": "object",
+      "properties": {
+        "durations": {
+          "type": "array",
+          "title": "runs status of a 24-hour duration",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunDurationStatus"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodeSegmentRolloutProgress": {
+      "type": "object",
+      "properties": {
+        "current_rollout_progress": {
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CurrentRolloutProgress"
+        },
+        "policy_domain_url": {
+          "type": "string"
+        },
+        "policy_name": {
+          "type": "string",
+          "title": "policy_name, policy_node_group, policy_domain_url make up a \"compound\nid\" for the node segment"
+        },
+        "policy_node_group": {
+          "type": "string"
+        },
+        "previous_rollouts": {
+          "type": "array",
+          "title": "This is the last, say 2 or 4 rollouts before the current one (to give a\ntotal of 3 or 5)",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.PastRolloutProgress"
+          }
+        },
+        "total_nodes": {
+          "type": "integer",
+          "format": "int32",
+          "title": "total nodes in elasticsearch in the node segment"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodeSegmentsWithRolloutProgress": {
+      "description": "A Node Segment is the set of Chef Infra nodes with a shared policy_name,\npolicy_node_group, and policy_domain_url.\n\nNodeSegmentsWithRolloutProgress lists all of the node segments matching the\nrequest with information about the progress and status of the code rollouts for each segment.",
+      "type": "object",
+      "title": "NodeSegmentsWithRolloutProgress",
+      "properties": {
+        "node_segment_rollout_progress": {
+          "description": "The NodeSegmentRolloutProgress are sorted by policy group, policy\nname, then domain URL.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.NodeSegmentRolloutProgress"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.NodesCounts": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "description": "Total count of nodes that have reported in to Automate whose last run was failed.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "missing": {
+          "description": "Total count of nodes that have been labeled as 'missing' as determined by node lifecycle settings.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "description": "Total count of nodes that have reported in to Automate whose last run was successful.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total": {
+          "description": "Total count of nodes that have reported in to Automate.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.PastRolloutProgress": {
+      "type": "object",
+      "properties": {
+        "build_link": {
+          "type": "string"
+        },
+        "latest_run_node_count": {
+          "description": "The number of nodes in the node segment for which the last recorded CCR\nwas part of this rollout. Note that no breakdown of success/errored is\nprovided, since some nodes may have moved on to the current rollout and\nare not included in the count.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "rollout": {
+          "description": "Rollout is the full rollout object, but we can change this to be a subset only.",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+        },
+        "source_link": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.PolicyCookbooks": {
+      "type": "object",
+      "properties": {
+        "cookbook_locks": {
+          "description": "Intentionally blank.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.CookbookLock"
+          }
+        },
+        "policy_name": {
+          "description": "Name of the policy.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Resource": {
+      "type": "object",
+      "properties": {
+        "conditional": {
+          "description": "Conditional rule associated with the resource.",
+          "type": "string"
+        },
+        "cookbook_name": {
+          "description": "Cookbook name associated with the resource.",
+          "type": "string"
+        },
+        "cookbook_version": {
+          "description": "Version of the cookbook associated with the resource.",
+          "type": "string"
+        },
+        "delta": {
+          "description": "Change diff for the resource (if it was changed during the run).",
+          "type": "string"
+        },
+        "duration": {
+          "description": "Duration of the resource processing.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Id of the resource.",
+          "type": "string"
+        },
+        "ignore_failure": {
+          "description": "Boolean that denotes whether or not the resource failure should be ignored.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "name": {
+          "description": "Name for the resource.",
+          "type": "string"
+        },
+        "recipe_name": {
+          "description": "Name of the recipe associated with the resource.",
+          "type": "string"
+        },
+        "result": {
+          "description": "String result of the resource.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the resource (e.g. 'up-to-date').",
+          "type": "string"
+        },
+        "type": {
+          "description": "Resource type.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Rollout": {
+      "description": "A Rollout represents the process of distributing Chef Infra code (with\nPolicyfiles) to a set of nodes. It's used to track which nodes have run the\nlatest version of the Chef Infra code assigned to them and also provide the\nuser insights about the code by aggregating Chef Client run results\naccording to the version of Chef Infra code applied. Metadata about the code\nis stored in order to provide the user with convenient references back to\nsystems they already use (such as SCM and Ci/CD systems) to manage their code.\n\nNodes are segmented by a triple of policy name, policy group, and policy domain URL:\npolicy name generally describes what kind of system it is, e.g., a database server\npolicy group generally describes where the system fits in the user's code\nlifecycle, e.g., \"QA\" or \"production.\" Policy groups may also represent a\nsubset of nodes within a code lifecycle stage, such as a \"production-canary\"\ngroup.\npolicy domain URL identifies the system that distributes the Chef Infra code\nand is the owner of the namespaces for policy name and group. E.g., a Chef\nServer URL with the `/organizations/:orgname` part.\n\nThere is one (or zero) revision(s) of the Chef Infra code applied to any\nsegment at a time. Rollouts track the changes to which revision of the code is\napplied to the node segments over time.",
+      "type": "object",
+      "properties": {
+        "ci_job_id": {
+          "description": "If the rollout was initiated by Ci/CD or similar system, the id of the job\nthat initiated the rollout. Should include the Ci system's nickname or\nother identifying information users would need to associate the job ID to\nthe Ci/CD system.",
+          "type": "string"
+        },
+        "ci_job_url": {
+          "description": "If the rollout was initiated via Ci/CD or similar system, the web URL\nfor the job that initiated the rollout.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A free-form description of the rollout, as given by the user. Long\nmessages may be displayed in a truncated form in the UI. The content may\nbe entered manually by the user or extracted from another system, for\nexample a git commit message.",
+          "type": "string"
+        },
+        "end_time": {
+          "description": "The time that the rollout was replaced with another rollout.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The system-generated ID for this rollout. The system currently provides\nautoincrementing integers for the Ids.",
+          "type": "string"
+        },
+        "policy_domain_url": {
+          "description": "In the Chef Server case, the policy domain URL is the Chef Server URL\nwith the `/organizations/:orgname` portion of the URL path included. In\ngeneral, this can be a URL for any content storage/distribution service,\nas long as the combination of policy_name and policy_node_group is unique\non that system.\n\nThe set of nodes configured to fetch policy content from the\npolicy_domain_url and configured with the same policy_name and\npolicy_node_group form the target set of nodes for a rollout and are\nexpected to apply the policy revision described by the rollout.",
+          "type": "string"
+        },
+        "policy_domain_username": {
+          "description": "The username of the entity who uploaded/promoted the policy code to the\ncode host. In a Chef Server architecture, this is the name of the Chef\nServer user who ran the `chef push` command to upload the policy.",
+          "type": "string"
+        },
+        "policy_name": {
+          "type": "string",
+          "title": "The name of the policy, i.e., the `name` attribute in the Policyfile"
+        },
+        "policy_node_group": {
+          "description": "The group of nodes which are targeted by the rollout. In the Chef Server\ncase, this is the policy_group to which the user is pushing the policy.",
+          "type": "string"
+        },
+        "policy_revision_id": {
+          "type": "string",
+          "title": "The revision_id of the compiled policy being rolled out"
+        },
+        "policy_scm_commit": {
+          "description": "The source control system's identifier for the repository version. This\nshould be the version where the policy's lockfile was committed.",
+          "type": "string"
+        },
+        "policy_scm_url": {
+          "type": "string",
+          "title": "The URL used to obtain a copy of the source code repository"
+        },
+        "policy_scm_web_url": {
+          "type": "string",
+          "title": "The URL used to view the source code repository via the web"
+        },
+        "scm_author_email": {
+          "description": "The email address of the author of the most recent commit to the source\ncode repository. In git, this is the setting `user.email`.",
+          "type": "string"
+        },
+        "scm_author_name": {
+          "description": "The username of the author of the most recent commit to the source code\nrepository. In git, this is the setting `user.name`.",
+          "type": "string"
+        },
+        "scm_type": {
+          "title": "The source control system used with the policyfile",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.SCMType"
+        },
+        "scm_web_type": {
+          "title": "The software/service used to host the source code repository",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.SCMWebType"
+        },
+        "start_time": {
+          "description": "The time that the rollout began. Whenever a new rollout is created, it\nbecomes the \"current\" rollout for its node segment; that is, any nodes\nthat start a Chef Infra Client run will run the policy revision described\nby this \"current\" rollout. The system will populate the previously current\nrollout's `end_time` attribute with the current time.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Rollouts": {
+      "type": "object",
+      "properties": {
+        "rollouts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Rollout"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.Run": {
+      "type": "object",
+      "properties": {
+        "chef_tags": {
+          "description": "List of tags associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chef_version": {
+          "description": "Chef-client version on the node.",
+          "type": "string"
+        },
+        "cloud_provider": {
+          "type": "string"
+        },
+        "cookbooks": {
+          "description": "List of cookbooks associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deprecations": {
+          "description": "Intentionally blank.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Deprecation"
+          }
+        },
+        "dmi_system_manufacturer": {
+          "type": "string"
+        },
+        "dmi_system_serial_number": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "end_time": {
+          "description": "End time of the infra run.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "environment": {
+          "description": "The environment for the node.",
+          "type": "string"
+        },
+        "error": {
+          "description": "Chef Error information, available on failed runs.",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ChefError"
+        },
+        "expanded_run_list": {
+          "description": "Expanded run list for the node.",
+          "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ExpandedRunList"
+        },
+        "fqdn": {
+          "description": "FQDN of the node.",
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "id": {
+          "description": "Id of the infra node run.",
+          "type": "string"
+        },
+        "ip6address": {
+          "description": "IP 6 Address for the node.",
+          "type": "string"
+        },
+        "ipaddress": {
+          "description": "IP Address for the node.",
+          "type": "string"
+        },
+        "kernel_release": {
+          "type": "string"
+        },
+        "kernel_version": {
+          "type": "string"
+        },
+        "macaddress": {
+          "type": "string"
+        },
+        "memory_total": {
+          "type": "string"
+        },
+        "node_id": {
+          "description": "The chef_guid associated with the node.",
+          "type": "string"
+        },
+        "node_name": {
+          "description": "Name of the node.",
+          "type": "string"
+        },
+        "organization": {
+          "description": "The organization the node is associated with.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Full platform string for the node (family + version).",
+          "type": "string"
+        },
+        "platform_family": {
+          "description": "Platform family for the node.",
+          "type": "string"
+        },
+        "platform_version": {
+          "description": "Platform version for the node.",
+          "type": "string"
+        },
+        "policy_group": {
+          "description": "Policy group associated with the node.",
+          "type": "string"
+        },
+        "policy_name": {
+          "description": "Policy name associated with the node.",
+          "type": "string"
+        },
+        "policy_revision": {
+          "description": "Policy revision associated with the node.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects the node belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recipes": {
+          "description": "List of recipes the node calls.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resource_names": {
+          "description": "List of resource names for the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "description": "Intentionally blank.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.Resource"
+          }
+        },
+        "roles": {
+          "description": "List of roles associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "run_list": {
+          "description": "Run list for the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "description": "Source of the node run (e.g. chef-solo).",
+          "type": "string"
+        },
+        "source_fqdn": {
+          "description": "Chef server associated with the node.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Start time of the infra run.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "description": "Status of the infra node run.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Unused field.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timezone": {
+          "type": "string",
+          "title": "timezone of the node"
+        },
+        "total_resource_count": {
+          "description": "Resource count reported on the infra node run.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "updated_resource_count": {
+          "description": "Count of resources updated in the infra node run.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "uptime_seconds": {
+          "description": "Count in seconds that the node has been active.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "versioned_cookbooks": {
+          "description": "List of versioned cookbooks associated with the node.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.VersionedCookbook"
+          }
+        },
+        "virtualization_role": {
+          "type": "string"
+        },
+        "virtualization_system": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.RunDurationStatus": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "title": "End of the duration (RFC3339)"
+        },
+        "run_id": {
+          "type": "string",
+          "title": "Prominent Run's ID"
+        },
+        "start": {
+          "type": "string",
+          "title": "Start of the duration (RFC3339)"
+        },
+        "status": {
+          "type": "string",
+          "title": "Prominent Run's status"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.RunList": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "description": "Intentionally blank.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.RunList"
+          }
+        },
+        "name": {
+          "description": "Name of run list item.",
+          "type": "string"
+        },
+        "skipped": {
+          "description": "Boolean denoting whether or not the run list item was skipped.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "type": {
+          "description": "Type of run list item (e.g. 'recipe').",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of run list item.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.RunsCounts": {
+      "type": "object",
+      "properties": {
+        "failure": {
+          "description": "Total count of failed run reports that have landed in Automate for the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "success": {
+          "description": "Total count of successful run reports that have landed in Automate for the node.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total": {
+          "description": "Total count of run reports that have landed in Automate for the node.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.SCMType": {
+      "type": "string",
+      "default": "UNKNOWN_SCM",
+      "enum": [
+        "UNKNOWN_SCM",
+        "GIT"
+      ]
+    },
+    "chef.automate.api.cfgmgmt.response.SCMWebType": {
+      "type": "string",
+      "default": "UNKNOWN_SCM_WEB",
+      "enum": [
+        "UNKNOWN_SCM_WEB",
+        "GITHUB"
+      ]
+    },
+    "chef.automate.api.cfgmgmt.response.TypeCount": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "The field type counted"
+        },
+        "values": {
+          "type": "array",
+          "title": "Values of the field type with a count for each",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.cfgmgmt.response.ValueCount"
+          }
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.ValueCount": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "title": "The number of this distinct value"
+        },
+        "value": {
+          "type": "string",
+          "title": "The value counted"
+        }
+      }
+    },
+    "chef.automate.api.cfgmgmt.response.VersionedCookbook": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the cookbook.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the cookbook.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.common.ExportData": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "Exported reports in JSON or CSV.",
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "chef.automate.api.common.query.Filter": {
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "description": "Include matches for this filter.(boolean)\n`true` (default) *includes* all nodes that match this filter. \n`false` *excludes* all nodes that match this filter.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "key": {
+          "description": "Field to filter on.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Field values to filter on.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.common.query.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Tag key.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Tag value.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.common.query.Pagination": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "description": "Page number of the results to return.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "description": "Amount of results to include per page.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.common.query.SortOrder": {
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.common.query.Sorting": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "description": "Field to sort the list results on.",
+          "type": "string"
+        },
+        "order": {
+          "description": "Order the results should be returned in.",
+          "$ref": "#/definitions/chef.automate.api.common.query.SortOrder"
+        }
+      }
+    },
+    "chef.automate.api.common.version.VersionInfo": {
+      "type": "object",
+      "properties": {
+        "built": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "sha": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Option"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.CheckMessage": {
+      "type": "object",
+      "properties": {
+        "column": {
+          "description": "Column where the error or warning exists.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "control_id": {
+          "description": "Control ID associated with the error or warning.",
+          "type": "string"
+        },
+        "file": {
+          "description": "Profile file where the error or warning exists.",
+          "type": "string"
+        },
+        "line": {
+          "description": "Profile line where the error or warning exists.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "msg": {
+          "description": "Message associated with the error or warning.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.CheckResult": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "description": "Errors returned by the `inspec check` command.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
+          }
+        },
+        "summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ResultSummary"
+        },
+        "warnings": {
+          "description": "Warnings returned by the `inspec check` command.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.CheckMessage"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Chunk": {
+      "description": "Profile contents in byte form.",
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "string",
+          "format": "byte"
+        },
+        "position": {
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Control": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The code (test) for the control.",
+          "type": "string"
+        },
+        "desc": {
+          "description": "The description of the control.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The ID of the control.",
+          "type": "string"
+        },
+        "impact": {
+          "description": "The impact of the control.",
+          "type": "number",
+          "format": "float"
+        },
+        "refs": {
+          "description": "The refs associated with the control.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Ref"
+          }
+        },
+        "results": {
+          "description": "The results of the control tests.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Result"
+          }
+        },
+        "source_location": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.SourceLocation"
+        },
+        "tags": {
+          "description": "The tags associated with the control.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "description": "The title of the control.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Dependency": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "description": "Branch of the profile.",
+          "type": "string"
+        },
+        "commit": {
+          "description": "Commit sha for the profile.",
+          "type": "string"
+        },
+        "compliance": {
+          "description": "Automate address of the profile.",
+          "type": "string"
+        },
+        "git": {
+          "description": "Git location of the profile.",
+          "type": "string"
+        },
+        "github": {
+          "description": "Github address of the profile.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the profile.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path of the profile.",
+          "type": "string"
+        },
+        "supermarket": {
+          "description": "Supermarket address of the profile.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "Tag associated with the profile.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL of the profile.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Group": {
+      "type": "object",
+      "properties": {
+        "controls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The field to filter on.",
+          "type": "string"
+        },
+        "values": {
+          "description": "List of values to filter on.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Metadata": {
+      "description": "Metadata about the profile.",
+      "type": "object",
+      "properties": {
+        "content_type": {
+          "type": "string",
+          "title": "Content type of the profile (e.g. application/json, application/x-gtar, application/gzip)"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name of the profile (as specified in the inspec.yml)"
+        },
+        "version": {
+          "description": "Version of the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Missing": {
+      "type": "object",
+      "properties": {
+        "missing_sha256": {
+          "description": "An array of profile sha256 IDs that are missing from the backend metadata store.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Option": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "The list of attributes in the profile.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Attribute"
+          }
+        },
+        "controls": {
+          "description": "The list of controls in the profile.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Control"
+          }
+        },
+        "copyright": {
+          "type": "string",
+          "title": "The profile copyright, as specified in the inspec.yml"
+        },
+        "copyright_email": {
+          "type": "string",
+          "title": "The profile copyright email, as specified in the inspec.yml"
+        },
+        "depends": {
+          "type": "array",
+          "title": "The list of dependencies the profile has, as specified in the inspec.yml",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Dependency"
+          }
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Group"
+          }
+        },
+        "latest_version": {
+          "description": "The latest version of the profile.",
+          "type": "string"
+        },
+        "license": {
+          "type": "string",
+          "title": "The profile license, as specified in the inspec.yml"
+        },
+        "maintainer": {
+          "type": "string",
+          "title": "The profile maintainer, as specified in the inspec.yml"
+        },
+        "name": {
+          "type": "string",
+          "title": "The profile name, as specified in the inspec.yml"
+        },
+        "owner": {
+          "description": "The Automate user associated with the profile.",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "The SHA256 of the profile.",
+          "type": "string"
+        },
+        "summary": {
+          "type": "string",
+          "title": "The profile summary, as specified in the inspec.yml"
+        },
+        "supports": {
+          "type": "array",
+          "title": "The list of operating systems compatible with the profile, as specified in the inspec.yml",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Support"
+          }
+        },
+        "title": {
+          "type": "string",
+          "title": "The profile title, as specified in the inspec.yml"
+        },
+        "version": {
+          "type": "string",
+          "title": "The profile version, as specified in the inspec.yml"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.ProfileData": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Profile contents in byte form.",
+          "type": "string",
+          "format": "byte"
+        },
+        "name": {
+          "description": "Name of the profile.",
+          "type": "string"
+        },
+        "owner": {
+          "description": "Automate user associated with the profile.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Profiles": {
+      "type": "object",
+      "properties": {
+        "profiles": {
+          "description": "List of profiles matching the query.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Profile"
+          }
+        },
+        "total": {
+          "description": "Total count of profiles matching the query.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "type": "array",
+          "title": "Filters to apply to the query",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.ListFilter"
+          }
+        },
+        "name": {
+          "description": "Name of the profile (as defined in `inspec.yml`).",
+          "type": "string"
+        },
+        "order": {
+          "description": "Order in which to sort. Defaults to ASC.",
+          "$ref": "#/definitions/chef.automate.api.compliance.profiles.v1.Query.OrderType"
+        },
+        "owner": {
+          "description": "Automate user associated with the profile.",
+          "type": "string"
+        },
+        "page": {
+          "description": "Page of results requested.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "Number of results to return per page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Field on which to sort.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the profile (as defined in `inspec.yml`).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Query.OrderType": {
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.compliance.profiles.v1.Ref": {
+      "type": "object",
+      "properties": {
+        "ref": {
+          "description": "Ref for the control.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL of the ref.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Result": {
+      "type": "object",
+      "properties": {
+        "code_desc": {
+          "description": "The code (test) executed.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The failure message.",
+          "type": "string"
+        },
+        "run_time": {
+          "description": "The amount of time it took to execute the test.",
+          "type": "number",
+          "format": "float"
+        },
+        "skip_message": {
+          "description": "Reason for skipping the test.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "The time the test started.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the test results (passed, failed, skipped).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.ResultSummary": {
+      "type": "object",
+      "properties": {
+        "controls": {
+          "description": "Count of controls in the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "location": {
+          "description": "Path of the checked profile.",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Timestamp of when the `inspec check` command was executed.",
+          "type": "string"
+        },
+        "valid": {
+          "description": "Boolean that denotes if the profile is valid or not (as reported by `inspec check`).",
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Sha256": {
+      "type": "object",
+      "properties": {
+        "sha256": {
+          "description": "An array of profile sha256 IDs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.SourceLocation": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "ref": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.profiles.v1.Support": {
+      "type": "object",
+      "properties": {
+        "inspec_version": {
+          "description": "Minimum InSpec version required for the profile.",
+          "type": "string"
+        },
+        "os_family": {
+          "description": "OS family supported by the profile.",
+          "type": "string"
+        },
+        "os_name": {
+          "description": "OS name supported by the profile.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Platform supported by the profile.",
+          "type": "string"
+        },
+        "release": {
+          "description": "OS release supported by the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ControlStats": {
+      "type": "object",
+      "properties": {
+        "control": {
+          "description": "Control ID.",
+          "type": "string"
+        },
+        "failed": {
+          "description": "Count of failed nodes that executed the control.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "impact": {
+          "description": "Impact of the control.",
+          "type": "number",
+          "format": "float"
+        },
+        "passed": {
+          "description": "Count of passed nodes that executed the control.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "Count of skipped nodes that executed the control.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "description": "Control title.",
+          "type": "string"
+        },
+        "waived": {
+          "description": "Count of waived nodes that executed the control.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ControlsSummary": {
+      "description": "Statistics for the controls executed in the compliance reports.",
+      "type": "object",
+      "properties": {
+        "criticals": {
+          "description": "The total number of failed controls with an impact of 0.7 or higher.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "failures": {
+          "description": "The total number of failed controls in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "majors": {
+          "description": "The total number of failed controls with an impact between 0.4 and 0.7.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minors": {
+          "description": "The total number of failed controls with an impact of 0.3 or less.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "description": "The total number of passed controls in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "The total number of skipped controls in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "The total number of waived controls in the reports.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.FailureSummary": {
+      "type": "object",
+      "properties": {
+        "failures": {
+          "description": "Total count of failures.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "description": "ID of the object, included if applicable.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the object failing.",
+          "type": "string"
+        },
+        "profile": {
+          "description": "Not used.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Failures": {
+      "type": "object",
+      "properties": {
+        "controls": {
+          "description": "Top failed controls across the infrastructure.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "environments": {
+          "description": "Top failed environments across the infrastructure.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "platforms": {
+          "description": "Top failed platforms across the infrastructure.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        },
+        "profiles": {
+          "description": "Top failed profiles across the infrastructure.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.FailureSummary"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The field to filter on.",
+          "type": "string"
+        },
+        "values": {
+          "description": "The list of values to filter on for the given type. We 'OR' between these fields.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.NodeSummary": {
+      "description": "Statistics about the nodes scanned in the compliance reports.",
+      "type": "object",
+      "properties": {
+        "compliant": {
+          "description": "The total number of nodes that passed their compliance scans.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "high_risk": {
+          "description": "The total number of nodes that failed their compliance scan with one or more control of critical impact.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "low_risk": {
+          "description": "The total number of nodes that failed their compliance scan with one or more control of minor impact.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "medium_risk": {
+          "description": "The total number of nodes that failed their compliance scan with one or more control of major impact.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "noncompliant": {
+          "description": "The total number of nodes that failed their compliance scans.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "The total number of nodes that skipped their compliance scans.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "The total number of nodes with a waived compliance scan.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "control_stats": {
+          "description": "Summary information about a specific profile's control results across the reports.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlStats"
+          }
+        },
+        "profile_list": {
+          "description": "Set of statistics about the profiles executed in the reports.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileList"
+          }
+        },
+        "profile_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileList": {
+      "type": "object",
+      "properties": {
+        "criticals": {
+          "description": "Total number of failed nodes with critical control failures that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "failures": {
+          "description": "Total number of nodes that failed this profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "description": "The profile SHA ID.",
+          "type": "string"
+        },
+        "majors": {
+          "description": "Total number of failed nodes with major control failures that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minors": {
+          "description": "Total number of failed nodes with minor control failures that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "description": "The profile name.",
+          "type": "string"
+        },
+        "passed": {
+          "description": "Total number of passed nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "Total number of skipped nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "Total number of waived nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummary": {
+      "description": "Summary information about a specific profile's execution across the reports.",
+      "type": "object",
+      "properties": {
+        "copyright": {
+          "description": "Copyright info for the profile.",
+          "type": "string"
+        },
+        "copyright_email": {
+          "description": "Copyright email info for the profile.",
+          "type": "string"
+        },
+        "depends": {
+          "description": "Dependency information about the profile (which profiles it inherits).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
+          }
+        },
+        "license": {
+          "description": "License info for the profile.",
+          "type": "string"
+        },
+        "maintainer": {
+          "description": "Maintainer for the profile.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the profile.",
+          "type": "string"
+        },
+        "stats": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats"
+        },
+        "summary": {
+          "description": "Summary description of the profile.",
+          "type": "string"
+        },
+        "supports": {
+          "description": "Supports information for the profile (which os it can run on).",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Support"
+          }
+        },
+        "title": {
+          "description": "Title of the profile.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ProfileSummaryStats": {
+      "description": "Statistics about the nodes that executed the profile.",
+      "type": "object",
+      "properties": {
+        "failed": {
+          "description": "Total number of failed nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "failed_nodes": {
+          "description": "Not used.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "description": "Total number of passed nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "Total number of skipped nodes that executed the profile.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_nodes": {
+          "description": "Not used.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "Total number of waived controls for the given profile across nodes.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Filters applied to the results.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ListFilter"
+          }
+        },
+        "id": {
+          "description": "Unique identifier, such as a profile ID.",
+          "type": "string"
+        },
+        "interval": {
+          "description": "The interval to use for ReadTrend results, in integer seconds. Default of one hour, 3600.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Query.OrderType"
+        },
+        "page": {
+          "description": "The offset for paginating requests. An offset defines a place in the results in order to fetch the next page of the results.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "The number of results on each paginated request page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "size": {
+          "description": "The number of results to return (used when pagination is not supported).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Sort the list of results by a field.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of data being requested, used for ReadTrend and ReadSummary.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Query.OrderType": {
+      "description": "Sort the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.ReportSummary": {
+      "description": "Statistics on the overall compliance reports.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "Not used.",
+          "type": "number",
+          "format": "double"
+        },
+        "start_date": {
+          "description": "Not used.",
+          "type": "string"
+        },
+        "stats": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Stats"
+        },
+        "status": {
+          "description": "Overall aggregated status for all the reports.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Stats": {
+      "description": "General statistics about the reports.",
+      "type": "object",
+      "properties": {
+        "controls": {
+          "description": "The number of unique controls scanned in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "environments": {
+          "description": "The number of unique environments in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "nodes": {
+          "type": "string",
+          "format": "int64",
+          "title": "Deprecated. int64 types render into string types when serialized to satisfy all browsers\nReplaced by the `nodes_cnt` field"
+        },
+        "nodes_cnt": {
+          "description": "The number of unique nodes scanned in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "platforms": {
+          "description": "The number of unique node platforms in the reports.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "profiles": {
+          "description": "The number of unique profiles in the reports.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Summary": {
+      "type": "object",
+      "properties": {
+        "controls_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ControlsSummary"
+        },
+        "node_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.NodeSummary"
+        },
+        "report_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.ReportSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Support": {
+      "type": "object",
+      "properties": {
+        "inspec_version": {
+          "description": "InSpec Version compatible with the profile.",
+          "type": "string"
+        },
+        "os_family": {
+          "description": "OS Family compatible with the profile. This is legacy InSpec syntax.",
+          "type": "string"
+        },
+        "os_name": {
+          "description": "OS Name compatible with the profile. This is legacy InSpec syntax.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Platform compatible with the profile.",
+          "type": "string"
+        },
+        "platform_family": {
+          "description": "Platform Family compatible with the profile.",
+          "type": "string"
+        },
+        "platform_name": {
+          "description": "Platform Name compatible with the profile.",
+          "type": "string"
+        },
+        "release": {
+          "description": "OS Release compatible with the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trend": {
+      "type": "object",
+      "properties": {
+        "failed": {
+          "description": "Total failed objects (nodes or controls) on the reports at the given report time.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "description": "Total passed objects (nodes or controls) on the reports at the given report time.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "report_time": {
+          "description": "Time in point for which the passed/failed/skipped data is valid.",
+          "type": "string"
+        },
+        "skipped": {
+          "description": "Total skipped objects (nodes or controls) on the reports at the given report time.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "Total waived objects (nodes or controls) on the reports at the given report time.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.stats.v1.Trends": {
+      "type": "object",
+      "properties": {
+        "trends": {
+          "description": "Set of statistics for passed/failed/skipped nodes or controls in a trendgraph friendly data format.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.stats.v1.Trend"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the attribute.",
+          "type": "string"
+        },
+        "options": {
+          "description": "The options defined for the attribute.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Option"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Control": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The full ruby code of the control defined in the profile.",
+          "type": "string"
+        },
+        "desc": {
+          "description": "The full description of the control.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The unique ID of this control.",
+          "type": "string"
+        },
+        "impact": {
+          "description": "The severity of the control.",
+          "type": "number",
+          "format": "float"
+        },
+        "refs": {
+          "description": "External supporting documents for the control.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Ref"
+          }
+        },
+        "removed_results_counts": {
+          "description": "When the control results are removed to reduce the size of the report, this summarize the status of the trimmed results.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.RemovedResultsCounts"
+        },
+        "results": {
+          "description": "The results of running all tests defined in the control against the node.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Result"
+          }
+        },
+        "source_location": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.SourceLocation"
+        },
+        "tags": {
+          "description": "Metadata defined on the control in key-value format.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "description": "The compact description of the control.",
+          "type": "string"
+        },
+        "waived_str": {
+          "type": "string",
+          "title": "Indicates if the control has been waived or not"
+        },
+        "waiver_data": {
+          "title": "Additional details for waived controls",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.OrigWaiverData"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ControlItem": {
+      "type": "object",
+      "properties": {
+        "control_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary"
+        },
+        "end_time": {
+          "description": "The time the report using the control was submitted at.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "The control's unique ID.",
+          "type": "string"
+        },
+        "impact": {
+          "description": "The severity of the control.",
+          "type": "number",
+          "format": "float"
+        },
+        "profile": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin"
+        },
+        "title": {
+          "description": "The control's compact description.",
+          "type": "string"
+        },
+        "waivers": {
+          "description": "A list of waivers for the nodes affected by this control.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.WaiverData"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ControlItemRequest": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "The criteria used to filter the controls returned.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
+          }
+        },
+        "size": {
+          "description": "The maximum number of controls to return (Default 100).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "text": {
+          "description": "The term to use to match resources on.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ControlItems": {
+      "type": "object",
+      "properties": {
+        "control_items": {
+          "description": "The paginated results of controls matching the filters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlItem"
+          }
+        },
+        "control_summary_totals": {
+          "title": "The summary totals for this list of control items",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ControlSummary": {
+      "description": "A minimal representation of the statuses of the controls in the report.",
+      "type": "object",
+      "properties": {
+        "failed": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Failed"
+        },
+        "passed": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total"
+        },
+        "skipped": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total"
+        },
+        "total": {
+          "description": "The total number of controls in the report.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Total"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Dependency": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "description": "The specific git branch of the dependency.",
+          "type": "string"
+        },
+        "commit": {
+          "description": "The specific git commit of the dependency.",
+          "type": "string"
+        },
+        "compliance": {
+          "description": "The short name of the dependency stored on the Chef Automate or Chef Compliance server.",
+          "type": "string"
+        },
+        "git": {
+          "description": "The git URL of the profile.",
+          "type": "string"
+        },
+        "github": {
+          "description": "The short name of the dependency stored on Github.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the profile.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path to the profile on disk.",
+          "type": "string"
+        },
+        "skip_message": {
+          "description": "The reason this profile was skipped in the generated report, if any.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the dependency in the report.",
+          "type": "string"
+        },
+        "supermarket": {
+          "description": "The name of the dependency stored in Chef Supermarket.",
+          "type": "string"
+        },
+        "tag": {
+          "description": "The specific git tag of the dependency.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL of the profile accessible over HTTP or HTTPS.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The specific git version of the dependency.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Failed": {
+      "description": "Stats of failed controls.",
+      "type": "object",
+      "properties": {
+        "critical": {
+          "description": "The number of failed controls with critical severity.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "major": {
+          "description": "The number of failed controls with major severity.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "minor": {
+          "description": "The number of failed controls with minor severity.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total": {
+          "description": "The total number of failed controls.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Group": {
+      "type": "object",
+      "properties": {
+        "controls": {
+          "description": "The ids of the controls defined in this file.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The name of the file the controls are defined in.",
+          "type": "string"
+        },
+        "title": {
+          "description": "The title of control group.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Kv": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The key of the tag.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value of the tag.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.LatestReportSummary": {
+      "description": "A summary of the latest report for this node.",
+      "type": "object",
+      "properties": {
+        "controls": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary"
+        },
+        "end_time": {
+          "description": "The time the report was submitted at.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "The latest report ID.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the run the report was made from.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ListFilter": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The field to filter on.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Filters applied to the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Node": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "description": "The environment assigned to the node.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The node ID.",
+          "type": "string"
+        },
+        "latest_report": {
+          "description": "A summary of the information contained in the latest report for this node.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.LatestReportSummary"
+        },
+        "name": {
+          "description": "The name assigned to the node.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform"
+        },
+        "profiles": {
+          "description": "A minimal representation of the compliance profiles run against the node.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMeta"
+          }
+        },
+        "tags": {
+          "description": "The tags assigned to this node.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Kv"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Nodes": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "description": "The nodes matching the request filters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Node"
+          }
+        },
+        "total": {
+          "description": "The total number of nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_failed": {
+          "description": "The total number of failed nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_passed": {
+          "description": "The total number of passing nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_skipped": {
+          "description": "The total number of skipped nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_waived": {
+          "description": "The total number of waived nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Option": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "The default value of the attribute.",
+          "type": "string"
+        },
+        "description": {
+          "description": "The description of the attribute.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.OrigWaiverData": {
+      "type": "object",
+      "title": "OrigWaiverData as it originally came from the InSpec report\nWill supplement this with waived_str to make consumption easier",
+      "properties": {
+        "expiration_date": {
+          "type": "string"
+        },
+        "justification": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "run": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "skipped_due_to_waiver": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Platform": {
+      "description": "The name and version of the node's operating system.",
+      "type": "object",
+      "properties": {
+        "full": {
+          "description": "The combined name and version of the node's operating system.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the node's operating system.",
+          "type": "string"
+        },
+        "release": {
+          "description": "The version of the node's operating system.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Profile": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "The attributes defined on the profile.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Attribute"
+          }
+        },
+        "controls": {
+          "description": "The controls defined on the profile.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Control"
+          }
+        },
+        "copyright": {
+          "description": "The name of the copyright holder.",
+          "type": "string"
+        },
+        "copyright_email": {
+          "description": "The contact information for the copyright holder.",
+          "type": "string"
+        },
+        "depends": {
+          "description": "Other profiles that this profile depends on.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Dependency"
+          }
+        },
+        "full": {
+          "description": "The combined name and version of the profile.",
+          "type": "string"
+        },
+        "groups": {
+          "description": "The groups of controls defined in the profile.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Group"
+          }
+        },
+        "latest_version": {
+          "description": "The highest version number of the profile stored in Automate.",
+          "type": "string"
+        },
+        "license": {
+          "description": "The license the profile is released under.",
+          "type": "string"
+        },
+        "maintainer": {
+          "description": "The maintainer listed in the profile metadata.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the profile. Must be unique.",
+          "type": "string"
+        },
+        "owner": {
+          "description": "The name of the account that uploaded the profile to Automate.",
+          "type": "string"
+        },
+        "sha256": {
+          "description": "A unique value generated from the profile used to identify it.",
+          "type": "string"
+        },
+        "skip_message": {
+          "description": "The reason this profile was skipped in the generated report, if any.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the profile in the generated report.",
+          "type": "string"
+        },
+        "status_message": {
+          "description": "A message to detail the reason why a profile is skipped or failed in the generated report.",
+          "type": "string"
+        },
+        "summary": {
+          "description": "A short description of the profile.",
+          "type": "string"
+        },
+        "supports": {
+          "description": "The supported platform targets.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Support"
+          }
+        },
+        "title": {
+          "description": "The profile title.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the profile.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ProfileCounts": {
+      "description": "Stats on the statuses of nodes matching the filters.",
+      "type": "object",
+      "properties": {
+        "failed": {
+          "description": "The total number of failed nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "passed": {
+          "description": "The total number of passing nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "skipped": {
+          "description": "The total number of skipped nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total": {
+          "description": "The total number of nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "waived": {
+          "description": "The total number of waived nodes matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ProfileMeta": {
+      "type": "object",
+      "properties": {
+        "full": {
+          "description": "The combined name and version of the profile.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The profile unique ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the profile.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the profile run against the node.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The profile version.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ProfileMin": {
+      "description": "Minimal representation of a profile.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The profile ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the profile.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The aggregated status of the profile across the nodes it has been run on.",
+          "type": "string"
+        },
+        "title": {
+          "description": "The profile title.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The profile version.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ProfileMins": {
+      "type": "object",
+      "properties": {
+        "counts": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileCounts"
+        },
+        "profiles": {
+          "description": "Minimal representations of the profiles matching the filters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ProfileMin"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Filters applied to the report results.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
+          }
+        },
+        "id": {
+          "description": "Unique identifier.",
+          "type": "string"
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Query.OrderType"
+        },
+        "page": {
+          "description": "The offset for paginating requests. An offset defines a place in the results in order to show the next page of the results.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "The number of results on each paginated request page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Sort the list of results by a field.",
+          "type": "string"
+        },
+        "type": {
+          "description": "File type, either JSON or CSV.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Query.OrderType": {
+      "description": "Sort the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.compliance.reporting.v1.Ref": {
+      "type": "object",
+      "properties": {
+        "ref": {
+          "description": "A description of the external document.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The external document URL.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.RemovedResultsCounts": {
+      "type": "object",
+      "properties": {
+        "failed": {
+          "type": "integer",
+          "format": "int32",
+          "title": "The number of results with status of `failed` that have been trimmed (removed) from a control"
+        },
+        "passed": {
+          "type": "integer",
+          "format": "int32",
+          "title": "The number of results with status of `passed` that have been trimmed (removed) from a control"
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32",
+          "title": "The number of results with status of `skipped` that have been trimmed (removed) from a control"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Report": {
+      "type": "object",
+      "properties": {
+        "chef_organization": {
+          "description": "The Organization the node belongs to.",
+          "type": "string"
+        },
+        "chef_server": {
+          "description": "The Chef Infra Server that manages the node making the report.",
+          "type": "string"
+        },
+        "chef_tags": {
+          "description": "The Chef Tags associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "controls": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary"
+        },
+        "end_time": {
+          "description": "The time that the report was completed.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "environment": {
+          "description": "The environment of the node making the report.",
+          "type": "string"
+        },
+        "fqdn": {
+          "description": "The FQDN (fully qualified domain name) of the node making the report.",
+          "type": "string"
+        },
+        "id": {
+          "description": "A unique report identifier.",
+          "type": "string"
+        },
+        "ipaddress": {
+          "description": "The reporting node IP address.",
+          "type": "string"
+        },
+        "job_id": {
+          "description": "The compliance scan job ID associated with the report.",
+          "type": "string"
+        },
+        "node_id": {
+          "description": "The reporting node's unique ID.",
+          "type": "string"
+        },
+        "node_name": {
+          "description": "The reporting node name.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Platform"
+        },
+        "profiles": {
+          "description": "The profiles run as part of this report.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Profile"
+          }
+        },
+        "projects": {
+          "description": "The projects the node is assigned to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "roles": {
+          "description": "The Roles associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statistics": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Statistics"
+        },
+        "status": {
+          "description": "The status of the run the report was made from.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the report.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ReportData": {
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "type": "string",
+          "format": "date-time",
+          "title": "The time in UTC that the scan was completed"
+        },
+        "id": {
+          "type": "string",
+          "title": "The report run_uuid"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.ReportIds": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "The list of unique report identifiers found matching the query.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "report_data": {
+          "description": "The list of unique report identifiers with their respective end_time, found matching the query.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ReportData"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Reports": {
+      "type": "object",
+      "properties": {
+        "reports": {
+          "description": "Paginated results of reports matching the filters.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Report"
+          }
+        },
+        "total": {
+          "description": "Total number of reports matching the filters.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Result": {
+      "type": "object",
+      "properties": {
+        "code_desc": {
+          "description": "The description of the test.",
+          "type": "string"
+        },
+        "message": {
+          "description": "The reason the test failed, if any.",
+          "type": "string"
+        },
+        "run_time": {
+          "description": "The time taken to run the test.",
+          "type": "number",
+          "format": "float"
+        },
+        "skip_message": {
+          "description": "The reason the test was skipped, if any.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "The timestamp of when this individual test was run.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the test.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.SourceLocation": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "description": "The line number the control is defined on.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "ref": {
+          "description": "The source code file the control is defined in.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Statistics": {
+      "description": "Statistics of the report's run.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "The duration of the report's generation time.",
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Suggestion": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The ID of the resource that was suggested.",
+          "type": "string"
+        },
+        "score": {
+          "description": "The confidence in the match quality.",
+          "type": "number",
+          "format": "float"
+        },
+        "text": {
+          "description": "The content that matched the search term.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of the suggestion.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.SuggestionRequest": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "The criteria used to filter the suggestions returned.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ListFilter"
+          }
+        },
+        "size": {
+          "description": "The maximum number of suggestions to return.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "text": {
+          "description": "The term to use to match resources on.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The type of resource to get suggestions for.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Suggestions": {
+      "type": "object",
+      "properties": {
+        "suggestions": {
+          "description": "The list of returned suggestions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.Suggestion"
+          }
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Support": {
+      "type": "object",
+      "properties": {
+        "inspec_version": {
+          "description": "The supported inspec version for this profile.",
+          "type": "string"
+        },
+        "os_family": {
+          "description": "The wider category of supported platform (e.g., linux, windows).",
+          "type": "string"
+        },
+        "os_name": {
+          "description": "The name of the supported operating system.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "The platform name and version combined.",
+          "type": "string"
+        },
+        "release": {
+          "description": "The specific operating system release number this profile supports.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.Total": {
+      "description": "A subtotal of controls.",
+      "type": "object",
+      "properties": {
+        "total": {
+          "description": "The total number of controls.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.reporting.v1.WaiverData": {
+      "type": "object",
+      "properties": {
+        "expiration_date": {
+          "description": "The expiration date for the waiver. After this date, the control is no longer waived.",
+          "type": "string"
+        },
+        "justification": {
+          "description": "The reason for the waiver.",
+          "type": "string"
+        },
+        "waived_str": {
+          "description": "The waived state of the control item. Possible values: `yes`, `yes_run`, `no`, `no_expired`.",
+          "type": "string"
+        },
+        "waiver_summary": {
+          "description": "Intentionally blank.",
+          "$ref": "#/definitions/chef.automate.api.compliance.reporting.v1.ControlSummary"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.Id": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique ID (UUID) assigned to object.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of object.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.Job": {
+      "type": "object",
+      "properties": {
+        "deleted": {
+          "description": "Boolean used to denote the job has been marked as \"deleted\" by the user.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "end_time": {
+          "description": "End time of the scan job, assigned by the service.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "Unique ID (UUID) of the scan job.",
+          "type": "string"
+        },
+        "job_count": {
+          "description": "Count of scans executed by the job.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "description": "User-specified name of the scan job.",
+          "type": "string"
+        },
+        "node_count": {
+          "description": "Count of nodes to be scanned as part of the job, assigned by the service.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "node_selectors": {
+          "description": "Set of node manager IDs and filters to associate with the scan job.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter"
+          }
+        },
+        "nodes": {
+          "description": "List of node IDs to associate with the scan job.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "parent_id": {
+          "description": "ID of parent job to associate with the job, if any.",
+          "type": "string"
+        },
+        "profile_count": {
+          "description": "Count of profiles to be executed as part of the job.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "profiles": {
+          "description": "List of profiles to execute as part of the scan job.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recurrence": {
+          "description": "Recurrence schedule string for the job.",
+          "type": "string"
+        },
+        "results": {
+          "description": "Results of the scan job, including a report ID if one was generated.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.ResultsRow"
+          }
+        },
+        "retries": {
+          "description": "Number of times to retry the scan job. Default: 3.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "retries_left": {
+          "description": "Number of retries left, assigned by the service.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "scheduled_time": {
+          "description": "Next scheduled scan execution time.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "start_time": {
+          "description": "Start time of the scan job, assigned by the service.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "description": "Status of the scan job, assigned by the service.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags to assign to the scan job.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Kv"
+          }
+        },
+        "timeout": {
+          "description": "Desired timeout (in seconds) for the scan job execution. Default: 7200 for exec jobs, 600 for detect jobs.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "type": {
+          "description": "Determines the type of Chef InSpec run, `detect` or `exec`.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.Jobs": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "description": "List of jobs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Job"
+          }
+        },
+        "total": {
+          "description": "Total number of jobs in the system.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.ManagerFilter": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Use filters to limit the set of items returned.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Filter"
+          }
+        },
+        "manager_id": {
+          "description": "Unique ID of a node manager.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Use filters to limit the set of items returned.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Filter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType"
+        },
+        "page": {
+          "description": "The number of result pages to return.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "The number of results on each page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Sort the results on a specific field.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.Query.OrderType": {
+      "description": "Return the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.RerunResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.compliance.scanner.jobs.v1.ResultsRow": {
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "description": "End time of the scan.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "job_id": {
+          "description": "ID of the scan.",
+          "type": "string"
+        },
+        "node_id": {
+          "description": "ID of the scanned node.",
+          "type": "string"
+        },
+        "report_id": {
+          "description": "ID of the report generated by the scan.",
+          "type": "string"
+        },
+        "result": {
+          "description": "Result error message for failed scans.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Start time of the scan.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "description": "Status of the scan (completed, failed, aborted).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.GetComplianceStatusResponse": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobStatus"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.GetEventFeedStatusResponse": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobStatus"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.GetInfraStatusResponse": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobStatus"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.GetServicesStatusResponse": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobStatus"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.GetStatusResponse": {
+      "type": "object",
+      "properties": {
+        "compliance": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetComplianceStatusResponse"
+        },
+        "event_feed": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetEventFeedStatusResponse"
+        },
+        "infra": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetInfraStatusResponse"
+        },
+        "services": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.GetServicesStatusResponse"
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.JobSettings": {
+      "type": "object",
+      "title": "JobSettings are a job configuration setting update",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "purge_policies": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.PurgePolicyUpdate"
+        },
+        "recurrence": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.JobStatus": {
+      "description": "JobStatus presents the current configuration of job, when it will be executed,\nand details about it's most recent execution.",
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "last_elapsed": {
+          "type": "string"
+        },
+        "last_ended_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_enqueued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "type": "string"
+        },
+        "next_due_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "purge_policies": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.PurgePolicies"
+        },
+        "recurrence": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.PurgePolicies": {
+      "type": "object",
+      "title": "PurgePolicies are data lifecycle purge policies",
+      "properties": {
+        "elasticsearch": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.infra.data_lifecycle.api.EsPolicy"
+          }
+        },
+        "postgres": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.infra.data_lifecycle.api.PgPolicy"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.PurgePolicyUpdate": {
+      "type": "object",
+      "title": "PurgePolicyUpdate is purge policy configuration update",
+      "properties": {
+        "elasticsearch": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.infra.data_lifecycle.api.EsPolicyUpdate"
+          }
+        },
+        "postgres": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.infra.data_lifecycle.api.PgPolicyUpdate"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.RunComplianceRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunComplianceResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunEventFeedRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunEventFeedResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunInfraRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunInfraResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunServicesRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.RunServicesResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.SetComplianceConfigRequest": {
+      "type": "object",
+      "properties": {
+        "job_settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobSettings"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.SetComplianceConfigResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.SetConfigRequest": {
+      "type": "object",
+      "properties": {
+        "compliance": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetComplianceConfigRequest"
+        },
+        "event_feed": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetEventFeedConfigRequest"
+        },
+        "infra": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetInfraConfigRequest"
+        },
+        "services": {
+          "$ref": "#/definitions/chef.automate.api.data_lifecycle.SetServicesConfigRequest"
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.SetConfigResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.SetEventFeedConfigRequest": {
+      "type": "object",
+      "properties": {
+        "job_settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobSettings"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.SetEventFeedConfigResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.SetInfraConfigRequest": {
+      "type": "object",
+      "properties": {
+        "job_settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobSettings"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.SetInfraConfigResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.data_lifecycle.SetServicesConfigRequest": {
+      "type": "object",
+      "properties": {
+        "job_settings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.data_lifecycle.JobSettings"
+          }
+        }
+      }
+    },
+    "chef.automate.api.data_lifecycle.SetServicesConfigResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.datafeed.AddDestinationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.AddDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.DeleteDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.GetDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.ListDestinationRequest": {
+      "type": "object"
+    },
+    "chef.automate.api.datafeed.ListDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "destinations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.datafeed.GetDestinationResponse"
+          }
+        }
+      }
+    },
+    "chef.automate.api.datafeed.SecretId": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.TestDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.URLValidationRequest": {
+      "type": "object",
+      "properties": {
+        "secret_id": {
+          "$ref": "#/definitions/chef.automate.api.datafeed.SecretId"
+        },
+        "url": {
+          "type": "string"
+        },
+        "username_password": {
+          "$ref": "#/definitions/chef.automate.api.datafeed.UsernamePassword"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.UpdateDestinationRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.UpdateDestinationResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.datafeed.UsernamePassword": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.deployment.ServiceVersion": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        },
+        "release": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.deployment.ServiceVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.deployment.ServiceVersion"
+          }
+        }
+      }
+    },
+    "chef.automate.api.deployment.Version": {
+      "description": "The manifest version constructed with:\n* build_timestamp",
+      "type": "object",
+      "title": "Version message",
+      "properties": {
+        "build_timestamp": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.Event": {
+      "type": "object",
+      "properties": {
+        "end_id": {
+          "type": "string",
+          "title": "Used for grouping events together; equal to start_id if not grouped"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Used for grouping events together; equal to start_time if not grouped"
+        },
+        "entity_name": {
+          "type": "string"
+        },
+        "event_count": {
+          "description": "Used for grouping events together.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "event_type": {
+          "description": "Type of event (cookbook, role, etc).",
+          "type": "string"
+        },
+        "parent_name": {
+          "description": "Used for grouping events together.",
+          "type": "string"
+        },
+        "parent_type": {
+          "description": "Used for grouping events together.",
+          "type": "string"
+        },
+        "requestor_name": {
+          "description": "Event record requestor name.",
+          "type": "string"
+        },
+        "requestor_type": {
+          "description": "Event record requestor type.",
+          "type": "string"
+        },
+        "service_hostname": {
+          "description": "Hostname from which the record was gathered.",
+          "type": "string"
+        },
+        "start_id": {
+          "description": "Used for grouping events together.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Event start time.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "task": {
+          "description": "Type of event task (create, update, delete).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.EventCollection": {
+      "type": "object",
+      "properties": {
+        "events_count": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
+          }
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.EventCount": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Count of events.",
+          "type": "string",
+          "format": "int64"
+        },
+        "name": {
+          "description": "Event name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.EventCounts": {
+      "type": "object",
+      "properties": {
+        "counts": {
+          "description": "Total count of events per type.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCount"
+          }
+        },
+        "total": {
+          "description": "Total count of events.",
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.EventString": {
+      "type": "object",
+      "properties": {
+        "collection": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventCollection"
+          }
+        },
+        "event_action": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.EventStrings": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string"
+        },
+        "hours_between": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "start": {
+          "type": "string"
+        },
+        "strings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.EventString"
+          }
+        }
+      }
+    },
+    "chef.automate.api.event_feed.response.Events": {
+      "type": "object",
+      "properties": {
+        "events": {
+          "description": "List of events.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.event_feed.response.Event"
+          }
+        },
+        "total_events": {
+          "description": "Total count of events.",
+          "type": "string",
+          "format": "int64"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.AddPolicyMembersReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "members"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the policy.",
+          "type": "string"
+        },
+        "members": {
+          "description": "List of members to add to the policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "team:local:viewers",
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.AddPolicyMembersResp": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "team:local:viewers",
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.AddTeamMembersReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "membership_ids"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "membership_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "id": "admins",
+        "membership_ids": [
+          "527ed96f-2ecb-4f8f-abd7-0bf6511459ac",
+          "353a62d4-85fa-4423-b12a-f6608a562ae9"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.AddTeamMembersResp": {
+      "type": "object",
+      "properties": {
+        "membership_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "membership_ids": [
+          "527ed96f-2ecb-4f8f-abd7-0bf6511459ac",
+          "353a62d4-85fa-4423-b12a-f6608a562ae9"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ApplyRulesCancelResp": {
+      "type": "object"
+    },
+    "chef.automate.api.iam.v2.ApplyRulesStartResp": {
+      "type": "object"
+    },
+    "chef.automate.api.iam.v2.ApplyRulesStatusResp": {
+      "type": "object",
+      "properties": {
+        "cancelled": {
+          "description": "Whether or not the project update was canceled.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "estimated_time_complete": {
+          "description": "Estimated time when the project update will complete.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "failed": {
+          "description": "Whether or not the project update has failed.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "failure_message": {
+          "description": "The error message from the failure.",
+          "type": "string"
+        },
+        "percentage_complete": {
+          "description": "The percentage complete in decimal format from 0 to 1.",
+          "type": "number",
+          "format": "float"
+        },
+        "state": {
+          "description": "One of two states: `not_running` and `running`.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "cancelled": false,
+        "estimated_time_complete": "2020-03-20T19:24:55Z",
+        "failed": false,
+        "failure_message": "",
+        "percentage_complete": 0.5,
+        "state": "running"
+      }
+    },
+    "chef.automate.api.iam.v2.Condition": {
+      "type": "object",
+      "properties": {
+        "attribute": {
+          "description": "Represents a property of an ingested resource. Depends on the rule type.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.ConditionAttribute"
+        },
+        "operator": {
+          "description": "Whether the attribute matches a single value (`EQUALS`) or\nmatches at least one of a set of values (`MEMBER_OF`).",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.ConditionOperator"
+        },
+        "values": {
+          "description": "The value(s) of the attribute that an ingested resource must match.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.ConditionAttribute": {
+      "type": "string",
+      "default": "CONDITION_ATTRIBUTE_UNSET",
+      "enum": [
+        "CONDITION_ATTRIBUTE_UNSET",
+        "CHEF_SERVER",
+        "CHEF_ORGANIZATION",
+        "ENVIRONMENT",
+        "CHEF_ROLE",
+        "CHEF_TAG",
+        "CHEF_POLICY_GROUP",
+        "CHEF_POLICY_NAME"
+      ]
+    },
+    "chef.automate.api.iam.v2.ConditionOperator": {
+      "type": "string",
+      "default": "CONDITION_OPERATOR_UNSET",
+      "enum": [
+        "CONDITION_OPERATOR_UNSET",
+        "MEMBER_OF",
+        "EQUALS"
+      ]
+    },
+    "chef.automate.api.iam.v2.CreatePolicyReq": {
+      "description": "Does not contain type as the enduser can only create 'custom' policies.",
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "statements"
+      ],
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "members": {
+          "description": "Members affected by this policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Name for the policy.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this policy belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statements": {
+          "description": "Statements for the policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Statement"
+          }
+        }
+      },
+      "example": {
+        "id": "custom-viewer-policy",
+        "members": [
+          "team:ldap:*"
+        ],
+        "name": "My Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.CreatePolicyResp": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Policy"
+        }
+      },
+      "example": {
+        "id": "custom-viewer-policy",
+        "members": [
+          "team:ldap:*"
+        ],
+        "name": "My Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.CreateProjectReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the new project.",
+          "type": "string"
+        },
+        "skip_policies": {
+          "description": "Boolean flag to skip adding policies associated with the project. Set to false by default.",
+          "type": "boolean",
+          "format": "boolean"
+        }
+      },
+      "example": {
+        "id": "custom-project",
+        "name": "My Custom Project",
+        "skip_policies": true
+      }
+    },
+    "chef.automate.api.iam.v2.CreateProjectResp": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Project"
+        }
+      },
+      "example": {
+        "id": "custom-project",
+        "name": "My Custom Project"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateRoleReq": {
+      "description": "Does not contain type as the enduser can only create 'custom' roles.",
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "actions"
+      ],
+      "properties": {
+        "actions": {
+          "description": "List of actions that this role scopes to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the role.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this role belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "id": "custom-role",
+        "name": "My Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateRoleResp": {
+      "type": "object",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Role"
+        }
+      },
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "id": "custom-role",
+        "name": "My Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateRuleReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "project_id",
+        "name",
+        "type",
+        "conditions"
+      ],
+      "properties": {
+        "conditions": {
+          "description": "Conditions that ingested resources must match to belong to the project.\nWill contain one or more.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Condition"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the project rule.",
+          "type": "string"
+        },
+        "project_id": {
+          "description": "Unique ID of the project this rule belongs to. Cannot be changed.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Whether the rule affects nodes (`NODE`) or events (`EVENT`).",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType"
+        }
+      },
+      "example": {
+        "conditions": [
+          {
+            "attribute": "CHEF_SERVER",
+            "operator": "MEMBER_OF",
+            "values": [
+              "example.co",
+              "example.io"
+            ]
+          }
+        ],
+        "id": "example-rule",
+        "name": "My Example Rule",
+        "project-id": "example-project",
+        "type": "NODE"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateRuleResp": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Rule"
+        }
+      },
+      "example": {
+        "conditions": [
+          {
+            "attribute": "CHEF_SERVER",
+            "operator": "MEMBER_OF",
+            "values": [
+              "example.co",
+              "example.io"
+            ]
+          }
+        ],
+        "id": "example-rule",
+        "name": "My Example Rule",
+        "project-id": "example-project",
+        "status": "STAGED",
+        "type": "NODE"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateTeamReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "id": "my-team-id",
+        "name": "My Test Team",
+        "projects": [
+          "project1",
+          "project2"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.CreateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+        }
+      },
+      "example": {
+        "team": {
+          "id": "test-id",
+          "name": "My Test Team",
+          "projects": [
+            "project1",
+            "project2"
+          ]
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.CreateTokenReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "active": {
+          "description": "Active state. Defaults to true.\nIf set to false, token will not be authenticated or authorized.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the token.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this token belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "value": {
+          "description": "Unique value for the token; if omitted the system will generate this.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "active": true,
+        "id": "token-1",
+        "name": "token 1",
+        "projects": [
+          "east-region",
+          "west-region"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.CreateTokenResp": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Token"
+        }
+      },
+      "example": {
+        "active": true,
+        "id": "token-1",
+        "name": "token 1",
+        "projects": [
+          "east-region",
+          "west-region"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.CreateUserReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "password"
+      ],
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed. Used to sign in.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Display name for local user.",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password for user. Used to sign in.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "id": "username001rulez",
+        "name": "Display Name",
+        "password": "aSafePassword"
+      }
+    },
+    "chef.automate.api.iam.v2.CreateUserResp": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.User"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.DeletePolicyResp": {
+      "type": "object",
+      "example": {
+        "id": "custom-viewer-policy",
+        "members": [
+          "team:ldap:*"
+        ],
+        "name": "My Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.DeleteProjectResp": {
+      "type": "object",
+      "example": {
+        "id": "custom-project",
+        "name": "My Custom Project"
+      }
+    },
+    "chef.automate.api.iam.v2.DeleteRoleResp": {
+      "type": "object",
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "id": "custom-role",
+        "name": "My Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.DeleteRuleResp": {
+      "type": "object"
+    },
+    "chef.automate.api.iam.v2.DeleteTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+        }
+      },
+      "example": {
+        "team": {
+          "id": "test-id",
+          "name": "My Test Team",
+          "projects": [
+            "project1",
+            "project2"
+          ]
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.DeleteTokenResp": {
+      "type": "object"
+    },
+    "chef.automate.api.iam.v2.DeleteUserResp": {
+      "type": "object"
+    },
+    "chef.automate.api.iam.v2.GetPolicyResp": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Policy"
+        }
+      },
+      "example": {
+        "id": "custom-viewer-policy",
+        "members": [
+          "team:ldap:*"
+        ],
+        "name": "My Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.GetPolicyVersionResp": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Version"
+        }
+      },
+      "example": {
+        "version": {
+          "major": "V2",
+          "minor": "V1"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.GetProjectResp": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Project"
+        }
+      },
+      "example": {
+        "id": "custom-project",
+        "name": "My Custom Project"
+      }
+    },
+    "chef.automate.api.iam.v2.GetRoleResp": {
+      "type": "object",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Role"
+        }
+      },
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "id": "custom-role",
+        "name": "My Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.GetRuleResp": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Rule"
+        }
+      },
+      "example": {
+        "conditions": [
+          {
+            "attribute": "CHEF_SERVER",
+            "operator": "EQUALS",
+            "values": [
+              "example.co"
+            ]
+          }
+        ],
+        "id": "example-rule",
+        "name": "My Applied Rule",
+        "project-id": "example-project",
+        "status": "APPLIED",
+        "type": "NODE"
+      }
+    },
+    "chef.automate.api.iam.v2.GetTeamMembershipResp": {
+      "type": "object",
+      "properties": {
+        "membership_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "membership_ids": [
+          "527ed96f-2ecb-4f8f-abd7-0bf6511459ac",
+          "353a62d4-85fa-4423-b12a-f6608a562ae9"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.GetTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+        }
+      },
+      "example": {
+        "team": {
+          "id": "test-id",
+          "name": "My Test Team",
+          "projects": [
+            "project1",
+            "project2"
+          ]
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.GetTeamsForMemberResp": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+          }
+        }
+      },
+      "example": {
+        "teams": [
+          {
+            "id": "test-1",
+            "name": "My Test Team",
+            "projects": [
+              "project1",
+              "project2"
+            ]
+          },
+          {
+            "id": "test-2",
+            "name": "My Test Team 2",
+            "projects": [
+              "project1"
+            ]
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.GetTokenResp": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Token"
+        }
+      },
+      "example": {
+        "active": true,
+        "id": "token-1",
+        "name": "token 1",
+        "projects": [
+          "east-region",
+          "west-region"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.GetUserResp": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.User"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.IntrospectReq": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.IntrospectResp": {
+      "type": "object",
+      "properties": {
+        "endpoints": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.MethodsAllowed"
+          }
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.IntrospectSomeReq": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.ListPoliciesResp": {
+      "type": "object",
+      "properties": {
+        "policies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Policy"
+          }
+        }
+      },
+      "example": {
+        "policies": [
+          {
+            "id": "custom-viewer-policy-1",
+            "members": [
+              "team:ldap:*"
+            ],
+            "name": "My Viewer Policy 1",
+            "projects": [],
+            "statements": [
+              {
+                "effect": "ALLOW",
+                "projects": [
+                  "project1",
+                  "project2"
+                ],
+                "role": "viewer"
+              },
+              {
+                "effect": "ALLOW",
+                "projects": [
+                  "acceptanceProject"
+                ],
+                "role": "qa"
+              }
+            ]
+          },
+          {
+            "id": "custom-policy-2",
+            "members": [
+              "team:local:test"
+            ],
+            "name": "My Custom Policy 2",
+            "projects": [],
+            "statements": [
+              {
+                "effect": "ALLOW",
+                "projects": [
+                  "project1"
+                ],
+                "role": "auditor"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListPolicyMembersResp": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "description": "List of policy members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "team:local:viewers",
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListProjectsResp": {
+      "type": "object",
+      "properties": {
+        "projects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Project"
+          }
+        }
+      },
+      "example": {
+        "projects": [
+          {
+            "id": "custom-project",
+            "name": "My Custom Project"
+          },
+          {
+            "id": "custom-project-2",
+            "name": "My Custom Project 2"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListRolesResp": {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Role"
+          }
+        }
+      },
+      "example": {
+        "roles": [
+          {
+            "actions": [
+              "secrets:*",
+              "iam:projects:list"
+            ],
+            "id": "custom-role",
+            "name": "My Custom Secret Manager Role"
+          },
+          {
+            "actions": [
+              "infra:*"
+            ],
+            "id": "custom-role-2",
+            "name": "My Custom Secret Role 2"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListRulesForProjectResp": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Rule"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.ProjectRulesStatus"
+        }
+      },
+      "example": {
+        "rules": [
+          {
+            "conditions": [
+              {
+                "attribute": "CHEF_SERVER",
+                "operator": "EQUALS",
+                "values": [
+                  "example.co"
+                ]
+              }
+            ],
+            "id": "example-rule",
+            "name": "My Applied Rule",
+            "project-id": "example-project",
+            "status": "APPLIED",
+            "type": "NODE"
+          },
+          {
+            "conditions": [
+              {
+                "attribute": "CHEF_ORGANIZATION",
+                "operator": "MEMBER_OF",
+                "values": [
+                  "east",
+                  "west"
+                ]
+              }
+            ],
+            "id": "example-rule-2",
+            "name": "My 2nd Example Rule",
+            "project-id": "example-project",
+            "status": "APPLIED",
+            "type": "EVENT"
+          }
+        ],
+        "status": "APPLIED"
+      }
+    },
+    "chef.automate.api.iam.v2.ListTeamsResp": {
+      "type": "object",
+      "properties": {
+        "teams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+          }
+        }
+      },
+      "example": {
+        "teams": [
+          {
+            "id": "test-1",
+            "name": "My Test Team",
+            "projects": [
+              "project1",
+              "project2"
+            ]
+          },
+          {
+            "id": "test-2",
+            "name": "My Test Team 2",
+            "projects": [
+              "project1"
+            ]
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListTokensResp": {
+      "type": "object",
+      "properties": {
+        "tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Token"
+          }
+        }
+      },
+      "example": {
+        "tokens": [
+          {
+            "active": true,
+            "id": "token-1",
+            "name": "token 1",
+            "projects": [
+              "east-region",
+              "west-region"
+            ]
+          },
+          {
+            "active": false,
+            "id": "token-2",
+            "name": "token 2",
+            "projects": [
+              "north-region",
+              "south-region"
+            ]
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ListUsersResp": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.User"
+          }
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.MethodsAllowed": {
+      "type": "object",
+      "properties": {
+        "delete": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "get": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "patch": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "post": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "put": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Policy": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "members": {
+          "description": "Members affected by this policy. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Name for the policy.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this policy belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statements": {
+          "description": "Statements for the policy. Will contain one or more.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Statement"
+          }
+        },
+        "type": {
+          "description": "This doc-comment is ignored for an enum.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Type"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the project.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The current status of the rules for this project.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.ProjectRulesStatus"
+        },
+        "type": {
+          "description": "Whether this policy is user created (`CUSTOM`) or chef managed (`CHEF_MANAGED`).",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Type"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.ProjectRulesStatus": {
+      "type": "string",
+      "default": "PROJECT_RULES_STATUS_UNSET",
+      "enum": [
+        "PROJECT_RULES_STATUS_UNSET",
+        "RULES_APPLIED",
+        "EDITS_PENDING",
+        "NO_RULES"
+      ]
+    },
+    "chef.automate.api.iam.v2.RemovePolicyMembersReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "members"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the policy.",
+          "type": "string"
+        },
+        "members": {
+          "description": "List of members to remove from the policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.RemovePolicyMembersResp": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "description": "Resulting list of policy members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.RemoveTeamMembersReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "membership_ids"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "membership_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "id": "admins",
+        "membership_ids": [
+          "527ed96f-2ecb-4f8f-abd7-0bf6511459ac",
+          "353a62d4-85fa-4423-b12a-f6608a562ae9"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.RemoveTeamMembersResp": {
+      "type": "object",
+      "properties": {
+        "membership_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "membership_ids": [
+          "527ed96f-2ecb-4f8f-abd7-0bf6511459ac",
+          "353a62d4-85fa-4423-b12a-f6608a562ae9"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ReplacePolicyMembersReq": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the policy.",
+          "type": "string"
+        },
+        "members": {
+          "description": "List of members that replaces previous policy member list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "team:local:viewers",
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.ReplacePolicyMembersResp": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "description": "Resulting list of policy members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "team:local:viewers",
+          "user:local:test"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.Role": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "description": "List of actions this role scopes to. Will contain one or more.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the role.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this role belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "description": "Whether this policy is user created (`CUSTOM`) or chef managed (`CHEF_MANAGED`).",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Type"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Rule": {
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Conditions that ingested resources must match to belong to the project.\nWill contain one or more.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Condition"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the project rule.",
+          "type": "string"
+        },
+        "project_id": {
+          "description": "Unique ID of the project this rule belongs to. Cannot be changed.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Whether the rule is `STAGED` (not in effect) or `APPLIED` (in effect).",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.RuleStatus"
+        },
+        "type": {
+          "description": "Whether the rule applies to ingested `NODE` or `EVENT resources.\nCannot be changed.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.RuleStatus": {
+      "type": "string",
+      "default": "RULE_STATUS_UNSET",
+      "enum": [
+        "RULE_STATUS_UNSET",
+        "STAGED",
+        "APPLIED"
+      ]
+    },
+    "chef.automate.api.iam.v2.RuleType": {
+      "type": "string",
+      "default": "RULE_TYPE_UNSET",
+      "enum": [
+        "RULE_TYPE_UNSET",
+        "NODE",
+        "EVENT"
+      ]
+    },
+    "chef.automate.api.iam.v2.Statement": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "description": "Actions defined inline. May be empty.\nBest practices recommend that you use custom roles rather than inline actions where practical.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "effect": {
+          "description": "This doc-comment is ignored for an enum.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Statement.Effect"
+        },
+        "projects": {
+          "description": "The project list defines the set of resources that the statement is scoped to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "description": "DEPRECATED: Resources defined inline. Use projects instead.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "role": {
+          "description": "The role defines a set of actions that the statement is scoped to.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Statement.Effect": {
+      "type": "string",
+      "default": "ALLOW",
+      "enum": [
+        "ALLOW",
+        "DENY"
+      ]
+    },
+    "chef.automate.api.iam.v2.Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Token": {
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Active state. Defaults to true.\nIf set to false, token will not authenticate.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "created_at": {
+          "description": "Created timestamp.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the token.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this token belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "updated_at": {
+          "description": "Updated timestamp.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Unique, optionally user-specified value.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Type": {
+      "type": "string",
+      "default": "CHEF_MANAGED",
+      "enum": [
+        "CHEF_MANAGED",
+        "CUSTOM"
+      ]
+    },
+    "chef.automate.api.iam.v2.UpdatePolicyReq": {
+      "description": "Does not contain type as the enduser can only create 'custom' policies.",
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "statements"
+      ],
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "members": {
+          "description": "Members affected by this policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Name for this policy.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this policy belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "statements": {
+          "description": "Statements for the policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Statement"
+          }
+        }
+      },
+      "example": {
+        "members": [
+          "user:ldap:newuser",
+          "team:ldap:newteam"
+        ],
+        "name": "My Updated Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.UpdatePolicyResp": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Policy"
+        }
+      },
+      "example": {
+        "members": [
+          "user:ldap:newuser",
+          "team:ldap:newteam"
+        ],
+        "name": "My Updated Viewer Policy",
+        "projects": [],
+        "statements": [
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "project1",
+              "project2"
+            ],
+            "role": "viewer"
+          },
+          {
+            "effect": "ALLOW",
+            "projects": [
+              "acceptanceProject"
+            ],
+            "role": "qa"
+          }
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateProjectReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the project.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "name": "My Custom Project"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateProjectResp": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Project"
+        }
+      },
+      "example": {
+        "id": "custom-project",
+        "name": "My Custom Project"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateRoleReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "actions"
+      ],
+      "properties": {
+        "actions": {
+          "description": "List of actions that this role scopes to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the role.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this role belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "name": "My Updated Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateRoleResp": {
+      "type": "object",
+      "properties": {
+        "role": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Role"
+        }
+      },
+      "example": {
+        "actions": [
+          "secrets:*",
+          "iam:projects:list"
+        ],
+        "id": "custom-role",
+        "name": "My Custom Secret Manager Role"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateRuleReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "project_id",
+        "name",
+        "type",
+        "conditions"
+      ],
+      "properties": {
+        "conditions": {
+          "description": "Conditions that ingested resources must match to belong to the project.\nWill contain one or more.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.iam.v2.Condition"
+          }
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the project rule.",
+          "type": "string"
+        },
+        "project_id": {
+          "description": "Unique ID of the project this rule belongs to. Cannot be changed.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Whether the rule applies to ingested `NODE` or `EVENT` resources.\nCannot be changed.",
+          "$ref": "#/definitions/chef.automate.api.iam.v2.RuleType"
+        }
+      },
+      "example": {
+        "conditions": [
+          {
+            "attribute": "CHEF_SERVER",
+            "operator": "EQUALS",
+            "values": [
+              "example.co"
+            ]
+          }
+        ],
+        "id": "example-rule",
+        "name": "My Updated Rule",
+        "project-id": "example-project",
+        "type": "NODE"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateRuleResp": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Rule"
+        }
+      },
+      "example": {
+        "conditions": [
+          {
+            "attribute": "CHEF_SERVER",
+            "operator": "EQUALS",
+            "values": [
+              "example.co"
+            ]
+          }
+        ],
+        "id": "example-rule",
+        "name": "My Updated Rule",
+        "project-id": "example-project",
+        "status": "STAGED",
+        "type": "NODE"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateSelfReq": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the user. Cannot be changed. Used to sign in.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Display name for local user.",
+          "type": "string"
+        },
+        "password": {
+          "description": "New password for user. Used to sign in.\nOptional, but if included, previous_password is also required.",
+          "type": "string"
+        },
+        "previous_password": {
+          "description": "Previous password for user.\nOptional, but if included, password is also required.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "name": "My New Name",
+        "password": "aNewSafePassword",
+        "previous_password": "aPreviousSafePassword"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateSelfResp": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.User"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateTeamReq": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "id": "my-team-id",
+        "name": "My Test Team",
+        "projects": [
+          "project1",
+          "project2"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateTeamResp": {
+      "type": "object",
+      "properties": {
+        "team": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Team"
+        }
+      },
+      "example": {
+        "team": {
+          "id": "test-id",
+          "name": "My Test Team",
+          "projects": [
+            "project1",
+            "project2"
+          ]
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateTokenReq": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "active": {
+          "description": "Active state. Defaults to true.\nIf set to false, token will not be authenticated or authorized.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "id": {
+          "description": "Unique ID. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name for the token.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this token belongs to.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "example": {
+        "active": true,
+        "name": "updated token name",
+        "projects": [
+          "east-region",
+          "south-region"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateTokenResp": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Token"
+        }
+      },
+      "example": {
+        "active": true,
+        "id": "token-1",
+        "name": "token 1",
+        "projects": [
+          "east-region",
+          "west-region"
+        ]
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateUserReq": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "description": "ID of the user. Cannot be changed. Used to sign in.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Display name for local user.",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password used to log in. Will overwrite preexisting password.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "name": "New Name",
+        "password": "aSafePassword"
+      }
+    },
+    "chef.automate.api.iam.v2.UpdateUserResp": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.User"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique ID. Cannot be changed. Used to log in.",
+          "type": "string"
+        },
+        "membership_id": {
+          "description": "Unique ID used to add local users to local teams. Cannot be changed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Display name for local user.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Version": {
+      "type": "object",
+      "title": "the only values that may be returned by GetPolicyVersion",
+      "properties": {
+        "major": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Version.VersionNumber"
+        },
+        "minor": {
+          "$ref": "#/definitions/chef.automate.api.iam.v2.Version.VersionNumber"
+        }
+      }
+    },
+    "chef.automate.api.iam.v2.Version.VersionNumber": {
+      "type": "string",
+      "default": "V0",
+      "enum": [
+        "V0",
+        "V1",
+        "V2"
+      ]
+    },
+    "chef.automate.api.infra_proxy.request.CreateDataBag": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.CreateDataBagItem": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Data bag item JSON data.",
+          "type": "object"
+        },
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.CreateEnvironment": {
+      "type": "object",
+      "properties": {
+        "cookbook_versions": {
+          "description": "Environment versioned cookbooks constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "default_attributes": {
+          "description": "Environment default attributes JSON.",
+          "type": "object"
+        },
+        "description": {
+          "description": "Environment description.",
+          "type": "string"
+        },
+        "json_class": {
+          "description": "Class name.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Environment name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Environment override attributes JSON.",
+          "type": "object"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.CreateOrg": {
+      "type": "object",
+      "properties": {
+        "admin_key": {
+          "description": "Chef organization admin key.",
+          "type": "string"
+        },
+        "admin_user": {
+          "description": "Chef organization admin user.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef organization name.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this chef organization belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.CreateRole": {
+      "type": "object",
+      "properties": {
+        "default_attributes": {
+          "description": "Role default attributes JSON.",
+          "type": "object"
+        },
+        "description": {
+          "description": "Role description.",
+          "type": "string"
+        },
+        "env_run_lists": {
+          "description": "Environment based run list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.request.EnvRunList"
+          }
+        },
+        "name": {
+          "description": "Role name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Role override attributes JSON.",
+          "type": "object"
+        },
+        "run_list": {
+          "description": "Role run list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.CreateServer": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "description": "Chef Infra Server FQDN.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        },
+        "ip_address": {
+          "description": "Chef Infra Server IP address.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef Infra Server name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.EnvRunList": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Environment name.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "Role run list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.ResetOrgAdminKey": {
+      "type": "object",
+      "properties": {
+        "admin_key": {
+          "description": "Chef organization admin key.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.UpdateDataBagItem": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Data bag item JSON data.",
+          "type": "object"
+        },
+        "item_id": {
+          "description": "Data bag item ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.UpdateEnvironment": {
+      "type": "object",
+      "properties": {
+        "cookbook_versions": {
+          "description": "Environment versioned cookbooks constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "default_attributes": {
+          "description": "Environment default attributes JSON.",
+          "type": "object"
+        },
+        "description": {
+          "description": "Environment description.",
+          "type": "string"
+        },
+        "json_class": {
+          "description": "Class name.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Environment name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Environment override attributes JSON.",
+          "type": "object"
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.UpdateOrg": {
+      "type": "object",
+      "properties": {
+        "admin_user": {
+          "description": "Chef organization admin user.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef organization name.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this chef organization belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.UpdateRole": {
+      "type": "object",
+      "properties": {
+        "default_attributes": {
+          "description": "Role default attributes JSON.",
+          "type": "object"
+        },
+        "description": {
+          "description": "Role description.",
+          "type": "string"
+        },
+        "env_run_lists": {
+          "description": "Environment based run list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.request.EnvRunList"
+          }
+        },
+        "name": {
+          "description": "Role name.",
+          "type": "string"
+        },
+        "org_id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Role override attributes JSON.",
+          "type": "object"
+        },
+        "run_list": {
+          "description": "Role run list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.request.UpdateServer": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "description": "Chef Infra Server FQDN.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        },
+        "ip_address": {
+          "description": "Chef Infra Server IP address.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef Infra Server name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.AffectedNodes": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "description": "List of the nodes which are affected by the chef object.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.NodeAttribute"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Client": {
+      "type": "object",
+      "properties": {
+        "chef_type": {
+          "description": "Chef object type.",
+          "type": "string"
+        },
+        "client_name": {
+          "description": "Client name return by Chef Infra Server API.",
+          "type": "string"
+        },
+        "json_class": {
+          "description": "Client JSON class.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Client name.",
+          "type": "string"
+        },
+        "org_name": {
+          "description": "Chef organization name.",
+          "type": "string"
+        },
+        "validator": {
+          "description": "Boolean indicates client type is validator or not.",
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.ClientListItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Client name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Clients": {
+      "type": "object",
+      "properties": {
+        "clients": {
+          "description": "Client list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.ClientListItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Cookbook": {
+      "type": "object",
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookAccess"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "chef_type": {
+          "type": "string"
+        },
+        "cookbook_name": {
+          "type": "string"
+        },
+        "definitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "frozen": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "json_class": {
+          "type": "string"
+        },
+        "libraries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookMeta"
+        },
+        "name": {
+          "type": "string"
+        },
+        "providers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "recipes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "root_files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "templates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookItem"
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookAccess": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "delete": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "grant": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "read": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "update": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookFileContent": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "Cookbook data file content.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookItem": {
+      "type": "object",
+      "properties": {
+        "checksum": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "specificity": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookLock": {
+      "type": "object",
+      "properties": {
+        "SCMDetail": {
+          "description": "SCM detail.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.SCMDetail"
+        },
+        "cache_key": {
+          "description": "Cookbook cache key.",
+          "type": "string"
+        },
+        "dotted_identifier": {
+          "description": "Cookbook decimal number identifier.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Cookbook identifier.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Cookbook name.",
+          "type": "string"
+        },
+        "source": {
+          "description": "Cookbook source.",
+          "type": "string"
+        },
+        "source_options": {
+          "description": "Cookbook source path.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.SourceOptions"
+        },
+        "version": {
+          "description": "Cookbook version.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookMeta": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "license": {
+          "type": "string"
+        },
+        "long_description": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "maintainer_email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookVersion": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the cookbook.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the cookbook.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CookbookVersions": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the cookbook.",
+          "type": "string"
+        },
+        "versions": {
+          "description": "List of all versions available for cookbook.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Cookbooks": {
+      "type": "object",
+      "properties": {
+        "cookbooks": {
+          "description": "List of cookbooks with name and version.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookVersion"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CreateDataBag": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CreateDataBagItem": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Data bag item ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CreateOrg": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "description": "Chef organization.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.CreateServer": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "description": "Chef Infra Server.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Server"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DataBag": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Stringified json of data bag item.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Data bag item ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DataBagListItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Data bag item name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DataBags": {
+      "type": "object",
+      "properties": {
+        "data_bags": {
+          "description": "Data bags item list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.DataBagListItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DeleteNode": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Node name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DeleteOrg": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "description": "Chef organization.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.DeleteServer": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "description": "Chef Infra Server.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Server"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Environment": {
+      "type": "object",
+      "properties": {
+        "chef_type": {
+          "description": "Chef object type.",
+          "type": "string"
+        },
+        "cookbook_versions": {
+          "description": "Environment versined cookbooks constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "default_attributes": {
+          "description": "Stringified json of the default attributes.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Environment description.",
+          "type": "string"
+        },
+        "json_class": {
+          "description": "Environment JSON class.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Environment name.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Stringified json of the override attributes.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.EnvironmentListItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Environment name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Environments": {
+      "type": "object",
+      "properties": {
+        "environments": {
+          "description": "Environments list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.EnvironmentListItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.ExpandedRunList": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "ID of the run list collection.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "List of the run list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.RunList"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.GetOrg": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "description": "Chef organization.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.GetOrgs": {
+      "type": "object",
+      "properties": {
+        "orgs": {
+          "description": "Chef organization list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.GetServer": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "description": "Chef Infra Server.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Server"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.GetServers": {
+      "type": "object",
+      "properties": {
+        "servers": {
+          "description": "List of Chef Infra Servers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Server"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.IncludedPolicyLock": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Included Policyfile name.",
+          "type": "string"
+        },
+        "revision_id": {
+          "description": "Policyfile revision ID.",
+          "type": "string"
+        },
+        "source_options": {
+          "description": "Included policyfile source options.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.SourceOptions"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.NamedRunList": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Run list name.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "Run list associated with the policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.NodeAttribute": {
+      "type": "object",
+      "properties": {
+        "check_in": {
+          "description": "Node last checkin.",
+          "type": "string"
+        },
+        "environment": {
+          "description": "Node environment name.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Node ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Node name.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Node platform.",
+          "type": "string"
+        },
+        "policy_group": {
+          "description": "Node policy group.",
+          "type": "string"
+        },
+        "uptime": {
+          "description": "Node uptime.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Org": {
+      "type": "object",
+      "properties": {
+        "admin_user": {
+          "description": "Chef organization admin user.",
+          "type": "string"
+        },
+        "credential_id": {
+          "description": "Chef organization credential ID.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef organization ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef organization name.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects this chef organization belongs to. May be empty.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "server_id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Policyfile": {
+      "type": "object",
+      "properties": {
+        "cookbook_locks": {
+          "description": "List of cookbook locks under this policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.CookbookLock"
+          }
+        },
+        "default_attributes": {
+          "description": "Stringified JSON of the default attributes.",
+          "type": "string"
+        },
+        "expanded_run_list": {
+          "description": "Expanded run-list associated with the policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.ExpandedRunList"
+          }
+        },
+        "included_policy_locks": {
+          "description": "Included policy locks files.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.IncludedPolicyLock"
+          }
+        },
+        "name": {
+          "description": "Policyfile name.",
+          "type": "string"
+        },
+        "named_run_list": {
+          "description": "Named run-list associated with the policy.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.NamedRunList"
+          }
+        },
+        "override_attributes": {
+          "description": "Stringified JSON of the override attributes.",
+          "type": "string"
+        },
+        "policy_group": {
+          "description": "Policy group name.",
+          "type": "string"
+        },
+        "revision_id": {
+          "description": "Policy revision ID.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "Run-list associated with the policy.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.PolicyfileListItem": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Policyfile name.",
+          "type": "string"
+        },
+        "policy_group": {
+          "description": "Policyfile policy group.",
+          "type": "string"
+        },
+        "revision_id": {
+          "description": "Policyfile Revision ID.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Policyfiles": {
+      "type": "object",
+      "properties": {
+        "policies": {
+          "description": "Policyfiles list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.PolicyfileListItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.ResetOrgAdminKey": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "description": "Chef organization.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Role": {
+      "type": "object",
+      "properties": {
+        "chef_type": {
+          "description": "Type of the chef object.",
+          "type": "string"
+        },
+        "default_attributes": {
+          "description": "Stringified json of the default attributes.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Descrption of the role.",
+          "type": "string"
+        },
+        "expanded_run_list": {
+          "description": "List of expanded run list for the role.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.ExpandedRunList"
+          }
+        },
+        "json_class": {
+          "description": "Json class name.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the role.",
+          "type": "string"
+        },
+        "override_attributes": {
+          "description": "Stringified json of the override attributes.",
+          "type": "string"
+        },
+        "run_list": {
+          "description": "Run list for the role.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.RoleListItem": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Desscription of the role.",
+          "type": "string"
+        },
+        "environments": {
+          "description": "Environment for the role.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "Name of the role.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Roles": {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "description": "List of the roles item.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.RoleListItem"
+          }
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.RunList": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "description": "List of the run list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.RunList"
+          }
+        },
+        "name": {
+          "description": "Name of run list item.",
+          "type": "string"
+        },
+        "skipped": {
+          "description": "Boolean denoting whether or not the run list item was skipped.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "type": {
+          "description": "Type of run list item (e.g. 'recipe').",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of run list item.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.SCMDetail": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "SCM name.",
+          "type": "string"
+        },
+        "published": {
+          "description": "Source's published information.",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "remote": {
+          "description": "SCM remote location.",
+          "type": "string"
+        },
+        "revision": {
+          "description": "SCM revision detail.",
+          "type": "string"
+        },
+        "synchronized_remote_branches": {
+          "description": "Synchronized remote branches list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "working_tree_clean": {
+          "description": "Boolean that denotes if the working tree is clean or not.",
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Server": {
+      "type": "object",
+      "properties": {
+        "fqdn": {
+          "description": "Chef Infra Server FQDN.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Chef Infra Server ID.",
+          "type": "string"
+        },
+        "ip_address": {
+          "description": "Chef Infra Server IP address.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Chef Infra Server name.",
+          "type": "string"
+        },
+        "orgs_count": {
+          "description": "Chef organizations count associated with Chef Infra Server.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.SourceOptions": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Source options path.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.UpdateDataBagItem": {
+      "type": "object",
+      "properties": {
+        "item_id": {
+          "description": "Data bag item ID.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Data bag name.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.UpdateOrg": {
+      "type": "object",
+      "properties": {
+        "org": {
+          "description": "Chef organization.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Org"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.UpdateServer": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "description": "Chef Infra Server.",
+          "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Server"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Action": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "This new field called 'content' is being used to send the entire raw JSON\nmessage in bytes, this field is heavily used by the gateway for the DataCollector\nFunc Handler that will send the Action message to the (receiver) ingest-service\nthat will manually unmarshal the message from this field if it is provided.\nThe main purpose of this field it to improve the performance of ingestion when\nthe requests comes in REST/HTTP format.",
+          "type": "string",
+          "format": "byte"
+        },
+        "entity_name": {
+          "type": "string"
+        },
+        "entity_type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "title": "ID of the action message itself"
+        },
+        "message_type": {
+          "type": "string"
+        },
+        "message_version": {
+          "type": "string"
+        },
+        "node_id": {
+          "type": "string"
+        },
+        "organization_name": {
+          "type": "string"
+        },
+        "parent_name": {
+          "type": "string"
+        },
+        "parent_type": {
+          "type": "string"
+        },
+        "recorded_at": {
+          "type": "string"
+        },
+        "remote_hostname": {
+          "type": "string"
+        },
+        "remote_request_id": {
+          "type": "string"
+        },
+        "request_id": {
+          "type": "string"
+        },
+        "requestor_name": {
+          "type": "string"
+        },
+        "requestor_type": {
+          "type": "string"
+        },
+        "revision_id": {
+          "type": "string"
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "service_hostname": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "user_agent": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Delete": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "ID of the action message itself"
+        },
+        "node_id": {
+          "type": "string"
+        },
+        "node_name": {
+          "type": "string"
+        },
+        "organization_name": {
+          "type": "string"
+        },
+        "remote_hostname": {
+          "type": "string"
+        },
+        "service_hostname": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Deprecation": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Description": {
+      "type": "object",
+      "properties": {
+        "sections": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "title": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Error": {
+      "type": "object",
+      "properties": {
+        "backtrace": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "class": {
+          "type": "string"
+        },
+        "description": {
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Description"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.ExpandedRunList": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "run_list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
+          }
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Liveness": {
+      "type": "object",
+      "properties": {
+        "chef_server_fqdn": {
+          "type": "string"
+        },
+        "entity_uuid": {
+          "type": "string"
+        },
+        "event_type": {
+          "type": "string"
+        },
+        "message_version": {
+          "type": "string"
+        },
+        "node_name": {
+          "type": "string"
+        },
+        "organization_name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.MultipleNodeDeleteRequest": {
+      "type": "object",
+      "properties": {
+        "node_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Resource": {
+      "type": "object",
+      "properties": {
+        "after": {
+          "type": "object"
+        },
+        "before": {
+          "type": "object"
+        },
+        "conditional": {
+          "type": "string"
+        },
+        "cookbook_name": {
+          "type": "string"
+        },
+        "cookbook_version": {
+          "type": "string"
+        },
+        "delta": {
+          "type": "string"
+        },
+        "duration": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "ignore_failure": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "recipe_name": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.Run": {
+      "type": "object",
+      "properties": {
+        "chef_server_fqdn": {
+          "type": "string"
+        },
+        "content": {
+          "description": "This new field called 'content' is being used to send the entire raw JSON\nmessage in bytes, this field is heavily used by the gateway for the DataCollector\nFunc Handler that will send the Run message to the (receiver) ingest-service\nthat will manually unmarshal the message from this field if it is provided.\nThe main purpose of this field it to improve the performance of ingestion when\nthe requests comes in REST/HTTP format.",
+          "type": "string",
+          "format": "byte"
+        },
+        "deprecations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Deprecation"
+          }
+        },
+        "end_time": {
+          "type": "string"
+        },
+        "entity_uuid": {
+          "type": "string"
+        },
+        "error": {
+          "$ref": "#/definitions/chef.automate.api.ingest.request.Error"
+        },
+        "expanded_run_list": {
+          "$ref": "#/definitions/chef.automate.api.ingest.request.ExpandedRunList"
+        },
+        "id": {
+          "description": "1 through 15 are for frequently occuring fields\nReserving for shared fields between run_start and run_converge mesages.",
+          "type": "string"
+        },
+        "message_type": {
+          "type": "string"
+        },
+        "message_version": {
+          "type": "string"
+        },
+        "node": {
+          "type": "object"
+        },
+        "node_name": {
+          "type": "string"
+        },
+        "organization_name": {
+          "type": "string"
+        },
+        "policy_group": {
+          "type": "string"
+        },
+        "policy_name": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.ingest.request.Resource"
+          }
+        },
+        "run_id": {
+          "type": "string"
+        },
+        "run_list": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "total_resource_count": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "updated_resource_count": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.RunList": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.ingest.request.RunList"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "skipped": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.request.SchedulerConfig": {
+      "description": "SchedulerConfig\nThe job message to configure the Delete Node Job\nevery - It accepts '1h30m', '1m', '2h30m', ...",
+      "type": "object",
+      "properties": {
+        "every": {
+          "type": "string"
+        },
+        "running": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "threshold": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.response.ConfigureDeleteNodesScheduler": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ConfigureMissingNodesForDeletionScheduler": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ConfigureNodesMissingScheduler": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.Job": {
+      "type": "object",
+      "properties": {
+        "every": {
+          "type": "string"
+        },
+        "last_elapsed": {
+          "type": "string"
+        },
+        "last_run": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "next_run": {
+          "type": "string"
+        },
+        "running": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "started_on": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.ingest.response.JobSchedulerStatus": {
+      "type": "object",
+      "properties": {
+        "jobs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.ingest.response.Job"
+          }
+        },
+        "running": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
+    "chef.automate.api.ingest.response.ProcessChefActionResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ProcessChefRunResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ProcessLivenessResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ProcessMultipleNodeDeleteResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.ingest.response.ProcessNodeDeleteResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.legacy.StatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.ApplyLicenseReq": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.ApplyLicenseResp": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp": {
+      "type": "object",
+      "properties": {
+        "configured_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "customer_name": {
+          "type": "string"
+        },
+        "license_id": {
+          "type": "string"
+        },
+        "licensed_period": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp.DateRange"
+        }
+      }
+    },
+    "chef.automate.api.license.GetStatusResp.DateRange": {
+      "type": "object",
+      "properties": {
+        "end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "chef.automate.api.license.RequestLicenseReq": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "gdpr_agree": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "last_name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.license.RequestLicenseResp": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/chef.automate.api.license.GetStatusResp"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.ConnectResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.nodes.manager.v1.CredentialsByTags": {
+      "type": "object",
+      "required": [
+        "tag_key",
+        "tag_value",
+        "credential_ids"
+      ],
+      "properties": {
+        "credential_ids": {
+          "description": "List of credential ids to associate with the key/value pair.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tag_key": {
+          "description": "Tag key to match on.",
+          "type": "string"
+        },
+        "tag_value": {
+          "description": "Tag value to match on.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.FieldQuery": {
+      "type": "object",
+      "required": [
+        "node_manager_id"
+      ],
+      "properties": {
+        "field": {
+          "description": "Possible search fields: regions, tags, name, subscription_id.",
+          "type": "string"
+        },
+        "node_manager_id": {
+          "description": "Node manager ID.",
+          "type": "string"
+        },
+        "query": {
+          "description": "Query details (filters) to be applied to the results.",
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Fields": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "description": "One or more fields: regions, tags, name, subscription_id.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Id": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "description": "UUID for the node manager.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "uuid": "cd3ad3d9-2776-4ef1-a904-4c229d1642ee"
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Ids": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "List of node manager UUIDs.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Id"
+          }
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.NodeManager": {
+      "type": "object",
+      "required": [
+        "id",
+        "credential_id",
+        "credential_data",
+        "type"
+      ],
+      "properties": {
+        "account_id": {
+          "description": "Account id associated with the nodemanager.",
+          "type": "string"
+        },
+        "credential_data": {
+          "description": "Use either 'credential_data' OR 'credential_id'.\n'credential_data' will overwrite values in 'credential_id'.\nUse 'credential_data' when you have not yet created node credentials\nand provide credential data (such as AWS_ACCESS_KEY) inline.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Kv"
+          }
+        },
+        "credential_id": {
+          "description": "Use either 'credential_id' OR 'credential_data'.\n'credential_data' will overwrite values in 'credential_id'.\nThe 'credential_id' is the UUID of credential with the information\nyou need to connect to aws, azure, or gcp.",
+          "type": "string"
+        },
+        "date_added": {
+          "description": "Date the nodemanager was created.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "UUID for the nodemanager.",
+          "type": "string"
+        },
+        "instance_credentials": {
+          "description": "List of tag and credential UUID associations for making node managers.\nThese are ssh, winrm, and sudo creds used to access instances.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.CredentialsByTags"
+          }
+        },
+        "name": {
+          "description": "User defined name for the node manager.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Status of the nodemanager (reachable, unreachable).",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of nodemanager (aws-ec2, azure-vm, aws-api, azure-api, gcp).",
+          "type": "string"
+        }
+      },
+      "example": {
+        "account_id": "12345EXAMPLE",
+        "credential_ID": "my-credential-UUID",
+        "credential_data": [
+          {
+            "key": "AWS_ACCESS_KEY_ID",
+            "value": "AKIAIOSFODNN7EXAMPLE"
+          },
+          {
+            "key": "AWS_SECRET_ACCESS_KEY",
+            "value": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+          },
+          {
+            "key": "AWS_SESSION_TOKEN",
+            "value": "AQoDYXdzEPT//////////wEXAMPLEt=="
+          }
+        ],
+        "id": "cd3ad3d9-2776-4ef1-a904-1EXAMPLEUUID",
+        "instance_credentials": [],
+        "name": "my aws api integration with session token",
+        "type": "aws-ec2"
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.NodeManagers": {
+      "type": "object",
+      "properties": {
+        "managers": {
+          "description": "List of nodemanagers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.NodeManager"
+          }
+        },
+        "total": {
+          "description": "Total count of nodemanagers.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "example": {
+        "total": "1"
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.NodeQuery": {
+      "type": "object",
+      "required": [
+        "node_manager_id"
+      ],
+      "properties": {
+        "node_manager_id": {
+          "description": "Node manager ID.",
+          "type": "string"
+        },
+        "query": {
+          "description": "Valid search filters: manager_type.",
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Nodes": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "description": "List of node names matching the request.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "total": {
+          "description": "Total count of node names matching the request.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Query": {
+      "type": "object",
+      "required": [
+        "filter_map"
+      ],
+      "properties": {
+        "filter_map": {
+          "description": "Filters for the query: \"manager_type\".",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Filter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.nodes.manager.v1.Query.OrderType"
+        },
+        "page": {
+          "description": "Starting page for the list. For example, if your query returns 100 pages,\nand you know you're looking for a node manager somewhere in the middle,\nyou might want to start on page 50.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "Number of results on each page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Field to use for sorting.\nValid fields are: name, type, status, status_message, date_added.",
+          "type": "string"
+        }
+      },
+      "example": {
+        "filter_map": [
+          {
+            "key": "manager_type",
+            "values": [
+              "aws-ec2"
+            ]
+          }
+        ],
+        "sort": "date_added"
+      }
+    },
+    "chef.automate.api.nodes.manager.v1.Query.OrderType": {
+      "description": "Sort the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.nodes.v1.BulkDeleteResponse": {
+      "type": "object",
+      "properties": {
+        "names": {
+          "description": "List of deleted nodes, by name.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.Id": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Unique node ID (UUID)"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.Ids": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "description": "List of node UUIDs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.LastContactData": {
+      "description": "Most recent node data from the latest Chef Infra run and InSpec scan.",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "description": "Last node report endtime.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "description": "Chef Infra run report ID or InSpec scan report ID.",
+          "type": "string"
+        },
+        "penultimate_status": {
+          "description": "Next-to-last node status report.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
+        },
+        "status": {
+          "description": "Last node report status.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData.Status"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.LastContactData.Status": {
+      "type": "string",
+      "default": "UNKNOWN",
+      "enum": [
+        "UNKNOWN",
+        "PASSED",
+        "FAILED",
+        "SKIPPED"
+      ]
+    },
+    "chef.automate.api.nodes.v1.Node": {
+      "description": "Node information.",
+      "type": "object",
+      "properties": {
+        "connection_error": {
+          "description": "Last connection error received when trying to contact the node.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique node ID (UUID).",
+          "type": "string"
+        },
+        "last_contact": {
+          "description": "Timestamp of the last `detect` or `exec` job.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_job": {
+          "description": "Results of the last compliance scan job for this node.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.ResultsRow"
+        },
+        "manager": {
+          "description": "Node manager (automate, aws-ec2, aws-api, azure-vm, azure-api, gcp).",
+          "type": "string"
+        },
+        "manager_ids": {
+          "description": "List of manager IDs for the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "User-specified node name.",
+          "type": "string"
+        },
+        "name_prefix": {
+          "description": "Prefix for node name. The full node name is the prefix + the host.",
+          "type": "string"
+        },
+        "platform": {
+          "description": "Node platform.",
+          "type": "string"
+        },
+        "platform_version": {
+          "description": "Node platform version.",
+          "type": "string"
+        },
+        "projects": {
+          "description": "List of projects associated with the node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "run_data": {
+          "description": "Most recent node data from the last Chef Infra run results.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
+        },
+        "scan_data": {
+          "description": "Most recent compliance scan data for the node from the last InSpec scan.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.LastContactData"
+        },
+        "state": {
+          "description": "Last known node state (running, stopped, terminated).",
+          "type": "string"
+        },
+        "status": {
+          "description": "Node status (unreachable, reachable, unknown).",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Node tags.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Kv"
+          }
+        },
+        "target_config": {
+          "description": "Node configuration for ssh or winrm.",
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.TargetConfig"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.Nodes": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "description": "List of nodes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.nodes.v1.Node"
+          }
+        },
+        "total": {
+          "description": "Total number of nodes in the system.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_reachable": {
+          "description": "Total number of reachable nodes in the system.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_unknown": {
+          "description": "Total number of unknown nodes in the system.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "total_unreachable": {
+          "description": "Total number of unreachable nodes in the system.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Use filters to limit the set of nodes to delete.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Filter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.nodes.v1.Query.OrderType"
+        },
+        "page": {
+          "description": "The number of result pages to return.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "The number of results on each page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Sort the results on a specific field.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.Query.OrderType": {
+      "description": "Return the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.nodes.v1.RerunResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.nodes.v1.ResultsRow": {
+      "description": "Summary of the last Chef InSpec scan job run on the node.",
+      "type": "object",
+      "properties": {
+        "end_time": {
+          "description": "End time on the report.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "job_id": {
+          "description": "Unique ID of the scan job that generated the report.",
+          "type": "string"
+        },
+        "node_id": {
+          "description": "Unique node ID.",
+          "type": "string"
+        },
+        "report_id": {
+          "description": "Unique ID of the report generated by the InSpec scan.",
+          "type": "string"
+        },
+        "result": {
+          "description": "Error message returned after several failed attempts to contact a node.",
+          "type": "string"
+        },
+        "start_time": {
+          "description": "Start time on the report.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "description": "Status of the report (failed, success, skipped).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.nodes.v1.TargetConfig": {
+      "description": "Details for ssh/winrm access of the node.",
+      "type": "object",
+      "properties": {
+        "backend": {
+          "description": "Node backend type (ssh, winrm, aws, ssm, azure, gcp).",
+          "type": "string"
+        },
+        "host": {
+          "description": "Node FQDN or IP address.",
+          "type": "string"
+        },
+        "hosts": {
+          "description": "List of hostnames (FQDN or IP address) for bulk creating nodes.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "title": "ssh or winrm connection port"
+        },
+        "secrets": {
+          "description": "List of credential IDs for a node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "self_signed": {
+          "description": "Allow self-signed certificate (boolean).",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "ssl": {
+          "description": "Check ssl (boolean).",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "sudo": {
+          "description": "Uses `sudo` (boolean).",
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "sudo_options": {
+          "description": "Sudo options to use when accessing the node.",
+          "type": "string"
+        },
+        "user": {
+          "description": "Username from the credential ID for this node.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.Empty": {
+      "type": "object"
+    },
+    "chef.automate.api.notifications.Rule": {
+      "type": "object",
+      "properties": {
+        "ServiceNowAlert": {
+          "$ref": "#/definitions/chef.automate.api.notifications.ServiceNowAlert"
+        },
+        "SlackAlert": {
+          "$ref": "#/definitions/chef.automate.api.notifications.SlackAlert"
+        },
+        "WebhookAlert": {
+          "$ref": "#/definitions/chef.automate.api.notifications.WebhookAlert"
+        },
+        "event": {
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule.Event"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.Rule.Event": {
+      "type": "string",
+      "default": "CCRFailure",
+      "enum": [
+        "CCRFailure",
+        "CCRSuccess",
+        "ComplianceFailure",
+        "ComplianceSuccess"
+      ]
+    },
+    "chef.automate.api.notifications.RuleAddRequest": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleAddResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleDeleteResponse": {
+      "type": "object",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleGetResponse": {
+      "type": "object",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleListResponse": {
+      "type": "object",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.notifications.Rule"
+          }
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleUpdateRequest": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "rule": {
+          "$ref": "#/definitions/chef.automate.api.notifications.Rule"
+        }
+      }
+    },
+    "chef.automate.api.notifications.RuleUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "chef.automate.api.notifications.SecretId": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.ServiceNowAlert": {
+      "type": "object",
+      "properties": {
+        "critical_controls_only": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "secret_id": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.SlackAlert": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.URLValidationRequest": {
+      "type": "object",
+      "properties": {
+        "none": {
+          "$ref": "#/definitions/chef.automate.api.notifications.Empty"
+        },
+        "secret_id": {
+          "$ref": "#/definitions/chef.automate.api.notifications.SecretId"
+        },
+        "url": {
+          "type": "string"
+        },
+        "username_password": {
+          "$ref": "#/definitions/chef.automate.api.notifications.UsernamePassword"
+        }
+      }
+    },
+    "chef.automate.api.notifications.URLValidationResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.notifications.UsernamePassword": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.VersionResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.notifications.WebhookAlert": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.secrets.DeleteResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.secrets.Id": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique node ID (UUID).",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.secrets.Query": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "description": "Use filters to limit the set of secrets.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Filter"
+          }
+        },
+        "order": {
+          "$ref": "#/definitions/chef.automate.api.secrets.Query.OrderType"
+        },
+        "page": {
+          "description": "The number of result pages to return.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "per_page": {
+          "description": "The number of results on each page.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "sort": {
+          "description": "Sort the results on a specific field.",
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.secrets.Query.OrderType": {
+      "description": "Return the results in ascending or descending order.",
+      "type": "string",
+      "default": "ASC",
+      "enum": [
+        "ASC",
+        "DESC"
+      ]
+    },
+    "chef.automate.api.secrets.Secret": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Secret data, where the kv structs for the credential data live.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Kv"
+          }
+        },
+        "id": {
+          "description": "Unique node ID (UUID).",
+          "type": "string"
+        },
+        "last_modified": {
+          "description": "Timestamp denoting when the secret was last modified.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "name": {
+          "description": "User-specified name for the secret.",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags to associate with the secret.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.common.query.Kv"
+          }
+        },
+        "type": {
+          "type": "string",
+          "title": "Type of credential: ssh, winrm, sudo, aws, azure, gcp, service_now"
+        }
+      }
+    },
+    "chef.automate.api.secrets.Secrets": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "description": "List of secrets.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.secrets.Secret"
+          }
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Total count of secrets"
+        }
+      }
+    },
+    "chef.automate.api.secrets.UpdateResponse": {
+      "type": "object"
+    },
+    "chef.automate.api.telemetry.TelemetryResponse": {
+      "type": "object",
+      "properties": {
+        "customer_id": {
+          "type": "string"
+        },
+        "customer_name": {
+          "type": "string"
+        },
+        "deployment_id": {
+          "type": "string"
+        },
+        "license_id": {
+          "type": "string"
+        },
+        "license_type": {
+          "type": "string"
+        },
+        "max_nodes": {
+          "type": "string",
+          "format": "int64"
+        },
+        "telemetry_enabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "telemetry_url": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.infra.data_lifecycle.api.EsPolicy": {
+      "type": "object",
+      "properties": {
+        "custom_purge_field": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "index": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "older_than_days": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "chef.automate.infra.data_lifecycle.api.EsPolicyUpdate": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "older_than_days": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "policy_name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.infra.data_lifecycle.api.PgPolicy": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "chef.automate.infra.data_lifecycle.api.PgPolicyUpdate": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "policy_name": {
+          "type": "string"
+        }
+      }
+    },
+    "google.protobuf.Any": {
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(&foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := &pb.Foo{...}\n     any, err := ptypes.MarshalAny(foo)\n     ...\n     foo := &pb.Foo{}\n     if err := ptypes.UnmarshalAny(any, foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": <string>,\n      \"lastName\": <string>\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }",
+      "type": "object",
+      "properties": {
+        "type_url": {
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Must be a valid serialized protocol buffer of the above specified type.",
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "google.protobuf.NullValue": {
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value.",
+      "type": "string",
+      "default": "NULL_VALUE",
+      "enum": [
+        "NULL_VALUE"
+      ]
+    },
+    "grpc.gateway.runtime.StreamError": {
+      "type": "object",
+      "properties": {
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/google.protobuf.Any"
+          }
+        },
+        "grpc_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "http_status": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "APIToken": {
+      "description": "Authenticate with the Automate API using an API Token.",
+      "type": "apiKey",
+      "name": "api-token",
+      "in": "header"
+    }
+  },
+  "tags": [
+    {
+      "name": "ReportingService",
+      "x-displayName": "Reporting"
+    },
+    {
+      "name": "ProfilesService",
+      "x-displayName": "Profiles"
+    },
+    {
+      "name": "StatsService",
+      "x-displayName": "Stats"
+    },
+    {
+      "name": "ConfigMgmt",
+      "x-displayName": "Nodes"
+    },
+    {
+      "name": "NodesService",
+      "x-displayName": "Managed Nodes"
+    },
+    {
+      "name": "EventFeed",
+      "x-displayName": "Event Feed"
+    },
+    {
+      "name": "SecretsService",
+      "x-displayName": "Secrets"
+    },
+    {
+      "name": "service_groups",
+      "x-displayName": "Service Groups and Services"
+    },
+    {
+      "name": "retention",
+      "x-displayName": "Service Management"
+    },
+    {
+      "name": "NodeManagerService",
+      "x-displayName": "Node Managers"
+    },
+    {
+      "description": "A policy defines permissions for who may perform what action on which resources, based on the project. The ‘who’ is a user, a team, or a system. A policy has three components, the agent, the action, and the project. The agent is a user, team, or system. Users and teams are designated by name while systems communicate with Chef Automate using pre-authorized API tokens. Actions are activities that agents can take in relation to Chef Automate’s content and operation. Projects are collections of resources, such as API tokens or ingested compliance nodes.",
+      "name": "policies",
+      "x-displayName": "IAM Policies"
+    },
+    {
+      "description": "A role encapsulates a list of actions. Chef Automate provides several default Chef-managed roles that cannot be altered but you may also define and use your own Custom roles.",
+      "name": "roles",
+      "x-displayName": "IAM Roles"
+    },
+    {
+      "description": "Projects are used to group and permission Chef Automate resources as well as ingested data, specifically Compliance reports, Chef Infra Server events, and Infrastructure nodes.",
+      "name": "projects",
+      "x-displayName": "IAM Projects"
+    },
+    {
+      "description": "Project rules define lists of one or more conditions that an ingested resource must meet in order to be assigned to a project.",
+      "name": "rules",
+      "x-displayName": "IAM Project Rules"
+    },
+    {
+      "description": "Tokens are used for API access to Automate endpoints as well as by systems (e.g. Chef Infra Servers) to communicate with Automate.",
+      "name": "tokens",
+      "x-displayName": "IAM API Tokens"
+    },
+    {
+      "name": "JobsService",
+      "x-displayName": "Scan Jobs"
+    },
+    {
+      "description": "IAM local users are not attached to external identity providers. They can be members of IAM teams and IAM policies.",
+      "name": "users",
+      "x-displayName": "IAM Users"
+    },
+    {
+      "description": "Teams are used to group local users for policy membership.",
+      "name": "teams",
+      "x-displayName": "IAM Teams"
+    }
+  ],
+  "x-stream-definitions": {
+    "chef.automate.api.common.ExportData": {
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/grpc.gateway.runtime.StreamError"
+        },
+        "result": {
+          "$ref": "#/definitions/chef.automate.api.common.ExportData"
+        }
+      },
+      "title": "Stream result of chef.automate.api.common.ExportData",
+      "type": "object"
+    }
+  },
+  "x-tagGroups": [
+    {
+      "name": "Compliance",
+      "tags": [
+        "ReportingService",
+        "StatsService",
+        "JobsService",
+        "ProfilesService"
+      ]
+    },
+    {
+      "name": "Infra",
+      "tags": [
+        "ConfigMgmt"
+      ]
+    },
+    {
+      "name": "Node Management",
+      "tags": [
+        "NodeManagerService",
+        "NodesService"
+      ]
+    },
+    {
+      "name": "Event Feed",
+      "tags": [
+        "EventFeed"
+      ]
+    },
+    {
+      "name": "Secrets",
+      "tags": [
+        "SecretsService"
+      ]
+    },
+    {
+      "name": "Applications",
+      "tags": [
+        "service_groups",
+        "retention"
+      ]
+    },
+    {
+      "name": "Identity",
+      "tags": [
+        "users",
+        "teams",
+        "tokens"
+      ]
+    },
+    {
+      "name": "Access Management",
+      "tags": [
+        "policies",
+        "roles",
+        "projects",
+        "rules"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This will commit the all-apis.swagger.json file instead of generating it when Hugo builds the automate site. It also updates the expeditor config to add future changes to that file.

I'm migrating the automate documentation from `automate.chef.io` to `docs.chef.io`. It will be much easier for me to grab the all-apis swagger file from the `chef/automate` repo than it will to grab several swagger files and then generate the all-apis swagger file when Hugo builds the docs site from `chef-web-docs`.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
