### PR TITLE
Remove references to max report size in the docs for the infra server

### DIFF
--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -76,7 +76,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server and bump the maximum report size:
+1. Add a stanza to the configuration file to deploy Chef Automate and Chef Infra Server:
 
     ```toml
       [deployment.v1.svc]
@@ -111,7 +111,7 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to disable Chef Automate data collection and bump the maximum report size:
+1. Add a stanza to the configuration file to disable Chef Automate data collection:
 
     ```toml
        [erchef.v1.sys.data_collector]
@@ -139,7 +139,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate init-config
     ```
 
-1. Add a stanza to the configuration file to deploy Chef Infra Server and bump the maximum report size:
+1. Add a stanza to the configuration file to deploy Chef Infra Server:
 
     ```toml
        [deployment.v1.svc]
@@ -162,7 +162,7 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 Patch an existing Chef Automate installation to add Chef Infra Server:
 
-1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy and bump the maximum report size:
+1. Create a `patch.toml` file to add `infra-server` to the list of products to deploy:
 
     ```toml
        [deployment.v1.svc]


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Remove references to max report size in the Infra Server docs; the underlying issue was addressed in https://github.com/chef/automate/pull/4069, and I removed the config settings from the docs but not the references.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
