### PR TITLE
Add habitat auth token to use when promoting habitat packages to the correct channel.

### DIFF
--- a/.expeditor/promote-hab-pkgs-and-cli.sh
+++ b/.expeditor/promote-hab-pkgs-and-cli.sh
@@ -19,6 +19,10 @@ fi
 #                  Habitat depot and private repos in Chef's GitHub org
 #
 
+# Export the HAB_AUTH_TOKEN for use of promoting habitat packages to {{TARGET_CHANNE}}
+HAB_AUTH_TOKEN=$(vault kv get -field auth_token account/static/habitat/chef-ci)
+export HAB_AUTH_TOKEN
+
 source_channel=$EXPEDITOR_PROMOTABLE
 
 # Download the manifest


### PR DESCRIPTION
Add habitat auth token to use when promoting habitat packages to the correct channel.

Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
`HAB_AUTH_TOKEN` does not by default get exported by expeditor. Need to go get that so we can promote habitat packages.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
