### PR TITLE
ci: fix ha cluster test failures

### DIFF
--- a/integration/services/ha_backend/init.sh
+++ b/integration/services/ha_backend/init.sh
@@ -86,7 +86,7 @@ ha_backend_setup() {
         echo "Trying to create dbuser (attempt #${try})"
         errcode="0"
         output="$(docker exec --env PGPASSWORD="$ha_admin_pg_password" --env HAB_LICENSE=accept-no-persist "$ha_backend_container1" \
-	hab pkg exec core/postgresql11 psql \
+	hab pkg exec core/postgresql11 -- psql \
             -h 127.0.0.1 -p 7432 -U admin -d postgres -c \
             "CREATE USER dbuser WITH PASSWORD '$ha_admin_pg_password'")" || errcode="$?"
         if [ "$errcode" -eq "0" ]; then


### PR DESCRIPTION
The argument parsing in Habitat has changed such that the command we
were using to create the database user actually displayed the
help (because of our use of the `-h` flag intended to be passed to
`psql` but now parsed by hab).  The help output returns an exit code
of 0, meaning that the user went uncreated without an error being
returned by our setup script.

Signed-off-by: Steven Danna <steve@chef.io>