### PR TITLE
Fix failure of `git checkout -b` running docs gen script

### DIFF
--- a/.expeditor/generate-automate-api-docs.sh
+++ b/.expeditor/generate-automate-api-docs.sh
@@ -10,9 +10,9 @@ if [[ ! -L /go/src/github.com/chef/automate ]]; then
 fi
 
 branch="expeditor/generate-automate-api-docs"
-git checkout -b "$branch"
+git checkout -B "$branch"
 
-git submodule update
+git submodule update --init --recursive
 
 pushd /go/src/github.com/chef/automate/components/docs-chef-io
   make sync_swagger_files


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The last run of this docs script failed with:

```
+++ Action Set Output
[2020-08-31 23:29:32 +0000] action bash:.expeditor/generate-automate-api-docs.sh started
Downloading .expeditor/generate-automate-api-docs.sh from chef/automate:master
fatal: A branch named 'expeditor/generate-automate-api-docs' already exists.
```

The help for `git checkout` says:

```
       git checkout -b|-B <new_branch> [<start point>]
           Specifying -b causes a new branch to be created as if git-branch(1) were called and then checked out. In this case you can use the --track or --no-track options, which will be passed to git branch. As a
           convenience, --track without -b implies branch creation; see the description of --track below.

           If -B is given, <new_branch> is created if it doesn't exist; otherwise, it is reset. This is the transactional equivalent of

               $ git branch -f <branch> [<start point>]
               $ git checkout <branch>

           that is to say, the branch is not reset/created unless "git checkout" is successful.
```

So `-B` should fix the error. That said, I don't know how to test the script locally 🤷 

