### PR TITLE
Assorted cleanup to backup and restore pages

### DIFF
--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -1,13 +1,13 @@
 +++
-title = "Backup & Restore"
+title = "Backup"
 
 date = 2018-03-26T15:27:52-07:00
 draft = false
 [menu]
   [menu.automate]
-    title = "Backup & Restore"
+    title = "Backup"
     parent = "automate/getting_started"
-    identifier = "automate/getting_started/backup.md Backup & Restore"
+    identifier = "automate/getting_started/backup.md Backup"
     weight = 70
 +++
 
@@ -16,7 +16,11 @@ draft = false
 Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure.
 The `chef-automate backup create` command creates a single backup that contains data for all products deployed with Chef Automate, including [Chef Infra Server]({{< ref "infra_server.md" >}}) and [Chef Habitat Builder on-prem]({{< ref "on_prem_builder.md" >}}).
 By default, Chef Automate stores backups to the filesystem in the directory `/var/opt/chef-automate/backups`.
-You can also configure Chef Automate to store backups in AWS S3 buckets.
+You can also configure Chef Automate to store backups in AWS S3 buckets or in Google Cloud
+Storage buckets.
+
+See the [restore]({{< ref "restore.md" >}}) page to learn how to restore a Chef Automate
+installation from a [filesystem backup]({{< ref "restore/#restore-from-a-filesystem-backup" >}}), an [AWS S3 backup]({{< ref "restore/#restore-from-an-aws-s3-backup" >}}), or a [GCS backup]({{< ref "restore/#restore-from-a-google-cloud-storage-backup" >}}).
 
 ## Backup Space Requirements
 
@@ -27,7 +31,7 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 * Elasticsearch snapshots of your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot
 * Chef Habitat Builder artifacts
 
-## Backup to a Filesystem
+## Set Up Backups to a Filesystem
 
 To store backups in a configurable backup directory, the backup directory should be on network-attached storage or synced periodically to a disk on another machine.
 This best practice ensures that you can restore from your backup data during a hardware failure.
@@ -55,13 +59,13 @@ To configure your Chef Automate installation's backup directory to another locat
 
 To store backups offline in single-file archives, single-file archives must include both the configuration data and the reporting data contained in the standard backup.
 
-The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
+The [configured backup directory]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
 
 A timestamp-based directory has a date-based name, such as `20180518010336`, in the `automate-elasticsearch-data` directory.
 
 To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must [configure Elasticsearch backup]({{< relref "install.md#configuring-external-elasticsearch" >}}) settings separately from Chef Automate's primary backup settings.
 
-## Backup to AWS S3
+## Set up Backups to AWS S3
 
 To store backups in an existing AWS S3 bucket, use the supported S3-related settings below:
 
@@ -96,8 +100,6 @@ To store backups in an existing AWS S3 bucket, use the supported S3-related sett
   ...
   -----END CERTIFICATE-----
 ```
-
-See how to [restore from AWS S3]({{< ref "restore/#restore-from-an-aws-s3-backup" >}}).
 
 ### AWS S3 Permissions
 
@@ -136,7 +138,7 @@ The following IAM policy describes the basic permissions Chef Automate requires 
 }
 ```
 
-## Backup to GCS
+## Set Up Backups to GCS
 
 To store backups in an existing Google Cloud Storage (GCS) bucket, [generate a service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) with the `storage.admin` permission for the associated project and GCS bucket, and use the supported GCS-related settings below:
 
@@ -169,8 +171,6 @@ json = '''
 }
 '''
 ```
-
-See how to [restore from GCS]({{< ref "restore/#restore-from-a-google-cloud-storage-backup" >}}).
 
 ## Backup Commands
 
@@ -276,7 +276,7 @@ y
 Success: Backups deleted
 ```
 
