### PR TITLE
Changes to fix long names in drop-down components should be wrapped

### DIFF
--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
@@ -124,5 +124,5 @@ chef-dropdown {
 }
 
 ::ng-deep chef-checkbox .label-wrap {
-  overflow-wrap: anywhere;
+  word-break: break-all;
 }

--- a/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
+++ b/components/automate-ui/src/app/components/resource-dropdown/resource-dropdown.component.scss
@@ -122,3 +122,7 @@ chef-dropdown {
   font-size: 12px;
   line-height: 1.6;
 }
+
+::ng-deep chef-checkbox .label-wrap {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Long values in dropdowns should be wrapped, this will occur wherever the dropdown is used, both in a details page and in a create modal.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/3916
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
visit the Settings >> projects/policies
create project or policy - if you have no data then add a project or policy entries with the long name using the create modal.
check the wrapped value in a dropdown - for check this you can go to  Settings >> API tokens then click to `create API token` 
a modal popup will be open and you can see the dropdown values also you can check any API token details page to see a dropdown with long value.
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
![dropdown1](https://user-images.githubusercontent.com/12297653/91410821-1d5a0080-e865-11ea-9083-c4aa43628de5.png)
![dropdown2](https://user-images.githubusercontent.com/12297653/91410828-2054f100-e865-11ea-91c9-0658ea3ff881.png)
