### PR TITLE
Introduce semgrep security/language validation

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -12,7 +12,11 @@ steps:
         docker:
           image: returntocorp/semgrep:latest
           entrypoint: semgrep
-          command: ["--error", "--config", "/go/src/github.com/chef/automate/semgrep" ]
+          command: [
+            "--error",
+            "--config", "/go/src/github.com/chef/automate/semgrep",
+            "/go/src/github.com/chef/automate"
+          ]
 
   #
   # A2 protobufs - Detect if there is any component that has protobuf files that hasn't been compiled

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -12,7 +12,7 @@ steps:
         docker:
           image: returntocorp/semgrep:latest
           entrypoint: semgrep
-          command: ["--error", "--config", "/workdir/semgrep" ]
+          command: ["--error", "--config", "/go/src/github.com/chef/automate/semgrep" ]
 
   #
   # A2 protobufs - Detect if there is any component that has protobuf files that hasn't been compiled

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -5,6 +5,15 @@ expeditor:
         workdir: /go/src/github.com/chef/automate
 
 steps:
+
+  - label: ":semgrep: Semgrep"
+    expeditor:
+      executor:
+        docker:
+          image: returntocorp/semgrep:latest
+          entrypoint: semgrep
+          command: ["--error", "--config", "/workdir/semgrep" ]
+
   #
   # A2 protobufs - Detect if there is any component that has protobuf files that hasn't been compiled
   #

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -5,19 +5,6 @@ expeditor:
         workdir: /go/src/github.com/chef/automate
 
 steps:
-
-  - label: ":semgrep: Semgrep"
-    expeditor:
-      executor:
-        docker:
-          image: returntocorp/semgrep:latest
-          entrypoint: semgrep
-          command: [
-            "--error",
-            "--config", "/go/src/github.com/chef/automate/semgrep",
-            "/go/src/github.com/chef/automate"
-          ]
-
   #
   # A2 protobufs - Detect if there is any component that has protobuf files that hasn't been compiled
   #
@@ -73,6 +60,18 @@ steps:
           environment:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
+
+  - label: ":semgrep: Semgrep"
+    expeditor:
+      executor:
+        docker:
+          image: returntocorp/semgrep:latest
+          entrypoint: semgrep
+          command: [
+            "--error",
+            "--config", "/go/src/github.com/chef/automate/semgrep",
+            "/go/src/github.com/chef/automate"
+          ]
 
   #
   # Static & Unit tests

--- a/Makefile.common_go
+++ b/Makefile.common_go
@@ -46,4 +46,17 @@ spell:
 	popd > /dev/null; \
 	exit $$EXIT_CODE
 
-.PHONY: lint fmt fmt-check golang_version_check
+#: Security validation via semgrep
+# NB: "third_party" only exists for automate-gateway, but no harm having it for other dirs here.
+semgrep:
+# uncomment if custom rules beyond automate-ui ever get added
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --autofix
+
+#: Security validation via semgrep; autofix where possible
+semgrep-and-fix:
+# uncomment if custom rules beyond automate-ui ever get added
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --autofix
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --autofix
+
+.PHONY: lint fmt fmt-check golang_version_check semgrep semgrep-and-fix

--- a/components/automate-ui/Makefile
+++ b/components/automate-ui/Makefile
@@ -8,6 +8,7 @@ COMPONENT_FLAGS := --prefix $(COMPONENT_PREFIX) --export true
 DEMO_DIR := pages/component-library/demos
 DEMO_FLAGS := --spec false
 NG_CMD := npm run ng --
+REPOROOT=../..
 
 install:
 	npm install
@@ -37,6 +38,16 @@ lint-html:
 
 lint-typescript:
 	npm run lint
+
+#: Security validation via semgrep
+semgrep:
+	semgrep --config $(REPOROOT)/semgrep
+	semgrep --config https://semgrep.dev/p/r2c-ci --autofix
+
+#: Security validation via semgrep; autofix where possible
+semgrep-and-fix:
+	semgrep --config $(REPOROOT)/semgrep --autofix
+	semgrep --config https://semgrep.dev/p/r2c-ci --autofix
 
 pr-ready: unit-all-browsers lint e2e
 
