### PR TITLE
Redirect all automate pages and layout links to docs.chef.io

### DIFF
--- a/components/automate-chef-io/content/docs/_index.md
+++ b/components/automate-chef-io/content/docs/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Docs"
-redirect_url = "/docs/quickstart"
+redirect_url = "https://docs.chef.io/automate/"
 layout = "redirect"
 +++

--- a/components/automate-chef-io/content/docs/airgapped-installation.md
+++ b/components/automate-chef-io/content/docs/airgapped-installation.md
@@ -3,6 +3,8 @@ title = "Airgapped Installation"
 description = "Install Chef Automate 2.0 on an airgapped host."
 draft = false
 bref = "Chef Automate 2.0 can be installed on an airgapped host."
+redirect_url = "https://docs.chef.io/automate/airgapped_installation/"
+layout = "redirect"
 toc = true
 [menu]
   [menu.docs]

--- a/components/automate-chef-io/content/docs/api-tokens.md
+++ b/components/automate-chef-io/content/docs/api-tokens.md
@@ -4,6 +4,8 @@ description = "Create and Use API Tokens"
 draft = false
 bref = "Create and Use API Tokens"
 toc = true
+redirect_url = "https://docs.chef.io/automate/api_tokens/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/api.md
+++ b/components/automate-chef-io/content/docs/api.md
@@ -5,10 +5,10 @@ date = 2019-03-06T17:25:30-07:00
 draft = false
 bref = ""
 toc = true
-layout = "data-api"
+redirect_url = "https://docs.chef.io/automate/api/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "reference"
     weight = 20
 +++
-

--- a/components/automate-chef-io/content/docs/applications-dashboard.md
+++ b/components/automate-chef-io/content/docs/applications-dashboard.md
@@ -5,6 +5,8 @@ date = 2019-10-18T18:54:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/applications_dashboard/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "applications"

--- a/components/automate-chef-io/content/docs/applications-setup.md
+++ b/components/automate-chef-io/content/docs/applications-setup.md
@@ -5,11 +5,14 @@ date = 2019-10-18T18:54:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/applications_setup/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "applications"
     weight = 20
 +++
+
 <!-- ## Health Checks
 
 To maximize the utility of the Chef Automate EAS Applications feature, it is recommended to implement meaningful health check hooks for your services.

--- a/components/automate-chef-io/content/docs/architectural-overview.md
+++ b/components/automate-chef-io/content/docs/architectural-overview.md
@@ -4,6 +4,8 @@ description = "Architectural Overview for Chef Automate"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/architectural_overview/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "reference"

--- a/components/automate-chef-io/content/docs/backup.md
+++ b/components/automate-chef-io/content/docs/backup.md
@@ -5,6 +5,8 @@ date = 2018-03-26T15:27:52-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/backup/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/cli-chef-automate.md
+++ b/components/automate-chef-io/content/docs/cli-chef-automate.md
@@ -5,7 +5,8 @@ date = 2018-03-26T15:29:24-07:00
 draft = false
 bref = ""
 toc = true
-layout = "data-cli"
+redirect_url = "https://docs.chef.io/automate/cli_chef_automate/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "reference"

--- a/components/automate-chef-io/content/docs/client-runs.md
+++ b/components/automate-chef-io/content/docs/client-runs.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:01:58-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/client_runs/"
+layout = "redirect"
 +++
 
 ## Overview

--- a/components/automate-chef-io/content/docs/configuration.md
+++ b/components/automate-chef-io/content/docs/configuration.md
@@ -5,6 +5,8 @@ date = 2018-05-08T18:54:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/configuration/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -4,6 +4,8 @@ description = "Set up Data Collection"
 draft = false
 bref = "Configure Data Collection"
 toc = true
