### PR TITLE
Use note shortcode instead of info

### DIFF
--- a/components/automate-chef-io/content/docs/data-collection.md
+++ b/components/automate-chef-io/content/docs/data-collection.md
@@ -71,7 +71,7 @@ if you are using a Chef Infra Server. Otherwise, you must
 
 ## Configure your Chef Infra Server to Send Data to Chef Automate
 
-{{< info >}} Multiple Chef Infra Servers can send data to a single Chef Automate server. {{< /info >}}
+{{< note >}} Multiple Chef Infra Servers can send data to a single Chef Automate server. {{< /note >}}
 
 In addition to forwarding Chef run data to Chef Automate, Chef Infra Server will send messages to Chef Automate whenever an action is taken on a Chef Infra Server object, such as when a cookbook is uploaded to the Chef Infra Server or when a user edits a role.
 

--- a/components/automate-chef-io/content/docs/datafeed.md
+++ b/components/automate-chef-io/content/docs/datafeed.md
@@ -13,9 +13,9 @@ layout = "redirect"
     weight = 15
 +++
 
-{{< info >}}
+{{< note >}}
 Data Feed is a beta feature in active development. To enable Data Feed, first select anywhere on the Chef Automate interface and enter 'feat' to open the feature flags window and then toggle "Chef Automate Data Feed" to the "ON" position.
-{{< /info >}}
+{{< /note >}}
 
 The Data Feed service sends node data to a 3rd party service.
 This can be useful when updating configuration management databases, external security dashboards and IT service management platforms.
@@ -67,9 +67,9 @@ To delete a Data Feed instance in Chef Automate:
 
 ## Configuring Global Data Feed Behavior
 
-{{< info >}}
+{{< note >}}
 The Data Feed configuration settings apply across all configured Data Feed instances.
-{{< /info >}}
+{{< /note >}}
 
 To modify Data Feed behavior with the available configuration settings:
 

--- a/components/automate-chef-io/content/docs/delivery_build_cookbook.md
+++ b/components/automate-chef-io/content/docs/delivery_build_cookbook.md
@@ -165,10 +165,10 @@ targets the master branch.
 
 ### Use the Delivery CLI
 
-{{< info >}}
+{{< note >}}
 These instructions assume that Chef Automate is the source of truth for your source
 code and that Chef Automate is not integrated with GitHub Enterprise or GitHub.com.
-{{< /info >}}
+{{< /note >}}
 
 This topic describes the recommended setup for a Chef cookbook project
 using Chef Automate.
@@ -191,9 +191,9 @@ privileges on the Chef Automate server, do the following:
     $ delivery setup --server=SERVER --ent=ENTERPRISE --org=ORGANIZATION --user=USERNAME --a2-mode
     ```
 
-{{< info >}}
+{{< note >}}
 The server, enterprise, organization, and user must already exist.
-{{< /info >}}
+{{< /note >}}
 
 1. Create a cookbook:
 

--- a/components/automate-chef-io/content/docs/delivery_truck.md
+++ b/components/automate-chef-io/content/docs/delivery_truck.md
@@ -407,9 +407,9 @@ privileges on the Chef Automate server, do the following:
     $ delivery setup --server=SERVER --ent=ENTERPRISE --org=ORGANIZATION --user=USERNAME
     ```
 
-    {{< info >}}
+    {{< note >}}
     The server, enterprise, organization, and user must already exist.
-    {{< /info >}}
+    {{< /note >}}
 
 1. Create a cookbook, then navigate into it:
 

--- a/components/automate-chef-io/content/docs/desktop.md
+++ b/components/automate-chef-io/content/docs/desktop.md
@@ -18,10 +18,10 @@ Enable the Desktop dashboard with: `chef-automate deploy --product automate --pr
 For more installation information, see [Install Chef Infra Server with Chef Automate](https://automate.chef.io/docs/infra-server/).
 The Desktop dashboard has no supported compliance profiles, and installation with the `--product desktop` flag includes no compliance profiles.
 
-{{< info >}}
+{{< note >}}
 When installing Chef Automate with the `--product desktop` flag, _Data Lifecycle_ settings will not mark nodes as missing and not delete missing nodes by default.
 We encourage users to not change these specific settings and not defeat the monitoring purpose of the Desktop dashboard.
-{{< /info >}}
+{{< /note >}}
 
 ## Desktop Dashboard Display
 
@@ -33,7 +33,7 @@ Node counts in the _Desktop_ dashboard may include liveness agents.
 
 ### Daily Check-in
 
-The _Daily Check-in_ display shows a top-level view of daily desktop check-in statistics.  
+The _Daily Check-in_ display shows a top-level view of daily desktop check-in statistics.
 A bar graphic illustrates the proportion of desktops with `unknown` and `checked-in` statuses.
 Below the bar, boxes display counts of all desktops, desktops with an `unknown` status, and desktops with a `checked-in` status.
 `Checked-in` refers to desktops reporting into Chef Automate.

--- a/components/automate-chef-io/content/docs/iam-v2-guide.md
+++ b/components/automate-chef-io/content/docs/iam-v2-guide.md
@@ -12,9 +12,9 @@ layout = "redirect"
     weight = 20
 +++
 
-{{< info >}}
+{{< note >}}
 This documentation covers Chef Automate's IAM feature in release 20200326170928 and later.
-{{< /info >}}
+{{< /note >}}
 
 This guide shows you how to perform important administrative operations.
 You will add members to Chef-managed v2 policies, delete a legacy policy, and write a Team Admin v2 policy that lets a Team Admin manage their users and teams.
@@ -373,7 +373,7 @@ To create a project that contains all Effortless Infra nodes, create a ingest ru
 
 ![](/images/docs/effortless-project-rule.png)
 
-The above rule matches on a node's Chef Infra Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Infra Server` attribute as `localhost`. 
+The above rule matches on a node's Chef Infra Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Infra Server` attribute as `localhost`.
 
 If desired, create subgroups of Effortless Infra nodes by adding a second condition that matches a specific `Chef Policy Name`.
 

