### PR TITLE
automate-gateway: use correct swagger configuration

### DIFF
--- a/components/automate-gateway/third_party/swagger-ui/index.html
+++ b/components/automate-gateway/third_party/swagger-ui/index.html
@@ -39,7 +39,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "https://petstore.swagger.io/v2/swagger.json",
+        configUrl: "./config.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
This got reset by re-vendoring the dependency.