### PR TITLE
automate-cs-oc-erchef: fix GEM_PATH in run hook

### DIFF
--- a/components/automate-cs-oc-erchef/habitat/hooks/run
+++ b/components/automate-cs-oc-erchef/habitat/hooks/run
@@ -49,7 +49,7 @@ HOME="{{pkg.svc_data_path}}" BUNDLE_GEMFILE="{{pkgPathFor "chef/oc_erchef"}}/Gem
 export PATH={{pkgPathFor "core/ruby26"}}/bin:${PATH}
 export LD_LIBRARY_PATH={{pkgPathFor "core/libffi"}}/lib:${LD_LIBRARY_PATH}
 export GEM_HOME={{pkgPathFor "chef/oc_erchef"}}/vendor/bundle
-export GEM_PATH={{pkgPathFor "core/oc_erchef"}}/vendor/bundle
+export GEM_PATH={{pkgPathFor "chef/oc_erchef"}}/vendor/bundle
 
 # non root svc user and we need write access to the file
 cp {{pkg.svc_config_path}}/dark_launch_features.json {{pkg.svc_data_path}}


### PR DESCRIPTION
This was using pkgPathFor on core/oc_erchef which doesn't exist. The
package is actually called chef/oc_erchef.

Astute readers may wonder whether we even need to step this variable
if all the tests pare passing even though it was previously
incorrectly set. That issue is left as an exercise for the reader.

Signed-off-by: Steven Danna <steve@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
