### PR TITLE
fix size of contros and contol tags suggestions

### DIFF
--- a/components/compliance-service/api/reporting/server/server.go
+++ b/components/compliance-service/api/reporting/server/server.go
@@ -12,11 +12,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/chef/automate/api/external/lib/errorutils"
 	"github.com/chef/automate/api/interservice/compliance/reporting"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
 	"github.com/chef/automate/components/compliance-service/reporting/util"
 	"github.com/chef/automate/components/compliance-service/utils"
-	"github.com/chef/automate/api/external/lib/errorutils"
 	"github.com/chef/automate/lib/grpc/auth_context"
 	"github.com/chef/automate/lib/io/chunks"
 	"github.com/sirupsen/logrus"
@@ -113,7 +113,12 @@ func (srv *Server) ReadReport(ctx context.Context, in *reporting.Query) (*report
 func (srv *Server) ListSuggestions(ctx context.Context, in *reporting.SuggestionRequest) (*reporting.Suggestions, error) {
 	var suggestions reporting.Suggestions
 	if in.Size == 0 {
-		in.Size = 100
+		if strings.HasPrefix(in.Type, "control") {
+			//for control or control_tag_key or control_tag_value, we only want 10 back by default
+			in.Size = 10
+		} else {
+			in.Size = 100
+		}
 	}
 	if in.Type == "" {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Parameter 'type' not specified"))

--- a/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_control_tags_spec.rb
@@ -119,11 +119,11 @@ describe File.basename(__FILE__) do
       filters: [
         Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
         Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
-        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: []),
+        Reporting::ListFilter.new(type: 'control_tag:satisfies', values: ["SRG"]), # N.B.  the control_tag filter gets ignored by the back end if it didn't, then the most you would see for suggs is what's in the filter
       ],
       size: 5
     )
-    expected = [ "apache-1", "apache-2", "NGX-1", "NGX-2", "SRG-00006" ]
+    expected = [ "apache-1", "NGX-1", "NGX-2", "SRG-00006", "SRG-00007" ]
     assert_suggestions_text(expected, actual_data)
   end
 
@@ -198,6 +198,23 @@ describe File.basename(__FILE__) do
       ]
     )
     expected = ["apache-1", "apache-2", "NGX-1", "NGX-2", "SRG-00006", "SRG-00007"]
+    assert_suggestions_text(expected, actual_data)
+  end
+
+  it "suggests control tag values when full control tag filter exists and search text is provided but only want 2" do
+    # suggest control tag values with a tag key filter without text
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+        type: 'control_tag_value',
+        text: 'srg',
+        size: 2,
+        filters: [
+            Reporting::ListFilter.new(type: 'start_time', values: ['2018-02-01T23:59:59Z']),
+            Reporting::ListFilter.new(type: 'end_time', values: ['2018-03-04T23:59:59Z']),
+            Reporting::ListFilter.new(type: 'control_tag:satisfies', values: ['apache-1', 'SRG-00006']),
+            Reporting::ListFilter.new(type: 'control_tag:scope', values: []),
+        ]
+    )
+    expected = ["SRG-00006", "SRG-00007"]
     assert_suggestions_text(expected, actual_data)
   end
 end

--- a/components/compliance-service/api/tests/07_suggestions_spec.rb
+++ b/components/compliance-service/api/tests/07_suggestions_spec.rb
@@ -193,4 +193,24 @@ describe File.basename(__FILE__) do
     ]
     assert_suggestions_text(expected, actual_data)
   end
+
+  it "list_suggestions controls, no date, 24h stuff" do
+    actual_data = GRPC reporting, :list_suggestions, Reporting::SuggestionRequest.new(
+        type: 'control',
+        text: 'Profile 2 - Control 1',
+        size: 5,
+        filters: [
+            Reporting::ListFilter.new(type: 'start_time', values: ['2018-01-01T00:00:00Z']),
+            Reporting::ListFilter.new(type: 'end_time', values: ['2018-06-06T23:59:59Z'])
+        ]
+    )
+    expected = [
+        "Profile 1 - Control 1--pro1-con1--",
+        "Profile 1 - Control 2--pro1-con2--",
+        "Profile 1 - Control 3--pro1-con3--",
+        "Profile 1 - Control 4--pro1-con4--",
+        "Profile 2 - Control 1--pro2-con1--"
+    ]
+    assert_suggestions_text_id_version(expected, actual_data)
+  end
 end

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -16,8 +16,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 
-	reportingapi "github.com/chef/automate/api/interservice/compliance/reporting"
 	"github.com/chef/automate/api/external/lib/errorutils"
+	reportingapi "github.com/chef/automate/api/interservice/compliance/reporting"
 )
 
 // GetSuggestions - Report #12
@@ -556,14 +556,20 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 	//Size(size * 50) // Multiplying size to ensure that same profile with multiple versions is not limiting our suggestions to a lower number
 	// ^ Because we can't sort by max_score of the inner hits: https://discuss.elastic.co/t/nested-objects-hits-inner-hits-and-sorting/32565
 
