### PR TITLE
Client runs node detail with optional run-id

### DIFF
--- a/components/automate-ui/src/app/app-routing.module.ts
+++ b/components/automate-ui/src/app/app-routing.module.ts
@@ -58,6 +58,9 @@ import { NodeDetailsResolverService } from './services/node-details/node-details
 import {
   NodeNoRunsDetailsResolverService
 } from './services/node-details/node-noruns-details-resolver.service';
+import {
+  NodeNoRunIdResolverService
+} from './services/node-details/node-norunid-resolver.service';
 
 // Other
 import { SettingsLandingComponent } from './pages/settings-landing/settings-landing.component';
@@ -226,6 +229,13 @@ const routes: Routes = [
             {
               path: '',
               component: ClientRunsComponent
+            },
+            {
+              path: ':node-id',
+              component: NodeNoRunsDetailsComponent,
+              resolve: {
+                node: NodeNoRunIdResolverService
+              }
             },
             {
               path: ':node-id/missing-runs',

--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -55,6 +55,9 @@ import { NodeDetailsService } from './services/node-details/node-details.service
 import {
   NodeNoRunsDetailsResolverService
 } from './services/node-details/node-noruns-details-resolver.service';
+import {
+  NodeNoRunIdResolverService
+} from './services/node-details/node-norunid-resolver.service';
 import { NodeRunsService } from './services/node-details/node-runs.service';
 import { ProjectService } from './entities/projects/project.service';
 import { ProductDeployedService } from './services/product-deployed/product-deployed.service';
@@ -327,6 +330,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     NotificationRuleRequests,
     NodeDetailsResolverService,
     NodeNoRunsDetailsResolverService,
+    NodeNoRunIdResolverService,
     NodeDetailsService,
     NodeRunsService,
     PolicyRequests,

--- a/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
+++ b/components/automate-ui/src/app/pages/node-noruns-details/node-noruns-details.component.html
@@ -5,7 +5,7 @@
         <main>
             <div class="node-noruns-details-container">
             <chef-breadcrumbs>
-                <chef-breadcrumb [link]="['/client-runs']">Client runs</chef-breadcrumb>
+                <chef-breadcrumb [link]="['/infrastructure/client-runs']">Client runs</chef-breadcrumb>
                 Node {{ node.name }}
             </chef-breadcrumbs>
 

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.spec.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.spec.ts
@@ -51,6 +51,25 @@ describe('NodeDetailsResolverService', () => {
     route = new MockRoute();
   });
 
+  describe('null nodeRun is returned', () => {
+    beforeEach(() => {
+      nodeRunsService.setResponse(Promise.resolve<NodeRun>(null));
+    });
+
+    it('should redirect to missing runs page', (done) => {
+
+      spyOn(route.paramMap, 'get').and.callFake(() => 'fake-node-id');
+      spyOn(router, 'navigate');
+
+      service.resolve(route, null).then((_nodeRun: NodeRun) => {
+        expect(router.navigate)
+          .toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
+        done();
+      });
+
+    });
+  });
+
   describe('non404 error in requesting nodeRun', () => {
     beforeEach(() => {
       nodeRunsService.setResponse(Promise.reject<NodeRun>('no real reason'));

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.spec.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NodeNoRunIdResolverService } from './node-norunid-resolver.service';
+import { NodeRunsService } from './node-runs.service';
+import { Router } from '@angular/router';
+import { NodeRun } from '../../types/types';
+
+class MockRouter {
+  constructor() {}
+  navigate(_route: Array<string>) {
+  }
+}
+
+class MockNodeRunsService {
+  response: Promise<NodeRun> = Promise.resolve<NodeRun>(null);
+
+  constructor() {}
+
+  public getNodeRunsByID(_nodeId: string) {
+    return this.response;
+  }
+
+  setResponse(response: Promise<NodeRun>) {
+    this.response = response;
+  }
+}
+
+class MockRoute {
+  paramMap = {
+    get() {}
+  };
+}
+
+describe('NodeDetailsResolverService', () => {
+  let route;
+  let service: NodeNoRunIdResolverService;
+  const router = new MockRouter();
+  let nodeRunsService: MockNodeRunsService;
+
+  nodeRunsService = new MockNodeRunsService();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NodeNoRunIdResolverService,
+        { provide: NodeRunsService, useValue: nodeRunsService },
+        { provide: Router, useValue: router }]
+    });
+
+    service = TestBed.inject(NodeNoRunIdResolverService);
+    route = new MockRoute();
+  });
+
+  describe('non404 error in requesting nodeRun', () => {
+    beforeEach(() => {
+      nodeRunsService.setResponse(Promise.reject<NodeRun>('no real reason'));
+    });
+
+    it('should redirect to client runs page', (done) => {
+      spyOn(router, 'navigate');
+
+      service.resolve(route, null).then((_nodeRun: NodeRun) => {
+        expect(router.navigate).toHaveBeenCalledWith(['/infrastructure/client-runs']);
+        done();
+      });
+    });
+  });
+
+  describe('404 error in requesting nodeRun', () => {
+    beforeEach(() => {
+      nodeRunsService.setResponse(Promise.reject<NodeRun>('run not found 404'));
+    });
+
+    it('should redirect to missing runs page', (done) => {
+      spyOn(router, 'navigate');
+      spyOn(route.paramMap, 'get').and.callFake(() => 'fake-node-id');
+
+      service.resolve(route, null).then((_nodeRun: NodeRun) => {
+        expect(router.navigate)
+          .toHaveBeenCalledWith(['/infrastructure/client-runs/fake-node-id/missing-runs']);
+        done();
+      });
+    });
+  });
+});

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
@@ -16,9 +16,9 @@ export class NodeNoRunIdResolverService implements Resolve<NodeRun> {
       then(nodeRuns => {
         // if the node runs is found we select the latest run-id.
         // Go to node runs detail page
-        if (nodeRuns.length) {
+        if (Object.keys(nodeRuns[0]).length !== 0) {
           this.router.navigate(
-            ['/infrastructure/client-runs/' + nodeId + '/runs/' + nodeRuns[0].id]
+            ['/infrastructure/client-runs/' + nodeId + '/runs/' + nodeRuns[0].runId]
           );
           return null;
         } else {

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { Router, Resolve, RouterStateSnapshot,
+         ActivatedRouteSnapshot } from '@angular/router';
+
+import { NodeRun } from '../../types/types';
+import { NodeRunsService } from './node-runs.service';
+
+@Injectable()
+export class NodeNoRunIdResolverService implements Resolve<NodeRun> {
+  constructor(private service: NodeRunsService, private router: Router) {}
+
+  resolve(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Promise<NodeRun> {
+    const nodeId = route.paramMap.get('node-id');
+
+    return this.service.getNodeRunsByID( nodeId ).
+      then(nodeRuns => {
+        // if the node runs is found we select the latest run-id.
+        // Go to node runs detail page
+        if (nodeRuns.length) {
+          this.router.navigate(
+            ['/infrastructure/client-runs/' + nodeId + '/runs/' + nodeRuns[0].id]
+          );
+          return null;
+        } else {
+          // if the node run was not found we assume this node has no runs.
+          // Go to node missing runs page
+          this.router.navigate(['/infrastructure/client-runs/' + nodeId + '/missing-runs']);
+          return null;
+        }
+      }).catch(e => {
+        // if the node run was not found we assume this node has no runs.
+        // Go to node missing runs page
+        if (JSON.stringify(e).indexOf('404') > 0) {
+          this.router.navigate(['/infrastructure/client-runs/' + nodeId + '/missing-runs']);
+        } else {
+          this.router.navigate(['/infrastructure/client-runs']);
+        }
+
+        return null;
+      });
+  }
+}

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
@@ -16,7 +16,7 @@ export class NodeNoRunIdResolverService implements Resolve<NodeRun> {
       then(nodeRuns => {
         // if the node runs is found we select the latest run-id.
         // Go to node runs detail page
-        if (Object.keys(nodeRuns[0]).length !== 0) {
+        if (nodeRuns && Object.keys(nodeRuns[0]).length !== 0) {
           this.router.navigate(
             ['/infrastructure/client-runs/' + nodeId + '/runs/' + nodeRuns[0].runId]
           );

--- a/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-norunid-resolver.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Router, Resolve, RouterStateSnapshot,
          ActivatedRouteSnapshot } from '@angular/router';
 
-import { NodeRun } from '../../types/types';
+import { NodeRun } from 'app/types/types';
 import { NodeRunsService } from './node-runs.service';
 
 @Injectable()
@@ -16,7 +16,7 @@ export class NodeNoRunIdResolverService implements Resolve<NodeRun> {
       then(nodeRuns => {
         // if the node runs is found we select the latest run-id.
         // Go to node runs detail page
-        if (nodeRuns && Object.keys(nodeRuns[0]).length !== 0) {
+        if (nodeRuns && nodeRuns.length) {
           this.router.navigate(
             ['/infrastructure/client-runs/' + nodeId + '/runs/' + nodeRuns[0].runId]
           );

--- a/components/automate-ui/src/app/services/node-details/node-runs.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-runs.service.ts
@@ -59,7 +59,7 @@ export class NodeRunsService {
       });
   }
 
-  getNodeRunsByID(nodeId: string) {
+  getNodeRunsByID(nodeId: string): Promise<AbridgedNodeRun[]> {
     const url = `${CONFIG_MGMT_URL}/nodes/${nodeId}/runs`;
 
     return this.httpClient

--- a/components/automate-ui/src/app/services/node-details/node-runs.service.ts
+++ b/components/automate-ui/src/app/services/node-details/node-runs.service.ts
@@ -59,6 +59,21 @@ export class NodeRunsService {
       });
   }
 
+  getNodeRunsByID(nodeId: string) {
+    const url = `${CONFIG_MGMT_URL}/nodes/${nodeId}/runs`;
+
+    return this.httpClient
+      .get<AbridgedRespNodeRun[]>(url).toPromise()
+      .then((res) =>
+        res.map(
+          (abridgedRespNodeRun: AbridgedRespNodeRun) =>
+            new AbridgedNodeRun(abridgedRespNodeRun))
+      ).catch( reason => {
+        console.error(reason);
+        return [];
+      });
+  }
+
   downloadRuns(type: string, filters: NodeHistoryFilter): Observable<string> {
     const url = `${CONFIG_MGMT_URL}/reports/export`;
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Navigate to client node detail page only with node-id by making run-id as optional, added route for node-id and its resolver service, now in route resolver service we have find out `run-id` of specific `node-id` if run-id exists then redirect to node details route if not then redirect to missing run page.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes: #3261 
### :+1: Definition of Done
1. Route created  for `node-id` with optional `run-id`
2. Breadcrumb redirection issue fixed in missing run page
### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve
Navigate to Infrastructure >>> Client Runs >>> now add existing node-id in route ( a2-dev.test/infrastructure/client-runs/`node-id` )
expectations if `run-id` exists for node then it will redirect to node-details else it will redirect to missing-runs route.
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