+redirect_url = "https://docs.chef.io/automate/data_collection/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/data-lifecycle.md
+++ b/components/automate-chef-io/content/docs/data-lifecycle.md
@@ -7,6 +7,8 @@ description = "Chef Automate Data Lifecycle: Data Management and Data Retention"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/data_lifecycle/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/datafeed.md
+++ b/components/automate-chef-io/content/docs/datafeed.md
@@ -5,6 +5,8 @@ date = 2020-05-05T13:19:02-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/datafeed/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/delivery_build_cookbook.md
+++ b/components/automate-chef-io/content/docs/delivery_build_cookbook.md
@@ -4,6 +4,8 @@ description = "Using the Delivery Build Cookbook"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/delivery_build_cookbook/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/delivery_manage_dependencies.md
+++ b/components/automate-chef-io/content/docs/delivery_manage_dependencies.md
@@ -4,6 +4,8 @@ description = "Managing Run-time Dependencies"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/delivery_manage_dependencies/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/delivery_manage_secrets.md
+++ b/components/automate-chef-io/content/docs/delivery_manage_secrets.md
@@ -4,6 +4,8 @@ description = "Manage Secrets in a build-cookbook"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/delivery_manage_secrets/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/delivery_truck.md
+++ b/components/automate-chef-io/content/docs/delivery_truck.md
@@ -4,6 +4,8 @@ description = "About the Delivery Truck Cookbook"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/delivery_truck/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/desktop.md
+++ b/components/automate-chef-io/content/docs/desktop.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:01:47-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/desktop/"
+layout = "redirect"
 +++
 
 The Chef Automate _Desktop_ dashboard displays status information about all desktops connected to Chef Automate.

--- a/components/automate-chef-io/content/docs/eas.md
+++ b/components/automate-chef-io/content/docs/eas.md
@@ -5,6 +5,8 @@ date = 2019-10-18T18:54:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/eas/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "applications"

--- a/components/automate-chef-io/content/docs/event-feed.md
+++ b/components/automate-chef-io/content/docs/event-feed.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:01:47-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/event_feed/"
+layout = "redirect"
 +++
 
 Use the _Event Feed_ for actionable insights and operational visibility.

--- a/components/automate-chef-io/content/docs/iam-actions.md
+++ b/components/automate-chef-io/content/docs/iam-actions.md
@@ -4,6 +4,8 @@ description = "Reference Actions for Roles"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/iam_actions/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "authorization"

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -4,6 +4,8 @@ description = "IAM Users Guide"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/iam_v2_guide/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "authorization"

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -10,6 +10,8 @@ description = "IAM Overview"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/iam_v2_overview/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "authorization"

--- a/components/automate-chef-io/content/docs/infra-server.md
+++ b/components/automate-chef-io/content/docs/infra-server.md
@@ -6,6 +6,8 @@ weight = 20
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/infra_server/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/install.md
+++ b/components/automate-chef-io/content/docs/install.md
@@ -4,6 +4,8 @@ description = "Install Chef Automate 2.0 directly on Ubuntu or CentOS servers."
 draft = false
 bref = "Chef Automate 2.0 can be installed directly on Ubuntu or CentOS servers."
 toc = true
+redirect_url = "https://docs.chef.io/automate/install/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -5,6 +5,8 @@ date = 2018-05-11T09:27:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/ldap/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/log-management.md
+++ b/components/automate-chef-io/content/docs/log-management.md
@@ -3,6 +3,8 @@ title = "Log Management"
 description = "Chef Automate 2.0 sends all log events to `stdout` and `stderr` allowing the process supervisor to handle logs in a standard way."
 draft = false
 bref = "Chef Automate 2.0 sends all log events to `stdout` and `stderr` allowing the process supervisor to handle logs in a standard way."
+redirect_url = "https://docs.chef.io/automate/log_management/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/migrate.md
+++ b/components/automate-chef-io/content/docs/migrate.md
@@ -7,6 +7,8 @@ description = "Migrate an existing Chef Automate 1 installation"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/migrate/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/monitoring.md
+++ b/components/automate-chef-io/content/docs/monitoring.md
@@ -5,6 +5,8 @@ date = 2019-10-28T14:44:28-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/monitoring/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "reference"

--- a/components/automate-chef-io/content/docs/node-credentials.md
+++ b/components/automate-chef-io/content/docs/node-credentials.md
@@ -6,6 +6,8 @@ weight = 20
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/node_credentials/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -6,6 +6,8 @@ weight = 20
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/node_integrations/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/nodes.md
+++ b/components/automate-chef-io/content/docs/nodes.md
@@ -4,6 +4,8 @@ description = "Using the Nodes Service"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/nodes/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "compliance"

--- a/components/automate-chef-io/content/docs/notifications.md
+++ b/components/automate-chef-io/content/docs/notifications.md
@@ -5,6 +5,8 @@ date = 2018-05-18T13:19:02-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/notifications/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/on-prem-builder.md
+++ b/components/automate-chef-io/content/docs/on-prem-builder.md
@@ -6,6 +6,8 @@ weight = 20
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/on_prem_builder/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/policies.md
+++ b/components/automate-chef-io/content/docs/policies.md
@@ -4,6 +4,8 @@ description = "IAM Policies"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/policies/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/profiles.md
+++ b/components/automate-chef-io/content/docs/profiles.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:02:53-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/profiles/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "compliance"

