### PR TITLE
Add 0BSD as an allowed open source license

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -58,6 +58,7 @@ habitat:
     - origin: chef
       channel: dev
 allowed_licenses:
+  - 0BSD
   - Apache-1.0
   - Apache-1.1
   - Apache-2.0


### PR DESCRIPTION
This license has been fully approved by the Chef/Progress legal team.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
