### PR TITLE
Introduce rxjs-spy diagnostic tool to UI

### DIFF
--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -2153,6 +2153,12 @@
         }
       }
     },
+    "@types/circular-json": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/circular-json/-/circular-json-0.4.0.tgz",
+      "integrity": "sha512-7+kYB7x5a7nFWW1YPBh3KxhwKfiaI4PbZ1RvzBU91LZy7lWJO822CI+pqzSre/DZ7KsCuMKdHnLHHFu8AyXbQg==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2231,6 +2237,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
+    "@types/stacktrace-js": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/stacktrace-js/-/stacktrace-js-0.0.32.tgz",
+      "integrity": "sha512-SdxmlrHfO0BxgbBP9HZWMUo2rima8lwMjPiWm6S0dyKkDa5CseamktFhXg8umu3TPVBkSlX6ZoB5uUDJK89yvg==",
       "dev": true
     },
     "@types/webpack-sources": {
@@ -3717,6 +3729,12 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz",
       "integrity": "sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
       "dev": true
     },
     "class-utils": {
@@ -5674,6 +5692,15 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "dev": true,
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -12814,6 +12841,19 @@
         "tslib": "^1.9.0"
       }
     },
+    "rxjs-spy": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/rxjs-spy/-/rxjs-spy-7.5.1.tgz",
+      "integrity": "sha512-dJ9mO4HvW2r16PsU15Qsc0RVkG7pFrfyCNTGx3vrxWje3kIgZ6QjMVnWblQxbniZ32lwLk/2x9+D2O6GhgXV/w==",
+      "dev": true,
+      "requires": {
+        "@types/circular-json": "^0.4.0",
+        "@types/stacktrace-js": "^0.0.32",
+        "circular-json": "^0.5.0",
+        "error-stack-parser": "^2.0.1",
+        "stacktrace-gps": "^3.0.2"
+      }
+    },
     "rxjs-tslint": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/rxjs-tslint/-/rxjs-tslint-0.1.8.tgz",
@@ -14101,6 +14141,30 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
+    },
+    "stackframe": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+      "integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ==",
+      "dev": true
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -93,6 +93,7 @@
     "ng2-mock-component": "^0.2.0",
     "node-sass": "^4.14.0",
     "protractor": "^5.4.4",
+    "rxjs-spy": "^7.5.1",
     "rxjs-tslint": "^0.1.8",
     "sass-lint": "^1.13.1",
     "ts-node": "^8.10.1",

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -2,9 +2,7 @@ import { Component, OnInit, ChangeDetectorRef, AfterViewChecked } from '@angular
 import { ActivationStart, ActivationEnd, Router, NavigationEnd } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { filter } from 'rxjs/operators';
-import { create } from 'rxjs-spy';
 
-import { environment } from 'environments/environment';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Feature } from 'app/services/feature-flags/types';
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
@@ -32,8 +30,6 @@ export class UIComponent implements OnInit, AfterViewChecked {
     }
   ];
 
-  public spy;
-
   legacyFeatures: Array<Feature> = [];
   hideFullPage = true;
 
@@ -43,14 +39,6 @@ export class UIComponent implements OnInit, AfterViewChecked {
     public layoutFacade: LayoutFacadeService,
     private cdRef: ChangeDetectorRef
   ) {
-
-    if (!environment.production) {
-      // This enables rxjs-spy in the browser console,
-      // which supports analyzing, debugging, and logging any tagged Observables.
-      // Available commands are shown at https://github.com/cartant/rxjs-spy#module-log
-      this.spy = create();
-    }
-
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
       filter(event => event instanceof ActivationEnd)

--- a/components/automate-ui/src/app/ui.component.ts
+++ b/components/automate-ui/src/app/ui.component.ts
@@ -2,7 +2,9 @@ import { Component, OnInit, ChangeDetectorRef, AfterViewChecked } from '@angular
 import { ActivationStart, ActivationEnd, Router, NavigationEnd } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { filter } from 'rxjs/operators';
+import { create } from 'rxjs-spy';
 
+import { environment } from 'environments/environment';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Feature } from 'app/services/feature-flags/types';
 import { LayoutFacadeService } from 'app/entities/layout/layout.facade';
@@ -30,6 +32,8 @@ export class UIComponent implements OnInit, AfterViewChecked {
     }
   ];
 
+  public spy;
+
   legacyFeatures: Array<Feature> = [];
   hideFullPage = true;
 
