### PR TITLE
Policyfile cookbooks display name in event feed

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.spec.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.spec.ts
@@ -193,6 +193,28 @@ describe('EventFeedTableComponent', () => {
       expect(label).toEqual(
         'Cookbooks <b>nginx</b>, version <b>1.2.3</b> deleted by <b>requestor_name</b>');
     });
+
+    it('cookbook_artifact_version event type', () => {
+      const event = new ChefEvent({
+        event_type: 'cookbook_artifact_version',
+        task: 'update',
+        start_time: new Date(1566457200000),
+        entity_name: 'ed458ff53f19c306484cb1f23e6d76f937a32ad6',
+        requestor_type: 'user',
+        requestor_name: 'delivery',
+        service_hostname: 'chef-server.chef.co',
+        parent_name: 'rabbitmq',
+        parent_type: 'cookbook_artifact',
+        event_count: 1,
+        end_time: new Date(1566975540000),
+        end_id: 'bd76527e-39a7-11eb-adc1-0242ac120002',
+        start_id: 'bd76527e-39a7-11eb-adc1-0242ac120002'
+      });
+
+      const label = component.getEventDescription(event);
+      expect(label).toEqual(
+        'Cookbook <b>rabbitmq</b>, version <b>ed458ff53f19c306484cb1f23e6d76f937a32ad6</b> updated by <b>delivery</b>');
+    });
   });
 
   describe('getEventGroupText', () => {

--- a/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-table/event-feed-table.component.ts
@@ -151,6 +151,9 @@ export class EventFeedTableComponent implements OnDestroy {
         break;
       // TODO @afiune format other event types like a data bag item
       // case 'item':
+      case 'cookbook_artifact_version':
+        text += `<b>${event.parentName}</b>, version <b>${event.entityName}</b>`;
+        break;
       default:
         text += `<b>${event.entityName}</b>`;
     }
@@ -174,6 +177,8 @@ export class EventFeedTableComponent implements OnDestroy {
         return `${event.parentName}: v${event.entityName}`;
       // TODO @afiune format other event types like a data bag item
       // case 'item':
+      case 'cookbook_artifact_version':
+        return `${event.parentName}: v${event.entityName}`;
       default:
         return event.entityName;
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This change fixes the situation where the event feed does not display the name of policyfile cookbook updates. 

### :athletic_shoe: How to Build and Test the Change
1. From the Automate hab studio run `start_all_services`
1. To start the Automate chef infra server run `start_chef_server`
1. To update the changes in the UI run `build components/automate-ui-devproxy/` and `start_automate_ui_background`
1. Create an example policyfile by running the `push_example_policyfile` function. 
1. Goto the event feed in the UI to see the new cookbook events https://a2-dev.test/dashboards/event-feed (image below)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Single cookbook
![policyfile_cookbook](https://user-images.githubusercontent.com/1679247/101553857-59275a80-396a-11eb-81b3-3d491ac0bde4.png)

Grouped cookbooks
![image](https://user-images.githubusercontent.com/1679247/101555154-e4a1eb00-396c-11eb-8a9b-b63e6fc41d49.png)
