### PR TITLE
[auth-4300] Add  guards to Save Rule and Add Condition

### DIFF
--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -68,7 +68,10 @@
         <div id="condition-section" *ngIf="ruleForm.get('type').value">
           <div class="label">Conditions</div>
           <small>All conditions must be true for the rule to be true.</small>
+          <app-authorized
+            [allOf]="['/apis/iam/v2/projects/{project_id}/rules/{id}', 'put', [project.id, rule.id]]">
           <chef-button primary (click)="addCondition()">Add Condition</chef-button>
+          </app-authorized>
 
           <div id="condition-list" formArrayName="conditions">
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -1,6 +1,6 @@
 <chef-page
   subheading="Resources that match the type and all conditions are included in the project."
-  [attr.confirm-btn-text]=" saving ? 'Saving Rule...' : 'Save Rule' "
+  [attr.confirm-btn-text]="isAuthorized ? saving ? 'Saving Rule...' : 'Save Rule' : ''"
   [attr.heading]="getHeading()"
   [attr.disable-confirm]="!ruleForm.valid || !ruleForm.dirty"
   [attr.page-loading]="(isLoading$ | async)"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.html
@@ -1,6 +1,6 @@
 <chef-page
   subheading="Resources that match the type and all conditions are included in the project."
-  [attr.confirm-btn-text]="isAuthorized ? saving ? 'Saving Rule...' : 'Save Rule' : ''"
+  [attr.confirm-btn-text]="(authorizedChecker.isAuthorized$ | async) ? saving ? 'Saving Rule...' : 'Save Rule' : ''"
   [attr.heading]="getHeading()"
   [attr.disable-confirm]="!ruleForm.valid || !ruleForm.dirty"
   [attr.page-loading]="(isLoading$ | async)"

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.spec.ts
@@ -246,18 +246,29 @@ describe('ProjectRulesComponent', () => {
       expect(component.showDelete()).toBeTruthy();
     });
 
-    it('should show "Save Rule" Button by default', () => {
+    it('should show "Save Rule" button by default', () => {
+      component.authorizedChecker.isAuthorized$ = observableOf(true);
+      fixture.detectChanges();
       const element = fixture.nativeElement;
       const confirmBtnText = element.querySelector('chef-page').getAttribute('confirm-btn-text');
       expect(confirmBtnText).toEqual('Save Rule');
     });
 
-    it('should show "Saving Rules" Button when saving', () => {
+    it('should show "Saving Rules" button when saving', () => {
       component.saving = true;
+      component.authorizedChecker.isAuthorized$ = observableOf(true);
       fixture.detectChanges();
       const element = fixture.nativeElement;
       const confirmBtnText = element.querySelector('chef-page').getAttribute('confirm-btn-text');
       expect(confirmBtnText).toEqual('Saving Rule...');
+    });
+
+    it('should not show save/saving button if not authorized', () => {
+      component.authorizedChecker.isAuthorized$ = observableOf(false);
+      fixture.detectChanges();
+      const element = fixture.nativeElement;
+      const confirmBtnText = element.querySelector('chef-page').getAttribute('confirm-btn-text');
+      expect(confirmBtnText).toEqual('');
     });
   });
 });

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -11,6 +11,7 @@ import { routeParams } from 'app/route.selectors';
 import { HttpStatus } from 'app/types/types';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Regex } from 'app/helpers/auth/regex';
+import { AuthorizedChecker } from 'app/helpers/auth/authorized';
 import { EntityStatus } from 'app/entities/entities';
 import {
   Rule, RuleTypeMappedObject, Condition, ConditionOperator, isConditionOperator, KVPair
@@ -52,6 +53,8 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   public attributes: RuleTypeMappedObject;
   public editingRule = false;
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
+  public authorizedChecker: AuthorizedChecker;
+  public isAuthorized = false;
 
   // Whether the edit ID form is open or not.
   public modifyID = false;
@@ -83,6 +86,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
         type: ['', Validators.required],
         conditions: this.fb.array(this.populateConditions())
       });
+      this.authorizedChecker = new AuthorizedChecker(this.store);
     }
 
   ngOnInit(): void {
@@ -111,7 +115,19 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
         id: rule_id,
         project_id
       }));
+      this.authorizedChecker.setPermissions([
+        {
+          endpoint: '/apis/iam/v2/projects/{project_id}/rules/{id}',
+          paramList: [project_id, rule_id],
+          verb: 'put'
+        }
+      ], []);
     });
