### PR TITLE
Activate semgrep differential mode and other refinements

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -114,14 +114,14 @@ steps:
             "/go/src/github.com/chef/automate"
           ]
 
-  - label: ":semgrep: Published"
+  - label: ":semgrep: Security"
     command:
     - echo "running in $(pwd)"
     - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
     - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
     - export SEMGREP_REPO_NAME=chef/automate
     - echo "branch=[$BUILDKITE_BRANCH], PR base branch=[$BUILDKITE_PULL_REQUEST_BASE_BRANCH]"
-    - if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ] ; then echo "manual build; using 'master' as base branch"; fi
+    - \[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" \] && echo "manual build; using 'master' as base branch"
     - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}
     timeout_in_minutes: 20
     expeditor:

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -119,7 +119,10 @@ steps:
     - echo "running in $(pwd)"
     - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
     - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
-    - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID
+    - export SEMGREP_REPO_NAME=chef/automate
+    - echo "branch=[$BUILDKITE_BRANCH], PR base branch=[$BUILDKITE_PULL_REQUEST_BASE_BRANCH]"
+    - if [ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ] ; then echo "manual build; using 'master' as base branch"; fi
+    - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}
     timeout_in_minutes: 20
     expeditor:
       secrets: true

--- a/.semgrep/general.yaml
+++ b/.semgrep/general.yaml
@@ -13,3 +13,39 @@ rules:
   languages: [ts]
   severity: ERROR
   fix: return $EXPR;
+
+- id: cyclomatic-complexity-whole-element
+  pattern: |
+    for (const $ITEM of $COLLECTION) {
+      if ($EXPR) {
+        return $ITEM;
+      }
+    }
+    return $DEFAULT_EXPR;
+  message: lookup-with-default loop can be simplified with the find method
+  languages: [ts]
+  severity: ERROR
+  fix: |
+    const retval = $COLLECTION.find($ITEM => $EXPR);
+    return retval !== undefined ? retval : $DEFAULT_EXPR;
+  metadata: {
+    edge-case: supports all falsy values EXCEPT undefined
+  }
+
+- id: cyclomatic-complexity-element-field
+  pattern: |
+    for (const $ITEM of $COLLECTION) {
+      if ($EXPR) {
+        return $ITEM.$FIELD;
+      }
+    }
+    return $DEFAULT_EXPR;
+  message: lookup-field-with-default loop can be simplified with the find method
+  languages: [ts]
+  severity: ERROR
+  fix: |
+    const retval = $COLLECTION.find($ITEM => $EXPR);
+    return retval ? retval.$FIELD : $DEFAULT_EXPR;
+  metadata: {
+    edge-case: supports all falsy values
+  }

--- a/.semgrep/rxjs-subscription.yaml
+++ b/.semgrep/rxjs-subscription.yaml
@@ -44,7 +44,7 @@ rules:
           }
           ...
         }
-    message: subscriptions never complete because isDestroyed never triggered from ngOnDestroy
+    message: subscription never completes because isDestroyed never triggered from ngOnDestroy
     languages: [ts]
     severity: ERROR
 
@@ -66,7 +66,7 @@ rules:
           }
           ...
         }
-    message: subscriptions never complete because they are not instrumented with takeUntil(this.isDestroyed)
+    message: subscription completion is not utilized with takeUntil(this.isDestroyed)
     metadata: {
       falseNegative: will not catch multiple subscriptions with takeUntil missing on some
       }

--- a/.semgrep/rxjs-subscription.yaml
+++ b/.semgrep/rxjs-subscription.yaml
@@ -14,6 +14,20 @@ rules:
     languages: [ts]
     severity: ERROR
 
+  - id: lifecycle-hook-not-used
+    patterns:
+    - pattern-either: 
+      - pattern: ngOnInit() { }
+      - pattern: ngOnDestroy() { }
+      - pattern: ngOnChanges() { }
+      - pattern: ngDoCheck() { }
+      - pattern: ngAfterContentInit() { }
+      - pattern: ngAfterContentChecked() { }
+      - pattern: ngAfterViewInit() { }
+      - pattern: ngAfterViewChecked() { }
+    message: lifecycle hook is not used; should be removed
+    languages: [ts]
+    severity: ERROR
 
   - id: isDestroyed-used-but-not-triggered
     patterns:

