### PR TITLE
Support compliance reporting for cloud resources

### DIFF
--- a/components/data-feed-service/service/credentials.go
+++ b/components/data-feed-service/service/credentials.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/pkg/errors"
+)
+
+const CredentialsError = "Could not create credentials"
+
+type Credentials interface {
+	GetAuthorizationHeaderValue() string
+}
+
+type CredentialsFactory struct {
+	data map[string]string
+}
+
+func NewCredentialsFactory(data map[string]string) *CredentialsFactory {
+	return &CredentialsFactory{data}
+}
+
+func (c *CredentialsFactory) NewCredentials() (Credentials, error) {
+	if username, ok := c.data["username"]; ok {
+		// assume Basic Auth
+		return NewBasicAuthCredentials(username, c.data["password"]), nil
+	}
+	if splunk, ok := c.data["Splunk"]; ok {
+		return NewSplunkAuthCredentials(splunk), nil
+	}
+	return nil, errors.New(CredentialsError)
+}
+
+type BasicAuthCredentials struct {
+	username string
+	password string
+}
+
+func NewBasicAuthCredentials(username string, password string) BasicAuthCredentials {
+	return BasicAuthCredentials{username: username, password: password}
+}
+
+func (c BasicAuthCredentials) GetAuthorizationHeaderValue() string {
+	return "Basic " + c.basicAuth()
+}
+
+func (c BasicAuthCredentials) basicAuth() string {
+	auth := c.username + ":" + c.password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+type SplunkAuthCredentials struct {
+	splunkToken string
+}
+
+func NewSplunkAuthCredentials(splunkToken string) SplunkAuthCredentials {
+	return SplunkAuthCredentials{splunkToken: splunkToken}
+}
+
+func (c SplunkAuthCredentials) GetAuthorizationHeaderValue() string {
+	return "Splunk " + c.splunkToken
+}
+
+func GetCredentials(ctx context.Context, client secrets.SecretsServiceClient, secretID string) (Credentials, error) {
+	secret, err := client.Read(ctx, &secrets.Id{Id: secretID})
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]string)
+	data := secret.GetData()
+	for kv := range data {
+		m[data[kv].Key] = data[kv].Value
+	}
+
+	credentialsFactory := NewCredentialsFactory(m)
+	return credentialsFactory.NewCredentials()
+}

