### PR TITLE
Test for Idempotent Schema Migration

### DIFF
--- a/components/applications-service/cmd/applications-service/commands/serve.go
+++ b/components/applications-service/cmd/applications-service/commands/serve.go
@@ -41,7 +41,7 @@ var serveCmd = &cobra.Command{
 			secureconn.WithVersionInfo(version.Version, version.GitSHA))
 
 		// Storage client (Postgres)
-		dbClient, err := postgres.New(&conf.Postgres)
+		dbClient, err := postgres.ConnectAndMigrate(&conf.Postgres)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err.Error(),

--- a/components/applications-service/integration_test/suite_test.go
+++ b/components/applications-service/integration_test/suite_test.go
@@ -67,10 +67,15 @@ func NewSuite(database string) *Suite {
 			},
 		}
 	)
-	dbClient, err := postgres.New(&c.Postgres)
+	dbClient, err := postgres.Connect(&c.Postgres)
 	if err != nil {
 		fmt.Printf("Could not create postgres client: %s\n", err)
 		os.Exit(1)
+	}
+
+	if err := dbClient.DestructiveMigrateForTests(); err != nil {
+		fmt.Println("Could not complete DestructiveMigrateForTests migrations")
+		fmt.Println(err.Error())
 	}
 
 	// A global Storage Client to call any storage function

--- a/components/config-mgmt-service/backend/postgres/schema/sql/02_add_rollouts.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/02_add_rollouts.up.sql
@@ -18,10 +18,10 @@ CREATE TABLE IF NOT EXISTS rollouts (
   end_time                  TIMESTAMP
 );
 
-CREATE INDEX policy_name_idx        ON rollouts (policy_name);
-CREATE INDEX policy_node_group_idx  ON rollouts (policy_node_group);
-CREATE INDEX policy_revision_id_idx ON rollouts (policy_revision_id);
-CREATE INDEX policy_domain_url_idx  ON rollouts (policy_domain_url);
+CREATE INDEX IF NOT EXISTS policy_name_idx        ON rollouts (policy_name);
+CREATE INDEX IF NOT EXISTS policy_node_group_idx  ON rollouts (policy_node_group);
+CREATE INDEX IF NOT EXISTS policy_revision_id_idx ON rollouts (policy_revision_id);
+CREATE INDEX IF NOT EXISTS policy_domain_url_idx  ON rollouts (policy_domain_url);
 
 
 -- We call the policy name, policy node group, and policy domain URL the

--- a/components/config-mgmt-service/backend/postgres/schema/sql/03_add_rollouts_author_initiator.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/03_add_rollouts_author_initiator.up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE rollouts ADD COLUMN scm_author_name TEXT NOT NULL DEFAULT '';
-ALTER TABLE rollouts ADD COLUMN scm_author_email TEXT NOT NULL DEFAULT '';
-ALTER TABLE rollouts ADD COLUMN policy_domain_username TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS scm_author_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS scm_author_email TEXT NOT NULL DEFAULT '';
+ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS policy_domain_username TEXT NOT NULL DEFAULT '';
 

--- a/components/config-mgmt-service/backend/postgres/schema/sql/04_rollouts_unique_exclude_constraint.up.sql
+++ b/components/config-mgmt-service/backend/postgres/schema/sql/04_rollouts_unique_exclude_constraint.up.sql
@@ -28,6 +28,7 @@ DROP FUNCTION IF EXISTS set_end_time_on_superseded();
 -- they all have current_rollout == NULL. Thus we can model our requirement
 -- that CURRENT rollouts must be unique, but old ones do not have to be unique.
 ALTER TABLE rollouts ADD COLUMN IF NOT EXISTS current_rollout BOOLEAN DEFAULT TRUE;
+ALTER TABLE rollouts DROP CONSTRAINT IF EXISTS current_rollout_unique;
 ALTER TABLE rollouts ADD CONSTRAINT current_rollout_unique UNIQUE (policy_name, policy_node_group, policy_domain_url, policy_revision_id, current_rollout);
 
 -- This function is added in 02. The prior version set `end_time` to `NOW()`,
