### PR TITLE
Prevent ellipsis-ing of control menu text

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
@@ -8,14 +8,14 @@
     right: 24px;
     width: 54px;
   }
-  
+
   ::ng-deep .mat-select-panel-wrap {
     margin-left: -75px;
   }
 
   .empty-state {
     text-align: center;
-  
+
     p {
       font-size: 18px;
       font-weight: 400;

--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
@@ -1,22 +1,25 @@
 @import "~styles/variables";
 
-.empty-state {
-  text-align: center;
+:host {
 
-  p {
-    font-size: 18px;
-    font-weight: 400;
-    margin-top: 42px;
+  ::ng-deep .mat-select-panel {
+    position: relative;
+    margin-top: 12px;
+    right: 24px;
+    width: 54px;
   }
-}
+  
+  ::ng-deep .mat-select-panel-wrap {
+    margin-left: -75px;
+  }
 
-::ng-deep .mat-select-panel {
-  position: relative;
-  margin-top: 12px;
-  right: 24px;
-  width: 54px;
-}
-
-::ng-deep .mat-select-panel-wrap {
-  margin-left: -75px;
+  .empty-state {
+    text-align: center;
+  
+    p {
+      font-size: 18px;
+      font-weight: 400;
+      margin-top: 42px;
+    }
+  }
 }


### PR DESCRIPTION
The control menu text in project files was getting ellipsed seemingly randomly.  @susanev hunted down the cause, and it turned out a css selector was leaking from the api-tokens page.

### :nut_and_bolt: Description: What code changed, and why?
The fix in this branch encapsulates those selectors so they no longer leak.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/3983

### :+1: Definition of Done
Text inside control menus is not longer being cut off and ellipsed.

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

on a clean branch to repro the issue
- navigate to api tokens
- create a token
- open the token control menu
- navigate to projects
- create a project
- open that menu and it will have the `...`
hard refresh, open projects again notice no `...`
then repeat above and it should show the `...` again

on this branch
Run through the repro sets and you should no longer see this happen.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
