### PR TITLE
Revert "Disable license scout in upload-files.sh (#4100)"

### DIFF
--- a/.expeditor/upload-files.sh
+++ b/.expeditor/upload-files.sh
@@ -13,11 +13,11 @@ aws s3 cp s3://chef-cd-citadel/packages_at_chef.io.pgp packages_at_chef.io.pgp -
 gpg --import packages_at_chef.io.pgp
 
 # Generate the License Scout Dependency Manifest
-#.expeditor/license_scout.sh
+.expeditor/license_scout.sh
 
 # Upload the License Scout Dependency Manifest to the S3 bucket
-#aws s3 cp a2-dependency-licenses.json "s3://chef-automate-artifacts/licenses/automate/$VERSION.json" --acl public-read --profile chef-cd
-#aws s3 cp a2-dependency-licenses.json s3://chef-automate-artifacts/dev/latest/automate/licenses.json --acl public-read --profile chef-cd
+aws s3 cp a2-dependency-licenses.json "s3://chef-automate-artifacts/licenses/automate/$VERSION.json" --acl public-read --profile chef-cd
+aws s3 cp a2-dependency-licenses.json s3://chef-automate-artifacts/dev/latest/automate/licenses.json --acl public-read --profile chef-cd
 
 #
 # Generate the manifest.json

--- a/components/automate-deployment/README.md
+++ b/components/automate-deployment/README.md
@@ -25,8 +25,8 @@ For most day-to-day development, you can use the Habitat studio-based
 development environment described in our [developer
 documentation](../../dev-docs/DEV_ENVIRONMENT)
 
-Most new development features and test should be designed to work in the
-studio if possible.
+Most new development features and test should be designed to work in
+the studio if possible.
 
 We also try to ensure that the build, unit tests, and linter work from
 outside the studio, using the Makefile directly:


### PR DESCRIPTION
This reverts commit 372a272ecda24e78451a2b988718de942929a627.

reverting this as promised. we want license scout running