### PR TITLE
protos: bump protoc to 3.12.3

### DIFF
--- a/api/config/scripts/grpc.sh
+++ b/api/config/scripts/grpc.sh
@@ -2,7 +2,7 @@
 set -e
 
 protoc_repo=github.com/golang/protobuf/protoc-gen-go
-protoc_version="3.9.2"
+protoc_version="3.12.3"
 
 [[ $(type -P "protoc") ]] || (echo "unable to proceed. protobuf is not installed" && exit 1)
 protoc --version | grep -q $protoc_version  || (echo "unable to proceed. protobuf must be version $protoc_version" && exit 1)

--- a/components/automate-deployment/scripts/grpc.sh
+++ b/components/automate-deployment/scripts/grpc.sh
@@ -4,7 +4,7 @@ set -e
 # shellcheck disable=SC2043
 
 protoc_repo=github.com/golang/protobuf/protoc-gen-go
-protoc_version="3.9.2"
+protoc_version="3.12.3"
 
 [[ $(type -P "protoc") ]] || (echo "unable to proceed. protobuf is not installed" && exit 1)
 [[ $(protoc --version | grep $protoc_version) ]] || (echo "unable to proceed. protobuf must be version $protoc_version" && exit 1)


### PR DESCRIPTION
The protobuf available in Habitat was just upgraded. This bumps the
version we expect in these scripts to match.

I've test this with a complete regen locally and it didn't produce any
changes.

Signed-off-by: Steven Danna <steve@chef.io>