### PR TITLE
Use Hugo asset pipeline for API docs

### DIFF
--- a/components/docs-chef-io/layouts/_default/data-api.html
+++ b/components/docs-chef-io/layouts/_default/data-api.html
@@ -11,6 +11,7 @@
   <body>
     <a class="return" href="/automate/">Return to Docs</a>
     <ReDoc spec-url="/automate-api-docs/all-apis.swagger.json" scroll-y-offset="34"></ReDoc>
-    <script src="{{ (resources.Get "js/vendor/redoc.standalone.js").Permalink }}"></script>
+    {{ $redocJs := resources.Get "js/vendor/redoc.standalone.js" }}
+    <script type="text/javascript" src="{{ $redocJs.Permalink }}"></script>
   </body>
 </html>


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Using the Hugo asset pipeline could help with 
`Error: Error building site: failed to render pages: render of "page" failed: "/chef-web-docs/_vendor/github.com/chef/automate/components/docs-chef-io/layouts/_default/data-api.html:14:35": execute of template failed: template: _default/data-api.html:14:35: executing "_default/data-api.html" at <"js/vendor/redoc.standalone.js">: nil pointer evaluating resource.Resource.Permalink
make: *** [serve] Error 255`

Consideration:
Slow. Possibly even slower than the original. We may need to call it earlier and minifiy, or something similar.
https://gohugo.io/hugo-pipes/