--- a/components/automate-chef-io/content/docs/projects.md
+++ b/components/automate-chef-io/content/docs/projects.md
@@ -4,6 +4,8 @@ description = "IAM Projects"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/projects/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/publish_cookbooks_multiple_servers.md
+++ b/components/automate-chef-io/content/docs/publish_cookbooks_multiple_servers.md
@@ -4,6 +4,8 @@ description = "Publishing Cookbooks to Multiple Chef Infra Servers"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/publish_cookbooks_multiple_servers/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/quickstart.md
+++ b/components/automate-chef-io/content/docs/quickstart.md
@@ -5,6 +5,8 @@ weight = 1
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/reports.md
+++ b/components/automate-chef-io/content/docs/reports.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:02:09-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/reports/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "compliance"

--- a/components/automate-chef-io/content/docs/restore.md
+++ b/components/automate-chef-io/content/docs/restore.md
@@ -5,6 +5,8 @@ date = 2018-03-26T15:27:52-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/restore/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/roles.md
+++ b/components/automate-chef-io/content/docs/roles.md
@@ -4,6 +4,8 @@ description = "IAM Roles"
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/roles/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/runners.md
+++ b/components/automate-chef-io/content/docs/runners.md
@@ -4,6 +4,8 @@ description = ""
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/runners/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -5,6 +5,8 @@ date = 2018-05-11T09:27:09+00:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/saml/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/scan-jobs.md
+++ b/components/automate-chef-io/content/docs/scan-jobs.md
@@ -5,6 +5,8 @@ date = 2018-03-26T16:02:35-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/scan_jobs/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "compliance"

--- a/components/automate-chef-io/content/docs/servicenow-integration-install.md
+++ b/components/automate-chef-io/content/docs/servicenow-integration-install.md
@@ -4,6 +4,8 @@ description = "Installing and Configuring the Automate ServiceNow Integration fo
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/servicenow_integration_install/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "reference"

--- a/components/automate-chef-io/content/docs/system-requirements.md
+++ b/components/automate-chef-io/content/docs/system-requirements.md
@@ -2,9 +2,11 @@
 title = "System Requirements"
 description = "Requirements for running Chef Automate"
 weight = 1
-draft = false 
+draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/system_requirements/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "get_started"

--- a/components/automate-chef-io/content/docs/teams.md
+++ b/components/automate-chef-io/content/docs/teams.md
@@ -5,6 +5,8 @@ date = 2018-05-16T16:03:13-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/teams/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/telemetry.md
+++ b/components/automate-chef-io/content/docs/telemetry.md
@@ -4,6 +4,8 @@ description = "About Telemetry"
 draft = false
 bref = "Telemetry"
 toc = true
+redirect_url = "https://docs.chef.io/automate/telemetry/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "configuring_automate"

--- a/components/automate-chef-io/content/docs/troubleshooting.md
+++ b/components/automate-chef-io/content/docs/troubleshooting.md
@@ -5,6 +5,8 @@ date = 2018-05-15T17:27:57-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/troubleshooting/"
+layout = "redirect"
 +++
 
 ## chef-automate CLI Errors

--- a/components/automate-chef-io/content/docs/users.md
+++ b/components/automate-chef-io/content/docs/users.md
@@ -5,6 +5,8 @@ date = 2018-05-16T16:03:13-07:00
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/users/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "settings"

--- a/components/automate-chef-io/content/docs/workflow.md
+++ b/components/automate-chef-io/content/docs/workflow.md
@@ -4,6 +4,8 @@ description = ""
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/workflow/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/docs/workflow_install.md
+++ b/components/automate-chef-io/content/docs/workflow_install.md
@@ -4,6 +4,8 @@ description = ""
 draft = false
 bref = ""
 toc = true
+redirect_url = "https://docs.chef.io/automate/workflow_install/"
+layout = "redirect"
 [menu]
   [menu.docs]
     parent = "workflow"

--- a/components/automate-chef-io/content/release-notes/_index.md
+++ b/components/automate-chef-io/content/release-notes/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Release Notes"
-layout = "release-notes"
+redirect_url = "https://docs.chef.io/release_notes_automate/"
+layout = "redirect"
 +++
 
 This page is meant to be empty. The release notes are dynamically loaded via the Javascript references in the 'release-notes' layout.

--- a/components/automate-chef-io/layouts/partials/cards.html
+++ b/components/automate-chef-io/layouts/partials/cards.html
@@ -33,7 +33,7 @@
       </div>
       <div class="cell small-12 text-center">
         <p>
