### PR TITLE
Add empty data states to desktop dashboard

### DIFF
--- a/components/automate-ui/src/app/entities/desktop/desktop.model.ts
+++ b/components/automate-ui/src/app/entities/desktop/desktop.model.ts
@@ -56,6 +56,7 @@ export interface NodeRunsDailyStatusCollection {
 export interface DayPercentage {
   daysAgo: number;
   percentage: number;
+  total: number;
 }
 
 export interface TopErrorsCollection {

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.html
@@ -8,9 +8,9 @@
           <p class="tooltip-text">Percentage of checked-in to total desktops at 24 hour intervals.</p>
         </chef-tooltip>
       </div>
-      <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+      <h6 *ngIf="hasData" class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
     </div>
-    <select (change)="dateChanged($event.target.value)">
+    <select *ngIf="hasData" (change)="dateChanged($event.target.value)">
       <option *ngFor="let selectableDaysAgo of selectableDaysAgoCollection" [value]="selectableDaysAgo"
         [selected]="selectableDaysAgo == selectedDaysAgo">
         Last {{ selectableDaysAgo }} Days
@@ -18,5 +18,6 @@
     </select>
   </div>
 
-  <app-simple-line-graph [data]="days"></app-simple-line-graph>
+  <app-simple-line-graph *ngIf="hasData" [data]="days"></app-simple-line-graph>
+  <app-empty-data *ngIf="!hasData"></app-empty-data>
 </div>

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.spec.ts
@@ -36,4 +36,32 @@ describe('CheckInTimeSeriesComponent', () => {
       expect(tooltip.getAttribute('for')).toEqual('checkin-history-info');
     });
   });
+
+  describe('when data is available', () => {
+    it('does not display empty data message', () => {
+      component.days = [
+        { daysAgo: 0, percentage: 60, total: 10 },
+        { daysAgo: 1, percentage: 40, total: 10 }
+      ];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeFalsy();
+    });
+  });
+
+  describe('when no data is available', () => {
+    it('displays empty data message', () => {
+      component.days = [
+        { daysAgo: 0, percentage: 100, total: 0 },
+        { daysAgo: 1, percentage: 100, total: 0 }
+      ];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeTruthy();
+    });
+  });
 });

--- a/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/check-in-time-series/check-in-time-series.component.ts
@@ -48,4 +48,8 @@ export class CheckInTimeSeriesComponent implements OnInit, OnDestroy, OnChanges 
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
+
+  get hasData(): boolean {
+    return this.days && this.days.some(item => item.total > 0);
+  }
 }

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.html
@@ -8,11 +8,11 @@
           <p class="tooltip-text">Check-in status in the last 24 hours.</p>
         </chef-tooltip>
       </div>
-      <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+      <h6 *ngIf="hasData" class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
     </div>
-    <app-chart-progress-bar size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>
+    <app-chart-progress-bar *ngIf="hasData" size="large" [value]="unknownCount" [max]="totalCount"></app-chart-progress-bar>
   </div>
-  <chef-phat-radio deselectable (change)="statusSelected.emit($event.target.value)" [value]="selectedStatus">
+  <chef-phat-radio *ngIf="hasData" deselectable (change)="statusSelected.emit($event.target.value)" [value]="selectedStatus">
     <chef-option value='unknown' tabindex="0">
       <div class="title">Unknown</div>
       <div class="total">{{ unknownCount }}</div>
@@ -26,4 +26,5 @@
       <div class="total">{{ totalCount }}</div>
     </chef-option>
   </chef-phat-radio>
+  <app-empty-data *ngIf="!hasData"></app-empty-data>
 </div>

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.spec.ts
@@ -36,4 +36,26 @@ describe('DailyCheckInComponent', () => {
       expect(tooltip.getAttribute('for')).toEqual('daily-checkin-info');
     });
   });
+
+  describe('when data is available', () => {
+    it('does not display empty data message', () => {
+      component.totalCount = 10;
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeFalsy();
+    });
+  });
+
+  describe('when no data is available', () => {
+    it('displays empty data message', () => {
+      component.totalCount = 0;
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeTruthy();
+    });
+  });
 });

