### PR TITLE
UI for empty state of cookbook when admin key invalid

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -1,6 +1,14 @@
 <section class="cookbooks">
   <chef-loading-spinner *ngIf="cookbooksListLoading" size="50"></chef-loading-spinner>
-  <ng-container  *ngIf="!cookbooksListLoading">
+  <chef-toolbar *ngIf="authFailure">
+      <div class="empty-state">
+        <p>Unable to show cookbooks because admin key is invalid.</p>
+      </div>
+      <div class="empty-state">
+        <chef-button primary (click)="tabRedirection()">Reset Admin Key</chef-button>
+      </div>
+  </chef-toolbar>
+  <ng-container  *ngIf="!cookbooksListLoading && !authFailure">
     <chef-table>
       <chef-thead>
         <chef-tr>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -5,7 +5,7 @@
         <p>Unable to show cookbooks because admin key is invalid.</p>
       </div>
       <div class="empty-state">
-        <chef-button primary (click)="tabRedirection()">Reset Admin Key</chef-button>
+        <chef-button primary (click)="ResetKeyTabRedirection()">Reset Admin Key</chef-button>
       </div>
   </chef-toolbar>
   <ng-container  *ngIf="!cookbooksListLoading && !authFailure">

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -3,8 +3,6 @@
   <chef-toolbar *ngIf="authFailure">
       <div class="empty-state">
         <p>Unable to show cookbooks because admin key is invalid.</p>
-      </div>
-      <div class="empty-state">
         <chef-button primary (click)="ResetKeyTabRedirection()">Reset Admin Key</chef-button>
       </div>
   </chef-toolbar>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.scss
@@ -1,5 +1,15 @@
 @import "~styles/variables";
 
+.empty-state {
+  text-align: center;
+
+  p {
+    font-size: 18px;
+    font-weight: 400;
+    margin-top: 42px;
+  }
+}
+
 thead {
   font-size: 14px;
   letter-spacing: 0.2px;

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -23,7 +23,7 @@ import {
 export class CookbooksComponent implements OnInit, OnDestroy {
   @Input() serverId: string;
   @Input() orgId: string;
-  @Output() resetKeyRedirection: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() resetKeyRedirection = new EventEmitter<boolean>();
 
   private isDestroyed$ = new Subject<boolean>();
   public cookbooks: Cookbook[] = [];

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -23,7 +23,7 @@ import {
 export class CookbooksComponent implements OnInit, OnDestroy {
   @Input() serverId: string;
   @Input() orgId: string;
-  @Output() resetLink: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() resetKeyRedirection: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   private isDestroyed$ = new Subject<boolean>();
   public cookbooks: Cookbook[] = [];
@@ -57,9 +57,9 @@ export class CookbooksComponent implements OnInit, OnDestroy {
     });
   }
 
-  tabRedirection() {
+  ResetKeyTabRedirection() {
     if (this.authFailure) {
-      this.resetLink.emit(true);
+      this.resetKeyRedirection.emit(true);
     }
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -2,9 +2,10 @@ import { Component, Input, OnInit, OnDestroy, Output, EventEmitter } from '@angu
 import { Store } from '@ngrx/store';
 import { Subject, combineLatest } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
-import { isNil } from 'lodash/fp';
 import { EntityStatus } from 'app/entities/entities';
 import { GetCookbooks } from 'app/entities/cookbooks/cookbook.actions';
 import { Cookbook } from 'app/entities/cookbooks/cookbook.model';

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -28,7 +28,7 @@
       <div class="main page-body">
         <app-tabs class="tabs-row" (tabChange)="tabChange($event)">
           <app-tab tabTitle="Cookbooks" #cookbooks_tab [active]="cookbooksTab">
-            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId"></app-cookbooks>
+            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId" (resetLink)="resetAdminKeyRedirection($event)"></app-cookbooks>
           </app-tab>
           <app-tab tabTitle="Roles" #roles_tab  [active]="rolesTab">
             <app-infra-roles *ngIf="roles_tab.active" [serverId]="serverId" [orgId]="orgId"></app-infra-roles>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -28,7 +28,7 @@
       <div class="main page-body">
         <app-tabs class="tabs-row" (tabChange)="tabChange($event)">
           <app-tab tabTitle="Cookbooks" #cookbooks_tab [active]="cookbooksTab">
-            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId" (resetLink)="resetAdminKeyRedirection($event)"></app-cookbooks>
+            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-cookbooks>
           </app-tab>
           <app-tab tabTitle="Roles" #roles_tab  [active]="rolesTab">
             <app-infra-roles *ngIf="roles_tab.active" [serverId]="serverId" [orgId]="orgId"></app-infra-roles>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -16,6 +16,8 @@ import {
 import { GetOrg } from 'app/entities/orgs/org.actions';
 import { ProjectConstants } from 'app/entities/projects/project.model';
 
+const ORG_DETAILS_TAB_NAME = 'orgDetailsTab';
+
 @Component({
   selector: 'app-org-details',
   templateUrl: './org-details.component.html',
@@ -102,40 +104,41 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   }
 
   tabChange(tab: number) {
+    // Tab indices here correspond with the order of `<app-tab>` elements in the template.
     switch (tab) {
       case 0:
-        this.telemetryService.track('orgDetailsTab', 'cookbooks');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'cookbooks');
         this.resetTabs();
         this.cookbooksTab = true;
         break;
       case 1:
-        this.telemetryService.track('orgDetailsTab', 'roles');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'roles');
         break;
       case 2:
-        this.telemetryService.track('orgDetailsTab', 'environments');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'environments');
         break;
       case 3:
-        this.telemetryService.track('orgDetailsTab', 'dataBags');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'dataBags');
         break;
       case 4:
-        this.telemetryService.track('orgDetailsTab', 'clients');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'clients');
         break;
       case 5:
-        this.telemetryService.track('orgDetailsTab', 'policyFiles');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'policyFiles');
         break;
       case 6:
-        this.telemetryService.track('orgDetailsTab', 'orgEdit');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'orgEdit');
         break;
       case 7:
-        this.telemetryService.track('orgDetailsTab', 'resetkey');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'resetkey');
         break;
     }
   }
 
-  resetAdminKeyRedirection(authFailuer: boolean) {
-    if (authFailuer) {
+  resetAdminKeyRedirection(authFailure: boolean) {
+    if (authFailure) {
       this.resetTabs();
-      this.resetKeyTab = authFailuer;
+      this.resetKeyTab = authFailure;
     }
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Introduced a UI of empty state for cookbooks when the admin key is invalid, before empty state UI we were showing empty cookbook list table. As a UX improvement we have introduced a UI for empty cookbooks state and redirection link for `Reset Admin Key` tab.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Fixes: #4244 
### :+1: Definition of Done
Used a common pattern for empty state UI with message and redirection link for `Reset Admin Key` tab, please refer the screenshots for the same.
### :athletic_shoe: How to Build and Test the Change
Call infra proxy API which gives 401 error.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
- Before
![cookbook-empty-state](https://user-images.githubusercontent.com/54940695/92489218-25bf1d80-f20d-11ea-8da2-75a9ffc6afba.png)

- After
![cookbook-empty-state-ui](https://user-images.githubusercontent.com/54940695/92488524-4b97f280-f20c-11ea-8754-aabc9a1a66db.png)