-To prune all but a certain number of the most recent backups manually, parsing the output of `chef-automate backup list` and applying the command `chef-automate backup delete`.
+To prune all but a certain number of the most recent backups manually, parse the output of `chef-automate backup list` and apply the command `chef-automate backup delete`.
 For example:
 
 ```bash

--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -16,11 +16,9 @@ draft = false
 Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure.
 The `chef-automate backup create` command creates a single backup that contains data for all products deployed with Chef Automate, including [Chef Infra Server]({{< ref "infra_server.md" >}}) and [Chef Habitat Builder on-prem]({{< ref "on_prem_builder.md" >}}).
 By default, Chef Automate stores backups to the filesystem in the directory `/var/opt/chef-automate/backups`.
-You can also configure Chef Automate to store backups in AWS S3 buckets or in Google Cloud
-Storage buckets.
+You can also configure Chef Automate to store backups in AWS S3 buckets or in Google Cloud Storage (GCS) buckets.
 
-See the [restore]({{< ref "restore.md" >}}) page to learn how to restore a Chef Automate
-installation from a [filesystem backup]({{< ref "restore/#restore-from-a-filesystem-backup" >}}), an [AWS S3 backup]({{< ref "restore/#restore-from-an-aws-s3-backup" >}}), or a [GCS backup]({{< ref "restore/#restore-from-a-google-cloud-storage-backup" >}}).
+After configuring your backups, see how to [restore]({{< ref "restore.md" >}}) a Chef Automate installation.
 
 ## Backup Space Requirements
 
@@ -31,7 +29,7 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 * Elasticsearch snapshots of your Chef Automate configuration and data, such as converge, scan, and report data. You will need enough disk space for the each Elasticsearch snapshot and the delta--or the list of changes--for each successive snapshot
 * Chef Habitat Builder artifacts
 
-## Set Up Backups to a Filesystem
+## Backup to a Filesystem
 
 To store backups in a configurable backup directory, the backup directory should be on network-attached storage or synced periodically to a disk on another machine.
 This best practice ensures that you can restore from your backup data during a hardware failure.
@@ -59,13 +57,14 @@ To configure your Chef Automate installation's backup directory to another locat
 
 To store backups offline in single-file archives, single-file archives must include both the configuration data and the reporting data contained in the standard backup.
 
-The [configured backup directory]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
+
+The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
 
 A timestamp-based directory has a date-based name, such as `20180518010336`, in the `automate-elasticsearch-data` directory.
 
 To provide externally-deployed Elasticsearch nodes access to Chef Automate's built-in backup storage services, you must [configure Elasticsearch backup]({{< relref "install.md#configuring-external-elasticsearch" >}}) settings separately from Chef Automate's primary backup settings.
 
-## Set up Backups to AWS S3
+## Backup to AWS S3
 
 To store backups in an existing AWS S3 bucket, use the supported S3-related settings below:
 
@@ -100,6 +99,8 @@ To store backups in an existing AWS S3 bucket, use the supported S3-related sett
   ...
   -----END CERTIFICATE-----
 ```
+
+See how to [restore from AWS S3]({{< ref "restore/#restore-from-an-aws-s3-backup" >}}).
 
 ### AWS S3 Permissions
 
@@ -138,7 +139,7 @@ The following IAM policy describes the basic permissions Chef Automate requires 
 }
 ```
 
-## Set Up Backups to GCS
+## Backup to GCS
 
 To store backups in an existing Google Cloud Storage (GCS) bucket, [generate a service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) with the `storage.admin` permission for the associated project and GCS bucket, and use the supported GCS-related settings below:
 
@@ -171,6 +172,8 @@ json = '''
 }
 '''
 ```
+
+See how to [restore from GCS]({{< ref "restore/#restore-from-a-google-cloud-storage-backup" >}}).
 
 ## Backup Commands
 

--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -34,7 +34,8 @@ This amount of space needed for a backup varies depending on your Chef Automate 
 To store backups in a configurable backup directory, the backup directory should be on network-attached storage or synced periodically to a disk on another machine.
 This best practice ensures that you can restore from your backup data during a hardware failure.
 
-The default backup directory is `/var/opt/chef-automate/backups`. If it does not exist, the deployment process creates it.
+The default backup directory is `/var/opt/chef-automate/backups`.
+If it does not exist, the deployment process creates it.
 
 To configure your Chef Automate installation's backup directory to another location:
 
