### PR TITLE
Accomodate more space for numbers

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.html
@@ -48,7 +48,7 @@
           <chef-thead>
             <chef-tr>
               <chef-th>{{ controls.length }} Controls</chef-th>
-              <chef-th>Impact</chef-th>
+              <chef-th class="impact-status">Impact</chef-th>
               <chef-th>Test Results</chef-th>
               <chef-th></chef-th>
             </chef-tr>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-profile/reporting-profile.component.scss
@@ -43,7 +43,6 @@
   chef-td {
 
     &:first-child {
-      flex-basis: 400%;
       word-break: break-all;
 
       chef-icon {
@@ -56,6 +55,7 @@
     }
 
     &:last-child {
+      max-width: 150px;
       justify-content: flex-end;
     }
 
@@ -82,6 +82,10 @@
     chef-icon, .waived-icon {
       margin-right: 5px;
     }
+  }
+
+  .impact-status {
+    max-width: 15%;
   }
 
   .status-icon,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Numbers were stacking vertically due to insufficient space in the compliance reports profile table, this branch addresses this problem by accommodating for more space.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/4107

### :+1: Definition of Done
Large numbers are accomodated for in compliance profile table

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

navigate to: https://a2-dev.test/compliance/reports/profiles
note: if you do not have any compliance profiles - run `load_compliance_reports` in hab studio.
click on an individual profile
you may need to manually plug in large numbers in order to see that the numbers fit.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![numbers](https://user-images.githubusercontent.com/16737484/88215257-3ccf8f00-cc10-11ea-8d52-4447cd4b4a99.gif)