--- a/components/data-feed-service/service/credentials_test.go
+++ b/components/data-feed-service/service/credentials_test.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/chef/automate/api/external/common/query"
+
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/golang/mock/gomock"
+)
+
+const username = "data"
+const password = "feed"
+const basicAuthHeaderValue = "Basic ZGF0YTpmZWVk"
+const splunkToken = "s45197c0-01b9-4184-a2c5-2d6ed45095cdf"
+const splunkHeaderValue = "Splunk " + splunkToken
+const secretId = "secret-id"
+
+func TestNewCredentialsFactoryNilData(t *testing.T) {
+	credentialsFactory := NewCredentialsFactory(nil)
+	credentials, err := credentialsFactory.NewCredentials()
+	if err.Error() != CredentialsError {
+		t.Logf("expected error: %v, got %v", CredentialsError, err)
+		t.Fail()
+	}
+	if credentials != nil {
+		t.Logf("expected credentials: nil, got %v", credentials)
+		t.Fail()
+	}
+}
+
+func TestNewCredentialsFactoryUnsupportedData(t *testing.T) {
+	data := map[string]string{"unsupported key": "unsupported value"}
+	credentialsFactory := NewCredentialsFactory(data)
+	credentials, err := credentialsFactory.NewCredentials()
+	if err.Error() != CredentialsError {
+		t.Logf("expected error: %v, got %v", CredentialsError, err)
+		t.Fail()
+	}
+	if credentials != nil {
+		t.Logf("expected credentials: nil, got %v", credentials)
+		t.Fail()
+	}
+}
+
+func TestNewBasicAuthCredentials(t *testing.T) {
+
+	credentials := NewBasicAuthCredentials(username, password)
+	if credentials.username != username {
+		t.Logf("expected username: %s, got: %s", username, credentials.username)
+		t.Fail()
+	}
+	if credentials.password != password {
+		t.Logf("expected password: %s, got: %s", password, credentials.password)
+		t.Fail()
+	}
+}
+
+func TestBasicAuthCredentials(t *testing.T) {
+	credentials := &BasicAuthCredentials{username: username, password: password}
+	if credentials.username != username {
+		t.Logf("expected username: %s, got: %s", username, credentials.username)
+		t.Fail()
+	}
+	if credentials.password != password {
+		t.Logf("expected password: %s, got: %s", password, credentials.password)
+		t.Fail()
+	}
+}
+
+func TestNewCredentialsFactoryBasicAuth(t *testing.T) {
+	data := map[string]string{"username": username, "password": password}
+	credentialsFactory := NewCredentialsFactory(data)
+	credentials, err := credentialsFactory.NewCredentials()
+	if err != nil {
+		t.Logf("expected error: nil, got %v", err)
+		t.Fail()
+	}
+	if credentials == nil {
+		t.Logf("expected credentials, got nil")
+		t.Fail()
+	}
+	switch credentials.(type) {
+	case BasicAuthCredentials:
+		break
+	default:
+		t.Logf("Expected BasicAuthCredentials, got %v", reflect.TypeOf(credentials))
+		t.Fail()
+	}
+	if credentials.GetAuthorizationHeaderValue() != basicAuthHeaderValue {
+		t.Logf("Expected header %v, got %v", basicAuthHeaderValue, credentials.GetAuthorizationHeaderValue())
+		t.Fail()
+	}
+}
+
+func TestNewSplunkAuthCredentials(t *testing.T) {
+
+	credentials := NewSplunkAuthCredentials(splunkToken)
+	if credentials.splunkToken != splunkToken {
+		t.Logf("expected splunkToken: %s, got: %s", splunkToken, credentials.splunkToken)
+		t.Fail()
+	}
+}
+
+func TestSplunkAuthCredentials(t *testing.T) {
+
+	credentials := &SplunkAuthCredentials{splunkToken: splunkToken}
+	if credentials.splunkToken != splunkToken {
+		t.Logf("expected splunkToken: %s, got: %s", splunkToken, credentials.splunkToken)
+		t.Fail()
+	}
+}
+
+func TestNewCredentialsFactorySplunk(t *testing.T) {
+	data := map[string]string{"Splunk": splunkToken}
+	credentialsFactory := NewCredentialsFactory(data)
+	credentials, err := credentialsFactory.NewCredentials()
+	if err != nil {
+		t.Logf("expected error: nil, got %v", err)
+		t.Fail()
+	}
+	if credentials == nil {
+		t.Logf("expected credentials, got nil")
+		t.Fail()
+	}
+	switch credentials.(type) {
+	case SplunkAuthCredentials:
+		break
+	default:
+		t.Logf("Expected SplunkAuthCredentials, got %v", reflect.TypeOf(credentials))
+		t.Fail()
+	}
+	if credentials.GetAuthorizationHeaderValue() != splunkHeaderValue {
+		t.Logf("Expected header %v, got %v", splunkHeaderValue, credentials.GetAuthorizationHeaderValue())
+		t.Fail()
+	}
+}
+
+func TestGetCredentialsError(t *testing.T) {
+	secretsClient := secrets.NewMockSecretsServiceClient(gomock.NewController(t))
+	secretsClient.EXPECT().Read(
+		context.Background(),
+		gomock.Any(),
+	).Return(nil, mockErr)
+	credentials, err := GetCredentials(context.Background(), secretsClient, secretId)
+
+	if err == nil {
+		t.Logf("Expected error: %v, got %v", mockErr, err)
+		t.Fail()
+	}
+	if credentials != nil {
+		t.Logf("Expected credentials: nil, got %v", credentials)
+		t.Fail()
+	}
+}
+
+func TestGetCredentialsUnsupported(t *testing.T) {
+	secret := &secrets.Secret{
+		Name: "name",
+		Type: "ssh",
+		Data: appendKvs(&query.Kv{Key: "unsupported", Value: "value"}),
+	}
+	secretsClient := secrets.NewMockSecretsServiceClient(gomock.NewController(t))
+	secretsClient.EXPECT().Read(
+		context.Background(),
+		gomock.Any(),
+	).Return(secret, nil)
+
+	credentials, err := GetCredentials(context.Background(), secretsClient, secretId)
+
+	if err == nil {
+		t.Logf("Expected error: %v, got %v", mockErr, err)
+		t.Fail()
+	}
+	if credentials != nil {
+		t.Logf("Expected credentials: nil, got %v", credentials)
+		t.Fail()
+	}
+}
+
+func TestGetCredentialsBasicAuth(t *testing.T) {
+	secret := &secrets.Secret{
+		Name: "name",
+		Type: "ssh",
+		Data: appendKvs(&query.Kv{Key: "username", Value: username}, &query.Kv{Key: "password", Value: password}),
+	}
+	secretsClient := secrets.NewMockSecretsServiceClient(gomock.NewController(t))
+	secretsClient.EXPECT().Read(
+		context.Background(),
+		gomock.Any(),
+	).Return(secret, nil)
+	// need to Mock the secret using witout a splunk or basic auth
+	credentials, err := GetCredentials(context.Background(), secretsClient, secretId)
+
+	if err != nil {
+		t.Logf("Expected error: nil, got %v", err)
+		t.Fail()
+	}
+	if credentials == nil {
+		t.Log("Expected credentials, got nil")
+		t.Fail()
+	} else if credentials.GetAuthorizationHeaderValue() != basicAuthHeaderValue {
+		t.Logf("Expected header: %s, got %s", basicAuthHeaderValue, credentials.GetAuthorizationHeaderValue())
+		t.Fail()
+	}
+}
+
+func TestGetCredentialsSplunk(t *testing.T) {
+	secret := &secrets.Secret{
+		Name: "name",
+		Type: "ssh",
+		Data: appendKvs(&query.Kv{Key: "Splunk", Value: splunkToken}),
+	}
+	secretsClient := secrets.NewMockSecretsServiceClient(gomock.NewController(t))
+	secretsClient.EXPECT().Read(
+		context.Background(),
+		gomock.Any(),
+	).Return(secret, nil)
+
+	credentials, err := GetCredentials(context.Background(), secretsClient, secretId)
+
+	if err != nil {
+		t.Logf("Expected error: nil, got %v", err)
+		t.Fail()
+	}
+	if credentials == nil {
+		t.Log("Expected credentials, got nil")
+		t.Fail()
+	} else if credentials.GetAuthorizationHeaderValue() != splunkHeaderValue {
+		t.Logf("Expected header: %s, got %s", splunkHeaderValue, credentials.GetAuthorizationHeaderValue())
+		t.Fail()
+	}
+}
+
+func appendKvs(kvs ...*query.Kv) []*query.Kv {
+	array := make([]*query.Kv, len(kvs))
+
+	for i, kv := range kvs {
+		array[i] = kv
+	}
+
+	return array
+}

