### PR TITLE
Added rule name in the notification instead of the id.

### DIFF
--- a/components/automate-ui/src/app/entities/rules/rule.effects.ts
+++ b/components/automate-ui/src/app/entities/rules/rule.effects.ts
@@ -91,7 +91,7 @@ export class RuleEffects {
       ofType(RuleActionTypes.CREATE_SUCCESS),
       map(({ payload: { rule } }: CreateRuleSuccess) => new CreateNotification({
       type: Type.info,
-      message: `Created rule ${rule.id}`
+      message: `Created rule ${rule.name}`
     })));
 
   @Effect()

--- a/e2e/cypress/integration/ui/settings/project_rule_mgmt.spec.ts
+++ b/e2e/cypress/integration/ui/settings/project_rule_mgmt.spec.ts
@@ -75,7 +75,7 @@ describe('project rule management', () => {
     cy.get('app-pending-edits-bar').contains('Project edits pending');
 
     // verify success notification and then dismiss it
-    cy.get('app-notification.info').contains(`Created rule ${ruleID}`);
+    cy.get('app-notification.info').contains(`Created rule ${ruleName}`);
     cy.get('app-notification.info chef-icon').click();
   });
 


### PR DESCRIPTION
Signed-off-by: samshinde <ashinde@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
After creating a rule, In the Notification bar, it shows the id of the particular rule, not the name so changed it to name.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#1130 
### :+1: Definition of Done
Rule name displayed in the notification instead of the id.
### :athletic_shoe: How to Build and Test the Change

1. visit the Settings >>Projects page
2. create Projects >> create Rule in a particular projects
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![rule-notify](https://user-images.githubusercontent.com/10369422/93068931-b4fb8380-f69a-11ea-84ce-a60b1788c8bc.png)
