### PR TITLE
Update links to inspec docs

### DIFF
--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -22,7 +22,7 @@ Access the _Node Integrations_ page from the **Settings** tab.
 
 Set up Chef Automate to detect and scan the nodes in your AWS EC2 account by providing your AWS Credentials and creating an _AWS EC2 Node Manager_ from the **Node Credentials** page in the **Settings** tab. Chef Automate requires your information to detect the nodes in your AWS EC2 account. Chef Automate creates a node reference for each EC2 instance in your account and collects all of the tags associated with each instance.
 
-Inspec 2+ supports running scan jobs against your AWS account configuration, such as CloudWatch or IAM, [see more here](https://www.inspec.io/docs/reference/resources/#aws-resources). Set up Chef Automate to run these scan jobs by providing your AWS Credentials and creating an _AWS API Node Manager_ in the **Node Integrations** page in the **Settings**  tab.
+Inspec 2+ supports running scan jobs against your AWS account configuration, such as CloudWatch or IAM, [see more here](https://docs.chef.io/inspec/resources/#aws). Set up Chef Automate to run these scan jobs by providing your AWS Credentials and creating an _AWS API Node Manager_ in the **Node Integrations** page in the **Settings**  tab.
 
 To create an AWS EC2 Node Manager, you need the following information:
 
@@ -186,7 +186,7 @@ Filter instances for scanning by specifying either regions or tags by their keys
 
 ## Use Case: Azure Account Scanning with Chef Automate
 
-Inspec 2+ supports running scan jobs against your Azure account configuration, such as network security groups and ad users. See [Azure resources](https://www.inspec.io/docs/reference/resources/#azure-resources) for more information.
+Inspec 2+ supports running scan jobs against your Azure account configuration, such as network security groups and ad users. See [Azure resources](https://docs.chef.io/inspec/resources/#azure) for more information.
 Set up Chef Automate to run these scan jobs by providing your Azure credentials and creating an _Azure API Node Manager_.
 
 ### Adding an Azure API Node Manager
@@ -208,7 +208,7 @@ Filter the regions for the scan job by specifying regions to include or exclude.
 
 ## Google Cloud Platform Account Scanning with Chef Automate
 
-Run scans against your GCP account infrastructure using Chef Automate. Set up Chef Automate to detect and scan the nodes in your Google Cloud Platform (GCP) account by providing your GCP Credentials and creating a _GCP Node Manager_. To create a GCP Node Manager, navigate to _Node Integrations_, select `Create Integration`, and you should see _Google Cloud_ as one of your node management service options. See the Chef InSpec documentation for more infomation about [GCP resources](https://www.inspec.io/docs/reference/resources/#gcp-resources).
+Run scans against your GCP account infrastructure using Chef Automate. Set up Chef Automate to detect and scan the nodes in your Google Cloud Platform (GCP) account by providing your GCP Credentials and creating a _GCP Node Manager_. To create a GCP Node Manager, navigate to _Node Integrations_, select `Create Integration`, and you should see _Google Cloud_ as one of your node management service options. See the Chef InSpec documentation for more infomation about [GCP resources](https://docs.chef.io/inspec/resources/#gcp).
 
 To run a GCP scan in Chef Automate:
 

--- a/components/automate-chef-io/content/docs/profiles.md
+++ b/components/automate-chef-io/content/docs/profiles.md
@@ -98,7 +98,7 @@ Total tests
 
 Severity
 : The impact of a control, from 0 to 1.
-  See the Chef InSpec documentation for more information about the [severity measure](https://www.inspec.io/docs/reference/dsl_inspec#syntax)
+  See the Chef InSpec documentation for more information about the [severity measure](https://docs.chef.io/inspec/dsl_inspec#syntax)
 
 Selecting the shaded area next to the control name or the `+` on the right side expands the control to show a more detailed description.
 Selecting **View Code** displays the control's InSpec code.
@@ -119,7 +119,7 @@ Users in a Chef Automate instance with the same username in both saml and local 
 ## Interacting with Chef Automate Profiles
 
 You can interact with Chef Automate Profiles from the command line, as well as from the user interface.
-For more information, see the [InSpec CLI](https://www.inspec.io/docs/reference/cli/) subcommand.
+For more information, see the [InSpec CLI](https://docs.chef.io/inspec/cli/) subcommand.
 
 ### API Calls
 

--- a/components/automate-chef-io/content/docs/reports.md
+++ b/components/automate-chef-io/content/docs/reports.md
@@ -79,7 +79,7 @@ _Nodes_ and _Profiles_ views include _Waived Nodes_ and _Waived Profiles_ status
 Select the _Waived_ status filter to display only the respective Node or Profile reporting with that status.
 Hover over the control's Waived icon under the Node Status column in _Controls_ to view more details about the waiver applied to the control.
 
-Use Chef InSpec to configure [waivers](https://www.inspec.io/docs/reference/waivers/).
+Use Chef InSpec to configure [waivers](https://docs.chef.io/inspec/waivers/).
 
 ### Download Report Results
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

The InSpec docs have migrated from inspec.io/docs. This updates links to InSpec docs to `docs.chef.io/inspec/<page>`

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
