### PR TITLE
cypress: store deploy recordings only in buildkite

### DIFF
--- a/.expeditor/buildkite/cypress.sh
+++ b/.expeditor/buildkite/cypress.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+#
+# cypress.sh:
+# this test file executes cypress automated ui tests against our long-lived
+# dev and acceptance deployments of automate on every deploy. it's triggered
+# from the .expeditor/deploy.pipeline.yml configuration in this repository
+#
+
 set -euo pipefail
 
 cd /workdir/e2e
@@ -20,7 +27,7 @@ do
 
   npm install # get dependencies defined in e2e/package.json
 
- if ! npm run cypress:record; then
+ if ! npm run cypress:run; then
       buildkite-agent artifact upload "cypress/videos/*;cypress/videos/**/*;cypress/screenshots/*;cypress/screenshots/**/*"
       exit 1
   fi

--- a/scripts/get_secrets.sh
+++ b/scripts/get_secrets.sh
@@ -61,7 +61,6 @@ vault kv get -field=license secret/a2/delivery_license | base64 --decode >compon
 target_host=$(vault kv get -field=data secret/a2/testing/target_host)
 target_user=$(vault kv get -field=data secret/a2/testing/target_user)
 target_key=$(vault kv get -field=data secret/a2/testing/target_key)
-record_key=$(vault kv get -field=record_key secret/a2/cypress)
 
 cat >dev/secrets-env.sh <<EOF
 # Secrets
@@ -74,5 +73,4 @@ export HAB_STUDIO_SECRET_AUTOMATE_ACCEPTANCE_TARGET_KEY="$target_key"
 export CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_HOST=$target_host
 export CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_USER=$target_user
 export CYPRESS_AUTOMATE_ACCEPTANCE_TARGET_KEY="$target_key"
-export CYPRESS_RECORD_KEY=$record_key
 EOF


### PR DESCRIPTION
the cypress tests that run for each pull request use the `cypress:run`
command instead of `cypress:record`. the difference between the two is
that `record` sends the artifacts to the cypress.io cloud dashboard
and run only saves them locally. our test logic already saves the
artifacts to buildkite in the event of a failure, where everybody has
access to the recording.

note: the deploy tests are currently turned off until we can fix them
and this change will only effect these runs once they're re-enabled.

Signed-off-by: Stephen Delano <stephen@chef.io>