### PR TITLE
Display message when no tests were run

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -240,6 +240,12 @@
                           <chef-snippet [code]="result.message + result.skip_message"></chef-snippet>
                         </div>
                       </div>
+                      <!-- display message when there are no results -->
+                      <div class="result-item" *ngIf="control.results.length === 0">
+                        <div class="result-item-header">
+                          <p>No tests were executed</p>
+                        </div>
+                      </div>
                     </div>
                     <chef-snippet
                       class="source"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This branch updates the Compliance Reports node detail view to show a message when no tests were run on that specific node.

### :chains: Related Resources
Addresses: https://github.com/chef/automate/issues/1761

### :+1: Definition of Done
A message is displayed when there are no results to show on the compliance report detail view

### :athletic_shoe: How to Build and Test the Change
`build components/automate-ui-devproxy`
`make serve`

1. Download profile that will have no test outcome: https://github.com/chef/automate/issues/1761#issuecomment-694437000
2. Upload profile into automate
3. Navigate to https://a2-dev.test/compliance/compliance-profiles and upload the profile downloaded in step 1
4. Navigate to https://a2-dev.test/compliance/scan-jobs/jobs and create a scan job with this profile
5. Navigate to https://a2-dev.test/compliance/reports/nodes and find the node you scanned with the profile from step 1
6. Open passed profile and see that it has no tests, with a message informing you similar to the image below.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
After
![No tests](https://user-images.githubusercontent.com/16737484/93528186-ce950900-f8ee-11ea-8189-418efbea818a.png)
