### PR TITLE
Increase go test timeout

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -201,8 +201,8 @@ steps:
   - label: "gateway-integration"
     command:
       - . scripts/verify_setup.sh
-      - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test ./components/automate-gateway/integration/..."
-    timeout_in_minutes: 20
+      - hab studio run "source scripts/verify_studio_init.sh && start_all_services && go_test -timeout 30m ./components/automate-gateway/integration/..."
+    timeout_in_minutes: 30
     retry:
       automatic:
         limit: 1


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Increasing the timeout time on the gateway-integration test in buildkite

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
