### PR TITLE
Add semgrep buildkite task for published rules

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -84,6 +84,7 @@ steps:
             "--exclude", "third_party",
             "--exclude", "*_test.go",
             "--exclude", "*.pb.go",
+            "--exclude", "*.bindata.go",
             "--exclude", "*.spec.ts",
             "--timeout", "120",
             "--config", "https://semgrep.dev/p/r2c-ci",

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -61,7 +61,7 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  - label: ":semgrep: Semgrep"
+  - label: ":semgrep: Custom"
     expeditor:
       executor:
         docker:
@@ -70,6 +70,23 @@ steps:
           command: [
             "--error",
             "--config", "/go/src/github.com/chef/automate/semgrep",
+            "/go/src/github.com/chef/automate"
+          ]
+
+  - label: ":semgrep: Published"
+    expeditor:
+      executor:
+        docker:
+          image: returntocorp/semgrep:latest
+          entrypoint: semgrep
+          command: [
+            "--error",
+            "--exclude", "third_party",
+            "--exclude", "*_test.go",
+            "--exclude", "*.pb.go",
+            "--exclude", "*.spec.ts",
+            "--timeout", "120",
+            "--config", "https://semgrep.dev/p/r2c-ci",
             "/go/src/github.com/chef/automate"
           ]
 

--- a/Makefile.common_go
+++ b/Makefile.common_go
@@ -50,13 +50,13 @@ spell:
 # NB: "third_party" only exists for automate-gateway, but no harm having it for other dirs here.
 semgrep:
 # uncomment if custom rules beyond automate-ui ever get added
-#	semgrep --config $(REPOROOT)/semgrep --exclude third_party
-	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --autofix
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go
 
 #: Security validation via semgrep; autofix where possible
 semgrep-and-fix:
 # uncomment if custom rules beyond automate-ui ever get added
-#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --autofix
-	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --autofix
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go --autofix
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go --autofix
 
 .PHONY: lint fmt fmt-check golang_version_check semgrep semgrep-and-fix

--- a/Makefile.common_go
+++ b/Makefile.common_go
@@ -50,13 +50,13 @@ spell:
 # NB: "third_party" only exists for automate-gateway, but no harm having it for other dirs here.
 semgrep:
 # uncomment if custom rules beyond automate-ui ever get added
-#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go
-	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go --exclude *.bindata.go
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go --exclude *.bindata.go
 
 #: Security validation via semgrep; autofix where possible
 semgrep-and-fix:
 # uncomment if custom rules beyond automate-ui ever get added
-#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go --autofix
-	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go --autofix
+#	semgrep --config $(REPOROOT)/semgrep --exclude third_party --exclude *_test.go --exclude *.pb.go --exclude *.bindata.go --autofix
+	semgrep --config https://semgrep.dev/p/r2c-ci --exclude third_party --exclude *_test.go --exclude *.pb.go --exclude *.bindata.go --autofix
 
 .PHONY: lint fmt fmt-check golang_version_check semgrep semgrep-and-fix

