### PR TITLE
Dependency problem with rustyio/sync

### DIFF
--- a/components/automate-workflow-server/rebar.config
+++ b/components/automate-workflow-server/rebar.config
@@ -44,7 +44,7 @@
          {git, "https://github.com/ferd/recon.git", {branch, "master"}}},
 
         {sync, ".*",
-         {git, "https://github.com/rustyio/sync.git", {branch, "master"}}},
+         {git, "https://github.com/rustyio/sync.git", {tag, "9106be75883d7646dae72d4ac80c6ea88464a5ca"}}},
 
         {meck, ".*",
          {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The current code on master for the https://github.com/rustyio/sync.git
project is failing with "Dependency not available" for the
{git,"https://github.com/synrc/fs",{tag,"6.1"}} dependency.

This change pins the dependency to a working version.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