@@ -86,10 +97,10 @@ page-component/%:
 
 # Adapted from Makefile.common_go
 spell:
-	@pushd ../.. > /dev/null; \
+	@pushd $(REPOROOT) > /dev/null; \
 	./scripts/spellcheck.sh components/automate-ui; \
 	EXIT_CODE=$$?; \
 	popd > /dev/null; \
 	exit $$EXIT_CODE
 
-.PHONY: build install test lint unit e2e lint-sass lint-typescript license_scout peer-dependencies e2e-aot unit-all-browsers pr-ready start
+.PHONY: build install test lint lint-html lint-sass lint-typescript semgrep semgrep-and-fix unit e2e license_scout peer-dependencies e2e-aot unit-all-browsers pr-ready start

--- a/components/automate-ui/src/app/components/authorized/authorized.component.ts
+++ b/components/automate-ui/src/app/components/authorized/authorized.component.ts
@@ -79,7 +79,6 @@ export class AuthorizedComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.cdr.detach();
     this.subscription.unsubscribe();
-    this.authorizedChecker.destroy();
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }

--- a/components/automate-ui/src/app/components/form-control/form-control.directive.ts
+++ b/components/automate-ui/src/app/components/form-control/form-control.directive.ts
@@ -71,14 +71,14 @@ export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
   constructor(private control: NgControl) {}
 
   private originalValue: any;
