### PR TITLE
tests: don't check cert validity period for internal CA

### DIFF
--- a/integration/helpers/ssl_filters.jq
+++ b/integration/helpers/ssl_filters.jq
@@ -13,6 +13,7 @@ map(select(
          # The checker wants your certs to be valid for less than 398 days. We
          # don't think this rule is valuable for the internal A2 CA
          (.id != "cert_validityPeriod" or .port == "443" ) and
+         (.id != "cert_extlifeSpan" or .port == "443") and
 
          # TODO notifications-service
          (.port != "10125") and
@@ -22,6 +23,7 @@ map(select(
          (.id != "cert_caIssuers" or .port != "443") and        # Test uses self-signed cert
          (.id != "cert_chain_of_trust" or .port != "443") and   # Test uses self-signed cert
          (.id != "cert_validityPeriod" or .port != "443") and   # Test uses self-signed cert
+         (.id != "cert_extlifeSpan" or .port != "443") and      # Test uses self-signed cert
 
          # automate-builder-memcache doesn't allow us to set server cipher order
          (.id != "cipher_order" or .port != "10102") and


### PR DESCRIPTION
We already put in a filter to ignore this check in
3a2e03b6e9e57bae4cd6fcf12c38fb153453cc11 but it appears that
drwetter/testssl.sh#1741 changed the name of the check.

Signed-off-by: Steven Danna <steve@chef.io>