--- a/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/daily-check-in/daily-check-in.component.ts
@@ -45,4 +45,8 @@ export class DailyCheckInComponent implements OnInit, OnDestroy, OnChanges {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
+
+  get hasData(): boolean {
+    return this.totalCount > 0;
+  }
 }

--- a/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/dashboard/dashboard.component.ts
@@ -138,7 +138,7 @@ export class DashboardComponent implements OnInit {
           if (bucket.total > 0) {
             percentage = (bucket.checkInCount / bucket.total) * 100;
           }
-          return {daysAgo: index, percentage: percentage};
+          return {daysAgo: index, percentage: percentage, total: bucket.total};
         }))
     );
 

--- a/components/automate-ui/src/app/modules/desktop/desktop.module.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop.module.ts
@@ -18,6 +18,7 @@ import { InsightComponent } from './insight/insight.component';
 import {
   InsightAttributesDropdownComponent
 } from 'app/page-components/insight-attributes-dropdown/insight-attributes-dropdown.component';
+import { EmptyDataComponent } from './empty-data/empty-data.component';
 import { DesktopRoutingModule } from './desktop-routing.module';
 
 @NgModule({
@@ -33,6 +34,7 @@ import { DesktopRoutingModule } from './desktop-routing.module';
     CheckInTimeSeriesComponent,
     DailyCheckInComponent,
     DashboardComponent,
+    EmptyDataComponent,
     InsightComponent,
     InsightAttributesDropdownComponent,
     SimpleLineGraphComponent,
@@ -44,6 +46,7 @@ import { DesktopRoutingModule } from './desktop-routing.module';
     DailyCheckInComponent,
     DashboardComponent,
     DesktopDetailComponent,
+    EmptyDataComponent,
     InsightComponent,
     InsightAttributesDropdownComponent,
     SimpleLineGraphComponent,

--- a/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.html
+++ b/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.html
@@ -1,0 +1,2 @@
+<img class="empty-icon" src="assets/img/chart.svg" width="50" alt="" aria-hidden="true" />
+<p class="empty-message">Data not found. Try checking in your Chef Infra Client configuration and give us a moment to load it.</p>

--- a/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.scss
@@ -1,0 +1,17 @@
+@import "~styles/variables";
+@import "@carbon/layout/scss/layout";
+
+:host {
+  display: flex;
+  align-items: center;
+
+  .empty-icon {
+    margin: $spacing-05;
+    margin-left: 0;
+    width: 50px;
+  }
+
+  .empty-message {
+    margin: 0;
+  }
+}

--- a/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.spec.ts
@@ -1,0 +1,32 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EmptyDataComponent } from './empty-data.component';
+import { By } from '@angular/platform-browser';
+
+describe('EmptyDataComponent', () => {
+  let fixture: ComponentFixture<EmptyDataComponent>;
+  let component: EmptyDataComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      declarations: [
+        EmptyDataComponent
+      ],
+      providers: [],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    });
+
+    fixture = TestBed.createComponent(EmptyDataComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('exists', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('displays help message for missing data', () => {
+    const message = fixture.debugElement.query(By.css('.empty-message')).nativeElement;
+    expect(message.innerText).toContain('Data not found.');
+  });
+});

--- a/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/empty-data/empty-data.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-empty-data',
+  templateUrl: './empty-data.component.html',
+  styleUrls: ['./empty-data.component.scss']
+})
+export class EmptyDataComponent {}

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.html
@@ -7,9 +7,9 @@
         <p class="tooltip-text">Most common error messages and classes returned from Chef Infra Client runs across all desktops.</p>
       </chef-tooltip>
     </div>
-    <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+    <h6 class="heading-time" *ngIf="hasData">Updated {{ lastUpdatedMessage }}</h6>
   </div>
-  <chef-table class="chart-list">
+  <chef-table class="chart-list" *ngIf="hasData">
     <chef-tbody>
       <chef-tr
         *ngFor="let item of topErrorsItems"
@@ -37,4 +37,5 @@
       </chef-tr>
     </chef-tbody>
   </chef-table>
+  <app-empty-data *ngIf="!hasData"></app-empty-data>
 </div>

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.spec.ts
@@ -36,4 +36,29 @@ describe('TopErrorsComponent', () => {
       expect(tooltip.getAttribute('for')).toEqual('top-errors-info');
     });
   });