--- a/.semgrep/rxjs-subscription.yaml
+++ b/.semgrep/rxjs-subscription.yaml
@@ -124,3 +124,13 @@ rules:
     message: subscriptions never complete because class does not implement OnDestroy Lifecycle hook
     languages: [ts]
     severity: ERROR
+
+  # TODO: cleanup results of this rule before activating it
+  # - id: subscription-lifecycle-not-managed
+  #   patterns:
+  #   - pattern: $EXPR.subscribe(...)
+  #   - pattern-not-inside: $EXPR2.pipe(..., takeUntil(...),...).subscribe(...)
+  #   - pattern-not-inside: $EXPR2.pipe(..., take(...),...).subscribe(...)
+  #   message: subscription lifecycle not managed: typically needs takeUntil(this.isDestroeyd)
+  #   languages: [ts]
+  #   severity: ERROR

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: help
+.PHONY: help revendor semgrep semgrep-all
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: revendor
 revendor: ## revendor dependencies in protovendor/ and update .bldr.toml with deps
 	@scripts/revendor.sh
+
+semgrep: ## runs differential semgrep, checking only changes in the current PR, just as is done in CI
+	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo "Need to set SEMGREP_TOKEN and SEMGREP_ID in your env."; else docker run -it --rm --init --volume $(realpath .):/automate --workdir /automate returntocorp/semgrep-action:v1 python -m semgrep_agent --publish-token ${SEMGREP_TOKEN} --publish-deployment ${SEMGREP_ID} --baseline-ref master; fi
+
+semgrep-all: ## runs full semgrep
+	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo "Need to set SEMGREP_TOKEN and SEMGREP_ID in your env."; else docker run -it --rm --init --volume $(realpath .):/automate --workdir /automate returntocorp/semgrep-action:v1 python -m semgrep_agent --publish-token ${SEMGREP_TOKEN} --publish-deployment ${SEMGREP_ID}; fi

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild, ElementRef, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, ViewChild, ElementRef, OnDestroy } from '@angular/core';
 import { capitalize, getOr, endsWith, replace, concat } from 'lodash/fp';
 import { Subject, Observable } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
@@ -14,7 +14,7 @@ const ENTITY_TYPE_TAG = 'event-type';
   styleUrls: ['./event-feed-table.component.scss']
 })
 
-export class EventFeedTableComponent implements OnDestroy, OnInit {
+export class EventFeedTableComponent implements OnDestroy {
   @Input() events: ChefEvent[];
   // The currently set collection of searchbar filters
   @Input() searchBarFilters: Chicklet[];
@@ -31,10 +31,6 @@ export class EventFeedTableComponent implements OnDestroy, OnInit {
   constructor(
     private eventFeedService: EventFeedService
   ) { }
-
-  ngOnInit() {
-
-  }
 
   ngOnDestroy(): void {
     this.isDestroyed.next(true);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?


1. Adding some new syntax checking rules.

2. Adding targets to global makefile so one can run semgrep on the entire codebase (in addition to the  individual targets on a per project basis introduced earlier), with a variation to run it differentially the way CI now does, per the next bullet.

3. Switching semgrep-agent to run in differential mode--it will check only the files in the current PR, providing several benefits:
(a) Checks only changes in each PR in Buildkite.
(b) Much faster run time.
(c) Newly introduced rules from the vendor cannot break the build on master.
(d) Reports in the web UI do not keep repeating pre-existing issues in the rest of the code base.

### :chains: Related Resources
NA

### :+1: Definition of Done
Globally:
 - `make semgrep` from the repo root to run differentially, the way buildkite does
 - `make semgrep-all` from the repo root to scan the entire codebase

Dashboard runs now report differential results...
```
=== setting up agent configuration
| using semgrep rules configured on the web UI
| using path ignore rules from .semgrepignore
| looking at 5 changed paths
| found 5 files in the paths to be scanned
=== looking for current issues in 5 files
```

... instead of the entire codebase:
```
== setting up agent configuration
| using semgrep rules configured on the web UI
| using path ignore rules from .semgrepignore
| found 7753 files in the paths to be scanned
| skipping 761 files based on path ignore rules
=== looking for current issues in 6992 files
```

### :athletic_shoe: How to Build and Test the Change
As above.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