-  private isDestroyed$ = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
 
   ngOnInit(): void {
     this.setOriginalValue();
 
     this.control.valueChanges
       .pipe(
-        takeUntil(this.isDestroyed$),
+        takeUntil(this.isDestroyed),
         distinctUntilChanged()
       )
       .subscribe(newValue => {
@@ -96,8 +96,8 @@ export class FormControlDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy(): void {
-    this.isDestroyed$.next(true);
-    this.isDestroyed$.complete();
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/automate-ui/src/app/helpers/auth/authorized.ts
+++ b/components/automate-ui/src/app/helpers/auth/authorized.ts
@@ -1,6 +1,6 @@
 import { Store } from '@ngrx/store';
-import { Subject, Observable } from 'rxjs';
-import { takeUntil, map as rxjsMap, filter, debounceTime } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map as rxjsMap, filter, debounceTime } from 'rxjs/operators';
 import {
   isArray,
   isEmpty,
@@ -34,12 +34,10 @@ export class AuthorizedChecker {
   private placeholderRE = /\{[^{]+\}/;
   private allOf: CheckObj[] = [];
   private anyOf: CheckObj[] = [];
-  private isDestroyed = new Subject<boolean>();
 
   constructor(private store: Store<NgrxStateAtom>) {
     this.isAuthorized$ =
       this.store.select(allPerms).pipe(
-        takeUntil(this.isDestroyed),
         debounceTime(AuthorizedChecker.DebounceTime),
         filter(perms => !isEmpty(perms)),
         filter(() => !isEmpty(this.allOf) || !isEmpty(this.anyOf)),
@@ -72,11 +70,6 @@ export class AuthorizedChecker {
       }
     });
     return inputs;
-  }
-
-  destroy() {
-    this.isDestroyed.next(true);
-    this.isDestroyed.complete();
   }
 
   // For a parameterized endpoint, we need to check the inflated endpoint--

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.ts
@@ -25,7 +25,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
   @Input() orgId: string;
   @Output() resetKeyRedirection = new EventEmitter<boolean>();
 
-  private isDestroyed$ = new Subject<boolean>();
+  private isDestroyed = new Subject<boolean>();
   public cookbooks: Cookbook[] = [];
   public cookbooksListLoading = true;
   public authFailure = false;
@@ -45,7 +45,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
     combineLatest([
       this.store.select(getAllCookbooksForOrgStatus),
       this.store.select(allCookbooks)
-    ]).pipe(takeUntil(this.isDestroyed$))
+    ]).pipe(takeUntil(this.isDestroyed))
     .subscribe(([ getCookbooksSt, allCookbooksState]) => {
       if (getCookbooksSt === EntityStatus.loadingSuccess && !isNil(allCookbooksState)) {
         this.cookbooks = allCookbooksState;
@@ -62,7 +62,7 @@ export class CookbooksComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.isDestroyed$.next(true);
-    this.isDestroyed$.complete();
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -104,7 +104,7 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.isDestroyed.next();
+    this.isDestroyed.next(true);
     this.isDestroyed.complete();
   }
 }

--- a/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-notifications/license-notifications.component.ts
@@ -13,7 +13,7 @@ import { Notification } from 'app/entities/notifications/notification.model';
 })
 export class LicenseNotificationsComponent implements OnDestroy {
   @Output() triggerApplyLicense = new EventEmitter<LicenseApplyReason>();
-  private isDestroyed$: Subject<boolean> = new Subject<boolean>();
+  private isDestroyed: Subject<boolean> = new Subject<boolean>();
 
   notifications: Notification[];
 
@@ -23,7 +23,7 @@ export class LicenseNotificationsComponent implements OnDestroy {
   ) {
     this.licenseFacade.notifications$
       .pipe(
-        takeUntil(this.isDestroyed$),
+        takeUntil(this.isDestroyed),
         distinctUntilChanged()
       ).subscribe(notifications => {
       this.notifications = notifications.filter((n) => n.type === 'license');
@@ -32,8 +32,8 @@ export class LicenseNotificationsComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.isDestroyed$.next(true);
-    this.isDestroyed$.complete();
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
   }
 
   handleNotificationDismissal(id: string): void {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -388,9 +388,6 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
-    if (this.authorizedChecker) {
-      this.authorizedChecker.destroy();
-    }
   }
 
   toggleFilters() {

--- a/semgrep/rxjs-subscription.yaml
+++ b/semgrep/rxjs-subscription.yaml
@@ -1,0 +1,116 @@
+rules:
+
+  - id: naming-for-isDestroyed
+    pattern: this.isDestroyed$.complete()
+    message: "'isDestroyed$' should be 'isDestroyed'"
+    languages: [ts]
+    severity: ERROR
+
+
+  - id: isDestroyed-needs-argument
+    pattern: this.isDestroyed.next()
+    message: must have a `true` argument
+    fix: this.isDestroyed.next(true)
+    languages: [ts]
+    severity: ERROR
+
+
+  - id: isDestroyed-used-but-not-triggered
+    patterns:
+    - pattern: $OBSERVABLE.pipe(...,takeUntil(this.isDestroyed),...).subscribe(...)
+    - pattern-inside: |
+        class $CLASS {
+          ...
+        }
+    - pattern-not-inside: |
+        class $CLASS {
+          ...
+          ngOnDestroy() {
+            ...
+          }
+          ...
+        }
+    message: isDestroyed never triggered from ngOnDestroy
+    languages: [ts]
+    severity: ERROR
+
+
+  - id: isDestroyed-triggered-but-not-used
+    patterns:
+    - pattern: this.isDestroyed.next(true);
+    - pattern-inside: |
+        class $CLASS {
+          ...
+        }
+    - pattern-not-inside: |
+        class $CLASS {
+          ...
+          $FUNC(...) {
+            ...
+            $OBSERVABLE.pipe(...,takeUntil(this.isDestroyed),...).subscribe(...);
+            ...
+          }
+          ...
+        }
+    message: isDestroyed never used with takeUntil()
+    metadata: {
+      falseNegative: will not catch multiple subscriptions with takeUntil missing on some
+      }
+    languages: [ts]
+    severity: ERROR
+
+
+  - id: ngOnDestroy-missing-next
+    patterns:
+    - pattern: |
+        class $CLASS {
+          ...
+          ngOnDestroy() {
+            ...
+            this.isDestroyed.complete(...);
+            ...
+          }
+        ...
+        }
+    - pattern-not: |
+        class $CLASS {
+          ...
+          ngOnDestroy() {
+            ...
+            this.isDestroyed.next(...);
+            this.isDestroyed.complete(...);
+            ...
+          }
+          ...
+        }
+    message: ngOnDestroy missing this.isDestroyed.next()
+    languages: [ts]
+    severity: ERROR
+
+
+  - id: ngOnDestroy-missing-complete
+    patterns:
+    - pattern: |
+        class $CLASS {
+          ...
+          ngOnDestroy() {
+            ...
+            this.isDestroyed.next(...);
+            ...
+          }
+        ...
+        }
+    - pattern-not: |
+        class $CLASS {
+          ...
+          ngOnDestroy() {
+            ...
+            this.isDestroyed.next(...);
+            this.isDestroyed.complete(...);
+            ...
+          }
+          ...
+        }
+    message: ngOnDestroy missing this.isDestroyed.complete()
+    languages: [ts]
+    severity: ERROR

--- a/semgrep/rxjs-syntax.yaml
+++ b/semgrep/rxjs-syntax.yaml
@@ -1,0 +1,12 @@
+rules:
+
+  - id: combineLatest-not-combining
+    pattern: combineLatest([$SINGLE_EXPRESSION])
+    fix:  $SINGLE_EXPRESSION.
+    message: replace combineLatest with a single operand is not useful
+    metadata: {
+      todo: "remove dot in fix once bug is fixed (https://github.com/returntocorp/semgrep/issues/1721)"
+      }
+    languages: [ts]
+    severity: WARNING
+ 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Semgrep provides security validation via published rulesets for a variety of languages, including Go and soon TypeScript (now in alpha); see https://semgrep.dev/ for current offerings and ruleset browsing. It also allows writing arbitrary language validation rules, i.e. non-specific to security concerns, but rather to enforce conventions or patterns that the team views as "best practice".

## Focus of this PR

This PR introduces custom semgrep rules focussing on **rxjs lifecycle management**. The patterns required to properly manage rxjs subscriptions are both "best practice" and necessary, yet cannot be enforced by the compiler. Semgrep, though, provides just the mechanism to enforce these patterns.

Here are the rules I have introduced, separated into two files a la the single responsibility principle. All files in the semgrep directory are pulled in automatically.
```
rxjs-subscription.yaml
 - naming-for-isDestroyed
 - isDestroyed-needs-argument
 - isDestroyed-used-but-not-triggered
 - isDestroyed-triggered-but-not-used
 - ngOnDestroy-missing-next
 - ngOnDestroy-missing-complete

rxjs-syntax.yaml
 - combineLatest-not-combining
```

You can see the errors exposed (before fixes in this PR were applied) from this buildkite run:
https://buildkite.com/chef-oss/chef-automate-master-verify/builds/14170#d286ce19-5fb3-4276-a85f-6edadb38bbd6

Here is the error output there:
<img width="816" alt="image" src="https://user-images.githubusercontent.com/6817500/95401900-425d7c80-08c3-11eb-9400-f8d32122386a.png">

Note: some time ago a couple of us (@scottopherson and myself, maybe others) were suggesting that both Observables and things derived from them (Subjects, ReplaySubjects) should use [Finnish notation](https://medium.com/@benlesh/observables-and-finnish-notation-df8356ed1c9b) -- end with a dollar sign ($) -- but that is not the way the code base is at present. Before this commit, about 97% of `isDestroyed` instances existed vs. 3% of `isDestroyed$`. So to minimize changes I just went with the flow for now and implemented the rule to enforce it without the dollar sign. (If someone wants to follow-up globally switching all of them the other way, that is fine, too.)

## More on Semgrep

Semgrep comes in two flavors, **semgrep** and **semgrep agent**. The latter is currently in private beta (which we are participating in) and will eventually be more useful as an enterprise management tool. This is the dashboard for semgrep agent--looks sort of familiar, eh, auth-team? In theory, any Chef logging in to https://semgrep.dev/manage/projects has access to this dashboard.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/6817500/95031586-a8e85d80-066b-11eb-9578-cc12c16bbb94.png">

In a nutshell, here are my learnings for both of them:
<img width="811" alt="image" src="https://user-images.githubusercontent.com/6817500/95603081-a6d72380-0a0a-11eb-9644-1214e84fd781.png">


I am starting us out with the `r2c-ci` ruleset, provided by r2c. There is also an eponymous `r2c` ruleset that is the default if no rulesets are specified. There is a lot of overlap between the two, but neither is a subset of the other. I inquired about the difference: `r2c-ci` is the "kinder, gentler" version. Paraphrasing our friends at r2c: it includes rules that would not be annoying; those that largely everyone would say, "oh, yeah, we should fix that".

Note that `r2c-ci` includes (at the time of writing) 103 rules but not too many of those are for Go (and none are for TypeScript). I am assured that there is no performance penalty because rules are only applied if a given file has the appropriate extension matching the rule.

Like lint, semgrep can automatically fix rules that have been instrumented to support it; just add `--autofix` to the semgrep command. This applies equally to published rules as well as our own custom rules.

I have added `semgrep` and `semgrep-and-fix` as make targets in Makefile.common_go, so they are available to all Go projects, and automate-ui/Makefile for the UI.  Semgrep applies rules based on file extensions, so if you have a Go project it will only be running the Go rules (and perhaps the JSON rules if there are also JSON files in the project). It is thus safe--and prudent--to run semgrep at any level of the source tree, including the root of the repository, as is done in CI.

Semgrep Docs: https://github.com/returntocorp/semgrep/tree/develop/docs
Semgrep Action Docs: https://github.com/returntocorp/semgrep-action

### :+1: Definition of Done

Buildkite has a new badge. (Note that once my PR to introduce a Semgrep icon gets approved, that `:semgrep:` tag will turn into an icon.)
<img width="920" alt="image" src="https://user-images.githubusercontent.com/6817500/95404554-388b4780-08ca-11eb-8281-66bfc62b383b.png">


### :athletic_shoe: How to Build and Test the Change

To run locally, install semgrep via homebrew; run as shown in the chart above. If you wanted to expose a failure, you could selectively revert any of the fix commits in this PR.

If you want to play with semgrep agent, I would be happy to provide the ID and token.

### Blocker with Semgrep Agent

It would be preferable to run Semgrep Agent instead of just Semgrep in CI, but I have not done that in this PR. Semgrep Agent needs an ID, which we can hard-code, and a token, which should be treated as a secret. I attempted to hook it up in buildkite following the secrets used in Automate, with this alternate recipe:
```
  - label: "Semgrep"
    command:
      - python -m semgrep_agent --publish-token $SEMGREP_TOKEN --publish-deployment CHEF_ID
    expeditor:
      secrets:
        SEMGREP_TOKEN:
          path: secret/chef-cloud/semgrep
          field: publish-token
      executor:
        docker:
          image: returntocorp/semgrep-action:v1
          workdir: /chef-cloud
```
But buildkite failed on the first step:
```
/app/lib/expeditor/cli/buildkite/executor/docker.rb:65:in `initialize':
accounts and secrets not supported
with 'returntocorp/semgrep action:v1'
```
According to @tduffield, we have no means to inject secrets into container images we don't build/own. To move forward we would need to install semgrep into the chefes/buildkite image, as @tduffield has suggested. But see next section...

### But Do We Need Semgrep Agent?
Though it would be nice to have the on-the-fly configurability provided in the GUI, plus soon to be tracking and stats, we can get by without it for the time being. One driving factor would be if we had either (a) more than one published ruleset we wanted to use regularly, or (b) wanting to publish our custom rules to multiple rulesets. The reason for both is that with the base semgrep, you can only specify a single ruleset per Buildkite task due to the way the semgrep docker image was constructed (with the entrypoint mode).
For our custom rules, at present I think it makes sense to commit those in the working repositories. Currently, I am only instrumenting chef-cloud and automate (a little bit of duplication, if it manifests, never hurt anyone, right...?). My plan is to have one Buildkite task against a published, public ruleset (`r2c-ci`) and a separate Buildkite task for Chef custom rules. (This PR, by the way, contains just the Chef custom rules; another PR will handle the `r2c-ci` and its necessary fixes.)

By the way, one very cool thing about semgrep agent--it is designed to be painless to turn on: it will only flag **new** things rather than flagging everything-you-have-previously-done-wrong in your code base, giving you breathing room to go back and fix the technical debt whenever you wish.

### :chains: Related Resources
https://github.com/chef/chef-cloud/pull/385

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

