### PR TITLE
fix esIndex computation for exactly one fully year selection

### DIFF
--- a/components/compliance-service/reporting/relaxting/indices.go
+++ b/components/compliance-service/reporting/relaxting/indices.go
@@ -115,7 +115,6 @@ func wholeCalendarYears(prefix string, startTime time.Time, endTime time.Time) (
 		err = errors.New(StartDateGreaterThanEndDateErrMsg)
 		return indices, straddle, err
 	}
-	//endOfStartYear := time.Date(startTime.Year(), time.December, 31, 23, 59, 59, 999999999, time.UTC)
 	endOfStartYear := time.Date(startTime.Year(), time.December, 31, 23, 59, 59, 0, time.UTC)
 
 	firstWholeCalYear := startTime.Year()

--- a/components/compliance-service/reporting/relaxting/indices.go
+++ b/components/compliance-service/reporting/relaxting/indices.go
@@ -115,10 +115,11 @@ func wholeCalendarYears(prefix string, startTime time.Time, endTime time.Time) (
 		err = errors.New(StartDateGreaterThanEndDateErrMsg)
 		return indices, straddle, err
 	}
+	//endOfStartYear := time.Date(startTime.Year(), time.December, 31, 23, 59, 59, 999999999, time.UTC)
 	endOfStartYear := time.Date(startTime.Year(), time.December, 31, 23, 59, 59, 0, time.UTC)
 
 	firstWholeCalYear := startTime.Year()
-	if !(startTime.Day() == 1 && startTime.Month() == 1 && (endTime.Equal(endOfStartYear) || endTime.After(endOfStartYear))) {
+	if !(startTime.Day() == 1 && startTime.Month() == 1 && ((endTime.Equal(endOfStartYear) && endTime.Year() > startTime.Year()) || endTime.After(endOfStartYear))) {
 		firstWholeCalYear++ //exclude from full year
 		straddle.left = &DateRange{StartTime: startTime}
 

--- a/components/compliance-service/reporting/relaxting/indices_test.go
+++ b/components/compliance-service/reporting/relaxting/indices_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -349,6 +350,20 @@ func TestIndexDatesNonLeapYear(t *testing.T) {
 			"%[1]s2015.08*,%[1]s2015.09*,%[1]s2015.10*,%[1]s2015.11*,%[1]s2015.12*,%[1]s2015.02.21*,%[1]s2015.02.22*,"+
 			"%[1]s2015.02.23*,%[1]s2015.02.24*,%[1]s2015.02.25*,%[1]s2015.02.26*,%[1]s2015.02.27*,%[1]s2015.02.28*,"+
 			"%[1]s2016.01*,%[1]s2016.02*,%[1]s2016.03.01*,%[1]s2016.03.02*", relaxting.CompDailySumIndexPrefix),
+			esIndex)
+	}
+}
+
+func TestIndexDatesSingleFullYearRightUpToFinal59Seconds(t *testing.T) {
+	// Let debug logs show up when running tests
+	logrus.SetLevel(logrus.DebugLevel)
+	startTime := "2018-01-01T00:00:00Z"
+	endTime := "2018-12-31T23:59:59Z"
+	esIndex, err := relaxting.IndexDates(relaxting.CompDailySumIndexPrefix, startTime, endTime)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fmt.Sprintf("%[1]s2018.01*,%[1]s2018.02*,%[1]s2018.03*,%[1]s2018.04*,%[1]s2018.05*,"+
+			"%[1]s2018.06*,%[1]s2018.07*,%[1]s2018.08*,%[1]s2018.09*,%[1]s2018.10*,%[1]s2018.11*,%[1]s2018.12*", relaxting.CompDailySumIndexPrefix),
 			esIndex)
 	}
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
There was an edge case in our esIndex computation where, if we had exactly one full year (nothing more, nothing less), we were computing the esIndices to be queried to be an empty string, which would yield not search results.

this pr fixes that.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
All original tests pass and new test that tests one full year also passes

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