--- a/components/data-feed-service/service/data-feed-aggregate-task.go
+++ b/components/data-feed-service/service/data-feed-aggregate-task.go
@@ -88,13 +88,13 @@ func (d *DataFeedAggregateTask) Run(ctx context.Context, task cereal.Task) (inte
 			"url":  destinations[destination].URL,
 		}).Debug("Destination")
 
-		username, password, err := GetCredentials(ctx, d.secrets, destinations[destination].Secret)
+		credentials, err := GetCredentials(ctx, d.secrets, destinations[destination].Secret)
 
 		if err != nil {
 			log.Errorf("Error retrieving credentials, cannot send asset notification: %v", err)
 		} else {
 			// build and send notification for this rule
-			notification := datafeedNotification{username: username, password: password, url: destinations[destination].URL, data: buffer}
+			notification := datafeedNotification{credentials: credentials, url: destinations[destination].URL, data: buffer}
 
 			client := NewDataClient(d.acceptedStatusCodes)
 			err = send(client, notification)

--- a/components/data-feed-service/service/data-feed-poll-task.go
+++ b/components/data-feed-service/service/data-feed-poll-task.go
@@ -275,19 +275,18 @@ func (d *DataFeedPollTask) listReports(ctx context.Context, pageSize int32, feed
 	for page <= pages {
 		log.Debugf("report query %v", query)
 		for report := range reports.Reports {
-			ipaddress := reports.Reports[report].Ipaddress
-			log.Debugf("report has ipaddress %v", ipaddress)
-			if _, ok := nodeIDs[ipaddress]; ok {
+			resourceId := resolveResourceId(reports.Reports[report])
+			if _, ok := nodeIDs[resourceId]; ok {
 				// We must have a client run in the interval for the node with this ip
-				log.Debugf("node data already exists for %v", ipaddress)
-				nodeID := nodeIDs[ipaddress]
+				log.Debugf("node data already exists for %v", resourceId)
+				nodeID := nodeIDs[resourceId]
 				// set the NodeId.ComplianceID for this ip to the report ID
 				nodeID.ComplianceID = reports.Reports[report].Id
-				nodeIDs[ipaddress] = nodeID
+				nodeIDs[resourceId] = nodeID
 			} else {
-				// ipaddress not in the mao so we add a new map entry with the report ID as ComplianceID
-				nodeIDs[ipaddress] = NodeIDs{ComplianceID: reports.Reports[report].Id}
-				log.Debugf("nodeID added %v", nodeIDs[ipaddress])
+				// key not in the map, so we add a new map entry with the report ID as ComplianceID
+				nodeIDs[resourceId] = NodeIDs{ComplianceID: reports.Reports[report].Id}
+				log.Debugf("nodeID added %v", nodeIDs[resourceId])
 			}
 		}
 		page++
@@ -300,4 +299,13 @@ func (d *DataFeedPollTask) listReports(ctx context.Context, pageSize int32, feed
 			log.Errorf("Error getting reporting/ListReports %v", err)
 		}
 	}
+}
+
+func resolveResourceId(report *reporting.Report) string {
+	resourceId := report.Ipaddress
+	log.Debugf("report has ipaddress %v", resourceId)
+	if resourceId == "" {
+		resourceId = report.NodeId
+	}
+	return resourceId
 }

--- a/components/data-feed-service/service/data-feed-poll-task_test.go
+++ b/components/data-feed-service/service/data-feed-poll-task_test.go
@@ -4,7 +4,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chef/automate/api/interservice/compliance/reporting"
 	"github.com/chef/automate/components/data-feed-service/config"
+)
+
+const (
+	reportNodeId = "e5a3d952-5dfc-3215-bfe4-541eb0b5d345"
 )
 
 func TestEmptyFilters(t *testing.T) {
@@ -130,4 +135,22 @@ func TestIncludeIPAddressWhenDisableTrue(t *testing.T) {
 		t.Error("Expected true")
 	}
 	t.Log("TestIncludeIPAddressWhenDisableTrue OK")
+}
+
+func TestResolveResourceIdNodeId(t *testing.T) {
+	report := &reporting.Report{NodeId: reportNodeId}
+	resourceId := resolveResourceId(report)
+	if resourceId != reportNodeId {
+		t.Logf("expected %s, got: %s", reportNodeId, resourceId)
+		t.Fail()
+	}
+}
+
+func TestResolveResourceIdIPAddress(t *testing.T) {
+	report := &reporting.Report{NodeId: reportNodeId, Ipaddress: ipAttr}
+	resourceId := resolveResourceId(report)
+	if resourceId != ipAttr {
+		t.Logf("expected %s, got: %s", ipAttr, resourceId)
+		t.Fail()
+	}
 }

--- a/components/data-feed-service/service/data-feed-service_test.go
+++ b/components/data-feed-service/service/data-feed-service_test.go
@@ -40,6 +40,7 @@ var automaticAttrs = "{\"dmi\":{\"system\":{\"serial_number\":\"serial-number\"}
 var automaticAttrsWin = "{\"os\":\"windows\",\"kernel\":{\"os_info\":{\"serial_number\":\"serial-number\",\"service_pack_major_version\":2,\"service_pack_minor_version\":1}},\"dmi\":{\"system\":{\"serial_number\":\"\"}},\"hostname\":\"test.chef.com\",\"ipaddress\":\"172.18.2.120\",\"macaddress\":\"00:1C:42:C1:2D:87\"}"
 var mockConfig = &config.DataFeedConfig{}
 var acceptedStatusCodes []int32 = []int32{200, 201, 202, 203, 204}
+var mockCredentials = NewBasicAuthCredentials("user", "pass")
 
 func TestAssetCreated(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +50,7 @@ func TestAssetCreated(t *testing.T) {
 
 	client := ts.Client()
 	dataClient := DataClient{client: *client, acceptedStatusCodes: acceptedStatusCodes}
-	notification := datafeedNotification{url: ts.URL}
+	notification := datafeedNotification{credentials: mockCredentials, url: ts.URL}
 	err := send(dataClient, notification)
 	if err != nil {
 		t.Errorf("error got: %s, want nil", err)
@@ -64,7 +65,7 @@ func TestSendError(t *testing.T) {
 
 	client := ts.Client()
 	dataClient := DataClient{client: *client}
-	notification := datafeedNotification{url: ts.URL}
+	notification := datafeedNotification{credentials: mockCredentials, url: ts.URL}
 	err := send(dataClient, notification)
 	if err == nil {
 		t.Error("error got: nil, wanted an error")

--- a/components/data-feed-service/service/data-feed-service_test.go
+++ b/components/data-feed-service/service/data-feed-service_test.go
@@ -689,7 +689,8 @@ func TestGetNodeDataNotWindows(t *testing.T) {
 		gomock.Any(),
 	).Return(run, nil)
 	aggTask := &DataFeedAggregateTask{cfgMgmt: mockCfgMgmtClient, externalFqdn: externalFqdn}
-	nodeData, err := aggTask.getNodeData(context.Background(), []string{})
+	filters := []string{"ipaddress:" + ipAttr}
+	nodeData, err := aggTask.safeGetNodeData(context.Background(), filters)
 	if nodeData["attributes"] == nil {
 		t.Log("expected attributes, got nil")
 		t.Fail()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The datafeed primary method of correlating infra node and compliance node data uses ip address.

Cloud resources may not have an ip address or any corresponding node data. Thus the ip address is "" in the code for a cloud resource, since this is used as a key in a map all cloud compliance reports map to the same key which means only a single report, the last aggregated is included in the feed.

For cloud resources the node_id can be used to identify reports for different nodes. This update uses a resourceId which can be the ip address or the node_id for a compliance report. The resourceId is resolved as ip address, then node_id.

For cloud resources the "node" section in the feed is irrelevant and has been dropped. this is only for cloud resources.
All other functionality remains the same.

Infra node and compliance reports have been comprehensively tested with the updated_nodes_only true and false.

There is also a commit to support splunk auth requirements for the datafeed, tested against splunk.

### :athletic_shoe: How to Build and Test the Change
build components/data-feed-service
deploy the new service
bootstrap nodes, run compliance scans and capture the datafeed in servicenow or requestbin.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated? NA
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
