### PR TITLE
Updating the actions migration

### DIFF
--- a/components/ingest-service/migration/a1_migration.go
+++ b/components/ingest-service/migration/a1_migration.go
@@ -53,11 +53,11 @@ func (ms *Status) calculateA1Tasks() {
 	insightsIndices, _ := ms.client.GetAllTimeseriesIndiceNames(ms.ctx, insightsIndexNameTag)
 	ms.total = ms.total + int64(len(insightsIndices))
 
-	// 4) finalCleanup
+	// 4) migrating actions to events
 	ms.total++
 
-	// migrating actions to events
-	ms.total += 2
+	// 5) finalCleanup
+	ms.total++
 }
 
 // stage1 - this is all done before the service says it is healthy.
@@ -106,12 +106,6 @@ func (ms *Status) stage2() {
 	err := ms.SendAllActionsThroughPipeline()
 	if err != nil {
 		logFatal(err.Error(), "Unable to re-insert actions")
-	}
-	ms.taskCompleted()
-
-	err = ms.DeleteAllActionsIndexes()
-	if err != nil {
-		logFatal(err.Error(), "Unable to delete action indexes")
 	}
 	ms.taskCompleted()
 

--- a/components/ingest-service/migration/migration.go
+++ b/components/ingest-service/migration/migration.go
@@ -145,11 +145,7 @@ func (ms *Status) Start() error {
 	}
 	if exists {
 		ms.update("Starting migration of actions to the event-feed-service")
-		err = ms.migrateAction()
-		if err != nil {
-			ms.updateErr(err.Error(), "Unable run actions to current migration")
-			return err
-		}
+		go ms.migrateAction()
 		return nil
 	}
 
@@ -301,7 +297,7 @@ func (ms *Status) migrateBerlinToCurrent() error {
 // NOTE: If any of these steps fails, we won't be in a healthy state, so we throw
 // an error to the end user to verify what happened with the migration.
 func (ms *Status) migrateNodeStateToCurrent(previousIndex string) error {
-	ms.total = 7
+	ms.total = 6
 
 	ms.update("Initializing new node state index")
 	err := ms.client.InitializeStore(ms.ctx)
@@ -363,13 +359,6 @@ func (ms *Status) migrateNodeStateToCurrent(previousIndex string) error {
 	err = ms.SendAllActionsThroughPipeline()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to re-insert actions")
-		return err
-	}
-	ms.taskCompleted()
-
-	err = ms.DeleteAllActionsIndexes()
-	if err != nil {
-		ms.updateErr(err.Error(), "Unable to delete action indexes")
 		return err
 	}
 	ms.taskCompleted()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The update runs the migration in the background.
It also migrates each action index one at a time and then delete it.

### :chains: Related Resources
#444 
### :+1: Definition of Done

The action migration runs in the background

### :athletic_shoe: How to Build and Test the Change
1. `start_all_services`
1. Get a version of the code before the initial migration `git checkout b97055d5329cb171a7583c5fc0a68a6f83a6d340`
1. `rebuild components/ingest-service && rebuild components/automate-deployment`
1. Add some actions with `chef_load_actions 1000`
1. Ensure there are "actions-*" indexes with `es_list_indices`
1. To watch the log run `sl | grep "ingest-service.default" &`
1. `git checkout lancewf/action_migration`
1. `rebuild components/automate-deployment && rebuild components/ingest-service`
1. ensure that the ingest-service is healthy before migration is complete. 
1. Ensure all the "actions-*" indexes are removed and you still see events on the event feed page. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
