### PR TITLE
Revert protocol change to es6-promisify package

### DIFF
--- a/components/chef-ui-library/package-lock.json
+++ b/components/chef-ui-library/package-lock.json
@@ -2074,7 +2074,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A recent PR inadvertently changed from `https` to `http` for a single package in the chef-ui-library.
This reverts that change, as all packages should use `https`.

### :chains: Related Resources
PR #3940 

### :+1: Definition of Done
All packages in package-lock.json use https.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
