### PR TITLE
Fixed mat-select-menu for the delete last token from API token table list 

### DIFF
--- a/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
+++ b/components/automate-ui/src/app/modules/token/token-list/api-token-list.component.scss
@@ -1,18 +1,6 @@
 @import "~styles/variables";
 
 :host {
-
-  ::ng-deep .mat-select-panel {
-    position: relative;
-    margin-top: 12px;
-    right: 24px;
-    width: 54px;
-  }
-
-  ::ng-deep .mat-select-panel-wrap {
-    margin-left: -75px;
-  }
-
   .empty-state {
     text-align: center;
 
@@ -22,4 +10,15 @@
       margin-top: 42px;
     }
   }
+}
+
+::ng-deep .mat-select-panel {
+  position: relative;
+  margin-top: 12px;
+  right: 24px;
+  width: 54px;
+}
+
+::ng-deep .mat-select-panel-wrap {
+  margin-left: -75px;
 }


### PR DESCRIPTION
Signed-off-by: vinay033 <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
user cannot delete the last token in the table. The last option in the control menu is cut off. This is not a problem on any of the other auth pages since they all only have one control menu option.

I have added CSS changes to fix this issue.

### :chains: Related Resources
fixes #2798
### :+1: Definition of Done
I have added `mat-select-panel` CSS to fix for last element of table list.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots
1. old behavior
![API-tokenold](https://user-images.githubusercontent.com/12297653/81058093-5d2e5e00-8eeb-11ea-9b7d-cb6e9db53fc7.png)
 2. after fix
![API-teken](https://user-images.githubusercontent.com/12297653/81058112-66b7c600-8eeb-11ea-89c6-779cd7923313.png)
