### PR TITLE
Document how to access on-prem builder's REST API

### DIFF
--- a/components/docs-chef-io/content/automate/on_prem_builder.md
+++ b/components/docs-chef-io/content/automate/on_prem_builder.md
@@ -243,9 +243,9 @@ export HAB_BLDR_URL=https://{{< example_fqdn "automate" >}}/bldr/v1/
 
 ## Access the Chef Habitat Builder On-prem REST API
 
-To access the [REST API](https://www.habitat.sh/docs/api/builder-api/) for your on-prem installation of Chef Habitat Builder, you must
-specify your Builder authentication token as a bearer token in your request's
-`Authorization` header. For example:
+To access the [REST API](https://www.habitat.sh/docs/api/builder-api/) for your on-prem installation of Chef Habitat Builder, you must specify your Builder authentication token as a bearer token in your request's
+`Authorization` header.
+For example:
 
 ```bash
 curl -H "Authorization: Bearer <your-habitat-builder-auth-token>" https://{{< example_fqdn

--- a/components/docs-chef-io/content/automate/on_prem_builder.md
+++ b/components/docs-chef-io/content/automate/on_prem_builder.md
@@ -242,6 +242,7 @@ export HAB_BLDR_URL=https://{{< example_fqdn "automate" >}}/bldr/v1/
 ```
 
 ## Access the Chef Habitat Builder On-prem REST API
+
 To access the [REST API](https://www.habitat.sh/docs/api/builder-api/) for your on-prem installation of Chef Habitat Builder, you must
 specify your Builder authentication token as a bearer token in your request's
 `Authorization` header. For example:

--- a/components/docs-chef-io/content/automate/on_prem_builder.md
+++ b/components/docs-chef-io/content/automate/on_prem_builder.md
@@ -241,6 +241,16 @@ The Chef Habitat command-line tools recognize the [`HAB_BLDR_URL` environment va
 export HAB_BLDR_URL=https://{{< example_fqdn "automate" >}}/bldr/v1/
 ```
 
+## Access the Chef Habitat Builder On-prem REST API
+To access the [REST API](https://www.habitat.sh/docs/api/builder-api/) for your on-prem installation of Chef Habitat Builder, you must
+specify your Builder authentication token as a bearer token in your request's
+`Authorization` header. For example:
+
+```bash
+curl -H "Authorization: Bearer <your-habitat-builder-auth-token>" https://{{< example_fqdn
+"automate" >}}/bldr/v1/...
+```
+
 ## Bootstrap Chef Habitat Builder with Core Packages (Optional)
 
 Prerequisites:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Provide an example of specifying an auth token for builder as a bearer token. The question has come up a couple of times recently in internal Slack, so it seems like a good thing to have in docs

For context, see
https://chefio.slack.com/archives/CB31Z9ZT8/p1598035405010400
https://chefio.slack.com/archives/CB31Z9ZT8/p1596475217166300
https://chefio.slack.com/archives/CB31Z9ZT8/p1597511362251800?thread_ts=1596653132.194900&cid=CB31Z9ZT8


### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
