### PR TITLE
Elasticsearch Publishers Full warning

### DIFF
--- a/components/ingest-service/pipeline/publisher/msg_distributor.go
+++ b/components/ingest-service/pipeline/publisher/msg_distributor.go
@@ -54,7 +54,7 @@ func sendMessage(pipeInChannels []chan message.ChefRun, msg message.ChefRun) {
 
 		log.WithFields(log.Fields{
 			"number_of_publishers": len(pipeInChannels),
-		}).Warn("All elasticsearch publishers are full")
+		}).Error("All elasticsearch publishers are full")
 		time.Sleep(time.Millisecond * 10)
 	}
 }

--- a/components/ingest-service/pipeline/publisher/msg_distributor.go
+++ b/components/ingest-service/pipeline/publisher/msg_distributor.go
@@ -54,7 +54,8 @@ func sendMessage(pipeInChannels []chan message.ChefRun, msg message.ChefRun) {
 
 		log.WithFields(log.Fields{
 			"number_of_publishers": len(pipeInChannels),
-		}).Error("All elasticsearch publishers are full")
+		}).Error("All elasticsearch publishers are full. " +
+			"Increase the max number of bundled messages and/or number of publishers")
 		time.Sleep(time.Millisecond * 10)
 	}
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When all the Elasticsearch publishers are full the log message should be an error and not a warning.

### :chains: Related Resources

https://github.com/chef/automate/issues/3152

### :+1: Definition of Done

The log message when all the Elasticsearch publishers are full is an error, not a warning. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
