### PR TITLE
Fix incorrect compliance calendar picker zindex

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -70,7 +70,7 @@
       <chef-icon>date_range</chef-icon>
       <span>{{ date | datetime: CHEF_SHORT_DATE }}</span>
     </chef-button>
-    <chef-dropdown [attr.visible]="calendarVisible">
+    <chef-dropdown class="calendar-dropdown" [attr.visible]="calendarVisible">
       <chef-click-outside omit="calendar-btn" (clickOutside)="hideCalendar()">
         <chef-calendar
           [selected]="date.toISOString()"

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.scss
@@ -44,10 +44,11 @@
       }
     }
 
-    chef-dropdown {
+    .calendar-dropdown {
       top: 100%;
       right: 0;
       padding: 0.5em;
+      z-index: 1;
     }
   }
 }


### PR DESCRIPTION
Depending on the browser viewport size, the compliance calendar picker would render underneath the compliance tab menu. This commit adds a zindex to the calendar picker dropdown to correct this issue.

Before:
![Screen Shot 2020-10-27 at 2 40 11 PM](https://user-images.githubusercontent.com/479121/97347578-5d3c6480-1863-11eb-976a-bef7ce029e87.png)

After:
![Screen Shot 2020-10-27 at 2 41 00 PM](https://user-images.githubusercontent.com/479121/97347594-63cadc00-1863-11eb-8897-c0b5cd1a0b64.png)