### PR TITLE
Correct error message for adding policy members

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -16,7 +16,7 @@ export class Regex {
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **
 
-    // Allows no special characters except hyphen
+    // Allows no special characters except hyphen and underscore.
     NO_MIXED_WILDCARD_ALLOW_HYPHEN: '^(\\*|[-\\w]+)$',
 
     // Allows all special characters except colon :

--- a/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
+++ b/components/automate-ui/src/app/modules/policy/add-members/policy-add-members.component.html
@@ -77,7 +77,7 @@
                   {{ nameOrId }} may contain a single wildcard or a {{ nameOrId }} without colons or wildcards.
                 </chef-error>
                 <chef-error *ngIf="!ldapOrSaml && expressionForm.get('name').hasError('pattern') && expressionForm.get('name').dirty">
-                  {{ nameOrId }} may contain text and hyphens or a wildcard but not both.
+                  {{ nameOrId }} may contain text, hyphens and underscores, or may be a single wildcard.
                 </chef-error>
               </chef-form-field>
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The regex we are using to constrain entries for policy members (`\w`) includes letters and digits--and the underscore. Just updating the text and code to note this.

The illustration shows the error pop-up upon entering an illegal character--an exclamation mark. But note that earlier in the same input is an underscore, which is legal, so it should be mentioned in the message.

<img width="896" alt="image" src="https://user-images.githubusercontent.com/6817500/89699396-76282000-d8db-11ea-9a05-dac30ad03688.png">

### :chains: Related Resources
NA

### :+1: Definition of Done
Corrected error message.

### :athletic_shoe: How to Build and Test the Change
Navigate to Settings >> Policy >> (specific policy) >> Members >> <kbd>Add Members</kbd> >> <kbd>Add Member Expression</kbd>
Select `Team`
Select `Local`
Type a name with an underscore and note there is no error.
Type a name with an exclamation point and note the revised error text.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
