### PR TITLE
ci: don't setup GOPATH in generate-automate-cli-docs.sh

### DIFF
--- a/.expeditor/generate-automate-cli-docs.sh
+++ b/.expeditor/generate-automate-cli-docs.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
-
 set -eou pipefail
-
-mkdir -p /go/src/github.com/chef
-ln -s /workspace /go/src/github.com/chef/automate
 
 # bumping expeditor to go 1.13
 hab pkg install --binlink core/go/1.13.5 --force
 
-pushd /go/src/github.com/chef/automate/components/automate-cli
+pushd components/automate-cli
   make docs
 popd


### PR DESCRIPTION
We should no longer require building from something that looks like a
GOPATH. We are removing this to reduce the number of possible causes
of the build system issues we are investigating.

Signed-off-by: Steven Danna <steve@chef.io>