### PR TITLE
DB Migrator: Only force migration levels on migration error

### DIFF
--- a/components/config-mgmt-service/backend/postgres/schema/sql/02_add_rollouts.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/02_add_rollouts.up.sql
@@ -18,10 +18,10 @@ CREATE TABLE IF NOT EXISTS rollouts (
   end_time                  TIMESTAMP
 );
 
-CREATE INDEX policy_name_idx        ON rollouts (policy_name);
-CREATE INDEX policy_node_group_idx  ON rollouts (policy_node_group);
-CREATE INDEX policy_revision_id_idx ON rollouts (policy_revision_id);
-CREATE INDEX policy_domain_url_idx  ON rollouts (policy_domain_url);
+CREATE INDEX IF NOT EXISTS policy_name_idx        ON rollouts (policy_name);
+CREATE INDEX IF NOT EXISTS policy_node_group_idx  ON rollouts (policy_node_group);
+CREATE INDEX IF NOT EXISTS policy_revision_id_idx ON rollouts (policy_revision_id);
+CREATE INDEX IF NOT EXISTS policy_domain_url_idx  ON rollouts (policy_domain_url);
 
 
 -- We call the policy name, policy node group, and policy domain URL the

--- a/components/config-mgmt-service/backend/postgres/schema/sql/03_add_rollouts_author_initiator.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/03_add_rollouts_author_initiator.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE rollouts ADD COLUMN scm_author_name TEXT NOT NULL DEFAULT '';
-ALTER TABLE rollouts ADD COLUMN scm_author_email TEXT NOT NULL DEFAULT '';
-ALTER TABLE rollouts ADD COLUMN policy_domain_username TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS scm_author_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS scm_author_email TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS policy_domain_username TEXT NOT NULL DEFAULT '';
 

--- a/components/config-mgmt-service/backend/postgres/schema/sql/04_rollouts_unique_exclude_constraint.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/04_rollouts_unique_exclude_constraint.up.sql
@@ -28,6 +28,7 @@ DROP FUNCTION IF EXISTS set_end_time_on_superseded();
 -- they all have current_rollout == NULL. Thus we can model our requirement
 -- that CURRENT rollouts must be unique, but old ones do not have to be unique.
 ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS current_rollout BOOLEAN DEFAULT TRUE;
+ALTER TABLE rollouts DROP CONSTRAINT IF EXISTS current_rollout_unique;
 ALTER TABLE rollouts ADD CONSTRAINT current_rollout_unique UNIQUE (policy_name, policy_node_group, policy_domain_url, policy_revision_id, current_rollout);
 
 -- This function is added in 02. The prior version set `end_time` to `NOW()`,
@@ -52,6 +53,7 @@ WHERE r.end_time IS NULL
 END;
 $$;
 
+DROP TRIGGER IF EXISTS set_current_rollout ON rollouts;
 CREATE TRIGGER set_current_rollout AFTER INSERT
 ON rollouts FOR EACH ROW EXECUTE PROCEDURE
 current_rollout_ended();