@@ -184,7 +185,8 @@ Make a backup with the [`backup create`]({{< ref "cli_chef_automate/#chef-automa
 chef-automate backup create
 ```
 
-The output shows the backup progress for each service. A successful backup displays a success message containing the timestamp of the backup:
+The output shows the backup progress for each service.
+A successful backup displays a success message containing the timestamp of the backup:
 
 ```shell
 Success: Created backup 20180518010336
@@ -214,7 +216,8 @@ The output shows each backup and its age:
 20180508201952    completed  4 minutes old
 ```
 
-By default, this command communicates with your running Chef Automate installation to list the backups. If the Chef Automate installation is down, you can still list the backups.
+By default, this command communicates with your running Chef Automate installation to list the backups.
+If the Chef Automate installation is down, you can still list the backups.
 
 To list filesystem backups:
 

--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -57,7 +57,6 @@ To configure your Chef Automate installation's backup directory to another locat
 
 To store backups offline in single-file archives, single-file archives must include both the configuration data and the reporting data contained in the standard backup.
 
-
 The [configured backup directory]({{< ref "backup.md#backup-to-a-filesystem" >}}) contains both the timestamp-based directory for the configuration and the reporting data stored in the `automate-elasticsearch-data` directory.
 
 A timestamp-based directory has a date-based name, such as `20180518010336`, in the `automate-elasticsearch-data` directory.

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -26,8 +26,8 @@ Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-fro
 1. To restore from **filesystem backups**, Chef Automate requires access to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 Ensure access for the backup type used:
 
-     1. To restore [a network-attached filesystem backup]({{< ref "backup.md#backup-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
-     1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#backup-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
+     1. To restore [a network-attached filesystem backup]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
+     1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
      1. To restore a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
 
 1. To restore a backup to a host with a different fully qualified domain name (FQDN) than the original backup host, create a `patch.toml` file that specifies the new FQDN and provide it at restore time:
@@ -73,7 +73,7 @@ To restore on an existing Chef Automate host by overwriting the existing install
 chef-automate backup restore </path/to/backups/>BACKUP_ID --skip-preflight
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
+Use the `--patch-config` option with a [configuration patch file]({{< relref "restore.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
 
 ```shell
 chef-automate backup restore </path/to/backups/>BACKUP_ID --patch-config </path/to/patch.toml> --skip-preflight
@@ -116,7 +116,7 @@ To restore using Google Cloud Storage (GCS) on an existing Chef Automate host, r
 chef-automate backup restore --airgap-bundle </path/to/bundle> gs://bucket_name/</path/to/backups/>BACKUP_ID --skip-preflight
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
+Use the `--patch-config` option with a [configuration patch file]({{< relref "restore.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host.
 
 Restores from a filesystem backup may fail with incorrect directory permissions.
 Run the [`fix-repo-permissions` command]({{< ref "cli_chef_automate/#chef-automate-backup-fix-repo-permissions" >}}) to address such issues:
@@ -143,7 +143,7 @@ To restore from an AWS S3 bucket backup on an existing Chef Automate host, run:
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --skip-preflight
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
+Use the `--patch-config` option with a [configuration patch file]({{< relref "restore.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
 
 ```shell
 chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --patch-config </path/to/patch.toml> --skip-preflight
@@ -173,7 +173,7 @@ To restore from a Google Cloud Storage (GCS) bucket backup on an existing Chef A
 chef-automate backup restore gs://bucket_name/path/to/backups/BACKUP_ID --skip-preflight
 ```
 
-Use the `--patch-config` option with a [configuration patch file]({{< relref "backup.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
+Use the `--patch-config` option with a [configuration patch file]({{< relref "restore.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
 
 ```shell
 chef-automate backup restore gs://bucket_name/path/to/backups/BACKUP_ID --patch-config </path/to/patch.toml> --skip-preflight

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -15,6 +15,8 @@ draft = false
 
 Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-from-a-filesystem-backup" >}}), an [Amazon S3 bucket backup]({{< ref "restore.md#restore-from-an-aws-s3-backup" >}}), or a [Google Cloud Storage (GCS) bucket backup]({{< ref "restore.md#restore-from-a-google-cloud-storage-backup" >}}).
 
+Before restoring a Chef Automate installation, see how to [configure your backups]({{< ref "backup.md" >}}).
+
 ## Prerequisites
 
 1. On the restore host, download and unzip the Chef Automate command-line tool:
@@ -26,8 +28,8 @@ Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-fro
 1. To restore from **filesystem backups**, Chef Automate requires access to a backup directory in the [configured location]({{< ref "backup.md#backup-to-a-filesystem" >}}).
 Ensure access for the backup type used:
 
-     1. To restore [a network-attached filesystem backup]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
-     1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#set-up-backups-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
+     1. To restore [a network-attached filesystem backup]({{< ref "backup.md#backup-to-a-filesystem" >}}), mount the shared backup directory to the same mount point configured at the time of the backup.
+     1. To restore [a backup directory that is not a network-attached filesystem]({{< ref "backup.md#backup-to-a-filesystem" >}}), copy the backup directory to the configured location at the time of the backup.
      1. To restore a [single-file backup archive]({{< ref "backup.md#store-a-filesystem-backup-in-a-single-file-archive" >}}), copy your archive to the restore host and extract it to the configured backup directory.
 
 1. To restore a backup to a host with a different fully qualified domain name (FQDN) than the original backup host, create a `patch.toml` file that specifies the new FQDN and provide it at restore time:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

* Point links to the (optional) restore config to the restore page instead of the backup page.
* Change the title formerly known as "Backup & Restore" to Backup because Restore is now a separate page.
* Add descriptive section headers for content about setting up/configuring backups under various circumstances.
* Move links to restore sections to the intro. 

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