-          <a class="button-animated" href="/docs/quickstart">
+          <a class="button-animated" href="https://docs.chef.io/automate/">
             <span class="text">Install Automate</span>
             <span class="line -right-top"></span>
             <span class="line -right-bottom"></span>

--- a/components/automate-chef-io/layouts/partials/hero.html
+++ b/components/automate-chef-io/layouts/partials/hero.html
@@ -14,7 +14,7 @@
           <div class="cell large-5 large-offset-1">
             <div class="white-text text-center valign-large">
               <p>
-                <a class="button-animated white-text" href="/docs/quickstart">
+                <a class="button-animated white-text" href="https://docs.chef.io/automate/">
                   <span class="text">Install Automate</span>
                   <span class="line -right-top"></span>
                   <span class="line -right-bottom"></span>
@@ -34,9 +34,9 @@
     <div class="cell medium-12">
       <ul class="vertical medium-horizontal menu align-center">
         <li class="{{ if $currentPage.IsHome }}active{{ end }}"><a href="/">About Chef Automate</a></li>
-        <li class="{{ if eq $currentSection "API" }}active{{end}}"><a href="/docs/api/">API</a></li>
-        <li class="{{ if eq $currentSection "docs" }}active{{end}}"><a href="/docs/quickstart/">Docs</a></li>
-        <li class="{{ if eq $currentSection "release-notes" }}active{{end}}"><a href="/release-notes/">Release Notes</a></li>
+        <li class="{{ if eq $currentSection "API" }}active{{end}}"><a href="https://docs.chef.io/automate/api/">API</a></li>
+        <li class="{{ if eq $currentSection "docs" }}active{{end}}"><a href="https://docs.chef.io/automate/">Docs</a></li>
+        <li class="{{ if eq $currentSection "release-notes" }}active{{end}}"><a href="https://docs.chef.io/release_notes_automate/">Release Notes</a></li>
       </ul>
     </div>
   </div>

--- a/components/automate-chef-io/layouts/partials/mini-hero.html
+++ b/components/automate-chef-io/layouts/partials/mini-hero.html
@@ -13,7 +13,7 @@
           <div class="cell large-5 large-offset-1">
             <div class="white-text text-center valign-large">
               <p>
-                <a class="button-animated white-text" href="/docs/quickstart">
+                <a class="button-animated white-text" href="https://docs.chef.io/automate/">
                   <span class="text">Install Automate</span>
                   <span class="line -right-top"></span>
                   <span class="line -right-bottom"></span>
@@ -33,9 +33,9 @@
     <div class="cell medium-12">
       <ul class="vertical medium-horizontal menu align-center">
         <li class="{{ if $currentPage.IsHome }}active{{ end }}"><a href="/">About Chef Automate</a></li>
-        <li class="{{ if eq $currentSection "API" }}active{{end}}"><a href="/docs/api/">API</a></li>
-        <li class="{{ if eq $currentSection "docs" }}active{{end}}"><a href="/docs/quickstart/">Docs</a></li>
-        <li class="{{ if eq $currentSection "release-notes" }}active{{end}}"><a href="/release-notes/">Release Notes</a></li>
+        <li class="{{ if eq $currentSection "API" }}active{{end}}"><a href="https://docs.chef.io/automate/api/">API</a></li>
+        <li class="{{ if eq $currentSection "docs" }}active{{end}}"><a href="https://docs.chef.io/automate/">Docs</a></li>
+        <li class="{{ if eq $currentSection "release-notes" }}active{{end}}"><a href="https://docs.chef.io/release_notes_automate">Release Notes</a></li>
       </ul>
     </div>
   </div>

--- a/components/docs-chef-io/content/automate/applications_dashboard.md
+++ b/components/docs-chef-io/content/automate/applications_dashboard.md
@@ -5,9 +5,9 @@ date = 2019-10-18T18:54:09+00:00
 draft = false
 [menu]
   [menu.automate]
-    title = "Setting up the Applications Dashboard"
+    title = "Applications Dashboard"
     parent = "automate/applications"
-    identifier = "automate/applications/applications_dashboard.md Setting up the Applications Dashboard"
+    identifier = "automate/applications/applications_dashboard.md Applications Dashboard"
     weight = 30
 +++
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

- Add meta refresh tags to each page to redirect to relevant pages in docs.chef.io
- Redirect links in layout templates to docs.chef.io
- Fix menu title in `components/docs-chef-io/content/automate/applications_dashboard.md`

### :chains: Related Resources

chef/release-engineering#1239

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

`make serve`

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
