### PR TITLE
Chef session logout issue on 401 error raised from chef servers API

### DIFF
--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-details.requests.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-details.requests.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { environment as env } from 'environments/environment';
 import { CookbookDetails, RespCookbookDetails } from './cookbook-details.model';
+import { InterceptorSkipHeader } from 'app/services/http/http-client-auth.interceptor';
 
 @Injectable()
 export class CookbookDetailsRequests {
@@ -13,8 +14,9 @@ export class CookbookDetailsRequests {
   public getCookbookDetails(
     server_id: string, org_id: string, cookbook_name: string, cookbook_version: string):
     Observable<CookbookDetails> {
+    const headers = new HttpHeaders().set(InterceptorSkipHeader, '');
     return this.http.get<RespCookbookDetails>(
-      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}/${cookbook_version}`)
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}/${cookbook_version}`, { headers })
       .pipe(
         map((respCookbookDetails:
           RespCookbookDetails) => this.createCookbookDetails(respCookbookDetails)));

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.requests.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.requests.ts
@@ -14,8 +14,8 @@ export class CookbookVersionsRequests {
   Observable<CookbookVersions> {
     const headers = new HttpHeaders().set(InterceptorSkipHeader, '');
     return this.http.get<CookbookVersions>(
-      // tslint:disable-next-line: max-line-length
-      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}`, { headers });
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}`,
+        { headers });
   }
 
 }

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.requests.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook-versions.requests.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment as env } from 'environments/environment';
 import { CookbookVersions } from './cookbook-versions.model';
+import { InterceptorSkipHeader } from 'app/services/http/http-client-auth.interceptor';
 
 @Injectable()
 export class CookbookVersionsRequests {
@@ -11,8 +12,10 @@ export class CookbookVersionsRequests {
 
   public getCookbookVersions(server_id: string, org_id: string, cookbook_name: string):
   Observable<CookbookVersions> {
+    const headers = new HttpHeaders().set(InterceptorSkipHeader, '');
     return this.http.get<CookbookVersions>(
-      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}`);
+      // tslint:disable-next-line: max-line-length
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks/${cookbook_name}`, { headers });
   }
 
 }

--- a/components/automate-ui/src/app/entities/cookbooks/cookbook.requests.ts
+++ b/components/automate-ui/src/app/entities/cookbooks/cookbook.requests.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment as env } from 'environments/environment';
 import { CookbooksSuccessPayload } from './cookbook.actions';
