### PR TITLE
Add UTC label in compliance trend graphs

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -157,7 +157,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
         return [
           moment.utc(this.domainX[0]).format(DateTime.CHEF_DATE_TIME),
           moment.utc(this.domainX[1]).format(DateTime.CHEF_DATE_TIME)
-        ].join(' - ');
+        ].join(' - ') + ' (UTC)';
       });
 
     this.axisXSelection.select('.domain')
@@ -285,7 +285,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     update
       .attr('for', (_d, i) => `dot-group-bg-${i}`);
     update.select('.tip-name')
-      .text(d => d3.timeFormat('%a %B %e %Y')(d.report_time));
+      .text(d => d3.timeFormat('%a %B %e %Y (UTC)')(d.report_time));
 
     statuses.forEach(status => {
       update.select(`.tip-legend-item.${status}`)


### PR DESCRIPTION
# :nut_and_bolt: Description: What code changed, and why?

After merging https://github.com/chef/automate/pull/4358 some users might get confused between local time selections (`Last 24 hours`) and the places where we select/show a day which is UTC.

As can be seen in the below screenshots, I added `(UTC)` suffixes in the trend graphs.

## Before

![Screenshot 2020-11-13 at 11 21 55](https://user-images.githubusercontent.com/107378/99091870-5e41f580-25c8-11eb-9b71-3b9cec79ac3a.png)

## After

![Screenshot 2020-11-13 at 13 44 37](https://user-images.githubusercontent.com/107378/99091886-6306a980-25c8-11eb-8ff3-b9fe2b822683.png)
