### PR TITLE
[client-runs] Fix run history counts issue

### DIFF
--- a/components/automate-ui/src/app/services/run-history-store/run-history.store.ts
+++ b/components/automate-ui/src/app/services/run-history-store/run-history.store.ts
@@ -46,7 +46,7 @@ export class RunHistoryStore {
       this._nodeHistoryFilter['page'] = 1;
     }
 
-    if (type === 'startDate' || type === 'endDate') {
+    if (type === 'startDate' || type === 'endDate' || type === 'status') {
       this._nodeHistoryCountsFilter[type] = filter;
       this._countsFilter.next(this._nodeHistoryCountsFilter);
     }
@@ -60,7 +60,7 @@ export class RunHistoryStore {
   }
 
   removeFilter(type) {
-    if (type === 'startDate' || type === 'endDate') {
+    if (type === 'startDate' || type === 'endDate' || type === 'status') {
       delete this._nodeHistoryCountsFilter[type];
       this._countsFilter.next(this._nodeHistoryCountsFilter);
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

Seems date filters `startDate` and `endDate` updated the list items as well as status count. Its required to add a status type filter to also update its count. 

### :chains: Related Resources

Fixes: #995

### :+1: Definition of Done
- Run status filter now gets updated when it clicked.

### :athletic_shoe: How to Build and Test the Change
Steps to build

- `build components/automate-ui-devproxy`
- `cd components/automate-ui`
- `make serve`

Steps to test:
- Configure chef server over data collector.
- Bootstrap a node.
- Go to Dashboard -> Client Runs -> Node details > Run History  
- Run chef-client on node multiple times.
- Click on Count filter.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Before fix:
![client-runs-history](https://user-images.githubusercontent.com/44496937/61615039-bc83f000-ac82-11e9-93ae-24933ee96928.png)

After fix:
![client-runs-history](https://user-images.githubusercontent.com/44496937/88267883-23e9db00-ccef-11ea-9b71-1ad358cbcec0.gif)

Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>