### PR TITLE
Initial integration testing for data-feed-service

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -141,6 +141,22 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
+  - label: "data-feed-service"
+    command:
+      - . scripts/verify_setup.sh
+      - hab studio run "source scripts/verify_studio_init.sh && datafeed_init_integration_tests && datafeed_run_integration_tests"
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - HAB_STUDIO_SUP=false
+            - HAB_NONINTERACTIVE=true
+
   # The nodemanager tests require access to AWS and Azure accounts as
   # they test against the actual API endpoints of those services.
   - label: "nodemanager-integration"

--- a/.studio/data-feed-service
+++ b/.studio/data-feed-service
@@ -52,6 +52,7 @@ document "datafeed_run_integration_tests" <<DOC
   Run the data feed service's integration tests
 DOC
 function datafeed_run_integration_tests() {
+  chef-automate config patch components/data-feed-service/integration_test/patch.toml
   api_token=$(get_admin_token)
   export AUTOMATE_API_TOKEN="${api_token}"
   go_test -v github.com/chef/automate/components/data-feed-service/integration_test/...

--- a/.studio/data-feed-service
+++ b/.studio/data-feed-service
@@ -39,3 +39,20 @@ function datafeed_quick_build() {
   done
   (cd components/data-feed-service && make hab_test)
 }
+
+
+document "datafeed_init_integration_tests" <<DOC
+  Start all services so that data feed service's integration tests can run
+DOC
+function datafeed_init_integration_tests() {
+  start_all_services
+}
+
+document "datafeed_run_integration_tests" <<DOC
+  Run the data feed service's integration tests
+DOC
+function datafeed_run_integration_tests() {
+  api_token=$(get_admin_token)
+  export AUTOMATE_API_TOKEN="${api_token}"
+  go_test -v github.com/chef/automate/components/data-feed-service/integration_test/...
+}

--- a/components/data-feed-service/integration_test/api_test.go
+++ b/components/data-feed-service/integration_test/api_test.go
@@ -1,0 +1,311 @@
+package integration_test
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	automateApiToken = os.Getenv("AUTOMATE_API_TOKEN")
+	addData          = []byte(`{"name":"test", "url":"https://test.com", "secret":"secret"}`)
+	addDataValues    = []string{"test", "https://test.com", "secret"}
+	emptyAddData     = []byte(`{}`)
+	updateData       = []byte(`{"name":"test update", "url":"https://update.test.com", "secret":"updated secret"}`)
+	updateDataValues = []string{"test update", "https://update.test.com", "updated secret"}
+	testSuccessData  = []byte(`{"url":"http://localhost:38080/success", "username_password": {"username":"user", "password":"password"}}`)
+	testFailsData    = []byte(`{"url":"http://localhost:38080/fails", "username_password": {"username":"user", "password":"password"}}`)
+	secretData       = []byte(`{"name":"integration test secret","type":"data_feed","data":[{"key":"username","value":"user"},{"key":"password","value":"password"}]}`)
+	client           = NewClient()
+)
+
+func NewClient() *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Transport: transport}
+}
+
+func TestDataFeedAPI(t *testing.T) {
+	// Add destination
+	destinationId := addDestination(t, addData, addDataValues)
+	// Get destination
+	getDestination(t, destinationId, 200)
+	//update destiantion
+	updateDestination(t, destinationId, updateData, updateDataValues)
+	//Delete destination
+	deleteDestination(t, destinationId, updateDataValues)
+	// Get should now be 404
+	getDestination(t, destinationId, 404)
+}
+
+func TestAddDuplicate(t *testing.T) {
+	destinationId := addDestination(t, addData, addDataValues)
+	addDuplicateDestination(t, addData)
+	//Delete destination
+	deleteDestination(t, destinationId, addDataValues)
+	// Get should now be 404
+	getDestination(t, destinationId, 404)
+}
+
+func TestAddError(t *testing.T) {
+	addDestinationRequest(t, emptyAddData, 500)
+}
+
+func TestUpdateUniqueViolation(t *testing.T) {
+	destinationId1 := addDestination(t, addData, addDataValues)
+	destinationId2 := addDestination(t, updateData, updateDataValues)
+	// update should return 400 Bad Request destinationId1 and destinationId2 cannot have the same name
+	updateDestinationRequest(t, destinationId1, updateData, 400)
+	// clean up the test data
+	deleteDestination(t, destinationId1, addDataValues)
+	deleteDestination(t, destinationId2, updateDataValues)
+}
+
+func TestListDestinations(t *testing.T) {
+	// Add 2 destinations
+	destinationId1 := addDestination(t, addData, addDataValues)
+	destinationId2 := addDestination(t, updateData, updateDataValues)
+	destinations := listDestinationRequest(t, 200)
+	// check we have 2 destinations
+	if assert.Equal(t, 2, len(destinations), "Expected 2 responses got: %v", len(destinations)) {
+		// validate the destinations
+		dest1 := destinations[0].(map[string]interface{})
+		dest2 := destinations[1].(map[string]interface{})
+		isValid, err := validateResponseBody(t, dest1, addDataValues)
+		assert.NotNil(t, err)
+		assert.True(t, isValid, "destination 1 is not valid")
+		isValid, err = validateResponseBody(t, dest2, updateDataValues)
+		assert.NotNil(t, err)
+		assert.True(t, isValid, "destination 2 is not valid")
+	}
+	// test data clean up
+	deleteDestination(t, destinationId1, addDataValues)
+	deleteDestination(t, destinationId2, updateDataValues)
+}
+
+func TestListNoDestinations(t *testing.T) {
+	destinations := listDestinationRequest(t, 200)
+	assert.Equal(t, 0, len(destinations), "Expected 0 responses got: %v", len(destinations))
+}
+
+func TestDeleteNonExistent(t *testing.T) {
+	deleteDestinationRequest(t, "10000", 404)
+}
+
+func TestTestDestination(t *testing.T) {
+	testDestinationRequestSuccess(t, testSuccessData)
+}
+
+func TestTestDestinationError(t *testing.T) {
+	testDestinationRequestFail(t, testFailsData)
+}
+
+func TestDestinationWithSecret(t *testing.T) {
+	secretId := addSecretRequest(t, secretData, 200)
+	dataWithSecret := []byte(`{"url":"http://localhost:38080/success", "secret_id": {"id":"` + secretId + `"}}`)
+	testDestinationRequestSuccess(t, dataWithSecret)
+	deleteSecretRequest(t, secretId, 200)
+}
+
+func TestDestinationWithSecretError(t *testing.T) {
+	secretId := addSecretRequest(t, secretData, 200)
+	dataWithSecret := []byte(`{"url":"http://localhost:38080/fails", "secret_id": {"id":"` + secretId + `"}}`)
+	testDestinationRequestFail(t, dataWithSecret)
+	deleteSecretRequest(t, secretId, 200)
+}
+
+func validateResponseBody(t *testing.T, responseBody map[string]interface{}, values []string) (bool, string) {
+	isValid := validateResponseBodyFields(t, responseBody, values)
+	destinationId, _ := responseBody["id"].(string)
+	isValid = assert.NotEqual(t, "", destinationId, "Expected an ID value, got: %v", destinationId)
+	return isValid, destinationId
+}
+
+func validateResponseBodyFields(t *testing.T, responseBody map[string]interface{}, values []string) bool {
+	isValid := true
+	if responseBody["name"] != values[0] {
+		t.Errorf("Expected name to be %v, got: %v", values[0], responseBody["name"])
+		isValid = false
+	}
+	if responseBody["url"] != values[1] {
+		t.Errorf("Expected url to be %v, got: %v", values[1], responseBody["url"])
+		isValid = false
+	}
+	if responseBody["secret"] != values[2] {
+		t.Errorf("Expected secret to be %v, got: %v", values[2], responseBody["secret"])
+		isValid = false
+	}
+	return isValid
+}
+
+func parseResponse(body io.ReadCloser) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	err := json.NewDecoder(body).Decode(&m)
+	if err != nil {
+		return nil, err
+	}
+	return m, err
+}
+
+func addDestination(t *testing.T, data []byte, expectedValues []string) string {
+	destinationId := ""
+	response := addDestinationRequest(t, data, 200)
+	if response != nil {
+		responseBody, err := parseResponse(response.Body)
+		if err != nil {
+			t.Errorf("Error parsing response body %v", err)
+		}
+		var isValid bool
+		isValid, destinationId = validateResponseBody(t, responseBody, expectedValues)
+		assert.True(t, isValid, "Add destination response body was not valid, got %v", responseBody)
+	}
+	return destinationId
+}
+
+func addDestinationRequest(t *testing.T, data []byte, statusCode int) *http.Response {
+	add, err := http.NewRequest("POST", "https://127.0.0.1/api/v0/datafeed/destination", bytes.NewBuffer(data))
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	add.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(add)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.Equal(t, statusCode, response.StatusCode, "Expected status code %d, got: %d", statusCode, response.StatusCode)
+	}
+	return response
+}
+
+func addDuplicateDestination(t *testing.T, data []byte) {
+	addDestinationRequest(t, data, 400)
+}
+
+func getDestination(t *testing.T, destinationId string, statusCode int) {
+	get, err := http.NewRequest("GET", "https://127.0.0.1/api/v0/datafeed/destination/"+destinationId, nil)
+	get.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(get)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.True(t, response.StatusCode == statusCode, "Expected status code %d, got: %d", statusCode, response.StatusCode)
+	}
+	if statusCode != 404 {
+		responseBody, err := parseResponse(response.Body)
+		assert.Nil(t, err, "Error parsing response body %v", err)
+		isValid, getDestinationId := validateResponseBody(t, responseBody, addDataValues)
+		assert.True(t, isValid, "Get destination response body was not valid, got %v", responseBody)
+		assert.Equal(t, destinationId, getDestinationId, "Expected GetDestination ID to be %s, got %s", destinationId, getDestinationId)
+	}
+}
+
+func updateDestinationRequest(t *testing.T, destinationId string, data []byte, statusCode int) *http.Response {
+	update, err := http.NewRequest("PATCH", "https://127.0.0.1/api/v0/datafeed/destination/"+destinationId, bytes.NewBuffer(data))
+	update.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(update)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.True(t, response.StatusCode == statusCode, "Expected status code %d, got: %d", statusCode, response.StatusCode)
+	}
+	return response
+}
+
+func updateDestination(t *testing.T, destinationId string, data []byte, expectedValues []string) {
+	response := updateDestinationRequest(t, destinationId, data, 200)
+	responseBody, err := parseResponse(response.Body)
+	assert.Nil(t, err, "Error parsing response body %v", err)
+	isValid, updateDestinationId := validateResponseBody(t, responseBody, expectedValues)
+	assert.True(t, isValid, "Update destination response body was not valid, got %v", responseBody)
+	assert.Equal(t, destinationId, updateDestinationId, "Expected UpdateDestination ID to be %s, got %s", destinationId, updateDestinationId)
+}
+
+func deleteDestinationRequest(t *testing.T, destinationId string, statusCode int) *http.Response {
+	delete, err := http.NewRequest("DELETE", "https://127.0.0.1/api/v0/datafeed/destination/"+destinationId, nil)
+	delete.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(delete)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.True(t, response.StatusCode == statusCode, "Expected status code %d, got: %d", statusCode, response.StatusCode)
+	}
+	return response
+}
+
+func deleteDestination(t *testing.T, destinationId string, expectedValues []string) {
+	response := deleteDestinationRequest(t, destinationId, 200)
+	responseBody, err := parseResponse(response.Body)
+	assert.Nil(t, err, "Error parsing response body %v", err)
+	isValid, _ := validateResponseBody(t, responseBody, expectedValues)
+	assert.True(t, isValid, "delete destination response body was not valid, got %v", responseBody)
+}
+
+func testDestinationRequest(t *testing.T, data []byte) (*http.Response, error) {
+	test, err := http.NewRequest("POST", "https://127.0.0.1/api/v0/datafeed/destinations/test", bytes.NewBuffer(data))
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	test.Header.Add("api-token", automateApiToken)
+	return client.Do(test)
+}
+
+func testDestinationRequestSuccess(t *testing.T, data []byte) {
+	response, err := testDestinationRequest(t, data)
+	assert.Nil(t, err, "Error: %v", err)
+	if assert.NotNil(t, response, "expected a response got nil") {
+		if assert.Equal(t, 200, response.StatusCode, "Expected 200, got %d", response.StatusCode) {
+			responseBody, err := parseResponse(response.Body)
+			assert.Nil(t, err, "Error parsing response %v", err)
+			assert.True(t, responseBody["success"].(bool), "Expected success=true, got %v", responseBody["success"])
+		}
+	}
+}
+
+func testDestinationRequestFail(t *testing.T, data []byte) {
+	response, err := testDestinationRequest(t, data)
+	assert.Nil(t, err, "Error: %v", err)
+	if assert.NotNil(t, response, "expected a response got nil") {
+		if assert.Equal(t, 500, response.StatusCode, "Expected 500, got %d", response.StatusCode) {
+			responseBody, err := parseResponse(response.Body)
+			assert.Nil(t, err, "Error parsing response %v", err)
+			assert.Equal(t, "404 Not Found posting test message to: http://localhost:38080/fails", responseBody["error"], "Expected 404 Not Found posting test message to: http://localhost:38080/fails, got %v", responseBody["error"])
+		}
+	}
+}
+
+func addSecretRequest(t *testing.T, data []byte, statusCode int) string {
+	add, err := http.NewRequest("POST", "https://127.0.0.1/api/v0/secrets", bytes.NewBuffer(data))
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	add.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(add)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.True(t, response.StatusCode == statusCode)
+	}
+	responseBody, err := parseResponse(response.Body)
+	assert.Nil(t, err, "Could not parse response body: %v", err)
+	secretId, ok := responseBody["id"].(string)
+	if !ok {
+		t.Errorf("Response body has no id")
+	}
+	return secretId
+}
+
+func deleteSecretRequest(t *testing.T, secretId string, statusCode int) {
+	delete, err := http.NewRequest("DELETE", "https://127.0.0.1/api/v0/secrets/id/"+secretId, nil)
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	delete.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(delete)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.True(t, response.StatusCode == statusCode)
+	}
+}
+
+func listDestinationRequest(t *testing.T, statusCode int) []interface{} {
+	var destinations []interface{}
+	list, err := http.NewRequest("POST", "https://127.0.0.1/api/v0/datafeed/destinations", nil)
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	list.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(list)
+	assert.Nil(t, err, "Error : %v", err)
+	if assert.Equal(t, statusCode, response.StatusCode, "Expected %d got: %d", statusCode, response.StatusCode) {
+		responseBody, err := parseResponse(response.Body)
+		assert.Nil(t, err, "Error parsing response body: %v", err)
+		destinations = responseBody["destinations"].([]interface{})
+	}
+	return destinations
+}

