### PR TITLE
Refine semgrep rules to have cleaner output

### DIFF
--- a/semgrep/rxjs-subscription.yaml
+++ b/semgrep/rxjs-subscription.yaml
@@ -62,7 +62,8 @@ rules:
 
   - id: ngOnDestroy-missing-next
     patterns:
-    - pattern: |
+    - pattern: this.isDestroyed.complete(...)
+    - pattern-inside: |
         class $CLASS {
           ...
           ngOnDestroy() {
@@ -72,7 +73,7 @@ rules:
           }
         ...
         }
-    - pattern-not: |
+    - pattern-not-inside: |
         class $CLASS {
           ...
           ngOnDestroy() {
@@ -90,7 +91,8 @@ rules:
 
   - id: ngOnDestroy-missing-complete
     patterns:
-    - pattern: |
+    - pattern: this.isDestroyed.next(...)
+    - pattern-inside: |
         class $CLASS {
           ...
           ngOnDestroy() {
@@ -100,7 +102,7 @@ rules:
           }
         ...
         }
-    - pattern-not: |
+    - pattern-not-inside: |
         class $CLASS {
           ...
           ngOnDestroy() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

One must take care when writing semgrep rules that the actual matched pattern is as concise as possible. Before the change in this commit, the pattern was matching a class, so the entire class is output by semgrep:
```
severity:error rule:Users.msorens.code.go.src.github.com.chef.automate.semgrep.ngOnDestroy-missing-complete: ngOnDestroy missing this.isDestroyed.complete()
17:export class ProjectsDropdownComponent implements OnInit, OnDestroy, OnChanges {
18:

... omitting 60 or so lines here!!

79:  onProjectDropdownClosing(ids: string[]): void {
80:    this.onDropdownClosing.emit(ids);
81:  }
82:
83:}

```

With the change to the pattern, the output is now just this single line:
```
severity:error rule:Users.msorens.code.go.src.github.com.chef.automate.semgrep.ngOnDestroy-missing-complete: ngOnDestroy missing this.isDestroyed.complete()
58:    this.isDestroyed.next(true);
```

### :chains: Related Resources
PR #4395 Introduce semgrep security/language validation

### :+1: Definition of Done
Rules that had verbose output now have single-line output.

### :athletic_shoe: How to Build and Test the Change
Edit any file UI implementing `OnDestroy`, e.g. projects-dropdown/projects-dropdown.component.ts,
commenting out either `this.isDestroyed.next(true)` or `this.isDestroyed.next(true)` but **not** both--that would flag a different error.
You can run `semgrep` from any directory in the repo but it will run incrementally faster the smaller the tree it has to traverse. Still, even from the automate root, this will only take about 10-15 seconds:
```
semgrep -f <your-repo-root-path>/semgrep
```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

