### PR TITLE
Be explicit about dependencies on coreutils

### DIFF
--- a/components/automate-builder-api-proxy/habitat/plan.sh
+++ b/components/automate-builder-api-proxy/habitat/plan.sh
@@ -11,6 +11,7 @@ pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_svc_user="root"
 pkg_deps=(
+  core/coreutils
   core/bash
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -9,6 +9,7 @@ pkg_license=('Chef-MLSA')
 # WARNING: Version managed by .expeditor/update_chef_server.sh
 pkg_version="13.0.47"
 pkg_deps=(
+  core/coreutils
   chef/mlsa
   # TODO 2020-05-12: PIN PIN PIN
   #

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -15,8 +15,7 @@ pkg_build_deps=(
   core/patchelf
 )
 pkg_deps=(
-  core/coreutils-static
-  core/busybox-static
+  core/coreutils
   core/glibc
   core/zlib
 

--- a/components/automate-es-gateway/habitat/plan.sh
+++ b/components/automate-es-gateway/habitat/plan.sh
@@ -26,6 +26,7 @@ chef_automate_hab_binding_mode="relaxed"
 pkg_svc_user="root"
 
 pkg_deps=(
+  core/coreutils
   chef/mlsa
   core/bash
   core/curl # health_check

--- a/components/automate-postgresql/habitat/plan.sh
+++ b/components/automate-postgresql/habitat/plan.sh
@@ -7,6 +7,7 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
+  core/coreutils
   chef/mlsa
   ${vendor_origin}/postgresql/${pkg_version}
 )

--- a/components/automate-ui/habitat/plan.sh
+++ b/components/automate-ui/habitat/plan.sh
@@ -5,8 +5,8 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 pkg_svc_user="root" # so we can start nginx properly
 pkg_deps=(
-  core/curl
   core/coreutils
+  core/curl
   chef/mlsa
   core/nginx
   core/jq-static

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -31,6 +31,7 @@ pkg_binds_optional=(
 )
 inspec_release="chef/inspec/4.21.3/20200702113741"
 pkg_deps=(
+  core/coreutils
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   "${inspec_release}"
   chef/mlsa

--- a/integration/tests/ldap_hab_user.sh
+++ b/integration/tests/ldap_hab_user.sh
@@ -71,11 +71,7 @@ EOF
     authconfig --enableldap --enableldapauth --ldapserver=127.0.0.1 --ldapbasedn="dc=example,dc=local" --enablemkhomedir --update
     systemctl restart nslcd
 
-    mkdir /etc/systemd/system/chef-automate.service.d
-    cat > /etc/systemd/system/chef-automate.service.d/custom.conf <<EOF
-[Service]
-Environment=LD_PRELOAD=/lib64/libnss_ldap.so
-EOF
+    systemctl start nscd
 
     umask "$previous_umask"
 }

--- a/integration/tests/ldap_hab_user.sh
+++ b/integration/tests/ldap_hab_user.sh
@@ -5,6 +5,8 @@ test_name="ldap_hab_user"
 test_backup_restore=true
 
 do_setup() {
+    do_setup_default
+
     previous_umask=$(umask)
     umask 022
     yum -y install openldap compat-openldap openldap-clients openldap-servers nslcd nss-pam-ldapd authconfig

--- a/integration/tests/ldap_hab_user.sh
+++ b/integration/tests/ldap_hab_user.sh
@@ -76,6 +76,16 @@ EOF
     systemctl start nscd
 
     umask "$previous_umask"
+
+    if grep 'hab' /etc/passwd;then
+        log_error "found hab user in /etc/passwd"
+        return 1
+    fi
+
+    if grep 'hab' /etc/group;then
+        log_error "found hab user in /etc/group"
+        return 1
+    fi
 }
 
 do_test_restore() {


### PR DESCRIPTION
Be explicit about dependencies on coreutils

We want to depend on coreutils as it will be able correctly look up UIDs
and GIDs when it comes to LDAP.

Don't use busybox

Follow up to #4110
Fixes #4105