--- a/components/data-feed-service/integration_test/global_test.go
+++ b/components/data-feed-service/integration_test/global_test.go
@@ -1,0 +1,27 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	suite = NewSuite()
+)
+
+func TestMain(m *testing.M) {
+
+	if err := suite.GlobalSetup(); err != nil {
+		fmt.Printf("Test suite setup failed: %s\n", err)
+		os.Exit(99)
+	}
+
+	// Execute the test suite and record the exit code
+	exitCode := m.Run()
+
+	suite.GlobalTeardown()
+
+	// call with result of m.Run()
+	os.Exit(exitCode)
+}

--- a/components/data-feed-service/integration_test/ingest_test.go
+++ b/components/data-feed-service/integration_test/ingest_test.go
@@ -1,0 +1,91 @@
+package integration_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/chef/automate/api/external/ingest/request"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngest(t *testing.T) {
+	data, err := buildClientRun(t, "../../ingest-service/examples/chef_client_run.json")
+	if assert.Nil(t, err) {
+		suite.registerAssetHandler(t)
+		addIngestRequest(t, data, 200)
+		t.Log("waiting 2 minutes for datafeed loop to execute")
+		time.Sleep(2 * time.Minute)
+	}
+}
+
+func addIngestRequest(t *testing.T, data []byte, statusCode int) *http.Response {
+	ingest, err := http.NewRequest("POST", "https://127.0.0.1/api/v0/ingest/events/chef/run", bytes.NewBuffer(data))
+	assert.Nil(t, err, "Error creating http request: %v", err)
+	ingest.Header.Add("api-token", automateApiToken)
+	response, err := client.Do(ingest)
+	if assert.Nil(t, err, "Error sending request %v", err) {
+		assert.Equal(t, statusCode, response.StatusCode, "Expected status code %d, got: %d", statusCode, response.StatusCode)
+	}
+	return response
+}
+
+func (handler *AssetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	node := make(map[string]interface{})
+	handler.t.Log("Data feed received")
+	hasErrors := false
+
+	reader, err := gzip.NewReader(r.Body)
+	if err != nil {
+		msg := fmt.Sprintf("%v", err)
+		handler.t.Error(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		msg := fmt.Sprintf("%v", err)
+		handler.t.Error(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	err = json.Unmarshal(buf, &node)
+	assert.Nil(handler.t, err, "%v", err)
+	clientRun := node["client_run"].(map[string]interface{})
+
+	result, message := testStringValue(clientRun, "node_name", "example.com")
+	hasErrors = assert.True(handler.t, result, message) && hasErrors
+
+	if !assert.False(handler.t, hasErrors, "Errors parsing Datafeed JSON") {
+		http.Error(w, "Errors parsing Datafeed JSON", http.StatusBadRequest)
+		return
+	}
+}
+
+func buildClientRun(t *testing.T, filePath string) ([]byte, error) {
+	var data []byte
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return data, err
+	}
+	var clientRun request.Run
+	err = json.Unmarshal(data, &clientRun)
+	if err != nil {
+		return data, err
+	}
+	layout := "2006-01-02T15:04:05Z"
+	clientRun.StartTime = time.Now().Format(layout)
+	clientRun.EndTime = clientRun.StartTime
+	data, err = json.Marshal(clientRun)
+	if err != nil {
+		return data, err
+	}
+	return data, err
+}

--- a/components/data-feed-service/integration_test/patch.toml
+++ b/components/data-feed-service/integration_test/patch.toml
@@ -1,0 +1,3 @@
+[data_feed_service.v1.sys]
+  [data_feed_service.v1.sys.service]
+    feed_interval = "1m"

--- a/components/data-feed-service/integration_test/suite_test.go
+++ b/components/data-feed-service/integration_test/suite_test.go
@@ -2,13 +2,20 @@ package integration_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"testing"
 )
 
 type Suite struct {
-	ctx    context.Context
-	server http.Server
+	ctx           context.Context
+	server        http.Server
+	mux           *http.ServeMux
+	destinationId string
+	secretId      string
 }
 
 // Just returns a new struct. You have to call GlobalSetup() to setup the
@@ -25,13 +32,28 @@ func NewSuite() *Suite {
 	mux.Handle("/fails", http.NotFoundHandler())
 	suite.ctx = ctx
 	suite.server = server
+	suite.mux = mux
 	return suite
 }
 
 // GlobalSetup makes backend connections to elastic and postgres. It also sets
 // global vars to usable values.
 func (s *Suite) GlobalSetup() error {
-
+	var err error
+	suite.secretId, err = addSecretRequest(secretData, 200)
+	if err != nil {
+		log.Fatal(err)
+	}
+	destination := []byte(`{"name":"integration_test_suite", "url":"http://localhost:38080/asset", "secret":"` + suite.secretId + `"}`)
+	response, err := addDestinationRequest(destination, 200)
+	if err != nil {
+		log.Fatal(err)
+	}
+	body, err := parseHttpBody(response.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	suite.destinationId = body["id"].(string)
 	go func() {
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatal(err)
@@ -43,5 +65,36 @@ func (s *Suite) GlobalSetup() error {
 // GlobalTeardown is the place where you tear everything down after we have finished
 // executing all our test suite, at the moment we are just deleting ES Indices
 func (s *Suite) GlobalTeardown() {
+	deleteDestinationRequest(suite.destinationId, 200)
+	deleteSecretRequest(suite.secretId, 200)
 	s.server.Shutdown(s.ctx)
+}
+
+func parseHttpBody(body io.ReadCloser) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	err := json.NewDecoder(body).Decode(&m)
+	if err != nil {
+		return nil, err
+	}
+	return m, err
+}
+
+type AssetHandler struct {
+	t *testing.T
+}
+
+func (suite Suite) registerAssetHandler(t *testing.T) {
+	suite.mux.Handle("/asset", &AssetHandler{t: t})
+}
+
+func testStringValue(body map[string]interface{}, key string, expected string) (bool, string) {
+	if value, ok := body[key]; ok {
+		if value == expected {
+			return true, ""
+		} else {
+			return false, fmt.Sprintf("Expected %s for key: %s, got %s", expected, key, value)
+		}
+	} else {
+		return false, fmt.Sprintf("Key not found: %s", key)
+	}
 }

--- a/components/data-feed-service/integration_test/suite_test.go
+++ b/components/data-feed-service/integration_test/suite_test.go
@@ -1,0 +1,47 @@
+package integration_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+)
+
+type Suite struct {
+	ctx    context.Context
+	server http.Server
+}
+
+// Just returns a new struct. You have to call GlobalSetup() to setup the
+// backend connections and such.
+func NewSuite() *Suite {
+	suite := new(Suite)
+	mux := http.NewServeMux()
+	server := http.Server{Addr: ":38080", Handler: mux}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mux.HandleFunc("/success", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+	mux.Handle("/fails", http.NotFoundHandler())
+	suite.ctx = ctx
+	suite.server = server
+	return suite
+}
+
+// GlobalSetup makes backend connections to elastic and postgres. It also sets
+// global vars to usable values.
+func (s *Suite) GlobalSetup() error {
+
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+	return nil
+}
+
+// GlobalTeardown is the place where you tear everything down after we have finished
+// executing all our test suite, at the moment we are just deleting ES Indices
+func (s *Suite) GlobalTeardown() {
+	s.server.Shutdown(s.ctx)
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding integration tests for data-feed-service
Initial tests cover the data-feed-service API

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated? NA
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
