### PR TITLE
Fix broken link to Knife setup docs

### DIFF
--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -63,7 +63,7 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
-Then, [set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
+Then, [set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
 
@@ -91,7 +91,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
 
 ## Install A Standalone Chef Infra Server
 
@@ -124,7 +124,7 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate deploy --product infra-server <configuration_file>
     ```
 
-1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
 
 1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 
@@ -177,7 +177,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`]({{< relref "infra_server.md#use-knife-with-chef-infra-server" >}}) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
 
 1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 

--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -63,7 +63,7 @@ Install Chef Automate and Chef Infra Server on the same host with this command:
 sudo chef-automate deploy --product automate --product infra-server
 ```
 
-Then, [set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
+Then, [set up `knife`](https://docs.chef.io/workstation/knife_setup) for use with Chef Infra Server.
 
 ### Configuration File Install of Chef Automate and Infra Server
 
@@ -91,7 +91,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup) for use with Chef Infra Server.
 
 ## Install A Standalone Chef Infra Server
 
@@ -124,7 +124,7 @@ Installations require elevated privileges, so run the commands as the superuser 
        sudo chef-automate deploy --product infra-server <configuration_file>
     ```
 
-1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup) for use with Chef Infra Server.
 
 1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 
@@ -177,7 +177,7 @@ Installations require elevated privileges, so run the commands as the superuser 
       sudo chef-automate deploy config.toml
     ```
 
-1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup/) for use with Chef Infra Server.
+1. [Set up `knife`](https://docs.chef.io/workstation/knife_setup) for use with Chef Infra Server.
 
 1. To send data from the Chef Infra Server to an external Chef Automate installation, first create a `patch.toml` file that contains the configuration stanza:
 


### PR DESCRIPTION
This page's link to the knife setup docs is currently broken. I took a random guess at where it should be linking to so feel free to correct me if this is incorrect.

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
