### PR TITLE
[auth-4300] Correct guard for "Create Rule" button

### DIFF
--- a/components/automate-gateway/handler/iam/v2/introspect/introspect_test.go
+++ b/components/automate-gateway/handler/iam/v2/introspect/introspect_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/chef/automate/api/interservice/authz"
 	"github.com/chef/automate/api/external/iam/v2/request"
 	"github.com/chef/automate/api/external/iam/v2/response"
+	"github.com/chef/automate/api/interservice/authz"
 	middleware_authz "github.com/chef/automate/components/automate-gateway/gateway/middleware/authz"
 	"github.com/chef/automate/components/automate-gateway/handler/iam/v2/introspect"
 	"github.com/chef/automate/lib/grpc/auth_context"
@@ -25,8 +25,8 @@ import (
 	// (primarily nodes, notifications, and secrets at the time of writing).
 	_ "github.com/chef/automate/api/external/cfgmgmt"
 	_ "github.com/chef/automate/api/external/compliance/profiles"
-	_ "github.com/chef/automate/api/external/ingest"
 	_ "github.com/chef/automate/api/external/iam/v2"
+	_ "github.com/chef/automate/api/external/ingest"
 	_ "github.com/chef/automate/components/automate-gateway/api/notifications"
 )
 
@@ -189,7 +189,7 @@ func TestIntrospect(t *testing.T) {
 				{Resource: "iam:policies:f33a996c-b4e8-4328-9730-90f4b351fa6e", Action: "iam:policies:delete"},
 			}},
 			&request.IntrospectReq{Path: "/apis/iam/v2/policies/f33a996c-b4e8-4328-9730-90f4b351fa6e"},
-			map[string]*response.MethodsAllowed{"/apis/iam/v2/policies/f33a996c-b4e8-4328-9730-90f4b351fa6e": &response.MethodsAllowed{Delete: true}},
+			map[string]*response.MethodsAllowed{"/apis/iam/v2/policies/f33a996c-b4e8-4328-9730-90f4b351fa6e": {Delete: true}},
 		},
 		"response pair matching the request with param in POST body": {
 			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
@@ -198,14 +198,29 @@ func TestIntrospect(t *testing.T) {
 			&request.IntrospectReq{
 				Parameters: []string{"entity_uuid=f33a996c-b4e8-4328-9730-90f4b351fa6e"},
 				Path:       "/api/v0/ingest/events/chef/run"},
-			map[string]*response.MethodsAllowed{"/api/v0/ingest/events/chef/run": &response.MethodsAllowed{Post: true}},
+			map[string]*response.MethodsAllowed{"/api/v0/ingest/events/chef/run": {Post: true}},
 		},
 		"response pair matching the request with multiple params in path": {
 			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
 				{Resource: "infra:nodes:42", Action: "infra:nodes:get"},
 			}},
 			&request.IntrospectReq{Path: "/api/v0/cfgmgmt/nodes/42/runs/509"},
-			map[string]*response.MethodsAllowed{"/api/v0/cfgmgmt/nodes/42/runs/509": &response.MethodsAllowed{Get: true}},
+			map[string]*response.MethodsAllowed{"/api/v0/cfgmgmt/nodes/42/runs/509": {Get: true}},
+		},
+		"response pair matching the request with multiple params in path and multiple http methods": {
+			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
+				{Resource: "iam:projects:42", Action: "iam:projects:update"},
+			}},
+			&request.IntrospectReq{Path: "/apis/iam/v2/projects/42/rules/509"},
+			map[string]*response.MethodsAllowed{"/apis/iam/v2/projects/42/rules/509": {Put: true, Delete: true}},
+		},
+		"multiple response pairs matching the request with multiple http methods": {
+			&authz.FilterAuthorizedPairsResp{Pairs: []*authz.Pair{
+				{Resource: "iam:projects:42", Action: "iam:projects:get"},
+				{Resource: "iam:projects:42", Action: "iam:projects:update"},
+			}},
+			&request.IntrospectReq{Path: "/apis/iam/v2/projects/42/rules"},
+			map[string]*response.MethodsAllowed{"/apis/iam/v2/projects/42/rules": {Get: true, Post: true}},
 		},
 		// TODO: AUTH-1337 Either: enable this test case after providing support
 		// or remove test case if decide not to support it

--- a/components/automate-ui/src/app/pages/project/details/project-details.component.html
+++ b/components/automate-ui/src/app/pages/project/details/project-details.component.html
@@ -56,7 +56,7 @@
       <section class="page-body" *ngIf="tabValue === 'rules'">
         <ng-container *ngIf="showRulesTable()">
           <chef-toolbar>
-            <app-authorized [allOf]="['/apis/iam/v2/projects', 'post']">
+            <app-authorized [allOf]="['/apis/iam/v2/projects/{project_id}/rules', 'post', project?.id]">
               <chef-button [routerLink]="['/settings', 'projects', project?.id, 'rules']" primary>Create Rule</chef-button>
             </app-authorized>
           </chef-toolbar>