+
+    this.authorizedChecker.isAuthorized$
+      .subscribe(isAuthorized => {
+        return this.isAuthorized = isAuthorized;
+      });
 
     this.store.select(projectFromRoute).pipe(
       filter(identity),

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -52,9 +52,8 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   public attributeList: KVPair;
   public attributes: RuleTypeMappedObject;
   public editingRule = false;
-  private isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
   public authorizedChecker: AuthorizedChecker;
-  public isAuthorized = false;
 
   // Whether the edit ID form is open or not.
   public modifyID = false;
@@ -116,11 +115,6 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
         project_id
       }));
    });
-
-    this.authorizedChecker.isAuthorized$
-      .subscribe(isAuthorized => {
-        return this.isAuthorized = isAuthorized;
-      });
 
     this.store.select(projectFromRoute).pipe(
       filter(identity),

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -115,14 +115,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
         id: rule_id,
         project_id
       }));
-      this.authorizedChecker.setPermissions([
-        {
-          endpoint: '/apis/iam/v2/projects/{project_id}/rules/{id}',
-          paramList: [project_id, rule_id],
-          verb: 'put'
-        }
-      ], []);
-    });
+   });
 
     this.authorizedChecker.isAuthorized$
       .subscribe(isAuthorized => {
@@ -134,6 +127,13 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe(project => {
       this.project = project;
+      this.authorizedChecker.setPermissions([
+        {
+          endpoint: '/apis/iam/v2/projects/{project_id}/rules/{id}',
+          paramList: [project.id, 'rule-any'], // specific rule is irrelevant
+          verb: 'put'
+        }
+      ], []);
     });
 
     this.store.select(ruleFromRoute).pipe(


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Users who do not have permission to update projects (`iam:projects:update`) should not be able to see the <kbd>Add Condition</kbd> or <kbd>Save Rule</kbd> buttons on the rule detail view. This PR adds the appropriate introspection guard to those two buttons.

It is guarding the same endpoint (`[/apis/iam/v2/projects/{project_id}/rules/{id}, PUT]`) but done differently for each because of limitations of the architecture. The <kbd>Save Rule</kbd> button is within the `<chef-page>` stencil component. Rather than increase the surface area of that interface, I just leveraged an existing capability: if the button label is empty then the button bar is not displayed. So the `<app-authorized>` functionality is done in code for the <kbd>Save Rule</kbd> button, using the `AuthorizedChecker` component.

But that is only half the story for this PR. It turns out that just making those guard additions did not do the job--in fact, the <kbd>Save Rule</kbd> button was not showing up at all! This work exposed that `AuthorizedChecker` did not have support for parameterized endpoints. That has also been included in this PR.

Method of failure before this PR: In making a determination of authorized or not, `AuthorizedChecker` was looking for the "raw" endpoint `apis/iam/v2/projects/{project_id}/rules/{id}` rather than the inflated endpoint with values filled in  (e.g. `apis/iam/v2/projects/proj-foo/rules/rule-1`). It would never find the raw endpoint path so it always determined authorization was denied.

Caveat: Since introspection is not yet project-aware, anyone with `iam:projects:update` permission will see the buttons, regardless of whether they have that permission on a specific project or not.

### :chains: Related Resources
NA

### :+1: Definition of Done
With `iam:projects:update` permission a user will see the <kbd>Add Condition</kbd> or <kbd>Save Rule</kbd> buttons on the rule detail view.

### :athletic_shoe: How to Build and Test the Change

As an admin:
1. Obtain an admin token and store in the environment variable $ADMINTOK.
2. Create a `proj-update` policy:
```
curl -sSkH "api-token: $ADMINTOK" $TARGET_HOST/apis/iam/v2/policies?pretty -X POST \
-d '{ "name": "proj-update", "id": "proj-update", "members": [ ], "statements": [ { "effect": "ALLOW", "actions": [ "iam:projects:update" ], "projects": [ "*" ] } ], "projects": [] }'
```
3. Create a user (e.g., "bob") in the UI and make bob a member of the viewer policy or team.
4. Create a project (e.g. "proj1") and create a rule within that project (e.g. "rule-1").

Login as bob:
1. Navigate to Settings >> Projects >> proj1 >> Ingest Rules >> rule-1
2. Observe that there is no <kbd>Add Condition</kbd> or <kbd>Save Rule</kbd> button on the rule details page.
3. Close the rule details page.
4. On the command line with the admin token, add bob to the `proj-update` policy:
```
curl -sSkH "api-token: $ADMINTOK" $TARGET_HOST/apis/iam/v2/policies/proj-update/members:add \
-d '{ "members": [ "user:local:bob" ] }'
```
5. Re-open the rule details page again. 
6. Observe that now there are <kbd>Add Condition</kbd> and <kbd>Save Rule</kbd> buttons on the rule details page.

<img width="1629" alt="image" src="https://user-images.githubusercontent.com/6817500/92334138-1ccd2100-f040-11ea-9c6b-5f01a72f76fe.png">


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
