### PR TITLE
Document data collection from an Automate-deployed Infra Server to an externally-deployed Automate

### DIFF
--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -126,8 +126,7 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
-1. To send data from the Chef Infra Server to an external Chef Automate installation,
-   first create a `patch.toml` file that contains the configuration stanza:
+1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 
     ```toml
     [global.v1.external.automate]
@@ -145,8 +144,8 @@ Installations require elevated privileges, so run the commands as the superuser 
     [erchef.v1.sys.data_collector]
     enabled = true
     ```
-   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server
-   configuration.
+  
+   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server configuration.
 
 ### Install a Standalone Chef Infra Server with a Configuration File
 
@@ -180,8 +179,7 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
-1. To send data from the Chef Infra Server to an external Chef Automate installation,
-   first create a `patch.toml` file that contains the configuration stanza:
+1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 
     ```toml
     [global.v1.external.automate]
@@ -199,9 +197,8 @@ Installations require elevated privileges, so run the commands as the superuser 
     [erchef.v1.sys.data_collector]
     enabled = true
     ```
-   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server
-   configuration.
 
+   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server configuration.
 
 ## Add a New Chef Infra Server to an Existing Chef Automate Installation
 

--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -126,6 +126,28 @@ Installations require elevated privileges, so run the commands as the superuser 
 
 1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
 
+1. To send data from the Chef Infra Server to an external Chef Automate installation,
+   first create a `patch.toml` file that contains the configuration stanza:
+
+    ```toml
+    [global.v1.external.automate]
+    enable = true
+    node = "https://<automate server url>"
+    [global.v1.external.automate.auth]
+    token = "<data-collector token>"
+    [global.v1.external.automate.ssl]
+    server_name = "<server name from the automate server ssl cert>"
+    root_cert = """<pem format root CA cert>
+    """
+    [auth_n.v1.sys.service]
+    # It is fine to use an A2 data collector token.
+    a1_data_collector_token = "<data-collector token>"
+    [erchef.v1.sys.data_collector]
+    enabled = true
+    ```
+   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server
+   configuration.
+
 ### Install a Standalone Chef Infra Server with a Configuration File
 
 Installing Chef Infra Server through Chef Automate using a configuration file also requires the use of the Chef Automate CLI.
@@ -157,6 +179,29 @@ Installations require elevated privileges, so run the commands as the superuser 
     ```
 
 1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
+
+1. To send data from the Chef Infra Server to an external Chef Automate installation,
+   first create a `patch.toml` file that contains the configuration stanza:
+
+    ```toml
+    [global.v1.external.automate]
+    enable = true
+    node = "https://<automate server url>"
+    [global.v1.external.automate.auth]
+    token = "<data-collector token>"
+    [global.v1.external.automate.ssl]
+    server_name = "<server name from the automate server ssl cert>"
+    root_cert = """<pem format root CA cert>
+    """
+    [auth_n.v1.sys.service]
+    # It is fine to use an A2 data collector token.
+    a1_data_collector_token = "<data-collector token>"
+    [erchef.v1.sys.data_collector]
+    enabled = true
+    ```
+   Then run `chef-automate config patch patch.toml` to patch your Chef Infra Server
+   configuration.
+
 
 ## Add a New Chef Infra Server to an Existing Chef Automate Installation
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Document the configuration to set up data collection for an Automate-deployed Infra Server pointing at an externally-deployed Automate installation.

Fixes #4239.
### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
