### PR TITLE
Fix compliance report summary style bug

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
@@ -193,6 +193,7 @@ chef-subheading {
     background: $chef-white;
 
     table {
+      width: 50%;
       flex-grow: 1;
       flex-basis: 50%;
       font-size: 14px;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This commit fixes styling bug where the report summary table was growing outside of its parent container and causing a horizontal scrollbar.

**Before**
![](https://user-images.githubusercontent.com/479121/93791851-bed53780-fc02-11ea-9faf-ddc22a06a01a.png)

**After**
![](https://user-images.githubusercontent.com/479121/93791871-c4328200-fc02-11ea-814b-a487c5b00c3b.png)

