### PR TITLE
ui-tooltip and circle changes made in graph for waived nodes and profiles

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
@@ -27,6 +27,10 @@
       &.skipped {
         stroke: $chef-dark-grey;
       }
+
+      &.waived {
+        stroke: $chef-med-grey;
+      }
     }
 
     .dot-group {
@@ -66,6 +70,10 @@
         &.skipped {
           stroke: $chef-dark-grey;
         }
+
+        &.waived {
+          stroke: $chef-med-grey;
+        }
       }
 
       &:hover {
@@ -93,6 +101,10 @@
 
           &.skipped {
             fill: $chef-dark-grey;
+          }
+          
+          &.waived {
+            fill: $chef-med-grey;
           }
         }
       }
@@ -168,6 +180,10 @@
 
       &.skipped::before {
         background: $chef-dark-grey;
+      }
+
+      &.waived::before {
+        background: $chef-med-grey;
       }
     }
   }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.scss
@@ -102,7 +102,7 @@
           &.skipped {
             fill: $chef-dark-grey;
           }
-          
+
           &.waived {
             fill: $chef-med-grey;
           }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -19,6 +19,7 @@ export interface TrendData {
   failed: number;
   passed: number;
   skipped: number;
+  waived: number;
 }
 
 @Component({
@@ -75,7 +76,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   get domainY() {
     const min = 0;
-    const max = d3.max(this.trendData, (d: TrendData) => d3.max([d.failed, d.passed, d.skipped]));
+    const max = d3.max(this.trendData, (d: TrendData) => d3.max([d.failed, d.passed, d.skipped, d.waived]));
     return [min, max];
   }
 
@@ -115,7 +116,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   get linesSelection() {
     return this.svgSelection.selectAll('.status-line')
-      .data(['skipped', 'passed', 'failed'].map(status => ({ status, values: this.trendData })));
+      .data(['skipped', 'passed', 'failed', 'waived'].map(status => ({ status, values: this.trendData })));
   }
 
   ngOnChanges() {
@@ -201,7 +202,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     const exit = this.dotsSelection.exit();
 
     const maxDots = 10;
-    const statuses = ['failed', 'passed', 'skipped'];
+    const statuses = ['failed', 'passed', 'skipped', 'waived'];
     const isHidden = (_d, i, ns) => i % Math.round(ns.length / maxDots) !== 0;
 
     enter
@@ -238,13 +239,23 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
     update.select('.status-dot.failed')
       .attr('r', d => {
+        if (d.failed === d.passed && d.failed === d.skipped && d.failed === d.waived) { return 10; }
         if (d.failed === d.passed && d.failed === d.skipped) { return 8; }
-        if (d.failed === d.passed || d.failed === d.skipped) { return 6; }
+        if (d.failed === d.passed && d.failed === d.waived) { return 8; }
+        if (d.failed === d.skipped && d.failed === d.waived) { return 8; }
+        if (d.failed === d.passed || d.failed === d.skipped || d.failed === d.waived) { return 6; }
         return 4;
       });
 
     update.select('.status-dot.passed')
-      .attr('r', d => d.passed === d.skipped ? 6 : 4);
+      .attr('r', d => {
+        if (d.passed === d.skipped && d.passed === d.waived) { return 8; }
+        if (d.passed === d.skipped || d.passed === d.waived) { return 6; }
+        return 4;  
+      })
+
+    update.select('.status-dot.skipped')
+      .attr('r', d => d.skipped === d.waived ? 6 : 4);
 
     update.select('.dot-group-bg')
       .attr('id', (_d, i) => `dot-group-bg-${i}`)
@@ -266,7 +277,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     const update = this.tipsSelection.merge(enter);
     const exit = this.tipsSelection.exit();
 
-    const statuses = ['failed', 'passed', 'skipped'];
+    const statuses = ['failed', 'passed', 'skipped', 'waived'];
     const tipText = (count, status, type) => `${d3.format(',')(count)} ${status} ${type}`;
 
     enter

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -76,7 +76,12 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   get domainY() {
     const min = 0;
-    const max = d3.max(this.trendData, (d: TrendData) => d3.max([d.failed, d.passed, d.skipped, d.waived]));
+    const max = d3.max(this.trendData, (d: TrendData) => d3.max([
+      d.failed,
+      d.passed, 
+      d.skipped, 
+      d.waived
+    ]));
     return [min, max];
   }
 
@@ -116,7 +121,12 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   get linesSelection() {
     return this.svgSelection.selectAll('.status-line')
-      .data(['skipped', 'passed', 'failed', 'waived'].map(status => ({ status, values: this.trendData })));
+      .data([
+        'skipped',
+        'passed',
+        'failed',
+        'waived'
+      ].map(status => ({ status, values: this.trendData })));
   }
 
   ngOnChanges() {
@@ -251,8 +261,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
       .attr('r', d => {
         if (d.passed === d.skipped && d.passed === d.waived) { return 8; }
         if (d.passed === d.skipped || d.passed === d.waived) { return 6; }
-        return 4;  
-      })
+        return 4;
+      });
 
     update.select('.status-dot.skipped')
       .attr('r', d => d.skipped === d.waived ? 6 : 4);

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -78,8 +78,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     const min = 0;
     const max = d3.max(this.trendData, (d: TrendData) => d3.max([
       d.failed,
-      d.passed, 
-      d.skipped, 
+      d.passed,
+      d.skipped,
       d.waived
     ]));
     return [min, max];


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

To show the waived nodes and profile data on the compliance graph.

### :chains: Related Resources
OFFR-E-10 #4382

### :+1: Definition of Done

Changes should be for both node status and profile status tab.
There should be a new waved line in the graph
Waived data should show up in the tooltip on compliance graph. 
The intersection dots should accommodate the new waived circle.

### :athletic_shoe: How to Build and Test the Change

Add some waived data. You can see the new line and numbers in the tooltip.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="1438" alt="Screenshot 2020-11-30 at 11 18 52 PM" src="https://user-images.githubusercontent.com/59958706/100645309-7eacd680-3362-11eb-964c-d8bb4d8232ab.png">