### PR TITLE
Manually lookup user and group when creating abb

### DIFF
--- a/components/automate-deployment/pkg/bootstrapbundle/bundle_creator.go
+++ b/components/automate-deployment/pkg/bootstrapbundle/bundle_creator.go
@@ -277,7 +277,7 @@ func (b *Creator) headerForFile(relPath string) (*tar.Header, error) {
 		}
 
 		if header.Gname == "" {
-			g, err := user.LookupGroupId(strconv.Itoa(header.Uid))
+			g, err := user.LookupGroupId(strconv.Itoa(header.Gid))
 			if err != nil {
 				return nil, errors.Errorf("could not determine group with id %d for %q", header.Gid, relPath)
 			}

--- a/components/automate-deployment/pkg/bootstrapbundle/bundle_creator.go
+++ b/components/automate-deployment/pkg/bootstrapbundle/bundle_creator.go
@@ -265,6 +265,25 @@ func (b *Creator) headerForFile(relPath string) (*tar.Header, error) {
 
 		header.Name = relPath
 
+		// We need to make sure tar was able to figure out the user and group.
+		// It will fail to do so if the user/group is not local. In that case,
+		// we will use our own lookup mechanism
+		if header.Uname == "" {
+			u, err := user.LookupId(strconv.Itoa(header.Uid))
+			if err != nil {
+				return nil, errors.Errorf("could not determine user with id %d for %q", header.Uid, relPath)
+			}
+			header.Uname = u.Username
+		}
+
+		if header.Gname == "" {
+			g, err := user.LookupGroupId(strconv.Itoa(header.Uid))
+			if err != nil {
+				return nil, errors.Errorf("could not determine group with id %d for %q", header.Gid, relPath)
+			}
+			header.Gname = g.Name
+		}
+
 		if uid, err := stringutils.IndexOf(b.allowedUsers, header.Uname); err != nil {
 			return nil, errors.Errorf("%q is not an allowed user", header.Uname)
 		} else {

--- a/integration/tests/ldap_hab_user.sh
+++ b/integration/tests/ldap_hab_user.sh
@@ -88,6 +88,11 @@ EOF
     fi
 }
 
+do_test_deploy() {
+    do_test_deploy_default
+    chef-automate bootstrap bundle create -o bootstrap.abb
+}
+
 do_test_restore() {
     do_test_restore_default || return 1
 }


### PR DESCRIPTION
When creating the abb, we use the golang tar library. It could fail to determine the user and group names for a file if those are not local users. This PR uses our user library to do the UID/GID -> name translation if the tar library is unable to