### PR TITLE
Resolve redux devtools crashing

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { StoreModule } from '@ngrx/store';
 import { StoreRouterConnectingModule } from '@ngrx/router-store';
 import { NgrxEffectsModule } from './ngrx.effects';
-import { ngrxReducers, RouterSerializer, runtimeChecks } from './ngrx.reducers';
+import { ngrxReducers, RouterSerializer, runtimeChecks, actionSanitizer, stateSanitizer } from './ngrx.reducers';
 
 // angular material stuff
 import {
@@ -284,7 +284,8 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
     StoreRouterConnectingModule.forRoot({
       serializer: RouterSerializer
     }),
-    !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 25 }) : []
+    environment.production ? []
+      : StoreDevtoolsModule.instrument({ maxAge: 25 /* states */, actionSanitizer, stateSanitizer })
   ],
   providers: [
     AdminKeyRequests,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -1,6 +1,8 @@
 import { Params, RouterStateSnapshot, UrlSegment } from '@angular/router';
 import * as router from '@ngrx/router-store';
+import { Action } from '@ngrx/store';
 import { set, get, pipe, map } from 'lodash/fp';
+
 import * as destinationEntity from './entities/destinations/destination.reducer';
 import * as scanner from './pages/+compliance/+scanner/state/scanner.state';
 import * as eventFeed from './services/event-feed/event-feed.reducer';
@@ -53,6 +55,8 @@ import * as nodeCredentialList from './pages/+compliance/+node-credentials/node-
 import * as teamEntity from './entities/teams/team.reducer';
 import * as userEntity from './entities/users/user.reducer';
 import * as userSelfEntity from './entities/users/userself.reducer';
+
+import { LayoutActionTypes, UpdateSidebars } from './entities/layout/layout.actions';
 
 // AOT likely won't allow dynamic object property names here even when the underlying
 // typescript bug preventing it is fixed
@@ -304,3 +308,22 @@ export const ngrxReducers = {
   users: userEntity.userEntityReducer,
   userSelf: userSelfEntity.userSelfEntityReducer
 };
+
+// Add other actions as needed if Redux Dev Tools starts crashing in the browser
+export const actionSanitizer = (action: Action): Action =>
+  action.type === LayoutActionTypes.UPDATE_SIDEBARS && (action as UpdateSidebars).payload
+    ? { ...action, payload: '<<LONG_BLOB>>' } as UpdateSidebars
+    : action;
+
+// The UPDATE_SIDEBARS action above creates a large chunk of state in the sidebars property.
+// Blank it out for Redux Dev Tools to reduce its memory footprint.
+export const stateSanitizer = (state: NgrxStateAtom): NgrxStateAtom =>
+  state?.layout?.sidebars
+    ? {
+      ...state,
+      layout: {
+        ...state.layout,
+        sidebars: {}
+      }
+    }
+    : state;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Before this patch, ReduxDevTools in the browser (Chrome or Firefox) would crash very soon after launching the Automate UI. Sometimes it would actually mention that it was going to be slow and consume a huge amount of memory.

To see this: install the Redux Dev Tools browser extension, enable it, navigate to a2-dev.test in your browser, open the browser Dev Tools (<kbd>cmd</kbd> + <kbd>opt</kbd> + <kbd>i</kbd>), and open the Redux tab in the browser Dev Tools.

Depending on your timing, you might see an initial few actions like this...
<img width="493" alt="image" src="https://user-images.githubusercontent.com/6817500/102509897-ee49e380-403b-11eb-902c-364d73a80317.png">

... but it will stop updating and eventually crash.

You can see that it is consuming huge amounts of memory via Activity Monitor, htop, or other process monitor. In the illustration I have filtered by chrome's helpers and sorted descending. The topmost "Google Chrome Helper (Renderer)" before this patch is applied will quickly grow to just about 5 GB -- yes, gigabytes! -- and that is precisely when the Redux Dev Tools will report a crash.

![image](https://user-images.githubusercontent.com/6817500/102510155-2b15da80-403c-11eb-92fa-485b4f8a697b.png)


The redux dev tools docs include a [Troubleshooting Section on Excessive Memory Use](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Troubleshooting.md#excessive-use-of-memory-and-cpu). There it talks about introducing sanitizing the state and action against huge pieces with an action sanitizer and a state sanitizer: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#actionsanitizer--statesanitizer

I went down a couple false trails trying to unravel this: the first was hunting the `ui-router` aspect mentioned on the troubleshooting page.

The second was ngrx/router-store crashing Chrome Redux DevTools Extension (https://github.com/ngrx/platform/issues/537). That may actually have been an issue in our code base at one time, but we already have the referenced code there integrated into ngrx.reducers.ts, so it is not involved in the current issue.

#### The path forward

There were two things I needed to figure out to resolve this issue:

##### What to prune

I needed to isolate the actions and state generating large data footprints in our data store, then  prune those using action/state sanitizers.

##### Wiring up the sanitizers

The only references (e.g., https://github.com/zalmoxisus/redux-devtools-extension/#14-using-in-production) only show using sanitizers via `createStore`, which is not used directly in an Angular application.

This issue (https://github.com/zalmoxisus/redux-devtools-extension/issues/455) -- which again discusses the not relevant ui-router problem -- goes as far as wiring them up to a thing called `composeEnhancers`... but then does not show what to do with that constant.

This article (https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f) ties together the createStore and the `composeEnhancers`, but alas, nothing further.

One more issue (https://github.com/zalmoxisus/redux-devtools-extension/issues/619) discusses some possibilities but nothing concrete there.

I finally divined that I need to use the [StoreDevtoolsModule](https://ngrx.io/api/store-devtools/StoreDevtoolsModule)...
<img width="423" alt="image" src="https://user-images.githubusercontent.com/6817500/102511477-adeb6500-403d-11eb-8412-3de1f79b63f3.png">

... and, in fact, `actionSanitizer` and `stateSanitizer` are components of the [StoreDevtoolsConfig](https://ngrx.io/api/store-devtools/StoreDevtoolsConfig).
<img width="367" alt="image" src="https://user-images.githubusercontent.com/6817500/102511593-cfe4e780-403d-11eb-9ecc-b9491a3a57d9.png">

### :chains: Related Resources
Because this was a non-trivial exercise, I pushed an update to their troubleshooting doc via [this PR](https://github.com/zalmoxisus/redux-devtools-extension/pull/770).

### :+1: Definition of Done
<img width="428" alt="image" src="https://user-images.githubusercontent.com/6817500/102511841-218d7200-403e-11eb-99c0-c9cd944e9175.png">


### :athletic_shoe: How to Build and Test the Change

- install the Redux Dev Tools browser extension
- enable it
- navigate to a2-dev.test in your browser
- open the browser Dev Tools (<kbd>cmd</kbd> + <kbd>opt</kbd> + <kbd>i</kbd>)
- open the Redux tab in the browser Dev Tools
- navigate around the Automate app
- observe the actions populating the store in the redux Dev Tools

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
