### PR TITLE
Automate-3673 Compliance reports pagination pages not correct

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.html
@@ -116,7 +116,7 @@
   <app-page-picker
     class="reporting-nodes-paging"
     [perPage]="reportData.nodesListParams.perPage"
-    [total]="reportData.nodesList.total"
+    [total]="getTotalNodes()"
     [page]="reportData.nodesListParams.page"
     (pageChanged)="onNodesListPageChanged($event)">
   </app-page-picker>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-nodes/reporting-nodes.component.ts
@@ -74,6 +74,12 @@ export class ReportingNodesComponent implements OnInit, OnDestroy {
     return this.nodeFilterStatus === status;
   }
 
+  getTotalNodes() {
+    const nodes = this.reportData.nodesList.total;
+    const statusNodes = this.reportData.nodesList['total_' + this.nodeFilterStatus];
+    return statusNodes || nodes;
+  }
+
   onNodesListPageChanged(event) {
     const reportQuery = this.reportQuery.getReportQuery();
     this.reportData.nodesListParams.page = event;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
There is a dependency on #3664

Prior to #3664, if you applied a status filter the nodes, profiles, or controls would still be distributed across all of their pages before the filter was applied.

#3664 improves it so that all objects get moved to the beginning of the pages, but all the empty pages are left around and if a user navigates to one of the empty pages they get stuck and have to do a hard refresh.

if a user applies a status filter, pagination buttons should only be shown if there are objects on them.

### :chains: Related Resources
https://github.com/chef/automate/issues/3673

### :+1: Definition of Done
Pagination shows correct page numbers

### :athletic_shoe: How to Build and Test the Change
add at least 101 compliance nodes, chef_load_compliance_nodes
navigate to compliance > reports > nodes (or profiles or controls)
apply a status filter
navigate to the second page via the pagination component
notice the blank pages where you get stuck

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
