### PR TITLE
Removes option to add teams for new project

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.html
@@ -62,9 +62,6 @@
           <chef-checkbox id="add-policy-checkbox" (change)="updatePolicyCheckbox($event.detail)" [checked]="addPolicies">
             Also create owner, editor, and viewer <b>policies</b> for this project.
           </chef-checkbox>
-          <chef-checkbox (change)="updateTeamCheckbox($event.detail)" [checked]="addTeams">
-            Also create owner, editor, and viewer <b>teams</b> for this project.
-          </chef-checkbox>
         </div>
         <div class="dropdown-margin" *ngIf="objectNoun === 'token'">
           <app-resource-dropdown

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.scss
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.scss
@@ -27,10 +27,6 @@ chef-modal {
 
       .checkbox-margin {
         margin-bottom: 30px;
-
-        #add-policy-checkbox {
-          margin-bottom: 30px;
-        }
       }
 
       .dropdown-margin {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.spec.ts
@@ -118,16 +118,14 @@ describe('CreateObjectModalComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(new GetPolicies());
   });
 
-  it('upon opening, "also create" checkboxes are checked', () => {
+  it('upon opening, "also create policies" checkbox is checked', () => {
     component.createForm = new FormBuilder().group({
       name: '',
-      addPolicies: '',
-      addTeams: ''
+      addPolicies: ''
     });
 
-    // force them to start at false
+    // force it to start at false
     component.createForm.controls.addPolicies.setValue(false);
-    component.createForm.controls.addTeams.setValue(false);
 
     component.createProjectModal = true;
 
@@ -135,7 +133,6 @@ describe('CreateObjectModalComponent', () => {
       { visible: new SimpleChange(false, true, true) });
 
     expect(component.createForm.controls.addPolicies.value).toEqual(true);
-    expect(component.createForm.controls.addTeams.value).toEqual(true);
   });
 
   describe('ordering', () => {

--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -37,7 +37,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   public modifyID = false; // Whether the edit ID form is open or not.
   public conflictError = false;
   public addPolicies = true;
-  public addTeams = true;
   public projectsUpdatedEvent = new EventEmitter();
   public policiesUpdatedEvent = new EventEmitter();
   public UNASSIGNED_PROJECT_ID = ProjectConstants.UNASSIGNED_PROJECT_ID;
@@ -96,7 +95,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
       if (this.createProjectModal) {
          // default to checked upon opening
         this.updatePolicyCheckbox(true);
-        this.updateTeamCheckbox(true);
       }
     }
   }
@@ -112,11 +110,6 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   updatePolicyCheckbox(event: boolean): void {
     this.addPolicies = event;
     this.createForm.controls.addPolicies.setValue(this.addPolicies);
-  }
-
-  updateTeamCheckbox(event: boolean): void {
-    this.addTeams = event;
-    this.createForm.controls.addTeams.setValue(this.addTeams);
   }
 
   handleNameInput(event: KeyboardEvent): void {

--- a/components/automate-ui/src/app/pages/project/list/project-list.component.ts
+++ b/components/automate-ui/src/app/pages/project/list/project-list.component.ts
@@ -18,7 +18,6 @@ import {
   allProjects, getAllStatus, createStatus, createError
 } from 'app/entities/projects/project.selectors';
 import { GetProjects, CreateProject, DeleteProject, ProjectPayload  } from 'app/entities/projects/project.actions';
-import { CreateTeam } from 'app/entities/teams/team.actions';
 import { Project } from 'app/entities/projects/project.model';
 import { LoadOptions } from 'app/services/projects-filter/projects-filter.actions';
 
@@ -45,12 +44,6 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       'RULES_APPLIED': 'Applied'
   };
 
-  readonly teamsToCreate = {
-    'project-owners': 'Project Owners',
-    'editors': 'Editors',
-    'viewers': 'Viewers'
-  };
-
   constructor(
     private layoutFacade: LayoutFacadeService,
     private store: Store<NgrxStateAtom>,
@@ -62,8 +55,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       name: ['', Validators.required],
       id: ['',
         [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(48)]],
-      addPolicies: [true],
-      addTeams: [true]
+      addPolicies: [true]
     });
   }
 
@@ -89,25 +81,11 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.creatingProject = false;
 
-        const createTeamsWasChecked = this.createProjectForm.controls['addTeams'].value;
-        const projectID = this.createProjectForm.controls['id'].value;
-        const projectName = this.createProjectForm.controls['name'].value;
-
         this.closeCreateModal();
 
         // This is issued periodically from projects-filter.effects.ts; we do it now
         // so the user doesn't have to wait.
         this.store.dispatch(new LoadOptions());
-
-        if (createTeamsWasChecked) {
-          for (const [teamID, teamName] of Object.entries(this.teamsToCreate)) {
-            this.store.dispatch(new CreateTeam({
-              id: `${projectID}-${teamID}`,
-              name: `${projectName} ${teamName}`,
-              projects: [projectID]
-            }));
-          }
-        }
       });
 
     combineLatest([

--- a/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_mgmt.spec.ts
@@ -73,8 +73,8 @@ describe('project management', () => {
     cy.get('app-create-object-modal chef-checkbox')
       .should('have.attr', 'aria-checked', 'true');
 
-    // don't create associated project policies or teams
-    cy.get('app-create-object-modal chef-checkbox').click({ multiple: true });
+    // don't create associated project policies
+    cy.get('app-create-object-modal chef-checkbox').click();
 
     cy.get('[data-cy=save-button]').click();
     cy.get('app-project-list chef-modal').should('not.be.visible');
@@ -100,8 +100,8 @@ describe('project management', () => {
     cy.get('[data-cy=edit-button]').contains('Edit ID').click();
     cy.get('[data-cy=id-label]').should('not.be.visible');
 
-    // don't create associated project policies or teams
-    cy.get('app-create-object-modal chef-checkbox').click({ multiple: true });
+    // don't create associated project policies
+    cy.get('app-create-object-modal chef-checkbox').click();
 
     cy.get('[data-cy=create-id]').should('be.visible').clear()
       .type(customWithoutPolsProjectID).should('have.value', customWithoutPolsProjectID);
@@ -126,21 +126,10 @@ describe('project management', () => {
       });
     });
 
-    // verify no associated teams were generated
-    associatedTeams.forEach((team) => {
-      cy.request({
-        auth: { bearer: adminIdToken },
-        url: `/apis/iam/v2/teams/${customWithoutPolsProjectID}-${team}`,
-        failOnStatusCode: false
-      }).then((response) => {
-        expect(response.status).to.equal(404);
-      });
-    });
-
     cy.url().should('include', '/settings/projects');
   });
 
-  it('can create a project with a custom ID and generate associated policies and teams', () => {
+  it('can create a project with a custom ID and generate associated policies', () => {
     cy.get('[data-cy=create-project]').contains('Create Project').click();
     cy.get('app-project-list chef-modal').should('have.class', 'visible');
 
@@ -175,16 +164,6 @@ describe('project management', () => {
       cy.request({
         auth: { bearer: adminIdToken },
         url: `/apis/iam/v2/policies/${customWithPolsProjectID}-${policy}`
-      }).then((response) => {
-        expect(response.status).to.equal(200);
-      });
-    });
-
-    // verify associated teams were generated
-    associatedTeams.forEach((team) => {
-      cy.request({
-        auth: { bearer: adminIdToken },
-        url: `/apis/iam/v2/teams/${customWithPolsProjectID}-${team}`
       }).then((response) => {
         expect(response.status).to.equal(200);
       });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Because teams is a separate service that is dependent on auth,
tying these created teams to policies in the most readable,
maintainable way requires significant effort (using cereal or merging teams into authz), so we are
removing the option for now.

### :athletic_shoe: How to Build and Test the Change

Enter the studio and bring up the UI-- Navigate to "Settings" in the UI, then "Projects". Click "Create Project":

-- there should not be an option to automatically create teams
-- when project is created, there should be no associated teams