### PR TITLE
ci: try using actions for expeditor promote

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -58,7 +58,44 @@ pipelines:
       env:
         - CHANNEL: dev
 
+# These actions are taken when `/expeditor promote` is run from Slack
 promote:
+# actions is deprecated. we need to switch to subscription model
+  actions:
+    - bash:.expeditor/promote-hab-pkgs-and-cli.sh:
+        post_commit: true
+    - bash:.expeditor/publish-release-notes.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: current
+    - purge_packages_chef_io_fastly:{{target_channel}}/automate/latest:
+        post_commit: true
+    - bash:.expeditor/announce-release.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: current
+    - bash:.expeditor/push-git-tag.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: current
+    - bash:.expeditor/announce-acceptance.sh:
+        post_commit: true
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: acceptance
+    - trigger_pipeline:deploy/acceptance:
+        only_if_conditions:
+          - value_one: "{{target_channel}}"
+            operator: equals
+            value_two: acceptance
+    - trigger_pipeline:deploy/automate-chef-io
   channels:
     - dev
     - acceptance
@@ -70,33 +107,6 @@ staging_areas:
       workload: pull_request_merged:chef/automate:master:*
 
 subscriptions:
-  # dev -> acceptance promotion
-  # These actions are taken when `/expeditor promote` is run from Slack
-  - workload: project_promoted:{{agent_id}}:dev:*
-    actions:
-    - bash:.expeditor/promote-hab-pkgs-and-cli.sh:
-        post_commit: true
-    - purge_packages_chef_io_fastly:{{target_channel}}/automate/latest:
-        post_commit: true
-    - bash:.expeditor/announce-acceptance.sh:
-        post_commit: true
-    - trigger_pipeline:deploy/acceptance
-    - trigger_pipeline:deploy/automate-chef-io
-  # acceptance -> current promotion
-  - workload: project_promoted:{{agent_id}}:acceptance:*
-    actions:
-    - bash:.expeditor/promote-hab-pkgs-and-cli.sh:
-        post_commit: true
-    - purge_packages_chef_io_fastly:{{target_channel}}/automate/latest:
-        post_commit: true
-    - bash:.expeditor/publish-release-notes.sh:
-        post_commit: true
-    - bash:.expeditor/announce-release.sh:
-        post_commit: true
-    - bash:.expeditor/push-git-tag.sh:
-        post_commit: true
-    - trigger_pipeline:deploy/automate-chef-io
-
   # These actions are taken, in order they are specified, anytime a Pull Request is merged.
   - workload: staged_workload_released:chef/automate:master:post_merge:*
     actions:


### PR DESCRIPTION
Signed-off-by: Victoria Jeffrey <vjeffrey@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

in https://github.com/chef/automate/pull/4146/files @stevendanna did some work to transition us to the subscription model. it looks like this requires a couple more changes to get it all the way transitioned. we need to get the promotion from dev -> acceptance through so we've decided to try to roll with the backwards compatible "actions" instead of trying to transition to the subscription model right away. we'll circle back around after.

### :chains: Related Resources

### :+1: Definition of Done
