### PR TITLE
Dont ssl check cert validity period for internal CA

### DIFF
--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -10,6 +10,10 @@ map(select(
          (.id != "secure_client_renego" or .port == "443") and
          (.id != "BREACH" or .port == "443") and
 
+         # The checker wants your certs to be valid for less than 398 days. We
+         # don't think this rule is valuable for the internal A2 CA
+         (.id != "cert_validityPeriod" or .port == "443" ) and
+
          # TODO notifications-service
          (.port != "10125") and
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The SSL Tester is now asserting that certs should be valid for less than 398 days. The constraints of our internal CA are much different than for normal web use, so we are disabling this check for the internal CA.

