### PR TITLE
Additional semgrep validation

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -69,6 +69,7 @@ steps:
           entrypoint: semgrep
           command: [
             "--error",
+            "--exclude", "*.spec.ts",
             "--config", "/go/src/github.com/chef/automate/semgrep",
             "/go/src/github.com/chef/automate"
           ]

--- a/components/automate-ui/Makefile
+++ b/components/automate-ui/Makefile
@@ -41,12 +41,12 @@ lint-typescript:
 
 #: Security validation via semgrep
 semgrep:
-	semgrep --config $(REPOROOT)/semgrep
+	semgrep --config $(REPOROOT)/semgrep --exclude *.spec.ts
 	semgrep --config https://semgrep.dev/p/r2c-ci
 
 #: Security validation via semgrep; autofix where possible
 semgrep-and-fix:
-	semgrep --config $(REPOROOT)/semgrep --autofix
+	semgrep --config $(REPOROOT)/semgrep --exclude *.spec.ts --autofix
 	semgrep --config https://semgrep.dev/p/r2c-ci --autofix
 
 pr-ready: unit-all-browsers lint e2e

--- a/components/automate-ui/Makefile
+++ b/components/automate-ui/Makefile
@@ -42,7 +42,7 @@ lint-typescript:
 #: Security validation via semgrep
 semgrep:
 	semgrep --config $(REPOROOT)/semgrep
-	semgrep --config https://semgrep.dev/p/r2c-ci --autofix
+	semgrep --config https://semgrep.dev/p/r2c-ci
 
 #: Security validation via semgrep; autofix where possible
 semgrep-and-fix:

