### PR TITLE
deployment-service/ci: retry file-access errors when waiting for upgrade

### DIFF
--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1981,6 +1981,7 @@ func (s *server) readOrGenDeploymentServiceCerts() (*certs.ServiceCerts, bool, e
 	if fileExist(constants.CertPath) && fileExist(constants.KeyPath) && fileExist(constants.RootCertPath) {
 		tlsCerts, err := s.readAndValidate(req)
 		if err != nil {
+			logrus.WithError(err).Info("deployment-service certificate regeneration required")
 			cleanupOldCerts()
 		} else {
 			return tlsCerts, false, nil

--- a/integration/helpers/deployment.sh
+++ b/integration/helpers/deployment.sh
@@ -76,6 +76,9 @@ wait_for_upgrade() {
             0)
                 :
                 ;;
+            90)
+                log_warning "File access error for chef-automate upgrade status: likely cause deploymet-service certificate regen"
+                ;;
             98|99)
                 log_warning "Error calling deployment service"
                 ;;

--- a/integration/helpers/deployment.sh
+++ b/integration/helpers/deployment.sh
@@ -77,7 +77,7 @@ wait_for_upgrade() {
                 :
                 ;;
             90)
-                log_warning "File access error for chef-automate upgrade status: likely cause deploymet-service certificate regen"
+                log_warning "File access error for chef-automate upgrade status: likely cause is deployment-service certificate regen"
                 ;;
             98|99)
                 log_warning "Error calling deployment service"


### PR DESCRIPTION
During upgrades from old versions, we may require a deployment-service
certificate regeneration. If the chef-automate command line tool
attempts to read the deployment-service certificate during this
regeneration, it may receive a FileAccessError such as:

    FileAccessError: Unable to access the file or directory: Failed to
    read deployment-service TLS certificates: Could not read the
    service cert: open
    /hab/svc/deployment-service/data/deployment-service.crt: no such
    file or directory

Since we expect this error to be transient, we now retry this error in
the wait_for_upgrade loop in CI. We also log a bit more information
about the deployment-service certificate regen.

Signed-off-by: Steven Danna <steve@chef.io>