+
+  describe('when data is available', () => {
+    it('does not display empty data message', () => {
+      component.topErrorsItems = [
+        { type: 'ErrorType1', message: 'ErrorMessage', count: 20 },
+        { type: 'ErrorType2', message: 'ErrorMessage', count: 10 }
+      ];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeFalsy();
+    });
+  });
+
+  describe('when no data is available', () => {
+    it('displays empty data message', () => {
+      component.topErrorsItems = [];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeTruthy();
+    });
+  });
 });

--- a/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/top-errors/top-errors.component.ts
@@ -54,4 +54,8 @@ export class TopErrorsComponent  implements OnInit, OnDestroy, OnChanges  {
   get topErrorsItemsMax() {
     return maxBy('count', this.topErrorsItems);
   }
+
+  get hasData(): boolean {
+    return this.topErrorsItems.length > 0;
+  }
 }

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.html
@@ -7,9 +7,9 @@
         <p class="tooltip-text">Count of desktops that haven't checked-in over different periods of time.</p>
       </chef-tooltip>
     </div>
-    <h6 class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
+    <h6 *ngIf="hasData" class="heading-time">Updated {{ lastUpdatedMessage }}</h6>
   </div>
-  <chef-table class="chart-list">
+  <chef-table class="chart-list" *ngIf="hasData">
     <chef-tbody>
       <chef-tr
         *ngFor="let item of countedDurationItems"
@@ -37,4 +37,5 @@
       </chef-tr>
     </chef-tbody>
   </chef-table>
+  <app-empty-data *ngIf="!hasData"></app-empty-data>
 </div>

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.spec.ts
@@ -36,4 +36,32 @@ describe('UnknownDesktopDurationCountsComponent', () => {
       expect(tooltip.getAttribute('for')).toEqual('since-last-checkin-info');
     });
   });
+
+  describe('when data is available', () => {
+    it('does not display empty data message', () => {
+      component.countedDurationItems = [
+        { 'count': 10, 'duration': '1M' },
+        { 'count': 0, 'duration': '2w' }
+      ];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeFalsy();
+    });
+  });
+
+  describe('when no data is available', () => {
+    it('displays empty data message', () => {
+      component.countedDurationItems = [
+        { 'count': 0, 'duration': '1M' },
+        { 'count': 0, 'duration': '2w' }
+      ];
+
+      fixture.detectChanges();
+
+      const emptyMsg = fixture.debugElement.query(By.css('app-empty-data'));
+      expect(emptyMsg).toBeTruthy();
+    });
+  });
 });

--- a/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/unknown-desktop-duration-counts/unknown-desktop-duration-counts.component.ts
@@ -71,4 +71,8 @@ export class UnknownDesktopDurationCountsComponent  implements OnInit, OnDestroy
         return duration;
     }
   }
+
+  get hasData(): boolean {
+    return this.countedDurationItems.some(item => item.count > 0);
+  }
 }

--- a/components/automate-ui/src/assets/img/chart.svg
+++ b/components/automate-ui/src/assets/img/chart.svg
@@ -1,0 +1,1 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>path{fill:#C5C7D0;}.cls-1{fill:none;}</style></defs><title>chart</title><path d="M27,28V6H19V28H15V14H7V28H4V2H2V28a2,2,0,0,0,2,2H30V28ZM13,28H9V16h4Zm12,0H21V8h4Z"/><rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/></svg>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

These commits add an 'empty data' state to the desktop dashboard components for when desktop API data is not available.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

Closes https://github.com/chef/automate/issues/3335

### :+1: Definition of Done

Desktop empty states display when desktop API endpoints return no data.

### :athletic_shoe: How to Build and Test the Change

- Have a fresh install of Automate with no client runs being reported yet
- Start all services and UI
- Navigate to `a2-dev.test/desktop`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

![Screen Shot 2020-07-29 at 2 59 13 PM](https://user-images.githubusercontent.com/479121/88855726-4aad8300-d1c1-11ea-978c-bf95b9cae1dd.png)
![Screen Shot 2020-07-29 at 2 59 48 PM](https://user-images.githubusercontent.com/479121/88855730-4b461980-d1c1-11ea-9cd1-751ab3fa675d.png)

