### PR TITLE
Add UTC label in the date picker

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -70,7 +70,7 @@
       <span *ngIf="last24h">Last 24 hours</span>
       <ng-container *ngIf="!last24h">
         <chef-icon>date_range</chef-icon>
-        <span>{{ date | datetime: CHEF_SHORT_DATE }}</span>
+        <span>{{ date | datetime: CHEF_SHORT_DATE }} (UTC)</span>
       </ng-container>
     </chef-button>
     <chef-dropdown class="calendar-menu-dropdown" [attr.visible]="calendarMenuVisible">
@@ -80,7 +80,7 @@
         </chef-button>
         <chef-button class="calendar-btn" secondary (click)="showCalendar()">
           <chef-icon>date_range</chef-icon>
-          <span>{{ date | datetime: CHEF_SHORT_DATE }}</span>
+          <span>PICK DAY (UTC)</span>
         </chef-button>
       </chef-click-outside>
     </chef-dropdown>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.html
@@ -80,7 +80,7 @@
         </chef-button>
         <chef-button class="calendar-btn" secondary (click)="showCalendar()">
           <chef-icon>date_range</chef-icon>
-          <span>PICK DAY (UTC)</span>
+          <span>Choose Date (UTC)</span>
         </chef-button>
       </chef-click-outside>
     </chef-dropdown>


### PR DESCRIPTION
# :nut_and_bolt: Description: What code changed, and why?

After merging #4358 some users might get confused between local time selections (`Last 24 hours`) and the places where we select/show a day which is UTC.

As can be seen in the below git that Scott uploaded in the UI pull request:

![](https://user-images.githubusercontent.com/479121/93793798-5045a900-fc05-11ea-9055-777c6cd27e71.gif)

In the same dropdown the user can choose between `Last 24 hours` in the local timezone to a DAY, without any hint that this day is not in their timezone, but in UTC.

In an effort to make this UTC aspect more clear, I'm submitting this PR with two changes as can be seen in the screenshots below:

---


## During date selection:

![pick-day-utc](https://user-images.githubusercontent.com/107378/99797351-00ad2c00-2b27-11eb-9a57-3a95050f5f52.png)


---


## After day selection from date picker: 

![day-picked](https://user-images.githubusercontent.com/107378/99797374-0c005780-2b27-11eb-82d5-d1da59f9d045.png)
