### PR TITLE
Jamie/4186 block beta flags

### DIFF
--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -39,6 +39,7 @@ export class FeatureFlagsComponent implements OnInit {
 
   public warning: string;
   public flagType: FlagTypes;
+  private blockedElements = ['input', 'textarea', 'button', 'select'];
 
   betaWarning = 'The warranties and indemnities in your license agreement do not apply ' +
                 'to experimental features. Experimental features are provided "as is" ' +
@@ -55,7 +56,7 @@ export class FeatureFlagsComponent implements OnInit {
 
   constructor(
     public featureFlagsService: FeatureFlagsService,
-    private telemetryService: TelemetryService
+    private telemetryService: TelemetryService,
   ) {}
 
   ngOnInit() {
@@ -76,6 +77,12 @@ export class FeatureFlagsComponent implements OnInit {
 
   @HostListener('document: keyup', ['$event.keyCode'])
   handleKeyUp(keyCode: number): void {
+    // Guard against launching when focused on input elements
+    if ( document.activeElement
+      && this.blockedElements.indexOf(document.activeElement.tagName.toLowerCase()) !== -1 ) {
+        return;
+      }
+
     // when reaching codeLength, drop first item
     if (this.keysCache.push(keyCode) === codeLength + 1) {
       this.keysCache.shift();

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -56,7 +56,7 @@ export class FeatureFlagsComponent implements OnInit {
 
   constructor(
     public featureFlagsService: FeatureFlagsService,
-    private telemetryService: TelemetryService,
+    private telemetryService: TelemetryService
   ) {}
 
   ngOnInit() {

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -39,7 +39,7 @@ export class FeatureFlagsComponent implements OnInit {
 
   public warning: string;
   public flagType: FlagTypes;
-  private blockedElements = ['input', 'textarea', 'button', 'select', 'chef-button', 'chef-select'];
+  private blockedElements = ['input', 'textarea'];
 
   betaWarning = 'The warranties and indemnities in your license agreement do not apply ' +
                 'to experimental features. Experimental features are provided "as is" ' +

--- a/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
+++ b/components/automate-ui/src/app/page-components/feature-flags/feature-flags.component.ts
@@ -39,7 +39,7 @@ export class FeatureFlagsComponent implements OnInit {
 
   public warning: string;
   public flagType: FlagTypes;
-  private blockedElements = ['input', 'textarea', 'button', 'select'];
+  private blockedElements = ['input', 'textarea', 'button', 'select', 'chef-button', 'chef-select'];
 
   betaWarning = 'The warranties and indemnities in your license agreement do not apply ' +
                 'to experimental features. Experimental features are provided "as is" ' +


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Users may opt in to accessing beta, legacy, or other unfinished features by turning the services on or off through our feature flag.  In order to do this, they type `feat`, `lega`, or `beta`, to open the option box.  This becomes problematic if a user is searching for, filtering by, or for any other reason, typing something related to any of these key strings.  

This branch updates the feature flag window to only open if the user does _not_ actively have focus on an input, textarea, button, or select element.

### :chains: Related Resources
Addresses: https://github.com/chef/automate/issues/4186

### :+1: Definition of Done
When user is actively focused on an input, textarea, button, or select element and types the code keys.  The feature flag modal does not open.
When a user is _not_ actively focused on an input, textarea, button, or select element and types the code keys, the feature flag window opens as expected.

### :athletic_shoe: How to Build and Test the Change
cd into root folder: `build components/automate-ui-devproxy && start_all_services`
cd into components/automate-ui: `make serve`

Click or tab to focus inside an input element (blinking cursor for input/text area) or on a button.
Type `feat` or `lega` or `beta` -> no modal should show

Focus out/off of any of the input elements
Type `feat` or `lega` or `beta` -> modal should show

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![block-inputs](https://user-images.githubusercontent.com/16737484/89692212-ed4fbb00-d8bf-11ea-96f1-fb28638e0440.gif)
