### PR TITLE
Compliance UI make use of root status_message

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -169,7 +169,16 @@
           </chef-option>
         </chef-phat-radio>
 
-        <chef-table class="controls-table">
+        <div class="metadata-container err-container">
+          <div class="metadata failed err-failed-container">
+            <span class="metadata-title err-color">
+              <chef-icon id="err-icon-id">{{ statusIcon('failed') }}</chef-icon>
+              <b class="err-bold">Execution Error:</b> {{activeReport.status_message}}
+            </span>
+          </div>
+        </div>
+
+        <chef-table class="controls-table" *ngIf="activeReport.controls.total > 0">
           <chef-thead>
             <chef-tr>
               <chef-th>Control</chef-th>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -169,7 +169,7 @@
           </chef-option>
         </chef-phat-radio>
 
-        <div class="metadata-container err-container">
+        <div class="metadata-container err-container" *ngIf="activeReport.status == 'failed' && activeReport.status_message.length">
           <div class="metadata failed err-failed-container">
             <span class="metadata-title err-color">
               <chef-icon id="err-icon-id">{{ statusIcon('failed') }}</chef-icon>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -586,3 +586,24 @@ dl.waiver-details {
     flex-grow: 1;
   }
 }
+
+.err-container {
+  background-color: $chef-lightest-grey;
+}
+
+.err-failed-container {
+  padding: 5px;
+}
+
+.err-color {
+  color: $chef-critical;
+}
+
+.err-bold {
+  padding-right: 5px;
+}
+
+#err-icon-id {
+  padding-left: 5px;
+  color: $chef-critical;
+}

--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -245,6 +245,10 @@ SCRIPT
 
 $enter_hab_studio = <<SCRIPT
 export HAB_LICENSE=accept-no-persist
+cat<<EOS >> /home/ubuntu/.screenrc
+caption always "%{-b ck}SCREEN SESSION%{= kc} on %{+b}$(curl -sS http://169.254.169.254/latest/meta-data/public-hostname)%{-} ($(curl -Ss http://169.254.169.254/latest/meta-data/local-ipv4)) %{+b kR}[system load: %l] %{-b kY}%f %t%{= kc}"
+EOS
+chown ubuntu:ubuntu /home/ubuntu/.screenrc
 cat<<EOF >/etc/profile.d/hab_studio_setup.sh
 export HAB_LICENSE=accept-no-persist
 if [ "\\$USER" == "ubuntu" ]; then
@@ -255,7 +259,6 @@ if [ "\\$USER" == "ubuntu" ]; then
   export AZURE_CLIENT_ID=#{ENV['AZURE_CLIENT_ID']}
   export AZURE_CLIENT_SECRET=#{ENV['AZURE_CLIENT_SECRET']}
   export AZURE_TENANT_ID=#{ENV['AZURE_TENANT_ID']}
-
   cd #{home_dir}/automate
   source .envrc
   if [ ! -f ~/.hab/etc/cli.toml ]; then
@@ -279,11 +282,13 @@ EOT
     hab studio run "mount -o discard /dev/\\$device_to_mount /hab/svc/automate-elasticsearch/data"
     hab studio run 'mkdir -p /hab/svc/automate-elasticsearch/data/es_data && chown -R hab:hab /hab/svc/automate-elasticsearch/data/es_data'
   fi
-  echo " * Running: 'hab studio enter' in 'screen'!!!"
-  if screen -ls; then
-    screen -r
+  if screen -ls hab_studio; then
+    screen -ls
+    echo " * Attaching to existing screen 'hab_studio'"
+    screen -x hab_studio
   else
-    screen hab studio enter
+    echo " * Running: 'hab studio enter' in 'screen'!!!"
+    screen -S hab_studio hab studio enter
   fi
 fi
 EOF


### PR DESCRIPTION
This is MVP UI change for this backend improvement: https://github.com/chef/automate/pull/4131

@jonong1972 is working into some designs to bring this together with the failure `status_message` fields when profiles inside a report fail.

To test, rebuild `components/automate-ui` and ingest a report, like the one from the tests of https://github.com/chef/automate/pull/4131 

I left the boxes with the zero control counts to further highlight that this report is empty/abnormal and needs investigation.

Screenshot of the error div here:
![Screenshot 2020-07-27 at 23 05 26](https://user-images.githubusercontent.com/107378/88596821-e3c38900-d05d-11ea-9834-bd64149f7ab8.png)
