### PR TITLE
ci: bump timeout from 20 to 25 minutes

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -490,7 +490,7 @@ steps:
   - label: "iam v2 with no legacy policies force-upgrade to v2"
     command:
       - integration/run_test integration/tests/iam_v2_no_legacy_to_v2_force_upgrade.sh
-    timeout_in_minutes: 20
+    timeout_in_minutes: 25
     expeditor:
       secrets:
         A2_LICENSE:


### PR DESCRIPTION
We are seeing this test timeout on master. Bumping the timeout to see
if it would eventualy pass.

Signed-off-by: Steven Danna <steve@chef.io>