### PR TITLE
automate-elasticsearch update to 6.8.12

### DIFF
--- a/.expeditor/create-manifest.rb
+++ b/.expeditor/create-manifest.rb
@@ -300,7 +300,7 @@ pins = {
   # while still allowing the clients of these databases to upgrade their client
   # libraries if any fixes are shipped there.
   "automate-postgresql"    => {"origin" => "chef", "name" => "automate-postgresql",    "version" => "9.6.11", "release" => "20200929122522"},
-  "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.8.3",  "release" => "20200929123629"},
+  # "automate-elasticsearch" => {"origin" => "chef", "name" => "automate-elasticsearch", "version" => "6.8.3",  "release" => "20200929123629"},
 }
 
 unless no_pin_hab

--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -4,12 +4,12 @@
 pkg_name="automate-elasticsearch"
 pkg_description="Wrapper package for core/elasticsearch"
 pkg_origin="chef"
-pkg_version="6.8.3"
+pkg_version="6.8.12"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz"
-pkg_shasum=824078e421c9f7e5ab9c875e4019d9ebfe3ada99db286b54dec090f97d1cbe25
+pkg_shasum=e7710bff2a2ab867f7538caddd009abaca90e0e33666d30e6e8acb480838d23c
 
 pkg_build_deps=(
   core/patchelf


### PR DESCRIPTION
The complete list of CVEs this will address is hard to compile as many
of the issues are in libraries used inside ES or the s3-repository
plugin we download.

For example, the jackson-databind dependency, was at version 2.8.11.3 previously:

    /hab/pkgs/chef/automate-elasticsearch/6.8.3/20201015010521/es/modules/ingest-geoip/jackson-databind-2.8.11.3.jar
    /hab/pkgs/chef/automate-elasticsearch/6.8.3/20201015010521/es/plugins/repository-s3/jackson-databind-2.8.11.3.jar

and should now be at 2.8.11.6

    /hab/pkgs/chef/automate-elasticsearch/6.8.12/20201016121850/es/modules/ingest-geoip/jackson-databind-2.8.11.6.jar
    /hab/pkgs/chef/automate-elasticsearch/6.8.12/20201016121850/es/plugins/repository-s3/jackson-databind-2.8.11.6.jar

The changelog for this library claims the following CVEs have been addressed:

https://github.com/FasterXML/jackson-databind/blob/2.8/release-notes/VERSION

CVE-2020-9546
CVE-2020-9547
CVE-2020-9548
CVE-2019-14540
CVE-2019-14439
CVE-2019-16335
CVE-2019-17267
CVE-2019-16942
CVE-2019-16943
CVE-2019-17531
CVE-2019-20330
CVE-2020-8840
CVE-2019-12384
CVE-2019-12814
CVE-2019-14379
CVE-2019-14439

Signed-off-by: Steven Danna <steve@chef.io>