### PR TITLE
Jamie/4044 token changes saved bug

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.html
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.html
@@ -63,7 +63,7 @@
           </chef-form-field>
         </form>
         <div id="save">
-          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !this.updateForm.dirty" (click)="saveToken()">
+          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !updateForm.dirty" (click)="saveToken()">
             <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
             <span *ngIf="saveInProgress">Saving...</span>
             <span *ngIf="!saveInProgress">Save</span>

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -86,6 +86,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
         if (this.saveSuccessful) {
           this.updateForm.markAsPristine();
 
+          // Delay 1.5 seconds so that a success message can be displayed.
           setTimeout(() => {
             this.saveSuccessful = false;
           }, 1500);

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -95,8 +95,8 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   }
 
   public saveToken(): void {
-    this.saveInProgress = true;
     this.saveSuccessful = false;
+    this.saveInProgress = true;
     const name: string = this.updateForm.controls.name.value.trim();
     const active = <TokenStatus>this.updateForm.controls.status.value === 'active';
     const projects: string[] = this.updateForm.controls.projects.value;

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -85,11 +85,6 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
         this.saveSuccessful = (state === EntityStatus.loadingSuccess);
         if (this.saveSuccessful) {
           this.updateForm.markAsPristine();
-
-          // Delay 1.5 seconds so that a success message can be displayed.
-          setTimeout(() => {
-            this.saveSuccessful = false;
-          }, 1500);
         }
       });
   }
@@ -101,6 +96,7 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
 
   public saveToken(): void {
     this.saveInProgress = true;
+    this.saveSuccessful = false;
     const name: string = this.updateForm.controls.name.value.trim();
     const active = <TokenStatus>this.updateForm.controls.status.value === 'active';
     const projects: string[] = this.updateForm.controls.projects.value;

--- a/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
+++ b/components/automate-ui/src/app/modules/token/token-details/api-token-details.component.ts
@@ -85,6 +85,10 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
         this.saveSuccessful = (state === EntityStatus.loadingSuccess);
         if (this.saveSuccessful) {
           this.updateForm.markAsPristine();
+
+          setTimeout(() => {
+            this.saveSuccessful = false;
+          }, 1500);
         }
       });
   }
@@ -95,7 +99,6 @@ export class ApiTokenDetailsComponent implements OnInit, OnDestroy {
   }
 
   public saveToken(): void {
-    this.saveSuccessful = false;
     this.saveInProgress = true;
     const name: string = this.updateForm.controls.name.value.trim();
     const active = <TokenStatus>this.updateForm.controls.status.value === 'active';

--- a/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-details/data-feed-details.component.html
@@ -46,7 +46,7 @@
             <span *ngIf="testInProgress">Testing...</span>
             <span *ngIf="!testInProgress">Test Data Feed</span>
           </chef-button>
-          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !this.updateForm.dirty" (click)="saveDataFeed()">
+          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !updateForm.dirty" (click)="saveDataFeed()">
             <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
             <span *ngIf="saveInProgress">Saving...</span>
             <span *ngIf="!saveInProgress">Save</span>

--- a/components/automate-ui/src/app/pages/notification-details/notification-details.component.html
+++ b/components/automate-ui/src/app/pages/notification-details/notification-details.component.html
@@ -95,7 +95,7 @@
             <span *ngIf="testInProgress">Testing...</span>
             <span *ngIf="!testInProgress">Test Data Feed</span>
           </chef-button>
-          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !this.updateForm.dirty" (click)="saveNotification()">
+          <chef-button primary [disabled]="saveInProgress || !updateForm.valid || !updateForm.dirty" (click)="saveNotification()">
             <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
             <span *ngIf="saveInProgress">Saving...</span>
             <span *ngIf="!saveInProgress">Save</span>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Changing the state of an API Token from Active to Inactive on the the token details page was working, but causing an "all changes saved" message to display constantly on the initial selection, as well as preventing a new/different active state to be selected.  The issue related to an accidental `this.` placed in the template.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/4044

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
build components/automate-ui-devproxy && start_all_services
make serve

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Token state changes 2](https://user-images.githubusercontent.com/16737484/89676327-57f0fe80-d8a0-11ea-95eb-a6c1787c650e.gif)
