### PR TITLE
Auto update widths of inputs on type

### DIFF
--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -18,7 +18,7 @@
         <chef-subheading>Manage the retention of events, service groups, Chef Infra Client runs, compliance reports and scans in Chef Automate.</chef-subheading>
       </chef-page-header>
 
-      <div class="page-body">
+      <div class="page-body" #dataLifeCycleFormElement>
 
         <div class="group-section">
           <chef-button primary [disabled]="(!automateSettingsForm.dirty || !automateSettingsForm.valid) || saving" (click)="applyChanges()">
@@ -39,6 +39,7 @@
             </div>
             <p>Remove event feed data after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing event feed data"
                 chefInput
                 formControlName="threshold"
@@ -46,7 +47,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>
@@ -60,6 +61,7 @@
             </div>
             <p>Remove Chef Infra Server actions after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing Chef Infra Server actions"
                 chefInput
                 formControlName="threshold"
@@ -67,7 +69,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>
@@ -87,6 +89,7 @@
 
             <p>When no health check reports have been received for a service in
               <input
+                class="auto-update-width"
                 aria-label="Amount of time before labeling a service disconnected"
                 chefInput
                 formControlName="threshold"
@@ -94,7 +97,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -117,6 +120,7 @@
             </div>
             <p>Remove services labeled as disconnected after
               <input
+                class="auto-update-width"
                 aria-label="Amount of time before removing disconnected services"
                 chefInput
                 formControlName="threshold"
@@ -124,7 +128,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -148,6 +152,7 @@
             </div>
             <p>Remove data for Chef Infra Client runs after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing Chef Infra Client runs"
                 chefInput
                 formControlName="threshold"
@@ -155,7 +160,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>
@@ -171,6 +176,7 @@
 
             <p>When no Chef Infra Client run data has been received from a node in
               <input
+                class="auto-update-width"
                 aria-label="Amount of time before labeling a node as missing"
                 chefInput
                 formControlName="threshold"
@@ -178,7 +184,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -201,6 +207,7 @@
             </div>
             <p>Remove nodes labeled as missing after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing missing nodes"
                 chefInput
                 formControlName="threshold"
@@ -208,7 +215,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>
@@ -225,6 +232,7 @@
             </div>
             <p>Remove compliance reports after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing compliance reports"
                 chefInput
                 formControlName="threshold"
@@ -232,7 +240,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>
@@ -246,6 +254,7 @@
             </div>
             <p>Remove compliance scans after
               <input
+                class="auto-update-width"
                 aria-label="Days before removing compliance scans"
                 chefInput
                 formControlName="threshold"
@@ -253,7 +262,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
-                (keyup)="autoUpdateInputWidth($event)"
+                (keyup)="autoUpdateInputWidth($event.target)"
               />days
             </p>
           </div>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.html
@@ -46,6 +46,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>
@@ -66,6 +67,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>
@@ -92,6 +94,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -121,6 +124,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -151,6 +155,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>
@@ -173,6 +178,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />
               <mat-form-field appearance="none">
                 <mat-select aria-label="Time type" panelClass="chef-dropdown" formControlName="unit" [resetOrigin]="shouldResetValues">
@@ -202,6 +208,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>
@@ -225,6 +232,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>
@@ -245,6 +253,7 @@
                 type="number"
                 min="0"
                 (keydown)="preventNegatives($event.key)"
+                (keyup)="autoUpdateInputWidth($event)"
               />days
             </p>
           </div>

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.scss
@@ -25,6 +25,7 @@ h2 {
 
     input {
       width: 64px;
+      transition: .2s;
     }
 
     p {

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ElementRef, ViewChild } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormGroup, FormBuilder, AbstractControl, Validators } from '@angular/forms';
 import { Store, select } from '@ngrx/store';
@@ -33,6 +33,7 @@ import { ProductDeployedService } from 'app/services/product-deployed/product-de
 })
 
 export class AutomateSettingsComponent implements OnInit, OnDestroy {
+  @ViewChild('dataLifeCycleFormElement', {read: ElementRef}) dataLifeCycleFormElement: ElementRef;
 
   public isDesktopView = false;
 
@@ -179,8 +180,7 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
   }
 
   // Update the width of input when greater than one number
-  public autoUpdateInputWidth($event: KeyboardEvent): void {
-    const element = $event.target as HTMLInputElement;
+  public autoUpdateInputWidth(element: HTMLInputElement): void {
     // Keep default in sync with input width in automate-settings.component.scss
     const DEFAULT_WIDTH = 64;
     const length = element.value.length;
@@ -331,6 +331,12 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
           break;
       }
     });
+
+    // Update all number inputs to grow if holding number larger than two digits
+    const numberInputs = Array.from(
+      this.dataLifeCycleFormElement.nativeElement.querySelectorAll('.auto-update-width'));
+    numberInputs.forEach((element: HTMLInputElement) => this.autoUpdateInputWidth(element));
+
     // After a successful load of initial values, trigger a notification
     // to FormControlDirective to treat them as the "original" values.
     this.shouldResetValues = true;

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -178,6 +178,20 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
     return allowedKeys.includes(key);
   }
 
+  // Update the width of input when greater than one number
+  public autoUpdateInputWidth($event: KeyboardEvent): void {
+    const element = $event.target as HTMLInputElement;
+    // Keep default in sync with input width in automate-settings.component.scss
+    const DEFAULT_WIDTH = 64;
+    const length = element.value.length;
+
+    if (length > 1) {
+      element.style.width = `${DEFAULT_WIDTH + (9 * (length - 1))}px`;
+    } else {
+      element.style.width = `${DEFAULT_WIDTH}px`;
+    }
+  }
+
   private setEnabled(control: AbstractControl, enabled: boolean): void {
     if (enabled) {
       control.enable();

--- a/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
+++ b/components/automate-ui/src/app/pages/automate-settings/automate-settings.component.ts
@@ -179,16 +179,16 @@ export class AutomateSettingsComponent implements OnInit, OnDestroy {
     return allowedKeys.includes(key);
   }
 
-  // Update the width of input when greater than one number
+  // Update the width of input when greater than one digit
   public autoUpdateInputWidth(element: HTMLInputElement): void {
     // Keep default in sync with input width in automate-settings.component.scss
-    const DEFAULT_WIDTH = 64;
-    const length = element.value.length;
+    const DEFAULT_WIDTH_PIXELS = 64;
+    const numDigits = element.value.length;
 
-    if (length > 1) {
-      element.style.width = `${DEFAULT_WIDTH + (9 * (length - 1))}px`;
+    if (numDigits > 1) {
+      element.style.width = `${DEFAULT_WIDTH_PIXELS + (9 * (numDigits - 1))}px`;
     } else {
-      element.style.width = `${DEFAULT_WIDTH}px`;
+      element.style.width = `${DEFAULT_WIDTH_PIXELS}px`;
     }
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
By default, the number inputs on data-lifecycle were only large enough to show two digits.  We will now auto update the width of the input upon typing so that the entire number is always visible.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/4040

### :+1: Definition of Done
Data Lifecycle input values are always visible to the user, regardless of how long.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

navigate to https://a2-dev.test/settings/data-lifecycle
In any/all of the type-able number inputs, type as many valid numbers as you wish and view the input expand/shrink as necessary.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![auto resize](https://user-images.githubusercontent.com/16737484/88345506-eab76800-ccfa-11ea-8402-59ab40f72af7.gif)
