### PR TITLE
Connected Services Filter (API only)

### DIFF
--- a/components/applications-service/integration_test/services_test.go
+++ b/components/applications-service/integration_test/services_test.go
@@ -232,6 +232,13 @@ func TestGetServicesWithDisconnectedServices(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, res.Services, 0)
 
+	reqConnectedOnly := &applications.ServicesReq{
+		Filter: []string{"status:connected"},
+	}
+	connectedOnlyRes, err := suite.ApplicationsServer.GetServices(ctx, reqConnectedOnly)
+	assert.NoError(t, err)
+	assert.Len(t, connectedOnlyRes.Services, 6)
+
 	_, err = suite.ApplicationsServer.MarkDisconnectedServices(300)
 	require.NoError(t, err)
 
@@ -259,6 +266,10 @@ func TestGetServicesWithDisconnectedServices(t *testing.T) {
 	res2, err := suite.ApplicationsServer.GetServices(ctx, reqDisconnectedOnly)
 	assert.NoError(t, err)
 	assert.Len(t, res2.Services, 6)
+
+	connectedOnlyRes2, err := suite.ApplicationsServer.GetServices(ctx, reqConnectedOnly)
+	assert.NoError(t, err)
+	assert.Len(t, connectedOnlyRes2.Services, 0)
 }
 
 func TestGetServicesMultiServicaSortDESC(t *testing.T) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

[Apps tab] A customer has requested to be able to filter on only connected services. They want to see if all supervisors that are expected to upgrade have indeed upgraded. Their estate includes systems distributed over sometimes unreliable WAN links, which can become disconnected and not expected to update. Therefore it will be helpful to filter out these disconnected systems to show only the connected ones.

This PR implements filtering by `status:connected` when listing services.

### :chains: Related Resources

UI Card: #4343

### :+1: Definition of Done

You can filter for only connected services in the Automate API

### :athletic_shoe: How to Build and Test the Change

```
hab pkg install -bf core/curl
hab pkg install -bf core/jq-static

build components/applications-service
start_all_services
applications_populate_database
```

At first all the services are connected, so nothing is filtered out. You can see the connected services with something like (adjust the jq query as you like):  

```
curl -fsS -k -H "api-token: ${api_token}" "https://localhost/api/v0/applications/services?filter=status:connected"  | jq '.services | .[] | .id, .disconnected '
```

After 5 minutes or so, all the services should be disconnected and you won't see them in the above query. At this point, if you re-run `applications_populate_database` you will have a mix of connected and disconnected, which you can see by flipping the filter from `status:connected` to `status:disconnected`.

