### PR TITLE
Studio function to create an example Policyfile

### DIFF
--- a/.studio/chef-server-collection
+++ b/.studio/chef-server-collection
@@ -19,6 +19,7 @@ function set_up_chef_server_test_environment() {
   chef_server_pivotal_key_path="/hab/svc/automate-cs-oc-erchef/data/pivotal.pem"
   chef_server_pivotal_rb_path="/tmp/.pivotal.rb"
   chef_server_client_rb_path="/tmp/.client.rb"
+  chef_server_policyfile_rb_path="/tmp/.policyfile.rb"
   chef_server_test_admin_key_path_path="/tmp/.admin_key.pem"
   chef_server_berksfile_path="/tmp/.Berksfile"
   chef_server_berksfile_config_path="/tmp/.berks.config.json"
@@ -26,6 +27,7 @@ function set_up_chef_server_test_environment() {
   chef_server_first_boot_json_path="/tmp/.first_boot.json"
   chef_server_compliance_profiles_test_path="/hab/svc/compliance-service/data/profiles/test"
   chef_server_test_node_name="test-admin"
+  chef_server_policyfile_test_node_name="test-policyfile"
   chef_server_test_admin_user_name="test-admin"
   chef_server_test_admin_user_email="admin@test.com"
   chef_server_test_user_name="test-user"
@@ -70,6 +72,19 @@ ssl_verify_mode        :verify_none
 client_key             '${chef_server_test_admin_key_path_path}'
 validation_client_name 'test-validator'
 validation_key         '${chef_server_test_validator_path}'
+EOH
+
+  cat << EOH > ${chef_server_policyfile_rb_path}
+log_location           STDOUT
+chef_server_url        'https://${chef_server_hostname}/organizations/${chef_server_test_org_name}'
+node_name              '${chef_server_policyfile_test_node_name}'
+ssl_verify_mode        :verify_none
+client_key             '${chef_server_test_admin_key_path_path}'
+validation_client_name 'test-validator'
+validation_key         '${chef_server_test_validator_path}'
+policy_group           'test_policy_group'
+policy_name            'examplecb'
+use_policyfile         true
 EOH
 
   cat << EOH > ${chef_server_berksfile_config_path}
@@ -141,18 +156,27 @@ DOC
 function push_example_policyfile() {
   bootstrap_chef_user_data || return 1
 
-  pushd /tmp &> /dev/null
+  pushd /tmp &> /dev/null || exit
 
   hab pkg install chef/chef-dk -bf
   CHEF_LICENSE=accept-no-persist chef generate cookbook examplecb
 
-  cd examplecb
+  cd examplecb || exit
 
   CHEF_LICENSE=accept-no-persist chef install
 
-  CHEF_LICENSE=accept-no-persist chef push test_policy_group -c ${chef_server_client_rb_path}
+  CHEF_LICENSE=accept-no-persist chef push test_policy_group -c ${chef_server_policyfile_rb_path}
 
-  popd &> /dev/null
+  popd &> /dev/null || exit
+}
+
+document "converge_policyfile_chef_client" <<DOC
+  Converges a test chef-client with a policyfile
+DOC
+function converge_policyfile_chef_client() {
+  push_example_policyfile || return 1
+
+  CHEF_LICENSE=accept-no-persist chef-client -c ${chef_server_policyfile_rb_path}
 }
 
 document "converge_chef_client" <<DOC

--- a/.studio/chef-server-collection
+++ b/.studio/chef-server-collection
@@ -134,6 +134,27 @@ EOH
   berks upload -b ${chef_server_berksfile_path} -c ${chef_server_berksfile_config_path}
 }
 
+document "push_policy_update" <<DOC
+  Pushes a policyfile update to chef server with a cookbook. This also creates a policyfile update 
+  in the event feed. 
+DOC
+function push_example_policyfile() {
+  bootstrap_chef_user_data || return 1
+
+  pushd /tmp &> /dev/null
+
+  hab pkg install chef/chef-dk -bf
+  CHEF_LICENSE=accept-no-persist chef generate cookbook examplecb
+
+  cd examplecb
+
+  CHEF_LICENSE=accept-no-persist chef install
+
+  CHEF_LICENSE=accept-no-persist chef push test_policy_group -c ${chef_server_client_rb_path}
+
+  popd &> /dev/null
+}
+
 document "converge_chef_client" <<DOC
   Converges a test chef-client
 DOC

--- a/.studio/chef-server-collection
+++ b/.studio/chef-server-collection
@@ -27,7 +27,6 @@ function set_up_chef_server_test_environment() {
   chef_server_first_boot_json_path="/tmp/.first_boot.json"
   chef_server_compliance_profiles_test_path="/hab/svc/compliance-service/data/profiles/test"
   chef_server_test_node_name="test-admin"
-  chef_server_policyfile_test_node_name="test-policyfile"
   chef_server_test_admin_user_name="test-admin"
   chef_server_test_admin_user_email="admin@test.com"
   chef_server_test_user_name="test-user"
@@ -77,7 +76,7 @@ EOH
   cat << EOH > ${chef_server_policyfile_rb_path}
 log_location           STDOUT
 chef_server_url        'https://${chef_server_hostname}/organizations/${chef_server_test_org_name}'
-node_name              '${chef_server_policyfile_test_node_name}'
+node_name              '${chef_server_test_node_name}'
 ssl_verify_mode        :verify_none
 client_key             '${chef_server_test_admin_key_path_path}'
 validation_client_name 'test-validator'

--- a/dev-docs/adding-data/adding_test_data.md
+++ b/dev-docs/adding-data/adding_test_data.md
@@ -88,7 +88,7 @@ from hab studio:
 
 ensure you have `jq` installed
 
-there are three options...
+there are four options...
 1. `infra_service_load_sample_data`
     
     By default, 50 records of the infra servers and orgs will be added with the prefix `chef-server` and `chef-org` respectively.
@@ -105,6 +105,11 @@ there are three options...
     This will spin up the local chef infra server and it will add the data resides at [chef-repo](./infra/chef-repo) folder using `knife upload` method.
 
 ----------------------------------------------------------------------------------
+
+## Adding a policyfile node
+1. Ensure Chef Infra Server is running. If it is not start it with `start_chef_server`
+1. Then run `converge_policyfile_chef_client`
+
 # DELETING DATA
 
 to delete the postgres scanjobs data:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding a new studio functions `push_example_policyfile` and `converge_policyfile_chef_client` that create a CCR with an example policyfile. This is useful when testing policyfiles with Infra nodes or the event feed. The `converge_policyfile_chef_client` function first calls the `push_example_policyfile` function to create the example policyfile and upload it to Chef-Server.

### :athletic_shoe: How to Build and Test the Change
1. From the Automate hab studio run `start_all_services`
1. To start the Automate chef infra server run `start_chef_server`
1. To create a CCR with an example policyfile run `converge_policyfile_chef_client`. This function first creates the example policyfile by calling the `push_example_policyfile` function. 
1. Goto the event feed in the UI to see the new events https://a2-dev.test/dashboards/event-feed (image below)
1. Goto the infrastructure tab in the UI to see the policyfile CCR node named "test-policyfile" https://a2-dev.test/infrastructure/client-runs (image below)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Event Feed
![policyfile](https://user-images.githubusercontent.com/1679247/101400835-53584900-3886-11eb-8ab7-4aaaa4e02970.png)

Infrastructure
![policyfile_node](https://user-images.githubusercontent.com/1679247/101422238-105c9c80-38ab-11eb-9d25-78da36d72746.png)
