### PR TITLE
docs/content/saml: add Azure AD section

### DIFF
--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -49,23 +49,26 @@ Users who sign in via SAML will have a session time of 24 hours before needing t
 - Ping
 - Tivoli Federated Identity Manager
 
-In the following section, you can find further details about specific supported identity management systems.
-
 ### Azure AD
 
-For using Chef Automate's SAML integration with Azure AD, please note that **signing key rotation** is
-not supported to be done automatically. The signing certificate used with Azure for SAML sign-ins
-has to be **managed manually**.
+Using Azure AD as an SAML IdP requires specific configuration for both Azure AD and Chef Automate.
 
-After setting up your application as a _"non-gallery application"_, configure its SAML sign-on method.
-For both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_, enter
-`https://{{< example_fqdn "automate" >}}/dex/callback`.
+{{< info >}}
+The signing certificate used for Chef Automate's SAML integration with Azure AD requires manual management.
+Signing key rotation is not done automatically.
+{{< /info >}}
 
-The default claims can be used, see below for their counterparts in the Chef Automate configuration.
-Download the _Certificate (Base64)_, and take note of the _Login URL_.
+First, set up your configuration within Azure AD.
+Set up your application as a _"non-gallery application"_, and then configure its SAML log-in method.
+Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_,.
 
-The minimal configuration snippet then looks like this (replace `<<something>>` with the values
-noted above):
+You may use the default claims provided by Azure AD.
+Remember to edit the Chef Automate configuration in `config.toml` to reflect this claims information.
+
+Download the _Certificate (Base64)_ and take note of the _Login URL_ for use in the Chef Automate configuration.
+
+After configuring Azure AD, edit your Chef Automate `config.toml` configuration file to reflect the values entered in the Azure AD interface.
+The minimal configuration snippet in `config.toml` will look similar to:
 
 ```toml
 [dex.v1.sys.connectors.saml]
@@ -78,7 +81,13 @@ username_attr = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddr
 entity_issuer = "https://{{< example_fqdn "automate" >}}/dex/callback"
 ```
 
-See below for further options.
+where
+
+- `ca_contents` contains the value of the _Certificate (Base64)_
+- `sso_url` contains the value of _Login URL_
+- `entity_issuer`  contains the value of _Identifier (Entity ID)_
+
+See the SAML Configuration Settings section below for further configuration options.
 
 ## SAML Configuration Settings
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -58,7 +58,7 @@ The signing certificate used for Chef Automate's SAML integration with Azure AD 
 Signing key rotation is not done automatically.
 {{< /info >}}
 
-In Azure AD, add Chef Automate as a _"non-gallery application"_, and then configure its SAML log-in method.
+In Azure AD, add Chef Automate as a _"non-gallery application"_, and then configure its SAML sign-in method.
 [The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-saml-single-sign-on) provides a detailed guide.
 Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_.
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -59,7 +59,7 @@ Signing key rotation is not done automatically.
 {{< /info >}}
 
 First you need to add Chef Automate as a _"non-gallery application"_, and then configure its SAML log-in method.
-[The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-single-sign-on-non-gallery-applications)
+[The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-saml-single-sign-on)
 provides a detailed guide.
 Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_,.
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -84,6 +84,7 @@ entity_issuer = "https://{{< example_fqdn "automate" >}}/dex/callback"
 where
 
 - `ca_contents` contains the value of the _Certificate (Base64)_
+  (including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers)
 - `sso_url` contains the value of _Login URL_
 - `entity_issuer`  contains the value of _Identifier (Entity ID)_
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -42,11 +42,43 @@ Users who sign in via SAML will have a session time of 24 hours before needing t
 
 ## Supported Identity Management Systems
 
+- [Azure AD]({{< relref "#azure-ad" >}})
 - Office365
 - OKTA
 - OneLogin
 - Ping
 - Tivoli Federated Identity Manager