--- a/components/automate-ui/src/app/entities/projects/project.effects.spec.ts
+++ b/components/automate-ui/src/app/entities/projects/project.effects.spec.ts
@@ -17,7 +17,7 @@ import { ProjectRequests } from './project.requests';
 
 describe('ProjectEffects', () => {
   let effects: ProjectEffects;
-  let actions: Observable<any>;
+  let actions$: Observable<any>;
   const initialState = { };
 
   beforeEach(() => {
@@ -29,7 +29,7 @@ describe('ProjectEffects', () => {
       providers: [
         ProjectEffects,
         ProjectRequests,
-        provideMockActions(() => actions)
+        provideMockActions(() => actions$)
       ]
     });
 
@@ -45,7 +45,7 @@ describe('ProjectEffects', () => {
       message: `Deleted project ${id}.`
     });
 
-    actions = of(new DeleteProjectSuccess({id}));
+    actions$ = of(new DeleteProjectSuccess({id}));
 
     let loadOptionSeen = false;
     let createNotificationSeen = false;

--- a/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+scanner/containers/nodes-add/nodes-add.component.ts
@@ -25,9 +25,9 @@ export class NodesAddComponent implements OnInit {
 
   addTypeControl: FormGroup;
   backendControl: FormGroup;
-  backendValue: Observable<string>;
+  backendValue$: Observable<string>;
   sslControl: FormGroup;
-  sslValue: Observable<boolean>;
+  sslValue$: Observable<boolean>;
 
   // Array of secrets available for user to select
   // TODO make ngrx/store selection
@@ -48,8 +48,9 @@ export class NodesAddComponent implements OnInit {
 
     // Swap fields based on selected "backend" value (ssh, winrm)
     this.backendControl = this.form.get('wizardStep2').get('backend') as FormGroup;
-    this.backendValue = this.backendControl.valueChanges.pipe(startWith(this.backendControl.value));
-    this.backendValue.subscribe(backend => {
+    this.backendValue$ =
+      this.backendControl.valueChanges.pipe(startWith(this.backendControl.value));
+    this.backendValue$.subscribe(backend => {
       const step = this.form.get('wizardStep2') as FormGroup;
       step.get('secrets').setValue([]);
       switch (backend) {
@@ -71,7 +72,7 @@ export class NodesAddComponent implements OnInit {
     // Switch selectable secrets based on selected "backend" value (ssh, winrm)
     this.secrets$ = combineLatest([
       this.fetchSecrets(),
-      this.backendValue
+      this.backendValue$
     ]).pipe(
       map(([secrets, backend]: [{ type: string }[], string]) =>
         secrets.filter(s => s.type === backend || s.type === 'sudo'))
@@ -80,8 +81,8 @@ export class NodesAddComponent implements OnInit {
 
   setWinRmPort(): void {
     this.sslControl = this.form.get('wizardStep2').get('ssl') as FormGroup;
-    this.sslValue = this.sslControl.valueChanges.pipe(startWith(this.sslControl.value));
-    this.sslValue.subscribe(ssl => {
+    this.sslValue$ = this.sslControl.valueChanges.pipe(startWith(this.sslControl.value));
+    this.sslValue$.subscribe(ssl => {
       if (ssl && this.backendControl.value === 'winrm') {
         this.form.get('wizardStep2').get('port').patchValue(5986);
       } else {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/report-data.service.ts
@@ -116,17 +116,11 @@ export class ReportDataService {
   }
 
   isEmpty(data) {
-    if (data === undefined || data.length === 0 || (data.length === 1 && data[0] === 'passed')) {
-      return true;
-    }
-    return false;
+    return data === undefined || data.length === 0 || (data.length === 1 && data[0] === 'passed');
   }
 
   isZero(count: number): boolean {
-    if (count === 0) {
-      return true;
-    }
-    return false;
+    return count === 0;
   }
 
   isAllZeros(data) {

--- a/components/automate-ui/src/app/types/types.ts
+++ b/components/automate-ui/src/app/types/types.ts
@@ -654,10 +654,7 @@ export class GuitarStringItem {
     if (this.eventTypeCount.length > 1) {
       return true;
     }
-    if (this.eventTypeCount.length === 1 && this.eventTypeCount[0].count > 1) {
-      return true;
-    }
-    return false;
+    return this.eventTypeCount.length === 1 && this.eventTypeCount[0].count > 1;
   }
 
   getEventType(): string {

--- a/semgrep/general.yaml
+++ b/semgrep/general.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: verbose-booleans
+  patterns:
+    - pattern-either: 
+      - pattern: if ($EXPR) { return true; } else { return false; }
+      - pattern: if (!$EXPR) { return false; } else { return true; }
+      - pattern: if ($EXPR) { return true; } return false;
+      - pattern: if (!$EXPR) { return false; } return true;
+  message: returning exhaustive booleans should just return the expression instead
+  metadata: {
+      todo: "as of 0.29.0, the autofix sometimes works, and sometimes goes haywire"
+      }
+  languages: [ts]
+  severity: ERROR
+  fix: return $EXPR;

--- a/semgrep/rxjs-subscription.yaml
+++ b/semgrep/rxjs-subscription.yaml
@@ -116,3 +116,11 @@ rules:
     message: ngOnDestroy missing this.isDestroyed.complete()
     languages: [ts]
     severity: ERROR
+
+  - id: onDestroy-not-implemented-in-class
+    patterns:
+    - pattern: this.isDestroyed.complete()
+    - pattern-not-inside: class $CLASS implements OnDestroy { ... }
+    message: subscriptions never complete because class does not implement OnDestroy Lifecycle hook
+    languages: [ts]
+    severity: ERROR

--- a/semgrep/rxjs-subscription.yaml
+++ b/semgrep/rxjs-subscription.yaml
@@ -30,7 +30,7 @@ rules:
           }
           ...
         }
-    message: isDestroyed never triggered from ngOnDestroy
+    message: subscriptions never complete because isDestroyed never triggered from ngOnDestroy
     languages: [ts]
     severity: ERROR
 
@@ -52,7 +52,7 @@ rules:
           }
           ...
         }
-    message: isDestroyed never used with takeUntil()
+    message: subscriptions never complete because they are not instrumented with takeUntil(this.isDestroyed)
     metadata: {
       falseNegative: will not catch multiple subscriptions with takeUntil missing on some
       }

--- a/semgrep/rxjs-syntax.yaml
+++ b/semgrep/rxjs-syntax.yaml
@@ -9,4 +9,26 @@ rules:
       }
     languages: [ts]
     severity: WARNING
- 
+
+  - id: observables-from-select-or-pipe-not-ending-with-dollar-sign
+    patterns:
+    - pattern-regex: '\w+\s*(:.+?)?=.*?(select|pipe)'
+    - pattern-either:
+      - pattern-inside: $VAR = $EXPR.select(...);
+      - pattern-inside: $VAR = $EXPR.pipe(...);
+    - pattern-not-inside: $VAR = d3.select(...);
+    message: |
+      Observable variable should end with a dollar sign.
+    languages: [ts]
+    severity: ERROR
+
+  - id: observables-from-values-not-ending-with-dollar-sign
+    patterns:
+    - pattern-regex: '\w+\s*(:.+?)?=\s*(observableOf|of)'
+    - pattern-either:
+      - pattern-inside: $VAR = observableOf(...)
+      - pattern-inside: $VAR = of(...)
+    message: |
+      Observable variable should end with a dollar sign.
+    languages: [ts]
+    severity: ERROR

--- a/semgrep/rxjs-syntax.yaml
+++ b/semgrep/rxjs-syntax.yaml
@@ -3,7 +3,7 @@ rules:
   - id: combineLatest-not-combining
     pattern: combineLatest([$SINGLE_EXPRESSION])
     fix:  $SINGLE_EXPRESSION.
-    message: replace combineLatest with a single operand is not useful
+    message: combineLatest is not needed with a single argument
     metadata: {
       todo: "remove dot in fix once bug is fixed (https://github.com/returntocorp/semgrep/issues/1721)"
       }

--- a/semgrep/rxjs-syntax.yaml
+++ b/semgrep/rxjs-syntax.yaml
@@ -2,11 +2,8 @@ rules:
 
   - id: combineLatest-not-combining
     pattern: combineLatest([$SINGLE_EXPRESSION])
-    fix:  $SINGLE_EXPRESSION.
+    fix:  $SINGLE_EXPRESSION
     message: combineLatest is not needed with a single argument
-    metadata: {
-      todo: "remove dot in fix once bug is fixed (https://github.com/returntocorp/semgrep/issues/1721)"
-      }
     languages: [ts]
     severity: WARNING
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

_Semgrep adds checking beyond what the compiler and linter can do;
custom rules can validate Chef conventions, best practices, and the like!_

(A) Adds a few new rules shown below and applies a couple fixes stemming from them.
(B) Removes workaround from rule "combineLatest-not-combining" as bug was fixed in semgrep 0.29.0.
(C) A bit of general semgrep refinement.

**Category:** general syntax
**Rule ids:** verbose-booleans
**Detail:** returning exhaustive booleans should just return the expression instead

**Category:** rxjs subscriptions
**Rule ids:** onDestroy-not-implemented-in-class
**Detail:** subscriptions never complete because class does not implement OnDestroy Lifecycle hook

**Category:** rxjs syntax
**Rule ids:** observables-from-select-or-pipe-not-ending-with-dollar-sign,
observables-from-values-not-ending-with-dollar-sign
**Detail:** Observable variable should end with a dollar sign.

### :chains: Related Resources
NA

### :+1: Definition of Done
Semgrep is a bit greener in buildkite.

### :athletic_shoe: How to Build and Test the Change
You can run semgrep manually to confirm what buildkite does.
(1) Install from e.g., homebrew (`brew install semgrep`).
(2) `cd automate`
(3) Run `semgrep -f semgrep`
(The `-f semgrep` is specifying an eponymous directory name.)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