@@ -39,6 +43,14 @@ export class UIComponent implements OnInit, AfterViewChecked {
     public layoutFacade: LayoutFacadeService,
     private cdRef: ChangeDetectorRef
   ) {
+
+    if (!environment.production) {
+      // This enables rxjs-spy in the browser console,
+      // which supports analyzing, debugging, and logging any tagged Observables.
+      // Available commands are shown at https://github.com/cartant/rxjs-spy#module-log
+      this.spy = create();
+    }
+
     // ActivationEnd specifically needs to be here in the constructor to catch early events.
     this.router.events.pipe(
       filter(event => event instanceof ActivationEnd)

--- a/components/automate-ui/src/main.ts
+++ b/components/automate-ui/src/main.ts
@@ -1,5 +1,7 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { create } from 'rxjs-spy';
+import { CyclePlugin } from 'rxjs-spy/plugin';
 
 import { applyPolyfills, defineCustomElements } from './assets/chef-ui-library/loader';
 
@@ -8,6 +10,22 @@ import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
+} else {
+  // This provides rxjs-spy access in the browser console,
+  // which supports analyzing, debugging, and logging any tagged Observables.
+  // Just execute `enableRxjsSpy()` in the console, then apply commands from
+  // https://github.com/cartant/rxjs-spy#module-log
+  (window as any).enableRxjsSpy = () => {
+
+    const spy = create();
+
+    // suppress "cycle-plugin.js:49 Cyclic next detected" warning in browser console
+    // reference: https://github.com/cartant/rxjs-spy/issues/41
+    spy.unplug(spy.find(CyclePlugin));
+
+    // not strictly necessary, but let's you see what is in the object at runtime
+    return spy;
+  };
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule, { preserveWhitespaces: true });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

rxjs-spy is a debugging library for RxJS, which is pervasive in our UI. This provides some infrastructure so you might be able to get away from a plethora of `console.log` statements when trying to diagnose an errant behavior.
With rxjs-spy you can add a simple tag to any observable in your code, then in the browser you can watch any or all tagged observables receiving values, being subscribed, and being unsubscribed.

### :chains: Related Resources
Project: https://github.com/cartant/rxjs-spy
More Details: https://ncjamieson.com/debugging-rxjs-part-1-tooling/

### :+1: Definition of Done
rxjs-spy is available for use in development (not production).

### :athletic_shoe: How to Build and Test the Change

1. Load the new package dependency on your machine: `npm install`.
2. Launch automate-ui using your method of choice (e.g. `make serve`).
3. Open automate-ui in your browser (https://a2-dev.test/).
4. Open the console in the browser's dev tools (<kbd>option</kbd> + <kbd>command</kbd> + <kbd>J</kbd>).
5. Enable rxjs-spy with this new command in the console: `enableRxjsSpy()`.

Now you can use methods on the `spy` object to activate/deactivate logging, show observables, and more (see https://github.com/cartant/rxjs-spy#module-api).

#### Sample session

We have not yet done anything so there is nothing to see:
```
> spy.show()
0 snapshot(s) matching /.+/
```

Navigate to Settings >> Teams and select any team to open its details page.
Now try the same call and you will see all the tagged observables. Here I have expanded one of them:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/6817500/98747209-ef686080-236b-11eb-9286-74eb32667ff5.png">
In there you will see that there is 1 subscriber; that the subscription is incomplete (i.e., the subscription is still active), and the value from the routeURL was `/settings/teams/t3`.

Go back to the parent teams page, run `spy.show()` again and you will see that the **State** has changed to `complete` and a new property, **Unsubscribed**, is `true`, and similarly for the other observables, so the observable lifecycle was properly cleaned up.

The `spy.show()` method also can take an  argument, either a string or a regular expression, to filter the output. Examples: `spy.show('team-routeUrl')` to see that single observable or `spy.show(/team-/)` to see all observables tagged with that prefix (which only coincidentally happens to be all of them at the moment).

Do the same exercise of viewing team details again, but this time witih logging. As setup just to be a bit more interesting, add a couple users to the team from the team details page, then return to the starting point at Settings >> Teams. The `spy.log()` method takes the same kind of argument. I will use that in this next example. Here I start on the Teams page after having added two users to the team, go into the details page, then back to the Teams page. Observe that I opened up the `team-users` tag so you actually see those two users.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/6817500/98748514-b4b3f780-236e-11eb-859a-958ffee5706e.png">

If you want to deactivate any particular log that you previously activated, run `spy.undo()` to list things that you can undo. Here you will see the two activating loggers; I pick one to deactivate then list again and you can see that it is gone.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/6817500/98748867-694e1900-236f-11eb-9c32-06c3456b2391.png">


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
