### PR TITLE
Resolved Add Users button overlaps with the user table.

### DIFF
--- a/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.scss
+++ b/components/automate-ui/src/app/modules/team/team-add-users/team-add-users.component.scss
@@ -31,7 +31,7 @@ chef-page {
     #inner-container {
       chef-table {
         chef-tbody {
-          height: calc(100vh - 350px);
+          height: calc(100vh - 375px);
           overflow-y: scroll;
         }
 


### PR DESCRIPTION
Signed-off-by: samshinde <ashinde@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
The `Add Users` button overlaps with the user table on the add-users-to-team modal and changed the height of the table to get a space between them.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#2752 
### :+1: Definition of Done
Add user button overlaps with the user table so added space between them.
### :athletic_shoe: How to Build and Test the Change
1. start Automate + UI
2. navigate to https://a2-dev.test/settings/users and create several users
3. navigate to https://a2-dev.test/settings/teams/editors/add-users
4. you should be able to see the overlap of the buttons with the last row of users 

```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screenshot from 2020-09-22 15-58-45](https://user-images.githubusercontent.com/10369422/93872485-de955a00-fced-11ea-8d58-6bf62ac85dcd.png)
