### PR TITLE
Give pagination some breathing room in reporting node

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -297,12 +297,14 @@
               </div>
             </li>
           </ul>
-          <app-page-picker
-            [perPage]="pageSize"
-            [total]="totalReports"
-            [page]="page"
-            (pageChanged)="onPageChanged($event)">
-          </app-page-picker>
+          <div class="side-panel-footer">
+            <app-page-picker
+              [perPage]="pageSize"
+              [total]="totalReports"
+              [page]="page"
+              (pageChanged)="onPageChanged($event)">
+            </app-page-picker>
+          </div>
         </div>
       </chef-side-panel>
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -607,3 +607,7 @@ dl.waiver-details {
   padding-left: 5px;
   color: $chef-critical;
 }
+
+.side-panel-footer {
+  padding: 1em;
+}


### PR DESCRIPTION
Add a little breathing room around the newly returned pagination component in scan history.

Before:
![Screen Shot 2020-11-02 at 11 04 32 AM](https://user-images.githubusercontent.com/16737484/97908190-3797db00-1cfb-11eb-9045-4436df50a895.png)

After:
![Screen Shot 2020-11-02 at 11 01 35 AM](https://user-images.githubusercontent.com/16737484/97908211-3f577f80-1cfb-11eb-9509-1be5f713c712.png)
