### PR TITLE
automate-dex: don't hardcode 24hrs expiry for saml, make it configurable

### DIFF
--- a/api/config/dex/config_request.go
+++ b/api/config/dex/config_request.go
@@ -41,8 +41,6 @@ func DefaultConfigRequest() *ConfigRequest {
 	c.V1.Sys.Service.Host = w.String("127.0.0.1")
 	c.V1.Sys.Service.Port = w.Int32(10117)
 
-	c.V1.Sys.Expiry.IdTokens = w.String("3m")
-
 	c.V1.Sys.Bootstrap.InsecureAdmin = w.Bool(false)
 
 	c.V1.Sys.Log.Level = w.String("info")
@@ -168,6 +166,15 @@ func (c *ConfigRequest) PrepareSystemConfig(creds *shared.TLSCredentials) (share
 
 	// default name_id_policy_format (SAML)
 	c.V1.Sys.GetConnectors().GetSaml().setNameIDPolicyDefault()
+
+	if c.V1.Sys.GetExpiry().GetIdTokens() == nil {
+		// Different defaults when SAML is or isn't used
+		if c.V1.Sys.GetConnectors().GetSaml() != nil {
+			c.V1.Sys.Expiry.IdTokens = w.String("24h")
+		} else {
+			c.V1.Sys.Expiry.IdTokens = w.String("3m")
+		}
+	}
 
 	return c.V1.Sys, nil
 }

--- a/api/config/dex/config_request_test.go
+++ b/api/config/dex/config_request_test.go
@@ -30,6 +30,18 @@ func TestValidate(t *testing.T) {
 		assert.NoError(t, cfg.Validate())
 	})
 
+	t.Run("Validates when the id_token expiry is too short", func(t *testing.T) {
+		cfg := dex.DefaultConfigRequest()
+		cfg.V1.Sys.Expiry.IdTokens = w.String("2m59s")
+		assert.Error(t, cfg.Validate())
+	})
+
+	t.Run("Validates when the id_token expiry is invalid", func(t *testing.T) {
+		cfg := dex.DefaultConfigRequest()
+		cfg.V1.Sys.Expiry.IdTokens = w.String("never")
+		assert.Error(t, cfg.Validate())
+	})
+
 	t.Run("Fails when there are no connectors and local users are disabled", func(t *testing.T) {
 		cfg := dex.DefaultConfigRequest()
 		cfg.V1.Sys.Connectors.DisableLocalUsers = w.Bool(true)

--- a/components/automate-dex/habitat/templates/config.yml
+++ b/components/automate-dex/habitat/templates/config.yml
@@ -239,9 +239,4 @@ staticPasswords:
 
 expiry:
   signingKeys: {{cfg.expiry.signing_keys}}
-  {{- if cfg.connectors.saml}}
-  # SAML is being used, so we cannot tweak ID token expiry
-  idTokens: 24h
-  {{- else}}
   idTokens: {{cfg.expiry.id_tokens}}
-  {{- end}}


### PR DESCRIPTION
If unset, it's still going to be 24hrs when SAML is used. However, it can now be
overridden if desired.

If it's set to something too small, like one minute, you'll end up in a sign-in
loop.

## 🔧 

`rebuild components/automate-dex` and play with the existing id_token expiry setting, e.g.
```toml
[dex.v1.sys.expiry]
id_tokens = "10m"
[dex.v1.sys.connectors]
disable_local_users = true
```

sign in using saml, wait for 10 minutes, see what happens ✨ 