### PR TITLE
Automate-4302 Console error in project notifications

### DIFF
--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, AfterViewChecked } from '@angular/core';
 import { ActivationStart, ActivationEnd, Router, NavigationEnd } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { filter } from 'rxjs/operators';
@@ -14,7 +14,7 @@ import { GetAllUserPerms } from './entities/userperms/userperms.actions';
   templateUrl: './ui.component.html',
   styleUrls: ['./ui.component.scss']
 })
-export class UIComponent implements OnInit {
+export class UIComponent implements OnInit, AfterViewChecked {
   // Feature Flags
   // TODO:eng-ex This static data seems out of place. Should it go in InitialState?
   experimentalFeatures: Array<Feature> = [
@@ -36,7 +36,8 @@ export class UIComponent implements OnInit {
   constructor(
     private store: Store<NgrxStateAtom>,
     private router: Router,
-    public layoutFacade: LayoutFacadeService
+    public layoutFacade: LayoutFacadeService,
+    private cdRef: ChangeDetectorRef
   ) {
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
@@ -52,6 +53,10 @@ export class UIComponent implements OnInit {
         this.layoutFacade.showFullPage();
       }
     });
+  }
+
+  ngAfterViewChecked() {
+    this.cdRef.detectChanges();
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Console error: hasUserNotifications does not change from its default value until you get projects in an "edits pending" state.

### :chains: Related Resources
https://github.com/chef/automate/issues/4320

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Steps to reproduce the behavior:

Login as admin.
Create a project.
Add a rule to the project.
Observe that the "edits pending" notification bar appears at the bottom of the screen.
Add or edit a rule so that it shows updates pending.

Navigate back to the Projects list (Settings > Projects).
Open the project details for the project.
Observe this error appears in the browser:
`ERROR Error: ExpressionChangedAfterItHasBeenCheckedError: 
Expression has changed after it was checked. 
Previous value for 'attr.hasUserNotifications': 'true'. Current value: 'null'.`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![Screen Shot 2020-09-22 at 8 01 31 AM](https://user-images.githubusercontent.com/4108100/93887008-bdac1500-fcab-11ea-80e7-e0837933151d.png)
