### PR TITLE
ci: don't run code_coverage post merge

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -123,8 +123,6 @@ subscriptions:
             - components/automate-gateway/api/**/*.swagger.json
       - trigger_pipeline:habitat/build:
           post_commit: true
-      - trigger_pipeline:code_coverage:
-          post_commit: true
       - trigger_pipeline:deploy/ui-library:
           post_commit: true
           only_if_modified:


### PR DESCRIPTION
I moved this to the post-promote pipeline. For some reason when I did
this I thought this was running post-build already, but I think I just
confused myself. Anyway, it should be fine wherever.

Signed-off-by: Steven Danna <steve@chef.io>