@@ -94,7 +94,7 @@
           </app-authorized>
         </ng-container>
         <ng-container *ngIf="showNoRulesMessage()">
-          <app-authorized [allOf]="['/apis/iam/v2/projects', 'post']">
+          <app-authorized [allOf]="['/apis/iam/v2/projects/{project_id}/rules', 'post', project?.id]">
             <div class="empty-case-container">
               <small class="empty-case-entry" *ngIf="project?.status === 'EDITS_PENDING'">
                 Edits are pending: update <a [routerLink]="['/settings/projects']">projects</a> to apply edits.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Users who have `iam:projects:update` permissions were unable to see the <kbd>Create Rule</kbd> button on the project details page becuase of this incorrect guard:
```
<app-authorized [allOf]="['/apis/iam/v2/projects', 'post']">
```
This PR corrects the guard to this:
```
<app-authorized [allOf]="['/apis/iam/v2/projects/{project_id}/rules', 'post', project?.id]"
```
But that is only a small part of the story of this PR. It turns out that just making that guard change did not do the job--in fact, the <kbd>Create Rule</kbd> button was not showing up at all! This change exposed that automate-gateway was not supporting this introspection call. 
And when I say "this", I mean this single, solitary, unique endpoint. _Any other endpoint would have been fine!_ Go figure...

This could be viewed as either a bug or a feature--take your pick. 😁  We have two endpoints that use the same endpoint path:
```
ListRulesForProject /apis/iam/v2/projects/{id}/rules
CreateRule /apis/iam/v2/projects/{project_id}/rules
```
They are equivalent--but not identical: different variable names. If they had used the same variable name, the code would have handled it. And one could argue that they should be the same variable name, but that would introduce a breaking change to the API, so did not seem prudent. The alternative was to revise introspection to now support multiple (i.e. non-identical) entries.

After eliminating the front-end as culpable, I was able to confirm this was a back-end issue.
When introspecting parameterized endpoints, one provides the inflated endpoint in the payload, not the "template". So here it is filled in with project `proj1`.

BEFORE (this result is incorrect):
```
$  curl -kH "api-token: $TOK" $TARGET_HOST/apis/iam/v2/introspect?pretty \
    -d "$(jq -n '{ path: "/apis/iam/v2/projects/proj1/rules"}')"
{
  "endpoints": {
    "/apis/iam/v2/projects/{id}/rules": {
      "get": true,
      "put": false,
      "post": false,
      "delete": false,
      "patch": false
    },
    "/apis/iam/v2/projects/{project_id}/rules": {
      "get": false,
      "put": false,
      "post": true,
      "delete": false,
      "patch": false
    }
  }
}
```
AFTER (this result is correct):
```
$ curl -kH "api-token: $TOK" $TARGET_HOST/apis/iam/v2/introspect?pretty \
    -d "$(jq -n '{ path: "/apis/iam/v2/projects/proj1/rules"}')"
{
  "endpoints": {
    "/apis/iam/v2/projects/proj1/rules": {
      "get": true,
      "put": false,
      "post": true,
      "delete": false,
      "patch": false
    }
  }
}
```
Notice that the HTTP methods are supposed to be combined under the single, inflated endpoint (GET and POST are both true), rather than getting the templates back individually with their individual permissions.

Caveat: Since introspection is not yet project-aware, anyone with iam:projects:update permission will see the buttons, regardless of whether they have that permission on a specific project or not.

### :chains: Related Resources

### :+1: Definition of Done

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/6817500/92336285-ded9f800-f053-11ea-9430-a66ba32ed64c.png">

### :athletic_shoe: How to Build and Test the Change

In hab studio `rebuild components/automate-gateway`.

As an admin:
1. Obtain an admin token and store in the environment variable $ADMINTOK.
2. Create a `proj-update` policy:
```
curl -sSkH "api-token: $ADMINTOK" $TARGET_HOST/apis/iam/v2/policies?pretty -X POST \
-d '{ "name": "proj-update", "id": "proj-update", "members": [ ], "statements": [ { "effect": "ALLOW", "actions": [ "iam:projects:update" ], "projects": [ "*" ] } ], "projects": [] }'
```
3. Create a user (e.g., "bob") in the UI and make bob a member of the viewer policy or team.
4. Create a project (e.g. "proj1").

Login as bob:
1. Navigate to Settings >> Projects >> proj1 >> Ingest Rules
2. Observe that there is no <kbd>Create Rule</kbd> button on the project details page.
3. Go back to the Projects page.
4. On the command line with the admin token, add bob to the `proj-update` policy:
```
curl -sSkH "api-token: $ADMINTOK" $TARGET_HOST/apis/iam/v2/policies/proj-update/members:add \
-d '{ "members": [ "user:local:bob" ] }'
```
5. Re-open the project details page again. 
6. Observe that now there is a <kbd>Create Rule</kbd> button on the project details page.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

