### PR TITLE
Make health filters case insensitive

### DIFF
--- a/components/applications-service/pkg/storage/postgres/services.go
+++ b/components/applications-service/pkg/storage/postgres/services.go
@@ -588,12 +588,12 @@ func buildHealthStatementFromValues(values []string) (string, error) {
 		if secondStatement {
 			ORConstraint = ORConstraint + " OR "
 		}
-		switch value {
+		switch strings.ToLower(value) {
 		case "disconnected":
 			ORConstraint = " disconnected"
 		case "connected":
 			ORConstraint = " disconnected = false"
-		case "CRITICAL", "WARNING", "UNKNOWN", "OK":
+		case "critical", "warning", "unknown", "ok":
 			ORConstraint = ORConstraint + fmt.Sprintf("%s = '%s'", "health",
 				pgutils.EscapeLiteralForPG(strings.ToUpper(value)))
 		default:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixes health filtering in the apps tab sidebar, which currently causes data validation failures in the API.

In #4339 we changed the status filters in the API supporting the apps tab sidebar to support filtering for connected services. Changes to the logic made the filter input for health status case-sensitive, where it had been case insensitive before. The UI sends lowercase filters, which are being rejected as "unknown" values.

### :athletic_shoe: How to Build and Test the Change

* start all services
* `applications_populate_database`
* visit the apps tab, select any service group, then click the filters in the sidebar. You will always see 0 results and "None of the services returned <your selection>"
* build applications service, wait for it to deploy
* visit the apps tab, select any service group, then click the filters in the sidebar. It works like it should
