### PR TITLE
Add Chef patents link

### DIFF
--- a/components/automate-ui/src/app/page-components/profile/profile.component.html
+++ b/components/automate-ui/src/app/page-components/profile/profile.component.html
@@ -45,7 +45,7 @@
               #focusElement>About</button>
           </li>
           <li>
-            <a href="https://www.chef.io/online-master-agreement/" target="_blank"
+            <a href="https://www.chef.io/online-master-agreement/" target="_blank" rel="noopener"
               (click)="closeDropdown()"
               (keydown.arrowup)="handleArrowUp($event)"
               (keydown.arrowdown)="handleArrowDown($event)"
@@ -55,7 +55,17 @@
             </a>
           </li>
           <li>
-            <a href="https://automate.chef.io/release-notes/?v={{ buildVersion }}" target="_blank" class="release-notes"
+            <a href="https://www.chef.io/patents" target="_blank" rel="noopener"
+              (click)="closeDropdown()"
+              (keydown.arrowup)="handleArrowUp($event)"
+              (keydown.arrowdown)="handleArrowDown($event)"
+              role="menuitem"
+              #focusElement>
+              Chef Patents <chef-icon aria-hidden="true" class="dropdown-link-icon">launch</chef-icon>
+            </a>
+          </li>
+          <li>
+            <a href="https://automate.chef.io/release-notes/?v={{ buildVersion }}" target="_blank" rel="noopener" class="release-notes"
               (click)="closeDropdown()"
               (keydown.arrowup)="handleArrowUp($event)"
               (keydown.arrowdown)="handleArrowDown($event)"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This commit adds a Chef patents link to the user profile dropdown menu.

![](https://user-images.githubusercontent.com/479121/91674637-7e086800-eb07-11ea-844e-f90213929dfb.gif)

### :chains: Related Resources

Closes: https://github.com/chef/automate/issues/4220

Aha! Link: https://chef.aha.io/features/SH-231