### PR TITLE
erchef: set verify depth for external automate to 32

### DIFF
--- a/components/automate-cs-oc-erchef/habitat/config/sys.config
+++ b/components/automate-cs-oc-erchef/habitat/config/sys.config
@@ -219,6 +219,7 @@
                                    {ssl_options, [
                                                   {{#if cfg.external_automate.ssl.root_cert}}
                                                   {cacertfile, "{{pkg.svc_config_path}}/external_automate_root_ca.crt"},
+                                                  {depth, 32},
                                                   {verify, verify_peer}
                                                   {{/if ~}}
                                                  ]}


### PR DESCRIPTION
The verify depth is the maximum number of non-self-issued intermediate
certificates that can follow the peer certificate in a valid
certification path.

By default the depth in Erlang 20.2 is 1 which isn't enough for some common TLS configurations.

The default depth limit in OpenSSL 1.0.2 and 1.1.1 is 100 according to

   https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify_depth.html
   https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify_depth.html

Here, we set a depth of 32 which should be more than enough for all
reasonable cases and is in line with what we've set for external
postgresql.

Signed-off-by: Steven Danna <steve@chef.io>