+import { InterceptorSkipHeader } from 'app/services/http/http-client-auth.interceptor';
 
 @Injectable()
 export class CookbookRequests {
@@ -11,8 +12,9 @@ export class CookbookRequests {
 
   public getCookbooks(server_id: string, org_id: string):
   Observable<CookbooksSuccessPayload> {
+    const headers = new HttpHeaders().set(InterceptorSkipHeader, '');
     return this.http.get<CookbooksSuccessPayload>(
-      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks`);
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/cookbooks`, {headers});
   }
 
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -1,9 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { combineLatest } from 'rxjs';
+import { Subject, combineLatest } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
-import { filter } from 'rxjs/operators';
 import { isNil } from 'lodash/fp';
 import { EntityStatus } from 'app/entities/entities';
 import { GetCookbooks } from 'app/entities/cookbooks/cookbook.actions';
@@ -19,10 +19,11 @@ import {
   styleUrls: ['./cookbooks.component.scss']
 })
 
-export class CookbooksComponent implements OnInit {
+export class CookbooksComponent implements OnInit, OnDestroy {
   @Input() serverId: string;
   @Input() orgId: string;
 
+  private isDestroyed = new Subject<boolean>();
   public cookbooks: Cookbook[] = [];
   public cookbooksListLoading = true;
 
@@ -41,13 +42,17 @@ export class CookbooksComponent implements OnInit {
     combineLatest([
       this.store.select(getAllCookbooksForOrgStatus),
       this.store.select(allCookbooks)
-    ]).pipe(
-      filter(([getCookbooksSt, allCookbooksState]) =>
-        getCookbooksSt === EntityStatus.loadingSuccess && !isNil(allCookbooksState))
-
-    ).subscribe(([ _getCookbooksSt, allCookbooksState]) => {
-      this.cookbooks = allCookbooksState;
+    ]).pipe(takeUntil(this.isDestroyed))
+    .subscribe(([ getCookbooksSt, allCookbooksState]) => {
       this.cookbooksListLoading = false;
+      if (getCookbooksSt === EntityStatus.loadingSuccess && !isNil(allCookbooksState)) {
+        this.cookbooks = allCookbooksState;
+      }
     });
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -23,7 +23,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
   @Input() serverId: string;
   @Input() orgId: string;
 
-  private isDestroyed = new Subject<boolean>();
+  private isDestroyed$ = new Subject<boolean>();
   public cookbooks: Cookbook[] = [];
   public cookbooksListLoading = true;
 
@@ -42,7 +42,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
     combineLatest([
       this.store.select(getAllCookbooksForOrgStatus),
       this.store.select(allCookbooks)
-    ]).pipe(takeUntil(this.isDestroyed))
+    ]).pipe(takeUntil(this.isDestroyed$))
     .subscribe(([ getCookbooksSt, allCookbooksState]) => {
       this.cookbooksListLoading = false;
       if (getCookbooksSt === EntityStatus.loadingSuccess && !isNil(allCookbooksState)) {
@@ -52,7 +52,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.isDestroyed.next(true);
-    this.isDestroyed.complete();
+    this.isDestroyed$.next(true);
+    this.isDestroyed$.complete();
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
@@ -9,7 +9,7 @@
       </chef-thead>
       <chef-tbody>
         <chef-tr *ngFor="let dataBag of dataBags">
-          <chef-td><a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'data_bags', dataBag.name]">{{ dataBag.name }}</a></chef-td>
+          <chef-td><a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'data-bags', dataBag.name]">{{ dataBag.name }}</a></chef-td>
         </chef-tr>
       </chef-tbody>
     </chef-table>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -60,7 +60,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         } else if (path.includes('policyFiles')) {
           this.resetTabs();
           this.policyFilesTab = true;
-        } else if (path.includes('data_bags')) {
+        } else if (path.includes('data-bags')) {
           this.resetTabs();
           this.dataBagsTab = true;
         } else if (path.includes('cookbooks')) {

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -49,12 +49,6 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
     if (this.projects && filtered) {
       headers = headers.set('projects', this.projects);
     }
-    // Check the interceptor skip header in API request
-    // To avoid session logout if 401 raised from external API
-    if (request.headers.has(InterceptorSkipHeader)) {
-      headers = headers.delete(InterceptorSkipHeader);
-      return next.handle(request.clone({ headers }));
-    }
 
     return this.chefSession.token_provider.pipe(
       take(1),
@@ -63,6 +57,12 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
         //           Right now, we're throwing the ID token across the internet for telemetry,
         //           where it's not needed. It would be nice to _not_ do that.
         headers = headers.set('Authorization', `Bearer ${id_token}`);
+        // Check the interceptor skip header in API request
+        // To avoid session logout if 401 raised from external API
+        if (request.headers.has(InterceptorSkipHeader)) {
+          headers = headers.delete(InterceptorSkipHeader);
+          return next.handle(request.clone({ headers }));
+        }
         return next
           .handle(request.clone({ headers, params })).pipe(
             catchError((error: HttpErrorResponse) => {

--- a/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
+++ b/components/automate-ui/src/app/services/http/http-client-auth.interceptor.ts
@@ -15,6 +15,8 @@ import { ChefSessionService } from 'app/services/chef-session/chef-session.servi
 import * as selectors from 'app/services/projects-filter/projects-filter.selectors';
 import { ProjectsFilterOption } from '../projects-filter/projects-filter.reducer';
 
+export const InterceptorSkipHeader = 'Skip-Interceptor';
+
 @Injectable()
 export class HttpClientAuthInterceptor implements HttpInterceptor {
 
@@ -46,6 +48,12 @@ export class HttpClientAuthInterceptor implements HttpInterceptor {
 
     if (this.projects && filtered) {
       headers = headers.set('projects', this.projects);
+    }
+    // Check the interceptor skip header in API request
+    // To avoid session logout if 401 raised from external API
+    if (request.headers.has(InterceptorSkipHeader)) {
+      headers = headers.delete(InterceptorSkipHeader);
+      return next.handle(request.clone({ headers }));
     }
 
     return this.chefSession.token_provider.pipe(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
For module like automate infra view we are communicating with chef servers API's that is external API's in that case we don't want session gets expired on getting 401 error, instead of that we need to show user a error notification so that user can take a preventive action for error so we have introduced a `skip-interceptor` header for external API's to ignore chef session logout loop in auth interceptor service on getting 401 error from server.


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes: #4137 , #4180 
### :+1: Definition of Done
Shown a authentication error notification on getting 401 error raised from chef servers API's please refer attached screenshot for the same. 

### :athletic_shoe: How to Build and Test the Change
Call infra proxy API which gives 401 error.
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![chef-server-401](https://user-images.githubusercontent.com/54940695/90030711-ff739400-dcd9-11ea-8e44-078ad7daa389.png)