--- a/components/automate-chef-io/content/docs/iam-v2-overview.md
+++ b/components/automate-chef-io/content/docs/iam-v2-overview.md
@@ -18,9 +18,9 @@ layout = "redirect"
     weight = 10
 +++
 
-{{< info >}}
+{{< note >}}
 This documentation covers Chef Automate's IAM feature in release 20200326170928 and later.
-{{< /info >}}
+{{< /note >}}
 
 Chef Automate's Identity and Access Management (IAM) allows direct management of policy members from Chef Automate in the browser.
 IAM supports the projects feature, which allow for filtering and segregation of your data amongst your user base.
@@ -137,10 +137,10 @@ The custom policies are Compliance Viewers and Compliance Editors.
 IAM projects are collections of resources either created in Chef Automate or ingested from external data providers, such as Chef Infra and Chef InSpec.
 Projects used in a policy reduce the scope of that policy's permissions to only the resources assigned to the given projects.
 
-{{< info >}}
+{{< note >}}
 Chef Automate limits you to 300 projects.
 See [Configuring Project Limit]({{< relref "iam-v2-guide.md#configuring-project-limit" >}}) for configuration instructions.
-{{< /info >}}
+{{< /note >}}
 
 ### Setting Up Projects
 

--- a/components/automate-chef-io/content/docs/ldap.md
+++ b/components/automate-chef-io/content/docs/ldap.md
@@ -36,9 +36,9 @@ not affect your policies, as they are both LDAP configurations.
 However, switching between either of those configurations and a SAML configuration will
 require you to adjust the [IAM]({{< relref "iam-v2-overview.md" >}}) policy membership.
 
-{{< info >}}
+{{< note >}}
 Local, MSAD, and LDAP users will have their Chef Automate sessions refreshed while their Chef Automate browser window remains open or until they sign out directly.
-{{< /info >}}
+{{< /note >}}
 
 ## Supported Identity Management Systems
 

--- a/components/automate-chef-io/content/docs/node-integrations.md
+++ b/components/automate-chef-io/content/docs/node-integrations.md
@@ -105,9 +105,9 @@ Ensure the policy attached to the role used by the instance you have Chef Automa
 }
 ```
 
-{{< info >}}
+{{< note >}}
 `"ssm:*"` uses a wildcard match on the AWS EC2 Systems Manager (SSM); You may wish to use a more restrictive policy.
-{{< /info >}}
+{{< /note >}}
 
 ### Install AWS EC2 Systems Manager on Instances
 
@@ -148,9 +148,9 @@ The service makes these API calls:
 
 Set up Chef Automate to detect and scan the nodes in your Azure account by providing your Azure Credentials and creating an _Azure VM Node Manager_. To add an Azure VM Node Manager, navigate to the [_Node Integrations_]({{< relref "node-integrations.md" >}}) page in the Settings tab, select `Create Integration`, and you should see _Azure_ as one of your node management service options.
 
-{{< info >}}
+{{< note >}}
 We do not support Azure Government Cloud.
-{{< /info >}}
+{{< /note >}}
 
 ### Adding an Azure VM Node Manager
 

--- a/components/automate-chef-io/content/docs/saml.md
+++ b/components/automate-chef-io/content/docs/saml.md
@@ -38,9 +38,9 @@ your existing configuration by following these steps:
 2. Edit `config.toml` to replace the `dex.sys.connectors` section with the config values for your new identity provider.
 3. Run `chef-automate config set config.toml` to set your updated config.
 
-{{< info >}}
+{{< note >}}
 Users who sign in via SAML will have a session time of 24 hours before needing to sign in again.
-{{< /info >}}
+{{< /note >}}
 
 ## Supported Identity Management Systems
 
@@ -55,10 +55,10 @@ Users who sign in via SAML will have a session time of 24 hours before needing t
 
 Using Azure AD as an SAML IdP requires specific configuration for both Azure AD and Chef Automate.
 
-{{< info >}}
+{{< note >}}
 The signing certificate used for Chef Automate's SAML integration with Azure AD requires manual management.
 Signing key rotation is not done automatically.
-{{< /info >}}
+{{< /note >}}
 
 In Azure AD, add Chef Automate as a _"non-gallery application"_, and then configure its SAML sign-in method.
 [The Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-saml-single-sign-on) provides a detailed guide.

--- a/components/automate-chef-io/markdownguide.md
+++ b/components/automate-chef-io/markdownguide.md
@@ -212,12 +212,12 @@ _An important statement_
 Use two asterisks (`**bold**`) to **bold** a text string.
 **A bold statement**
 
-{{< info >}}
+{{< note >}}
 Hugo italicizes words surrounded by single asterisks or underlines (*)(_)
 and emboldens all double asterisks or underlines (**)(__).
 Help your editors understand your intent by following the established conventions
 and use single underlines for _italics_ and double asterisks for **bold**.
-{{< /info >}}
+{{< /note >}}
 
 ### Links
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

Changes the `{{< info >}}` shortcodes to `{{< note >}}` in components/automate-chef-io. 

This change makes it possible to build locally.