+
+In the following section, you can find further details about specific supported identity management systems.
+
+### Azure AD
+
+For using Chef Automate's SAML integration with Azure AD, please note that **signing key rotation** is
+not supported to be done automatically. The signing certificate used with Azure for SAML sign-ins
+has to be **managed manually**.
+
+After setting up your application as a _"non-gallery application"_, configure its SAML sign-on method.
+For both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_, enter
+`https://{{< example_fqdn "automate" >}}/dex/callback`.
+
+The default claims can be used, see below for their counterparts in the Chef Automate configuration.
+Download the _Certificate (Base64)_, and take note of the _Login URL_.
+
+The minimal configuration snippet then looks like this (replace `<<something>>` with the values
+noted above):
+
+```toml
+[dex.v1.sys.connectors.saml]
+ca_contents="""
+<<Certificate (Base64)>>
+"""
+sso_url = "<<Login URL>>"
+email_attr = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+username_attr = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+entity_issuer = "https://{{< example_fqdn "automate" >}}/dex/callback"
+```
+
+See below for further options.
 
 ## SAML Configuration Settings
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -58,15 +58,14 @@ The signing certificate used for Chef Automate's SAML integration with Azure AD 
 Signing key rotation is not done automatically.
 {{< /info >}}
 
-First you need to add Chef Automate as a _"non-gallery application"_, and then configure its SAML log-in method.
-[The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-saml-single-sign-on)
-provides a detailed guide.
-Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_,.
+In Azure AD, add Chef Automate as a _"non-gallery application"_, and then configure its SAML log-in method.
+[The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-saml-single-sign-on) provides a detailed guide.
+Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_.
 
 You may use the default claims provided by Azure AD.
 Remember to edit the Chef Automate configuration in `config.toml` to reflect this claims information.
 
-Download the _Certificate (Base64)_ and take note of the _Login URL_ for use in the Chef Automate configuration.
+Download the _Certificate (Base64)_ in Azure AD and take note of the _Login URL_ for use in the Chef Automate configuration.
 
 After configuring Azure AD, edit your Chef Automate `config.toml` configuration file to reflect the values entered in the Azure AD interface.
 The minimal configuration snippet in `config.toml` will look similar to:
@@ -82,14 +81,13 @@ username_attr = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddr
 entity_issuer = "https://{{< example_fqdn "automate" >}}/dex/callback"
 ```
 
-where
+where:
 
-- `ca_contents` contains the value of the _Certificate (Base64)_
-  (including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers)
+- `ca_contents` contains the value of the _Certificate (Base64)_, and includes the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers
 - `sso_url` contains the value of _Login URL_
-- `entity_issuer`  contains the value of _Identifier (Entity ID)_
+- `entity_issuer` contains the value of _Identifier (Entity ID)_
 
-See the SAML Configuration Settings section below for further configuration options.
+See the SAML Configuration Settings below for further configuration options.
 
 ## SAML Configuration Settings
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -58,8 +58,9 @@ The signing certificate used for Chef Automate's SAML integration with Azure AD 
 Signing key rotation is not done automatically.
 {{< /info >}}
 
-First, set up your configuration within Azure AD.
-Set up your application as a _"non-gallery application"_, and then configure its SAML log-in method.
+First you need to add Chef Automate as a _"non-gallery application"_, and then configure its SAML log-in method.
+[The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-single-sign-on-non-gallery-applications)
+provides a detailed guide.
 Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_,.
 
 You may use the default claims provided by Azure AD.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Some of our customers have been using this for a while now. I've verified that the instructions work, and added it, together with an emphasis on manual signing certificate management, to the docs.

### :chains: Related Resources

#2887 

### :+1: Definition of Done

There's docs describing how to use Azure AD's SAML with A2.

### :athletic_shoe: How to Build and Test the Change

- `cd docs; make serve` and `open http://localhost:1313/docs/saml/` given that you've gotten all the docs tools installed.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
