### PR TITLE
Ingest service Elasticsearch migration lock

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1526,6 +1526,7 @@ paths = [
   "vendor/github.com/codahale/hdrhistogram/*",
   "vendor/github.com/envoyproxy/protoc-gen-validate/*",
   "vendor/github.com/fsnotify/fsnotify/*",
+  "vendor/github.com/go-gorp/gorp/*",
   "vendor/github.com/gofrs/uuid/*",
   "vendor/github.com/golang-migrate/migrate/*",
   "vendor/github.com/golang/mock/*",

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -28,6 +28,7 @@ import (
 	"github.com/chef/automate/lib/cereal"
 	"github.com/chef/automate/lib/cereal/postgres"
 	"github.com/chef/automate/lib/datalifecycle/purge"
+	libdb "github.com/chef/automate/lib/db"
 	"github.com/chef/automate/lib/grpc/secureconn"
 	platform_config "github.com/chef/automate/lib/platform/config"
 )
@@ -55,18 +56,27 @@ func Spawn(opts *serveropts.Opts) error {
 		return err
 	}
 
-	var (
-		grpcServer = opts.ConnFactory.NewServer()
-		migrator   = migration.New(client)
-		uri        = fmt.Sprintf("%s:%d", opts.Host, opts.Port)
-	)
-
+	uri := fmt.Sprintf("%s:%d", opts.Host, opts.Port)
 	log.WithField("uri", uri).Info("Starting gRPC Server")
 	conn, err := net.Listen("tcp", uri)
 	if err != nil {
 		log.WithError(err).Error("TCP listen failed")
 		return err
 	}
+
+	grpcServer := opts.ConnFactory.NewServer()
+
+	pgURL, err := pgURL(opts.PGURL, opts.PGDatabase)
+	if err != nil {
+		log.WithError(err).Fatal("could not get PG URL")
+		return err
+	}
+
+	dbMap, err := libdb.PGOpen(pgURL)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to open database with uri: %s", pgURL)
+	}
+	migrator := migration.New(client, dbMap)
 
 	// Register Status Server
 	ingestStatus := server.NewIngestStatus(client, migrator)
@@ -83,19 +93,29 @@ func Spawn(opts *serveropts.Opts) error {
 		return err
 	}
 
