### PR TITLE
lib/platform: fix bad format string in externalConnURIRenderer

### DIFF
--- a/lib/platform/config/config.go
+++ b/lib/platform/config/config.go
@@ -167,10 +167,17 @@ func (c *PGConnInfo) String() string {
 
 func externalConnURIRenderer(ip string, port int, user string, password string, opts []string) (pgConnURIRenderer, string) {
 	fmtStr := "postgresql://%s@%s:%d/%s?%s"
+
+	userInfoDebugStr := user
+	if password != "" {
+		userInfoDebugStr += ":<redacted>"
+	}
+	debugStr := fmt.Sprintf(fmtStr, userInfoDebugStr, ip, port, "<database>", strings.Join(opts, "&"))
+
 	userInfo := url.UserPassword(user, password)
 	return func(dbname string) string {
 		return fmt.Sprintf(fmtStr, userInfo.String(), ip, port, dbname, strings.Join(opts, "&"))
-	}, fmt.Sprintf(fmtStr, user, "<readacted>", ip, port, "<database>", strings.Join(opts, "&"))
+	}, debugStr
 }
 
 func internalConnURIRenderer(ip string, port int, user string, certPath string,


### PR DESCRIPTION
The previous code produced log messages such as:

    pg-sidecar-service.default(O): time="2020-08-24T22:26:00Z" level=error msg="failed to create database" action=create_db
    conn_info="postgresql://admin@<readacted>:%!d(string=172.17.0.5)/%!s(int=10145)?<database>%!(EXTRA string=sslmode=verify-ca&sslrootcert=/hab/svc/pg-sidecar-service/config/_a2_platform_external_pg_root_ca.crt)"
    db=dex db_database=postgres error="pq: role \"dbuser\" does not exist" role=dbuser user=admin

Signed-off-by: Steven Danna <steve@chef.io>
