### PR TITLE
Add name filtering to ListSecrets API

### DIFF
--- a/api/external/secrets/secrets.pb.go
+++ b/api/external/secrets/secrets.pb.go
@@ -797,7 +797,7 @@ type SecretsServiceClient interface {
 	//Makes a list of secrets.
 	//Supports filtering, pagination, and sorting.
 	//Adding a filter narrows the list of secrets to only those that match the filter or filters.
-	//Supported filters: type
+	//Supported filters: type, name
 	//Supported sort types: name, type, last modified
 	//
 	//Example:
@@ -960,7 +960,7 @@ type SecretsServiceServer interface {
 	//Makes a list of secrets.
 	//Supports filtering, pagination, and sorting.
 	//Adding a filter narrows the list of secrets to only those that match the filter or filters.
-	//Supported filters: type
+	//Supported filters: type, name
 	//Supported sort types: name, type, last modified
 	//
 	//Example:

--- a/api/external/secrets/secrets.proto
+++ b/api/external/secrets/secrets.proto
@@ -138,7 +138,7 @@ service SecretsService {
 	Makes a list of secrets.
 	Supports filtering, pagination, and sorting.
 	Adding a filter narrows the list of secrets to only those that match the filter or filters.
-	Supported filters: type
+	Supported filters: type, name
 	Supported sort types: name, type, last modified
 
 	Example:

--- a/api/external/secrets/secrets.swagger.json
+++ b/api/external/secrets/secrets.swagger.json
@@ -151,7 +151,7 @@
     "/api/v0/secrets/search": {
       "post": {
         "summary": "List and filter secrets",
-        "description": "Makes a list of secrets.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of secrets to only those that match the filter or filters.\nSupported filters: type\nSupported sort types: name, type, last modified\n\nExample:\n```\n{\n\"sort\": \"type\",\n\"order\": \"ASC\",\n\"filters\": [\n{ \"key\": \"type\", \"values\": [\"ssh\",\"winrm\",\"sudo\"] }\n],\n\"page\":1,\n\"per_page\":100\n}\n```\n\nAuthorization Action:\n```\nsecrets:secrets:list\n```",
+        "description": "Makes a list of secrets.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of secrets to only those that match the filter or filters.\nSupported filters: type, name\nSupported sort types: name, type, last modified\n\nExample:\n```\n{\n\"sort\": \"type\",\n\"order\": \"ASC\",\n\"filters\": [\n{ \"key\": \"type\", \"values\": [\"ssh\",\"winrm\",\"sudo\"] }\n],\n\"page\":1,\n\"per_page\":100\n}\n```\n\nAuthorization Action:\n```\nsecrets:secrets:list\n```",
         "operationId": "SecretsService_List",
         "responses": {
           "200": {

--- a/components/automate-gateway/api/secrets.pb.swagger.go
+++ b/components/automate-gateway/api/secrets.pb.swagger.go
@@ -154,7 +154,7 @@ func init() {
     "/api/v0/secrets/search": {
       "post": {
         "summary": "List and filter secrets",
-        "description": "Makes a list of secrets.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of secrets to only those that match the filter or filters.\nSupported filters: type\nSupported sort types: name, type, last modified\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\n{\n\"sort\": \"type\",\n\"order\": \"ASC\",\n\"filters\": [\n{ \"key\": \"type\", \"values\": [\"ssh\",\"winrm\",\"sudo\"] }\n],\n\"page\":1,\n\"per_page\":100\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nsecrets:secrets:list\n` + "`" + `` + "`" + `` + "`" + `",
+        "description": "Makes a list of secrets.\nSupports filtering, pagination, and sorting.\nAdding a filter narrows the list of secrets to only those that match the filter or filters.\nSupported filters: type, name\nSupported sort types: name, type, last modified\n\nExample:\n` + "`" + `` + "`" + `` + "`" + `\n{\n\"sort\": \"type\",\n\"order\": \"ASC\",\n\"filters\": [\n{ \"key\": \"type\", \"values\": [\"ssh\",\"winrm\",\"sudo\"] }\n],\n\"page\":1,\n\"per_page\":100\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nAuthorization Action:\n` + "`" + `` + "`" + `` + "`" + `\nsecrets:secrets:list\n` + "`" + `` + "`" + `` + "`" + `",
         "operationId": "SecretsService_List",
         "responses": {
           "200": {

--- a/components/secrets-service/dao/secrets.go
+++ b/components/secrets-service/dao/secrets.go
@@ -18,8 +18,8 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/chef/automate/api/external/common/query"
-	"github.com/chef/automate/api/external/secrets"
 	"github.com/chef/automate/api/external/lib/errorutils"
+	"github.com/chef/automate/api/external/secrets"
 	"github.com/chef/automate/lib/stringutils"
 )
 
@@ -333,6 +333,7 @@ func (secretsDb *DB) GetSecrets(sortField string, insortOrder secrets.Query_Orde
 
 var secretsFilterField = map[string]string{
 	"type": "type",
+	"name": "name",
 }
 
 func validateSecretFilters(filters []*query.Filter) error {
@@ -351,7 +352,7 @@ func validateSecretFilters(filters []*query.Filter) error {
 
 func isValidSecretType(secretType string) bool {
 	switch secretType {
-	case "ssh", "winrm", "sudo", "aws", "azure", "service_now":
+	case "ssh", "winrm", "sudo", "aws", "azure", "service_now", "data_feed":
 		return true
 	default:
 		return false

--- a/components/secrets-service/integration_test/list_secret_test.go
+++ b/components/secrets-service/integration_test/list_secret_test.go
@@ -301,3 +301,142 @@ func TestListSecretPaging(t *testing.T) {
 
 	deleteAllSecrets()
 }
+
+func TestListSecretFilterByName(t *testing.T) {
+	ctx := context.Background()
+
+	testData := struct {
+		order         secrets.Query_OrderType
+		sort          string
+		inputSecrets  []*secrets.Secret
+		outputSecrets []*secrets.Secret
+		message       string
+	}{
+
+		order: secrets.Query_ASC,
+		sort:  "name",
+		inputSecrets: []*secrets.Secret{
+			{
+				Name: "data feed secret",
+				Type: "data_feed",
+				Data: appendKvs(
+					&query.Kv{Key: "username", Value: "username"},
+					&query.Kv{Key: "password", Value: "password"}),
+			},
+			{
+				Name: "service now secret",
+				Type: "service_now",
+				Data: appendKvs(
+					&query.Kv{Key: "username", Value: "username"},
+					&query.Kv{Key: "password", Value: "password"}),
+			},
+		},
+		outputSecrets: []*secrets.Secret{
+			{
+				Name: "data feed secret",
+				Type: "data_feed",
+			},
+		},
+		message: "Order asc",
+	}
+
+	for _, secret := range testData.inputSecrets {
+		id, err := secretsServer.Create(ctx, secret)
+		assert.NoError(t, err)
+		assert.NotNil(t, id)
+	}
+
+	nameFilter := &query.Filter{
+		Key:    "name",
+		Values: []string{"data feed secret"},
+	}
+	req := &secrets.Query{
+		Order:   testData.order,
+		Sort:    testData.sort,
+		Filters: []*query.Filter{nameFilter},
+	}
+
+	responseSecrets, err := secretsServer.List(ctx, req)
+	assert.NoError(t, err, testData.message)
+	assert.NotNil(t, responseSecrets)
+	assert.Equal(t, len(testData.outputSecrets), int(responseSecrets.Total), testData.message)
+
+	for index, actualSecret := range responseSecrets.Secrets {
+		expectedSecret := testData.outputSecrets[index]
+		assert.Equal(t, actualSecret.Name, expectedSecret.Name, testData.message)
+		assert.Equal(t, actualSecret.Type, expectedSecret.Type, testData.message)
+	}
+
+	deleteAllSecrets()
+
+}
+
+
+func TestListSecretFilterByType(t *testing.T) {
+	ctx := context.Background()
+
+	testData := struct {
+		order         secrets.Query_OrderType
+		sort          string
+		inputSecrets  []*secrets.Secret
+		outputSecrets []*secrets.Secret
+		message       string
+	}{
+
+		order: secrets.Query_ASC,
+		sort:  "name",
+		inputSecrets: []*secrets.Secret{
+			{
+				Name: "data feed secret",
+				Type: "data_feed",
+				Data: appendKvs(
+					&query.Kv{Key: "username", Value: "username"},
+					&query.Kv{Key: "password", Value: "password"}),
+			},
+			{
+				Name: "service now secret",
+				Type: "service_now",
+				Data: appendKvs(
+					&query.Kv{Key: "username", Value: "username"},
+					&query.Kv{Key: "password", Value: "password"}),
+			},
+		},
+		outputSecrets: []*secrets.Secret{
+			{
+				Name: "data feed secret",
+				Type: "data_feed",
+			},
+		},
+		message: "Order asc",
+	}
+
+	for _, secret := range testData.inputSecrets {
+		id, err := secretsServer.Create(ctx, secret)
+		assert.NoError(t, err)
+		assert.NotNil(t, id)
+	}
+
+	typeFilter := &query.Filter{
+		Key:    "type",
+		Values: []string{"data_feed"},
+	}
+	req := &secrets.Query{
+		Order:   testData.order,
+		Sort:    testData.sort,
+		Filters: []*query.Filter{typeFilter},
+	}
+
+	responseSecrets, err := secretsServer.List(ctx, req)
+	assert.NoError(t, err, testData.message)
+	assert.NotNil(t, responseSecrets)
+	assert.Equal(t, len(testData.outputSecrets), int(responseSecrets.Total), testData.message)
+
+	for index, actualSecret := range responseSecrets.Secrets {
+		expectedSecret := testData.outputSecrets[index]
+		assert.Equal(t, actualSecret.Name, expectedSecret.Name, testData.message)
+		assert.Equal(t, actualSecret.Type, expectedSecret.Type, testData.message)
+	}
+
+	deleteAllSecrets()
+
+}


### PR DESCRIPTION
Signed-off-by: Martin Scott <mscott@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Added filtering by name to the ListSecrets API to help with data-feed-service integration tests.

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