@@ -52,6 +53,7 @@ WHERE r.end_time IS NULL
 END;
 $$;
 
+DROP TRIGGER IF EXISTS set_current_rollout ON rollouts;
 CREATE TRIGGER set_current_rollout AFTER INSERT
 ON rollouts FOR EACH ROW EXECUTE PROCEDURE
 current_rollout_ended();

--- a/lib/db/migrator/migrator.go
+++ b/lib/db/migrator/migrator.go
@@ -28,7 +28,7 @@ func Migrate(pgURL, migrationsPath string, l logger.Logger, verbose bool) error 
 // MigrateWithMigrationsTable executes all migrations we have, using the
 // specified migrations table.
 func MigrateWithMigrationsTable(pgURL, migrationsPath, migrationsTable string, l logger.Logger, verbose bool) error {
-	l.Infof("Running db migrations from %q", migrationsPath)
+	l.Infof("running db migrations from %q", migrationsPath)
 	purl, err := addMigrationsTable(pgURL, migrationsTable)
 	if err != nil {
 		return errors.Wrap(err, "parse PG URL")
@@ -65,6 +65,41 @@ func MigrateWithMigrationsTable(pgURL, migrationsPath, migrationsTable string, l
 	// that's always nil
 	_, err = m.Close()
 	return errors.Wrap(err, "close migrations connection")
+}
+
+// DestructiveMigrateForTests will:
+// * Drop the database to give you a clean slate
+// * Run all your migrations
+// * Forcibly run all the migrations again to verify that they are idempotent.
+//
+// Obviously you don't want this for production, but you should use it instead
+// of the plain Migrate function in your tests if you can.
+func DestructiveMigrateForTests(pgURL, migrationsPath string, l logger.Logger, verbose bool) error {
+	l.Infof("running db migrations in destructo test mode for DB %q from %q", pgURL, migrationsPath)
+	purl, err := addMigrationsTable(pgURL, "")
+
+	m, err := migrate.New(addScheme(migrationsPath), purl)
+	if err != nil {
+		return errors.Wrapf(err, "migrator setup failed for %q", pgURL)
+	}
+	m.Log = migrationLog{Logger: l, verbose: verbose}
+	if err := m.Drop(); err != nil {
+		return errors.Wrapf(err, "drop database failed for %q", pgURL)
+	}
+	if err := m.Drop(); err != nil {
+		return errors.Wrapf(err, "drop database failed for %q", pgURL)
+	}
+	if err := m.Up(); err != nil {
+		return errors.Wrapf(err, "failed applying migrations to clean database %q", pgURL)
+	}
+	if err := m.Force(-1); err != nil {
+		return errors.Wrapf(err, "failed to force migration state to version 0 for db %q", pgURL)
+	}
+	if err := m.Up(); err != nil {
+		return errors.Wrapf(err, "failed to re-apply migration to migrated database %q - missing IF (NOT) EXISTS?", pgURL)
+	}
+
+	return nil
 }
 
 func addScheme(p string) string {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In https://github.com/chef/automate/pull/4183 we fixed an error in the migrator that was re-running migrations in multiple front-end cluster topologies, but we still try to forcibly redo migrations if they fail and leave a dirty schema state. So it's best if our migrations are able to re-run. This PR adds a function to our migrator library which drops all the data in the database, then runs a service's migrations all the way through twice. In addition to checking that migrations are idempotent, this approach makes it convenient to develop new migrations, you can keep re-running the integration tests and any bad state created by mistakes gets cleaned up.

I only modified the two services I know well in this pass, it should be pretty easy to add to others if we like.

### :chains: Related Resources

https://github.com/chef/automate/pull/4183
https://github.com/chef/automate/pull/4169

### :athletic_shoe: How to Build and Test the Change

The fix is in the tests mostly :) but you can run them with:

```
start_deployment_service
chef-automate dev deploy-some chef/config-mgmt-service --with-deps
chef-automate dev deploy-some chef/applications-service --with-deps
```

```
config_mgmt_integration
applications_integration
```

You can delete some of the `IF NOT EXISTS` things to make it fail.

