### PR TITLE
Helper for listing policies for local user

### DIFF
--- a/scripts/auth_resources.sh
+++ b/scripts/auth_resources.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 ###
-### user_policies.sh -- adds utility commands to your shell
+### auth_resources.sh -- adds auth utilities to your shell
 ###
-### usage: source user_policies.sh
+### usage: source auth_resources.sh
 ###
 ### Commands added:
 ###
@@ -25,10 +25,12 @@
 ###   a2teams <local_user_name>
 ###     Enumerates all local teams for <local_user_name>.
 ###
-###
 ###   a2userid <local_user_name>
 ###     Returns the user id for <local_user_name>.
 ###     (The user id is required rather than the user name for querying the team API.)
+###
+###   a2rules
+###     Enumerates all rules for all projects. Projects with no rules are skipped.
 ###
 ### Reference:
 ###   https://blog.chef.io/now-what-were-those-permissions-for-this-user-again/
@@ -88,3 +90,13 @@ a2teams() {
   curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/users/$user_id/teams" | jq -r '.teams[] | .id'
 }
 
+a2rules() {
+  local projects
+  projects=$(curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/projects" | \
+    jq -r '.projects[] | select(.status != "NO_RULES") | .id')
+  for proj in $projects
+  do
+    printf "\nProject %s...\n" "$proj"
+    curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/projects/$proj/rules" | jq
+  done
+}

--- a/scripts/user_policies.sh
+++ b/scripts/user_policies.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+###
+### user_policies.sh -- adds utility commands to your shell
+###
+### usage: source user_policies.sh
+###
+### Commands added:
+###
+###   a2policies <local_user_name>
+###     Enumerates all policies for <local_user_name>, including direct mention,
+###     or indirect through local team membership or wildcard mention.
+###
+###     EXAMPLE: a2policies bob
+###     If user:local:bob is a member of team:local:foo, then policies with
+###     any of these members will be returned:
+###       user:local:bob
+###       user:local:*
+###       user:*
+###       team:local:foo
+###       team:local:*
+###       team:*
+###       *
+###
+###   a2teams <local_user_name>
+###     Enumerates all local teams for <local_user_name>.
+###
+###
+###   a2userid <local_user_name>
+###     Returns the user id for <local_user_name>.
+###     (The user id is required rather than the user name for querying the team API.)
+###
+### Reference:
+###   https://blog.chef.io/now-what-were-those-permissions-for-this-user-again/
+###
+### Prerequisites:
+###  * `jq` must be installed.
+###  * env var TOK must be defined and specify a valid A2 admin token.
+###  * env var TARGET_HOST must be defined in the form https://your.automate.host.
+
+
+# source for this help infrastructure: https://samizdat.dev/help-message-for-shell-scripts/
+help() {
+  awk -F'### ' '/^###/{print $2}' "$0"
+}
+
+if [[ $# == 0 ]] || [[ "$1" == "-h" ]]; then
+  help
+  exit 1
+fi
+
+# Commands
+
+a2policies() {
+  local user_and_teams=("$1")
+  local user_id=$(curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/users/$1" | jq -cr '.user.membership_id')
+  if [[ $user_id != "null" ]]; then
+    user_and_teams=(
+      "$1"
+      $(curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/users/$user_id/teams" | jq -r '.teams[] | .id')
+    )
+  fi
+  local resourceType="user"
+  for resource in ${user_and_teams[@]}
+  do
+    echo Checking $resourceType:local:$resource...
+    curl -sSkH "api-token: $TOK" -H "" "$TARGET_HOST/apis/iam/v2/policies" | \
+      jq -cr --arg name "$resourceType:local:$resource" \
+             --arg allLocal "$resourceType:local:*" \
+             --arg allType "$resourceType:*" \
+        '.policies[] |
+           select (.members | contains([$name]) or contains([$allLocal]) or contains([$allType]) or (index("*") != null)) |
+           .id, .members'
+    resourceType="team"
+  done
+}
+
+# Works for local users only
+a2userid() {
+  curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/users/$1" | jq -cr '.user.membership_id'
+}
+
+# Works for local users only
+a2teams() {
+  local user_id=$(a2userid $1)
+  curl -sSkH "api-token: $TOK" "$TARGET_HOST/apis/iam/v2/users/$user_id/teams" | jq -r '.teams[] | .id'
+}
+

--- a/scripts/user_policies.sh
+++ b/scripts/user_policies.sh
@@ -44,7 +44,8 @@ help() {
   awk -F'### ' '/^###/{print $2}' "$0"
 }
 
-if [[ $# == 0 ]] || [[ "$1" == "-h" ]]; then
+# Sourced scripts cannot include the no-arg check here!
+if [[ "$1" == "-h" ]]; then
   help
   exit 1
 fi


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Original version of this script was presented on the Chef blog, but I think it makes sense to have it generally available, since I have been updating it "off the record".

### :chains: Related Resources
https://blog.chef.io/now-what-were-those-permissions-for-this-user-again/

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
1. Source the file (`source scripts/auth_resources.sh`).
2. Define env vars for token and target host. The host could be your local machine (`https://a2-dev.test` or some acceptance box):
```
export TARGET_HOST=https://a2-local-inplace-upgrade-acceptance.cd.chef.co
export TOK=<token value here>
```

There are several small shell functions available: a2policies, a2teams, a2userid, and a2rules.
To see a short summary of what each of those does, invoke the script (rather than source it) with the `-h`option:
```
./scripts/auth_resources -h
```

Here is a specific example of the main function, `a2policies`:
1. Define a local user in the UI
2. Provide membership for the user on some local teams and some policies.

Example: for local user `bob` run `a2policies bob` (not `a2policies user:local:bob`). Output looks like this:
```
Checking user:local:bob...
deleteme-project-viewers
["user:local:*"]
deletemetoo-project-owners
["*"]
ms_test-project-owners
["user:local:bob","token:asdfasdf"]
new-horizons-project-editors
["user:local:bob"]
new-horizons-project-owners
["user:local:bob"]

Checking team:local:a-team...
deletemetoo-project-owners
["*"]
new-horizons-project-viewers
["team:local:*"]

Checking team:local:whoa2...
deletemetoo-project-owners
["*"]
new-horizons-project-viewers
["team:local:*"]
compliance-viewer-access
["user:local:sr","team:local:whoa2"]
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
