### PR TITLE
Bump chef-server versions

### DIFF
--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-bookshelf"
 pkg_description="Wrapper package for chef/bookshelf"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.0.22"
+pkg_version="14.0.25"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/14.0.22/20200812153852"
+  "${vendor_origin}/bookshelf/14.0.25/20200828081447"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -7,7 +7,7 @@ vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.0.22"
+pkg_version="14.0.25"
 pkg_deps=(
   core/coreutils
   chef/mlsa
@@ -20,8 +20,8 @@ pkg_deps=(
   core/curl/7.68.0/20200601114640
   core/ruby26/2.6.5/20200404043345
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/14.0.22/20200812154419"
-  "${vendor_origin}/chef-server-ctl/14.0.22/20200812153852"
+  "${vendor_origin}/chef-server-nginx/14.0.25/20200828082112"
+  "${vendor_origin}/chef-server-ctl/14.0.25/20200828081545"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-bifrost"
 pkg_description="Wrapper package for chef/oc_bifrost"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.0.22"
+pkg_version="14.0.25"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/14.0.22/20200812153858"
+  "${vendor_origin}/oc_bifrost/14.0.25/20200828081545"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/config/sys.config
+++ b/components/automate-cs-oc-erchef/habitat/config/sys.config
@@ -220,7 +220,7 @@
                                                   {{#if cfg.external_automate.ssl.root_cert}}
                                                   {cacertfile, "{{pkg.svc_config_path}}/external_automate_root_ca.crt"},
                                                   {depth, 32},
-                                                  {verify, verify_peer}
+                                                  {verify, verify_ca}
                                                   {{/if ~}}
                                                  ]}
                                   ]},

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-erchef"
 pkg_description="Wrapper package for chef/oc_erchef"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.0.22"
+pkg_version="14.0.25"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/14.0.22/20200812153858"
+  "${vendor_origin}/oc_erchef/14.0.25/20200828081545"
 )
 
 pkg_build_deps=(

--- a/components/automate-workflow-nginx/habitat/plan.sh
+++ b/components/automate-workflow-nginx/habitat/plan.sh
@@ -10,7 +10,7 @@ vendor_origin=${vendor_origin:-"chef"}
 
 pkg_deps=(
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/openresty-noroot/1.13.6.2/20200812153852"
+  "${vendor_origin}/openresty-noroot/1.13.6.2/20200828081447"
   "${vendor_origin}/automate-workflow-web"
   chef/mlsa
   core/bash


### PR DESCRIPTION
This pulls in a workaround for TLS issues with external automate. The
workaround requires some new configuration with restores the old
behavior where we validate the certificate against the configured CA
but ignore hostname mismatches.

Our hope is to have full hostname checking support when Chef Server
upgrades to Erlang 22.

Signed-off-by: Steven Danna <steve@chef.io>