+	//default to 10 suggs
+	numOfSugg := 10
+	if size > 0 {
+		numOfSugg = size
+	}
+
 	controlsTitles := elastic.NewTermsAggregation().
 		Field("profiles.controls.title").
-		Size(10).
+		Size(numOfSugg).
 		Order("_count", false)
 
 	controlIds := elastic.NewTermsAggregation().
 		Field("profiles.controls.id").
-		Size(10).
+		Size(numOfSugg).
 		Order("_count", false)
 
 	controlsTitles.SubAggregation("ids", controlIds)
@@ -671,9 +677,15 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		FetchSource(false).
 		Size(0) //set to 0 because we do aggs now
 
+	//default to 10 suggs
+	numOfSugg := 10
+	if size > 0 {
+		numOfSugg = size
+	}
+
 	controlsTitles := elastic.NewTermsAggregation().
 		Field(target).
-		Size(10).
+		Size(numOfSugg).
 		Order("_count", false)
 
 	stringTagsAgg := elastic.NewFilterAggregation().Filter(finalInnerBoolQuery).

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -623,18 +623,20 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 							logrus.Errorf("could not convert the value of titleBucket: %v, to a string!", titleBucket)
 						}
 						logrus.Debugf("%s titleBucket.Key: %s", myName, title)
-						if idsBuckets, found := titleBucket.Aggregations.Terms("ids"); found && len(idsBuckets.Buckets) > 0 {
-							for _, idsBucket := range idsBuckets.Buckets {
-								id, ok := idsBucket.Key.(string)
-								if !ok {
-									logrus.Errorf("could not convert the value of idsBucket: %v, to a string!", idsBucket)
+						if len(title) > 0 {
+							if idsBuckets, found := titleBucket.Aggregations.Terms("ids"); found && len(idsBuckets.Buckets) > 0 {
+								for _, idsBucket := range idsBuckets.Buckets {
+									id, ok := idsBucket.Key.(string)
+									if !ok {
+										logrus.Errorf("could not convert the value of idsBucket: %v, to a string!", idsBucket)
+									}
+									if !singular || !addedControls[id] {
+										oneSugg := reportingapi.Suggestion{Id: id, Text: title}
+										suggs = append(suggs, &oneSugg)
+										addedControls[id] = true
+									}
+									logrus.Debugf("%s idsBucket.Key: %s", myName, id)
 								}
-								if !singular || !addedControls[id] {
-									oneSugg := reportingapi.Suggestion{Id: id, Text: title}
-									suggs = append(suggs, &oneSugg)
-									addedControls[id] = true
-								}
-								logrus.Debugf("%s idsBucket.Key: %s", myName, id)
 							}
 						}
 					}

--- a/components/compliance-service/reporting/relaxting/suggestions.go
+++ b/components/compliance-service/reporting/relaxting/suggestions.go
@@ -553,23 +553,15 @@ func (backend ES2Backend) getControlSuggestions(ctx context.Context, client *ela
 		Query(boolQuery).
 		FetchSource(false).
 		Size(0) //setting size to 0 because we now use aggs to get this stuff and don't need the actual docs
-	//Size(size * 50) // Multiplying size to ensure that same profile with multiple versions is not limiting our suggestions to a lower number
-	// ^ Because we can't sort by max_score of the inner hits: https://discuss.elastic.co/t/nested-objects-hits-inner-hits-and-sorting/32565
-
-	//default to 10 suggs
-	numOfSugg := 10
-	if size > 0 {
-		numOfSugg = size
-	}
 
 	controlsTitles := elastic.NewTermsAggregation().
 		Field("profiles.controls.title").
-		Size(numOfSugg).
+		Size(size).
 		Order("_count", false)
 
 	controlIds := elastic.NewTermsAggregation().
 		Field("profiles.controls.id").
-		Size(numOfSugg).
+		Size(size).
 		Order("_count", false)
 
 	controlsTitles.SubAggregation("ids", controlIds)
@@ -679,15 +671,9 @@ func (backend ES2Backend) getControlTagsSuggestions(ctx context.Context, client 
 		FetchSource(false).
 		Size(0) //set to 0 because we do aggs now
 
-	//default to 10 suggs
-	numOfSugg := 10
-	if size > 0 {
-		numOfSugg = size
-	}
-
 	controlsTitles := elastic.NewTermsAggregation().
 		Field(target).
-		Size(numOfSugg).
+		Size(size).
 		Order("_count", false)
 
 	stringTagsAgg := elastic.NewFilterAggregation().Filter(finalInnerBoolQuery).


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
For controls and control-tags suggestions, we were retrieving 10 suggestions, and then, when "size" was passed into the API call, we were returning the first "size" results.  This was causing some results to come back that seemed imperfect with respect to text string being passed in.  Now we set the search size to the exact amount specified in request and return that amount, yeilding a more predictable result.
