### PR TITLE
docs: add Azure AD note on SAML NameID setting and transformations

### DIFF
--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -92,17 +92,13 @@ where:
 See the [SAML Configuration Settings]({{< relref "saml.md#saml-configuration-settings" >}}) for further configuration options.
 
 {{< warning >}}
-Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_
-to it. The setting is only respected if the value selected in "Choose name identifier
-format" matches the `name_id_policy_format` configured in Chef Automate.
+Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_ to it.
+The SAML configuration setting is only respected if the selected value in "Choose name identifier format" in Azure AD matches the `name_id_policy_format` configuration in Chef Automate.
 
-For example, if you want to select a specific user attribute to be used as NameID,
-say, `user.email`, and you want to apply a transformation to it, these values need
-to up:
-1. In "Choose name identifier format", select "Email address", and configure the
-   attribute, and eventually transformation, you want to use for that.
-2. In Chef Automate's configuration, `name_id_policy_format` needs to be set to
-   `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
+For example, when selecting the specific user attribute `user.email` for NameID in Azure AD:
+
+1. In Azure AD for "Choose name identifier format", select "EmailAddress", and configure the attribute and (optional) transformation.
+1. In Chef Automate's configuration, set `name_id_policy_format` to `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
 {{< /warning >}}
 
 ## SAML Configuration Settings

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -95,6 +95,7 @@ See the [SAML Configuration Settings]({{< relref "saml.md#saml-configuration-set
 Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_
 to it. The setting is only respected if the value selected in "Choose name identifier
 format" matches the `name_id_policy_format` configured in Chef Automate.
+
 For example, if you want to select a specific user attribute to be used as NameID,
 say, `user.email`, and you want to apply a transformation to it, these values need
 to up:

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -91,7 +91,7 @@ where:
 
 See the [SAML Configuration Settings]({{< relref "saml.md#saml-configuration-settings" >}}) for further configuration options.
 
-{{% warning %}}
+{{< warning >}}
 Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_
 to it. The setting is only respected if the value selected in "Choose name identifier
 format" matches the `name_id_policy_format` configured in Chef Automate.
@@ -102,7 +102,7 @@ to up:
    attribute, and eventually transformation, you want to use for that.
 2. In Chef Automate's configuration, `name_id_policy_format` needs to be set to
    `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
-{{% /warning %}}
+{{< /warning >}}
 
 ## SAML Configuration Settings
 

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -92,13 +92,8 @@ where:
 See the [SAML Configuration Settings]({{< relref "saml.md#saml-configuration-settings" >}}) for further configuration options.
 
 {{< warning >}}
-Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_ to it.
+Azure AD lets you choose the _NameID_ field, and optionally apply _transformations_ to it.
 The SAML configuration setting is only respected if the selected value in "Choose name identifier format" in Azure AD matches the `name_id_policy_format` configuration in Chef Automate.
-
-For example, when selecting the specific user attribute `user.email` for NameID in Azure AD:
-
-1. In Azure AD for "Choose name identifier format", select "Email address", and configure the attribute and (optional) transformation.
-1. In Chef Automate's configuration, set `name_id_policy_format` to `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
 {{< /warning >}}
 
 ## SAML Configuration Settings

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -89,22 +89,19 @@ where:
 - `sso_url` contains the value of _Login URL_
 - `entity_issuer` contains the value of _Identifier (Entity ID)_
 
-See the SAML Configuration Settings below for further configuration options.
+See the [SAML Configuration Settings]({{< relref "saml.md#saml-configuration-settings" >}}) for further configuration options.
 
 {{% warning %}}
 Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_
 to it. The setting is only respected if the value selected in "Choose name identifier
 format" matches the `name_id_policy_format` configured in Chef Automate.
-
 For example, if you want to select a specific user attribute to be used as NameID,
 say, `user.email`, and you want to apply a transformation to it, these values need
 to up:
-
 1. In "Choose name identifier format", select "Email address", and configure the
    attribute, and eventually transformation, you want to use for that.
 2. In Chef Automate's configuration, `name_id_policy_format` needs to be set to
    `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
-
 {{% /warning %}}
 
 ## SAML Configuration Settings

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -91,6 +91,22 @@ where:
 
 See the SAML Configuration Settings below for further configuration options.
 
+{{% warning %}}
+Azure AD lets you chose the _NameID_ field, and optionally apply _transformations_
+to it. The setting is only respected if the value selected in "Choose name identifier
+format" matches the `name_id_policy_format` configured in Chef Automate.
+
+For example, if you want to select a specific user attribute to be used as NameID,
+say, `user.email`, and you want to apply a transformation to it, these values need
+to up:
+
+1. In "Choose name identifier format", select "Email address", and configure the
+   attribute, and eventually transformation, you want to use for that.
+2. In Chef Automate's configuration, `name_id_policy_format` needs to be set to
+   `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
+
+{{% /warning %}}
+
 ## SAML Configuration Settings
 
 The SAML configuration settings are:

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -97,7 +97,7 @@ The SAML configuration setting is only respected if the selected value in "Choos
 
 For example, when selecting the specific user attribute `user.email` for NameID in Azure AD:
 
-1. In Azure AD for "Choose name identifier format", select "EmailAddress", and configure the attribute and (optional) transformation.
+1. In Azure AD for "Choose name identifier format", select "Email address", and configure the attribute and (optional) transformation.
 1. In Chef Automate's configuration, set `name_id_policy_format` to `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`.
 {{< /warning >}}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

This tries to add a useful hint to avoid people stumbling over this, as has happened in a recent customer issue.

I'm finding it difficult to describe the Azure UI succinctly; the dropdown that matters is this one:

<img src="https://user-images.githubusercontent.com/870638/90750427-0fd8cf80-e2d5-11ea-9a15-175d0b3d1dde.png" width=50% />

### :camera: Screenshots, if applicable

<img src="https://user-images.githubusercontent.com/870638/90750642-68a86800-e2d5-11ea-99f7-f69c888e8263.png" width=50% />