--- a/lib/db/migrator/migrator.go
+++ b/lib/db/migrator/migrator.go
@@ -31,7 +31,7 @@ func Migrate(pgURL, migrationsPath string, l logger.Logger, verbose bool) error 
 // MigrateWithMigrationsTable executes all migrations we have, using the
 // specified migrations table.
 func MigrateWithMigrationsTable(pgURL, migrationsPath, migrationsTable string, l logger.Logger, verbose bool) error {
-	l.Infof("Running db migrations from %q", migrationsPath)
+	l.Infof("running db migrations from %q", migrationsPath)
 	purl, err := addMigrationsTable(pgURL, migrationsTable)
 	if err != nil {
 		return errors.Wrap(err, "parse PG URL")
@@ -87,6 +87,41 @@ func MigrateWithMigrationsTable(pgURL, migrationsPath, migrationsTable string, l
 	// that's always nil
 	_, err = m.Close()
 	return errors.Wrap(err, "close migrations connection")
+}
+
+// DestructiveMigrateForTests will:
+// * Drop the database to give you a clean slate
+// * Run all your migrations
+// * Forcibly run all the migrations again to verify that they are idempotent.
+//
+// Obviously you don't want this for production, but you should use it instead
+// of the plain Migrate function in your tests if you can.
+func DestructiveMigrateForTests(pgURL, migrationsPath string, l logger.Logger, verbose bool) error {
+	l.Infof("running db migrations in destructo test mode for DB %q from %q", pgURL, migrationsPath)
+	purl, err := addMigrationsTable(pgURL, "")
+
+	m, err := migrate.New(addScheme(migrationsPath), purl)
+	if err != nil {
+		return errors.Wrapf(err, "migrator setup failed for %q", pgURL)
+	}
+	m.Log = migrationLog{Logger: l, verbose: verbose}
+	if err := m.Drop(); err != nil {
+		return errors.Wrapf(err, "drop database failed for %q", pgURL)
+	}
+	if err := m.Drop(); err != nil {
+		return errors.Wrapf(err, "drop database failed for %q", pgURL)
+	}
+	if err := m.Up(); err != nil {
+		return errors.Wrapf(err, "failed applying migrations to clean database %q", pgURL)
+	}
+	if err := m.Force(-1); err != nil {
+		return errors.Wrapf(err, "failed to force migration state to version 0 for db %q", pgURL)
+	}
+	if err := m.Up(); err != nil {
+		return errors.Wrapf(err, "failed to re-apply migration to migrated database %q - missing IF (NOT) EXISTS?", pgURL)
+	}
+
+	return nil
 }
 
 func addScheme(p string) string {

--- a/lib/db/migrator/migrator.go
+++ b/lib/db/migrator/migrator.go
@@ -1,7 +1,10 @@
 package migrator
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/golang-migrate/migrate"
 	_ "github.com/golang-migrate/migrate/database/postgres" // make driver available
@@ -33,30 +36,49 @@ func MigrateWithMigrationsTable(pgURL, migrationsPath, migrationsTable string, l
 	if err != nil {
 		return errors.Wrap(err, "parse PG URL")
 	}
+
 	m, err := migrate.New(addScheme(migrationsPath), purl)
 	if err != nil {
 		return errors.Wrap(err, "init migrator")
 	}
 	m.Log = migrationLog{Logger: l, verbose: verbose}
+
 	version, dirty, err := m.Version()
 	if err != nil && err != migrate.ErrNilVersion {
 		return errors.Wrap(err, "init migrator - error getting migration version")
 	}
 
-	if dirty {
-		// force to prior version to reattempt migration
-		err := m.Force(int(version) - 1)
-		if err != nil {
-			return errors.Wrap(err, "force to working schema version")
-		}
-		l.Infof("Forced to previous version: %v to reattempt migration", int(version)-1)
-	} else {
-		l.Infof("Current schema version: %v", version)
-	}
+	// Do not take action based on the return value of m.Version(); Version() is
+	// not protected by the exclusive lock, if it reports dirty, it could be
+	// another front-end is running a migration now.
+	l.Infof("Current schema version: %v dirty: %t", version, dirty)
 
 	err = m.Up()
 	if err != nil && err != migrate.ErrNoChange {
 		return errors.Wrap(err, "migration attempt failed")
+	}
+	if err != nil && err == migrate.ErrLocked {
+		return errors.Wrap(err, "database locked: peer attempting migration?")
+	}
+	if _, ok := err.(migrate.ErrDirty); ok {
+		l.WithError(err).Error("Migration attempt failed due to previous migration error leaving database in a dirty state")
+		// this is vulnerable to a race condition if two or more front-ends reach
+		// this branch of the code at once, they might both run all of the steps,
+		// but they had to have gotten a dirty schema state while no process had
+		// the lock, so this will only happen following some other error.
+		version, _, err := m.Version()
+		if err != nil {
+			return errors.Wrap(err, "init migrator - error getting migration version")
+		}
+		l.Infof("Attempting to set recorded schema level to %d and rerun subsequent migration(s)", version)
+		err = m.Force(int(version) - 1)
+		if err != nil {
+			return errors.Wrap(err, "force to previous schema version")
+		}
+		err = m.Up()
+		if err != nil {
+			return errors.Wrap(err, "re-migration attempt after force schema version failed")
+		}
 	}
 
 	l.Infof("Completed db migrations")
@@ -85,4 +107,17 @@ func addMigrationsTable(u, table string) (string, error) {
 		pgURL.RawQuery = q.Encode()
 	}
 	return pgURL.String(), nil
+}
+
+func lockIdForURL(pgURL string) (int64, error) {
+	u, err := url.Parse(pgURL)
+	if err != nil {
+		return 0, err
+	}
+	hex := fmt.Sprintf("%x", sha256.Sum256([]byte(u.Path)))
+	dec, err := strconv.ParseInt(hex, 16, 64)
+	if err != nil {
+		return 0, err
+	}
+	return dec, nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Alternative option to #4182 -- I prefer this one

#### Bug Behavior:

A customer with 4 FE systems found that migrations that are not written defensively will fail. After investigating the relevant code, I found that:
* The migration library we use imposes locks on writes but not reads. In particular, the `Up()` and `Force()` methods we use are guarded by a lock, but the `Version` function we use to check for dirty state is not.
* The migration method sets the version to the desired version and the dirty flag to true, then runs the migration logic, then sets dirty to false.
* Our code calls `Version` to get the value of the `dirty` flag, and if it's set to true, then we use `Force` to set the migration version back by one (and reset the dirty flag to false).

Thus, if two or more copies of the migrator are running concurrently, you can have:
* The first one sees a clean database, skips the cleanup step, starts the migration, sets dirty to true
* the second one sees a dirty database when it calls `Version()`, meaning it will take the code branch to `Force()` set the migration level and re-run the last migration, but before it starts that:
* the first one finishes migrating
* the second one force sets the migration level down one and re-runs the migration that had just succeeded
* the second one will fail if it's not defensively coded.

#### Fix

This PR solves the problem by attempting the "happy path" upgrade first. All machines will try `Up()` first. If some attempt it while another is in-progress, they will get `migrate.ErrLocked` and fail (which is good). Eventually the first machine finishes the migration, the others will then see a migrated database and skip. 

If the `Up()` method fails because the database was dirty, this will trigger the same force version and retry behavior as we had before this PR. This is implemented in the same way as before with the same concurrency flaw, but it should only occur in cases where there was already an error. 

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