-	if migrationNeeded {
-		err = migrator.Start()
-		if err != nil {
-			log.WithError(err).Error("Failed starting a migration")
-			return err
+	migrationRunning, err := migrator.MigrationRunning()
+	if err != nil {
+		log.WithError(err).Error("Failed checking if a migration is running")
+		return err
+	}
+
+	if !migrationRunning {
+		if migrationNeeded {
+			err = migrator.Start()
+			if err != nil {
+				log.WithError(err).Error("Failed starting a migration")
+				return err
+			}
+		} else {
+			migrator.MarkUnneeded()
+			err = client.InitializeStore(context.Background())
+			if err != nil {
+				log.WithError(err).Error("Failed initializing elasticsearch")
+				return err
+			}
 		}
 	} else {
-		migrator.MarkUnneeded()
-		err = client.InitializeStore(context.Background())
-		if err != nil {
-			log.WithError(err).Error("Failed initializing elasticsearch")
-			return err
-		}
+		log.Info("HA Frontend: migration is currently running on another service")
 	}
 
 	// Authz Interface
@@ -146,13 +166,6 @@ func Spawn(opts *serveropts.Opts) error {
 
 	// Pass the chef ingest server to give status about the pipelines
 	ingestStatus.SetChefIngestServer(chefIngest)
-
-	// JobSchedulerServer
-	pgURL, err := pgURL(opts.PGURL, opts.PGDatabase)
-	if err != nil {
-		log.WithError(err).Fatal("could not get PG URL")
-		return err
-	}
 
 	jobManager, err := cereal.NewManager(postgres.NewPostgresBackend(pgURL))
 	if err != nil {

--- a/components/ingest-service/grpc/grpc.go
+++ b/components/ingest-service/grpc/grpc.go
@@ -115,7 +115,9 @@ func Spawn(opts *serveropts.Opts) error {
 			}
 		}
 	} else {
-		log.Info("HA Frontend: migration is currently running on another service")
+		log.Warnf("HA Frontend: migration is currently running on another service. "+
+			"If this is an error, remove the lock from postgresql with the "+
+			"'SELECT pg_advisory_unlock(%d);' command inside the chef_ingest_service database.", migration.PgMigrationLockID)
 	}
 
 	// Authz Interface

--- a/components/ingest-service/migration/migration.go
+++ b/components/ingest-service/migration/migration.go
@@ -2,13 +2,20 @@ package migration
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
+
+	"github.com/go-gorp/gorp"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/components/ingest-service/backend"
 	"github.com/chef/automate/components/ingest-service/backend/elastic/mappings"
+)
+
+const (
+	selectLockCount = "SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND objid = $1;"
 )
 
 var (
@@ -36,9 +43,11 @@ type Status struct {
 	finished  bool
 	ctx       context.Context
 	client    backend.Client
+	pgLockID  int64
+	mapper    *gorp.DbMap
 }
 
-func New(client backend.Client) *Status {
+func New(client backend.Client, postgresql *sql.DB) *Status {
 	return &Status{
 		total:     0,
 		completed: 0,
@@ -46,6 +55,8 @@ func New(client backend.Client) *Status {
 		finished:  false,
 		ctx:       context.Background(),
 		client:    client,
+		pgLockID:  77,
+		mapper:    &gorp.DbMap{Db: postgresql, Dialect: gorp.PostgresDialect{}},
 	}
 }
 
@@ -58,6 +69,13 @@ func New(client backend.Client) *Status {
 // For the migration framework we are always going to migrate from the current state to the current version.
 // This does cause a maintenance problem because for each new version the old migration stages need to be updated.
 func (ms *Status) Start() error {
+	err := ms.lock()
+	if err != nil {
+		ms.updateErr(err.Error(), "Unable to lock for migration")
+		return err
+	}
+	defer ms.unlock()
+
 	exists, err := ms.hasA1ElasticsearchData()
 	if err != nil {
 		ms.updateErr(err.Error(), "Unable to detect migration status")
@@ -182,6 +200,17 @@ func (ms *Status) MigrationNeeded() (bool, error) {
 	return false, nil
 }
 
+// MigrationRunning - Is a migration currently running on another service.
+// This would only be the case if this service is running in a HA frontend.
+func (ms *Status) MigrationRunning() (bool, error) {
+	count, err := ms.mapper.WithContext(context.Background()).SelectInt(selectLockCount, ms.pgLockID)
+	if err != nil {
+		return false, err
+	}
+
+	return count == 1, nil
+}
+
 // MarkUnneeded marks the migrations status to done
 func (ms *Status) MarkUnneeded() {
 	ms.status = "No migration is needed."
@@ -211,6 +240,23 @@ func (ms *Status) String() string {
 // Done reports when the migration is done or it is still in progress
 func (ms *Status) Done() bool {
 	return ms.finished
+}
+
+func (ms *Status) lock() error {
+	query := `SELECT pg_advisory_lock($1)`
+
+	if _, err := ms.mapper.WithContext(context.Background()).Exec(query, ms.pgLockID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ms *Status) unlock() error {
+	query := `SELECT pg_advisory_unlock($1)`
+	if _, err := ms.mapper.WithContext(context.Background()).Exec(query, ms.pgLockID); err != nil {
+		return err
+	}
+	return nil
 }
 
 // update the migration status message (private)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

For ingest-service elasticsearch migrations, we added PostgreSQL lock to prevent Automate HA frontend with multiple ingest-services from running the same migration at the same time.

### :chains: Related Resources

#4201 

### :athletic_shoe: How to Build and Test the Change
1. `start_all_services`
1. While automate is starting, change this line from "false" to "true". https://github.com/chef/automate/blob/c0a74e9df9db459d2d5b2fa9f8b74ca1d0c2386d/components/ingest-service/migration/migration.go#L200
1. Add the below code to here https://github.com/chef/automate/blob/c0a74e9df9db459d2d5b2fa9f8b74ca1d0c2386d/components/ingest-service/migration/migration.go#L153
```
	log.Info("Starting migration")
	time.Sleep(time.Minute)
	log.Info("Finished Migration")
```
1. Setup tmux with 
```
cat > /root/.profile <<'endmsg'
if [ -f /tmp/tmux ]; then
  source /src/.studiorc
fi

touch /tmp/tmux
endmsg
```
1. Install tmux with `hab pkg install -b core/tmux`
1. Start a tmux session with `tmux`
1. Create a new terminal with `CTR-b "` Switch between the terminal with `CTR-b` down or up arrows.
1. In one of the terminals (A) run `chef-automate dev psql chef_ingest_service`
1. In the other (B) run `sl | grep "ingest-service.default" &`
1. Then run `rebuild components/ingest-service` in terminal B
1. To watch the postgresql lock in terminal A run `SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND objid =77;`
1. When you see the "Starting migration" in terminal B there is a lock in postgresql.
1. After seeing "Finished Migration" the lock should be removed. 
1. Run the `rebuild components/ingest-service` another time and when the migration is running (right after "Starting migration" is logged) run `kill_running_service ingest-service` and ensure the postgresql lock is removed. 
1. Simulate another ingest-service is running a migration with adding the lock manually with `SELECT pg_advisory_lock(77);` in terminal A. 
1. Then in terminal B run `rebuild components/ingest-service` and ensure you see this message in the logs "HA Frontend: migration is currently running on another service". 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/1679247/89942989-57bf6e80-dbd2-11ea-9fc8-a2257f24a289.png)
