### PR TITLE
Pin semgrep for custom rules

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -65,7 +65,7 @@ steps:
     expeditor:
       executor:
         docker:
-          image: returntocorp/semgrep:latest
+          image: returntocorp/semgrep:0.29.0
           entrypoint: semgrep
           command: [
             "--error",

--- a/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
+++ b/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
@@ -78,12 +78,9 @@ export class UserPermEffects {
   @Effect()
   fetchParameterizedPerms$ = this.actions$.pipe(
     ofType(UserPermsTypes.GET_PARAMETERIZED),
-    mergeMap((action: GetUserParamPerms) => {
-      const response$ = this.requests.fetchParameterized(action.payload);
-       return response$.pipe(
+    mergeMap((action: GetUserParamPerms) => this.requests.fetchParameterized(action.payload).pipe(
       map((resp: UserPermsResponsePayload) => new GetUserParamPermsSuccess(resp.endpoints)),
-      catchError((error: HttpErrorResponse) => of(new GetUserParamPermsFailure(error))));
-    }));
+      catchError((error: HttpErrorResponse) => of(new GetUserParamPermsFailure(error))))));
 
   private stale(lastTime: Date): boolean {
     return moment().diff(moment(lastTime)) > this.freshLimitPlusANudge;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Looks like a fresh release of semgrep 0.30.0 introduced a bug that flagged this line incorrectly:
```
/go/src/github.com/chef/automate/components/automate-ui/src/app/entities/userperms/userperms.effects.ts
severity:error rule:go.src.github.com.chef.automate.semgrep.observables-from-select-or-pipe-not-ending-with-dollar-sign: Observable variable should end with a dollar sign.
81:action: GetUserParamPerms) => this.requests.fetchParameterized(action.payload).pipe
```

The prior version of semgrep worked fine with that, so just pinning that version for now, and reverting the well-meaning change @lancewf put in today to get unblocked. (Thanks, @lancewf, and sorry for the inconvenience!)

### :chains: Related Resources
https://github.com/chef/automate/pull/4424

### :+1: Definition of Done
Semgrep passes in buildkite 

### :athletic_shoe: How to Build and Test the Change
Just check "Custom" semgrep task in buildkite

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

