### PR TITLE
Replace 'chef server' hardcoded desktop value

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -86,7 +86,7 @@
         </chef-tr>
         <chef-tr>
           <chef-th>Chef Infra Server</chef-th>
-          <chef-td>fakechefserver.eastus.cloudapp.azure.com</chef-td>
+          <chef-td>{{ nodeRun.sourceFqdn }}</chef-td>
         </chef-tr>
         <chef-tr>
           <chef-th>Node ID</chef-th>


### PR DESCRIPTION
# :nut_and_bolt: Description: What code changed, and why?

This commit replaces a hardcoded value that got left in the desktop detail template.

`source_fqdn` is the field used based on https://docs.chef.io/automate/api/#operation/GetNodeRun docs.

![Screen Shot 2020-09-02 at 6 00 29 PM](https://user-images.githubusercontent.com/479121/92041637-95816400-ed46-11ea-8e58-ef959c39f70f.png)
