### PR TITLE
ci: move more things to the nightlies

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -105,6 +105,80 @@ steps:
         linux:
           privileged: true
 
+  - label: "ha data services"
+    command:
+      - integration/run_test integration/tests/ha_data_services.sh
+    timeout_in_minutes: 35
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+
+  - label: "ha data services migrate"
+    command:
+      - integration/run_test integration/tests/ha_data_services_migrate.sh
+    timeout_in_minutes: 35
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+
+  - label: "backup w external es"
+    command:
+      - integration/run_test integration/tests/backup_external_es.sh
+    timeout_in_minutes: 25
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+
+  - label: "backup w external es to gcs"
+    command:
+      - integration/run_test integration/tests/backup_external_es_gcs.sh
+    timeout_in_minutes: 35
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+      secrets:
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
+        GOOGLE_APPLICATION_JSON:
+          path: secret/a2/gcp
+          field: backup-creds
+
+  - label: "backup w external es to s3"
+    command:
+      - integration/run_test integration/tests/backup_external_es_s3.sh
+    timeout_in_minutes: 30
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+      secrets:
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
+        AWS_ACCESS_KEY_ID:
+          account: aws/chef-cd
+          field: access_key_id
+        AWS_SECRET_ACCESS_KEY:
+          account: aws/chef-cd
+          field: secret_access_key
+        AWS_SESSION_TOKEN:
+          account: aws/chef-cd
+          field: session_token
+
   # TODO(ssd) 2019-12-13: This test is broken given the current design
   # of config patch and backup/restore.  We are working on fixes for
   # the various problems that make this test incorrect.
@@ -118,12 +192,44 @@ steps:
   #       linux:
   #         single-use: true
   #         privileged: true
+  - label: "product deployment stress mode"
+    command:
+      - integration/run_test integration/tests/product_deployment_stress.sh
+    timeout_in_minutes: 20
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
 
   - label: "[integration] product mitm"
     command:
       - integration/run_test integration/tests/product_mitm.sh
     timeout_in_minutes: 20
     expeditor:
+      executor:
+        linux:
+          privileged: true
+
+  - label: "cypress (flaky included) :cypress:"
+    command:
+      - FLAKY=yes integration/run_test integration/tests/cypress_e2e.sh
+    timeout_in_minutes: 35
+    soft_fail: true
+    expeditor:
+      secrets: &cypress_secrets
+        A2_LICENSE:
+          path: secret/a2/license
+          field: license
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_HOST:
+          path: secret/a2/testing/target_host
+          field: data
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_USER:
+          path: secret/a2/testing/target_user
+          field: data
+        CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_KEY:
+          path: secret/a2/testing/target_key
+          field: data
       executor:
         linux:
           privileged: true

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -389,11 +389,10 @@ steps:
   # end-to-end testing. These tests all test full deployments of
   # Automate in different configurations.
   #
-  - label: "cypress (flaky included) :cypress:"
+  - label: "cypress :cypress:"
     command:
-      - FLAKY=yes integration/run_test integration/tests/cypress_e2e.sh
+      - FLAKY=no integration/run_test integration/tests/cypress_e2e.sh
     timeout_in_minutes: 35
-    soft_fail: true
     expeditor:
       secrets: &cypress_secrets
         A2_LICENSE:
@@ -408,16 +407,6 @@ steps:
         CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_KEY:
           path: secret/a2/testing/target_key
           field: data
-      executor:
-        linux:
-          privileged: true
-
-  - label: "cypress :cypress:"
-    command:
-      - FLAKY=no integration/run_test integration/tests/cypress_e2e.sh
-    timeout_in_minutes: 35
-    expeditor:
-      secrets: *cypress_secrets
       executor:
         linux:
           privileged: true
@@ -510,16 +499,6 @@ steps:
   - label: "product"
     command:
       - integration/run_test integration/tests/product.sh
-    timeout_in_minutes: 20
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
-
-  - label: "product deployment stress mode"
-    command:
-      - integration/run_test integration/tests/product_deployment_stress.sh
     timeout_in_minutes: 20
     expeditor:
       executor:
@@ -649,7 +628,7 @@ steps:
           path: secret/a2/gcp
           field: backup-creds
 
-  - label: "ontop backup "
+  - label: "ontop backup"
     command:
       - integration/run_test integration/tests/backup_ontop.sh
     timeout_in_minutes: 25
@@ -658,61 +637,6 @@ steps:
         linux:
           single-use: true
           privileged: true
-
-  - label: "backup w external es"
-    command:
-      - integration/run_test integration/tests/backup_external_es.sh
-    timeout_in_minutes: 25
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
-
-  - label: "backup w external es to s3"
-    command:
-      - integration/run_test integration/tests/backup_external_es_s3.sh
-    timeout_in_minutes: 30
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        linux:
-          single-use: true
-          privileged: true
-      secrets:
-        A2_LICENSE:
-          path: secret/a2/license
-          field: license
-        AWS_ACCESS_KEY_ID:
-          account: aws/chef-cd
-          field: access_key_id
-        AWS_SECRET_ACCESS_KEY:
-          account: aws/chef-cd
-          field: secret_access_key
-        AWS_SESSION_TOKEN:
-          account: aws/chef-cd
-          field: session_token
-
-  - label: "backup w external es to gcs"
-    command:
-      - integration/run_test integration/tests/backup_external_es_gcs.sh
-    timeout_in_minutes: 35
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        linux:
-          single-use: true
-          privileged: true
-      secrets:
-        A2_LICENSE:
-          path: secret/a2/license
-          field: license
-        GOOGLE_APPLICATION_JSON:
-          path: secret/a2/gcp
-          field: backup-creds
-
 
   - label: "upgrade dev -> master"
     command:
@@ -817,26 +741,6 @@ steps:
     expeditor:
       executor:
         linux:
-          privileged: true
-
-  - label: "ha data services"
-    command:
-      - integration/run_test integration/tests/ha_data_services.sh
-    timeout_in_minutes: 35
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
-
-  - label: "ha data services migrate"
-    command:
-      - integration/run_test integration/tests/ha_data_services_migrate.sh
-    timeout_in_minutes: 35
-    expeditor:
-      executor:
-        linux:
-          single-use: true
           privileged: true
 
   - label: "shellcheck hooks"


### PR DESCRIPTION
This brings us from 114 to 107 jobs between verify and
verify_private. It is barely a dent. But, it is a start I suppose.

Signed-off-by: Steven Danna <steve@chef.io>
