### PR TITLE
Link fix for Migrate doc

### DIFF
--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -25,7 +25,7 @@ The Chef Automate migration process performs the following steps, in order:
 
 1. Runs preflight checks to ensure the system is suitable for Chef Automate 2, your Chef Automate 1 installation can be migrated safely, and that the upgrade process will be able to migrate your data.
 1. Analyzes your Chef Automate 1 configuration files and migrates the relevant settings to a configuration file for Chef Automate 2. If incompatibilities are detected, the migration process fails and emits a description of the problem. You will have an opportunity to make any necessary changes to the generated Chef Automate 2 configuration.
-1. Downloads Automate 2. Chef Automate 2 is distributed via [Habitat](https://www.habitat.sh/) packages that are installed early in the process to minimize the downtime required for the migration.
+1. Download Chef Automate 2. Chef Automate 2 is distributed via [Habitat](https://www.habitat.sh/) packages that are installed early in the process to minimize the downtime required for the migration.
 1. Puts your Chef Automate 1 installation into maintenance mode, waits for queued data to be processed, and then backs up all Chef Automate 1 data. This ensures that data will not be lost in the migration process and that you will be able to recover to a working state should an unforeseen error occur.
 1. Creates a local snapshot of Chef Automate 1 data for import into Chef Automate 2.
 1. Shuts down Chef Automate 1.
@@ -66,7 +66,9 @@ You will need the `chef-automate` command line tool to initiate your upgrade.
 
 ### Internet Access
 
-The Chef Automate upgrade process currently requires connectivity to the internet to install the Chef Automate 2 binaries. The standard Automate installation requires current versions for Chrome, Edge, or Firefox browsers. If you filter internet access via proxy or by other means, you must ensure the following domains are accessible:
+The Chef Automate upgrade process currently requires connectivity to the internet to install the Chef Automate 2 binaries.
+The standard Chef Automate installation requires current versions for Chrome, Edge, or Firefox browsers.
+If you filter internet access via proxy or by other means, you must ensure the following domains are accessible:
 
 * `packages.chef.io`
 * `licensing.chef.io`
@@ -101,9 +103,11 @@ While we've taken care to make the migration process as smooth as possible, this
 
 ### Plan for Downtime
 
-The Chef Automate 2 migration process puts your Chef Automate 1 installation into maintenance mode, shuts it down, and starts Chef Automate 2. During the downtime, the migration process takes a backup of your Chef Automate 1 data and exports some of its data to a local snapshot, which is imported into Chef Automate 2.
+The Chef Automate 2 migration process puts your Chef Automate 1 installation into maintenance mode, shuts it down, and starts Chef Automate 2.
+During the downtime, the migration process takes a backup of your Chef Automate 1 data and exports some of its data to a local snapshot, which is imported into Chef Automate 2.
 
-To minimize this downtime, we recommended that you create an online backup of Chef Automate 1 just prior to the upgrade. Historical information such as Chef Infra Client run data and compliance scan data is backed up incrementally, which means that the upgrade only needs to transfer data that has been added since the last backup.
+To minimize this downtime, we recommended that you create an online backup of Chef Automate 1 just prior to the upgrade.
+Historical information such as Chef Infra Client run data and compliance scan data is backed up incrementally, which means that the upgrade only needs to transfer data that has been added since the last backup.
 
 By default, the Chef Automate 2 upgrade process will not proceed if your Chef Automate 1 installation does not have backups configured. Invoke the migration using the `--skip-backup-check` flag to avoid this check.
 
@@ -114,7 +118,7 @@ To configure Chef Automate 1 backups, see the [Chef Automate 1 Documentation](ht
 Chef Automate 2 includes significant architectural and technical improvements to the core product platform.
 If you rely on any of the capabilities listed below, we recommend you continue to using your existing Chef Automate installation.
 
-* **Chef Manage:** Chef Automate 2, unlike Automate 1, cannot serve as a SAML auth proxy
+* **Chef Manage:** Chef Automate 2, unlike Chef Automate 1, cannot serve as a SAML auth proxy
 * **FIPS:** Chef Automate 2 cannot currently operate in FIPS mode
 * **Disaster Recovery:** Chef Automate 2 cannot currently operate in a primary/standby mode
 * **Custom Kibana dashboards:** Chef Automate 2 does not include Kibana in its technology stack
@@ -145,9 +149,10 @@ If you use dedicated disks or partitions for either of these applications in Che
 
 ### Workflow
 
-Follow the instructions in [Upgrade Workflow]{{< relref "workflow_install.md" >}}
+Follow the instructions in [Upgrade Workflow]({{< relref "workflow_install.md" >}}).
 The migration process will stop if it detects that you used the Workflow component of Chef Automate 1.
-To use Workflow with Chef Automate 2 specify the `--enable-workflow` option to enable the Workflow component. You can enable the Workflow component after upgrading with `chef-automate deploy --enable-workflow`.
+To use Workflow with Chef Automate 2, specify the `--enable-workflow` option to enable the Workflow component.
+You can enable the Workflow component after upgrading with `chef-automate deploy --enable-workflow`.
 
 ### Chef Automate 2 License
 
@@ -186,4 +191,6 @@ If you've been using LDAP for authenticating users, that configuration will have
 Historical data will be migrated in the background.
 
 ### Upgrades
-Chef Automate 2 handles upgrades differently than Chef Automate 1 did. The [Installation]({{< relref "install.md#upgrade" >}}) documentation and [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation provide further detail.
+
+Chef Automate 2 handles upgrades differently than Chef Automate 1 did.
+The [Installation]({{< relref "install.md#upgrade" >}}) documentation and [Airgapped Installation]({{< relref "airgapped-installation.md#upgrade" >}}) documentation provide further detail.


### PR DESCRIPTION
Signed-off-by: Mary Jinglewski <mjinglewski@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Broken link on https://automate.chef.io/docs/migrate/ needed fixing. Added a few quick formatting fixes, and a comma or two.

### :+1: Definition of Done

🟢 means go

### :athletic_shoe: How to Build and Test the Change

`make serve`

Go to: `localhost:1313/automate/`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