--- a/api/config/cs_nginx/config_request.go
+++ b/api/config/cs_nginx/config_request.go
@@ -174,6 +174,6 @@ func (c *ConfigRequest) PrepareSystemConfig(creds *ac.TLSCredentials) (ac.Prepar
 //  Digest::MD5.base64digest
 //
 func CalculateContentMD5(data []byte) string {
-	md5sum := md5.Sum(data)
+	md5sum := md5.Sum(data) // nosem
 	return base64.StdEncoding.EncodeToString(md5sum[:])
 }

--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -100,13 +100,14 @@ func (dl *netHabDownloader) DownloadHabBinary(version string, release string, w 
 		return errors.Errorf("Could not get hab binary. Got status %s", resp.Status)
 	}
 
-	gzipReader, err := gzip.NewReader(resp.Body)
-
+	// NOTE: We're downloading this via HTTPS from a location that's trusted.
+	gzipReader, err := gzip.NewReader(resp.Body) // nosem: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
 	if err != nil {
 		return errors.Wrap(err, "Failed to download hab binary. Could not open gzip")
 	}
 
-	tarReader := tar.NewReader(gzipReader)
+	// NOTE: See above.
+	tarReader := tar.NewReader(gzipReader) // nosem: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
 	for {
 		hdr, err := tarReader.Next()
 		if err == io.EOF {

--- a/components/automate-deployment/pkg/backup/artifact_repo.go
+++ b/components/automate-deployment/pkg/backup/artifact_repo.go
@@ -629,7 +629,8 @@ func (repo *ArtifactRepo) openGzipFile(ctx context.Context, name string) (*os.Fi
 		return nil, "", err
 	}
 
-	g, err := gzip.NewReader(reader)
+	// NOTE: This reads a backup archive, provided by an admin. It's trusted input.
+	g, err := gzip.NewReader(reader) // nosem: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
 	if err != nil {
 		logClose(tmpFile, "failed to close temp file")
 		return nil, "", err

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -744,7 +744,7 @@ func (s *server) ConfigureDeployment(ctx context.Context,
 	}
 
 	deploymentStatus := s.deployment.Status()
-	configSHA1 := sha1.Sum([]byte(overrideConfig.String()))
+	configSHA1 := sha1.Sum([]byte(overrideConfig.String())) // nosem
 
 	logrus.WithFields(logrus.Fields{
 		"config_sha1": fmt.Sprintf("%x", configSHA1),

--- a/components/automate-gateway/pkg/nullbackend/backend.go
+++ b/components/automate-gateway/pkg/nullbackend/backend.go
@@ -34,7 +34,9 @@ import (
 
 // NewServer returns a pointer to a new instance of the null backend server
 func NewServer() *grpc.Server {
-	s := grpc.NewServer()
+	// The nullbackend only listens on a unix socket. And it doesn't deal with interesting data,
+	// but only "no implemented" responses.
+	s := grpc.NewServer() // nosem
 
 	applications.RegisterApplicationsServiceServer(s, &applications.UnimplementedApplicationsServiceServer{})
 	cds.RegisterCdsServer(s, &cds.UnimplementedCdsServer{})

--- a/components/automate-gateway/pkg/nullbackend/backend.go
+++ b/components/automate-gateway/pkg/nullbackend/backend.go
@@ -36,7 +36,7 @@ import (
 func NewServer() *grpc.Server {
 	// The nullbackend only listens on a unix socket. And it doesn't deal with interesting data,
 	// but only "no implemented" responses.
-	s := grpc.NewServer() // nosem
+	s := grpc.NewServer() // nosem: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 
 	applications.RegisterApplicationsServiceServer(s, &applications.UnimplementedApplicationsServiceServer{})
 	cds.RegisterCdsServer(s, &cds.UnimplementedCdsServer{})

--- a/components/cereal-service/cmd/cereal-service/cmd.go
+++ b/components/cereal-service/cmd/cereal-service/cmd.go
@@ -146,7 +146,7 @@ func serve(*cobra.Command, []string) error {
 	}
 
 	if C.Service.DisableTLS {
-		grpcServer = grpc.NewServer(grpcServerOpts...)
+		grpcServer = grpc.NewServer(grpcServerOpts...) // nosem: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 	} else {
 		serviceCerts, err := C.TLS.ReadCerts()
 		if err != nil {

--- a/components/compliance-service/reporting/util/zip.go
+++ b/components/compliance-service/reporting/util/zip.go
@@ -18,7 +18,10 @@ import (
 
 // Zip2Path extracts a zip file on disk to a destination folder on disk.
 func Zip2Path(zipPath string, extractPath string) error {
-	reader, err := zip.OpenReader(zipPath)
+	// TODO(sr): This is not entirely ignorable, but worse things can happen
+	// when a user uploads an inspec profile. So, let's keep it in mind but
+	// move on.
+	reader, err := zip.OpenReader(zipPath) // nosem: go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb
 	if err != nil {
 		return err
 	}

--- a/lib/grpc/secureconn/factory.go
+++ b/lib/grpc/secureconn/factory.go
@@ -86,7 +86,7 @@ func (f *Factory) DialContext(
 // the factory's root CA
 func (f *Factory) NewServer(opt ...grpc.ServerOption) *grpc.Server {
 	// f.ServerOptions() includes TLS settings, so this is not insecure (semgrep thinks so)
-	s := grpc.NewServer(append(f.ServerOptions(), opt...)...) // nosem
+	s := grpc.NewServer(append(f.ServerOptions(), opt...)...) // nosem: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 
 	if !f.DisableDebugServer {
 		debug_api.RegisterDebugServer(s, debug.NewDebugServer(f.DebugServerOpts...))

--- a/lib/grpc/secureconn/factory.go
+++ b/lib/grpc/secureconn/factory.go
@@ -85,7 +85,8 @@ func (f *Factory) DialContext(
 // NewServer is a wrapper for grpc.NewServer that adds server options to verify clients using
 // the factory's root CA
 func (f *Factory) NewServer(opt ...grpc.ServerOption) *grpc.Server {
-	s := grpc.NewServer(append(f.ServerOptions(), opt...)...)
+	// f.ServerOptions() includes TLS settings, so this is not insecure (semgrep thinks so)
+	s := grpc.NewServer(append(f.ServerOptions(), opt...)...) // nosem
 
 	if !f.DisableDebugServer {
 		debug_api.RegisterDebugServer(s, debug.NewDebugServer(f.DebugServerOpts...))

--- a/tools/cereal-scaffold/main.go
+++ b/tools/cereal-scaffold/main.go
@@ -234,7 +234,7 @@ func runResetDB(_ *cobra.Command, args []string) error {
 
 func getBackend() cereal.Driver {
 	if opts.Endpoint != "" {
-		conn, err := grpc.Dial(opts.Endpoint, grpc.WithInsecure(), grpc.WithMaxMsgSize(64*1024*1024))
+		conn, err := grpc.Dial(opts.Endpoint, grpc.WithInsecure(), grpc.WithMaxMsgSize(64*1024*1024)) // nosem: go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This is a follow-on to "Introduce semgrep security/language validation" (PR #4395). That first PR added a buildkite task for running custom validation rules--rules that we write--to validate whatever conventions we want. This PR adds a second buildkite task for using published rulesets (that focus mainly on security validations).

**TO DO: I have added the validation that reports the failures, but I have not addressed some of the fixes. The associated issue has prior discussion over these with suggestions on what is needed. Looking for team collaboration to address these.**

Our starting point was 12 findings but only 3 types of errors there:
A. go.lang.security.audit.crypto.bad_imports.insecure-module-used: Insecure module used.
B. go.lang.security.decompression_bomb.potential-dos-via-decompression-bomb: Potential DOS via zip bomb attack
C. go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection: Found an insecure gRPC connection.

See the details here: https://buildkite.com/chef-oss/chef-automate-master-verify/builds/14196#3fb5498f-9a8c-4bab-ba99-95c6b32eb6b8

#### Remediation -- Step 1
Per notes from the associated issue (#4383), I added ignore flags for the few instances of (A), leaving just 8 findings to address for (B) and (C):
https://buildkite.com/chef-oss/chef-automate-master-verify/builds/14198#300d1713-b7c5-494d-83e4-626d2a496eab

### :chains: Related Resources
PR #4395

### :+1: Definition of Done
Buildkite task is green.

### :athletic_shoe: How to Build and Test the Change
From any go project in automate you can run `make semgrep` to check for violations, or `make semgrep-and-fix` to check and fix those that are auto-fixable. (Same `make` commands are also available for the UI component, automate-ui.)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

