### PR TITLE
page crash on trend graph on selecting 3 month/1 year data

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -52,7 +52,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   private get trendData(): TrendData[] {
-    if(this.trendDataCache === undefined || this.trendDataCache.length == 0) {
+    if (this.trendDataCache === undefined || this.trendDataCache.length == 0) {
       this.trendDataCache = this.data.map(d => {
         return { ...d, report_time: this.createUtcDate(d.report_time) };
       });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -53,7 +53,6 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   private get trendData(): TrendData[] {
     if(this.trendDataCache === undefined || this.trendDataCache.length == 0) {
-      console.log("trendDataCache..!")
       this.trendDataCache = this.data.map(d => {
         return { ...d, report_time: this.createUtcDate(d.report_time) };
       });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -33,6 +33,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     private el: ElementRef,
     @Inject(DOCUMENT) private document: Document
   ) {}
+  treandDataCache = [];
 
   @Input() data = [];
 
@@ -51,9 +52,13 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   get trendData(): TrendData[] {
-    return this.data.map(d => {
-      return { ...d, report_time: this.createUtcDate(d.report_time) };
-    });
+    if(this.treandDataCache === undefined || this.treandDataCache.length == 0) {
+      console.log("trendDataCache..!")
+      this.treandDataCache = this.data.map(d => {
+        return { ...d, report_time: this.createUtcDate(d.report_time) };
+      });
+    }
+    return this.treandDataCache
   }
 
   get domainX() {
@@ -128,8 +133,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
         'waived'
       ].map(status => ({ status, values: this.trendData })));
   }
-
   ngOnChanges() {
+    this.treandDataCache = [];
     this.resize();
     this.draw();
   }
@@ -317,12 +322,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   createUtcDate(time: string): Date {
-    const utcDate = moment(time).utc();
-    if (utcDate.isValid) {
-      return new Date(utcDate.year(), utcDate.month(), utcDate.date());
-    } else {
-      console.error('Not a valid date ' + time);
-      return new Date();
-    }
+    const utcDate = moment(time);
+    return new Date(utcDate.year(), utcDate.month(), utcDate.date());
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -33,7 +33,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     private el: ElementRef,
     @Inject(DOCUMENT) private document: Document
   ) {}
-  treandDataCache = [];
+  trendDataCache = [];
 
   @Input() data = [];
 
@@ -51,35 +51,35 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     return `0 0 ${this.vbWidth} ${this.vbHeight}`;
   }
 
-  get trendData(): TrendData[] {
-    if(this.treandDataCache === undefined || this.treandDataCache.length == 0) {
+  private get trendData(): TrendData[] {
+    if(this.trendDataCache === undefined || this.trendDataCache.length == 0) {
       console.log("trendDataCache..!")
-      this.treandDataCache = this.data.map(d => {
+      this.trendDataCache = this.data.map(d => {
         return { ...d, report_time: this.createUtcDate(d.report_time) };
       });
     }
-    return this.treandDataCache
+    return this.trendDataCache
   }
 
-  get domainX() {
+  private get domainX() {
     const min = d3.min(this.trendData, (d: TrendData) => d.report_time);
     const max = d3.max(this.trendData, (d: TrendData) => d.report_time);
     return [min, max];
   }
 
-  get rangeX() {
+  private get rangeX() {
     const min = 50;
     const max = this.vbWidth - 50;
     return [min, max];
   }
 
-  get scaleX() {
+  private get scaleX() {
     return d3.scaleTime()
       .domain(this.domainX)
       .range(this.rangeX);
   }
 
-  get domainY() {
+  private get domainY() {
     const min = 0;
     const max = d3.max(this.trendData, (d: TrendData) => d3.max([
       d.failed,
@@ -90,41 +90,41 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     return [min, max];
   }
 
-  get rangeY() {
+  private get rangeY() {
     const min = 10;
     const max = this.vbHeight - 30;
     return [max, min];
   }
 
-  get scaleY() {
+  private get scaleY() {
     return d3.scaleLinear()
       .domain(this.domainY)
       .range(this.rangeY);
   }
 
-  get svgSelection() {
+  private get svgSelection() {
     return d3.select(this.svg.nativeElement);
   }
 
-  get axisXSelection() {
+  private get axisXSelection() {
     return this.svgSelection.select('.x-axis');
   }
 
-  get axisYSelection() {
+  private get axisYSelection() {
     return this.svgSelection.select('.y-axis');
   }
 
-  get dotsSelection() {
+  private get dotsSelection() {
     return this.svgSelection.selectAll('.dot-group')
       .data(this.trendData, (d: TrendData) => d.report_time.getTime());
   }
 
-  get tipsSelection() {
+  private get tipsSelection() {
     return d3.select(this.document.body).selectAll('.dot-group-tip')
       .data(this.trendData, (d: TrendData) => d.report_time.getTime());
   }
 
-  get linesSelection() {
+  private get linesSelection() {
     return this.svgSelection.selectAll('.status-line')
       .data([
         'skipped',
@@ -134,7 +134,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
       ].map(status => ({ status, values: this.trendData })));
   }
   ngOnChanges() {
-    this.treandDataCache = [];
+    this.trendDataCache = [];
     this.resize();
     this.draw();
   }
@@ -322,7 +322,11 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   createUtcDate(time: string): Date {
-    const utcDate = moment(time);
-    return new Date(utcDate.year(), utcDate.month(), utcDate.date());
-  }
+    const utcDate = moment.utc(time);
+    if (utcDate.isValid) {	    
+      return new Date(utcDate.year(), utcDate.month(), utcDate.date());	
+    } else {	
+      console.error('Not a valid date ' + time);	
+      return new Date();	
+    }  }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -45,7 +45,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   @Input() vbHeight = 300;
 
   @ViewChild('svg', { static: true }) svg;
-  
+
   trendDataCache = [];
 
   get viewBox() {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -52,12 +52,12 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   private get trendData(): TrendData[] {
-    if (this.trendDataCache === undefined || this.trendDataCache.length == 0) {
+    if (this.trendDataCache === undefined || this.trendDataCache.length === 0) {
       this.trendDataCache = this.data.map(d => {
         return { ...d, report_time: this.createUtcDate(d.report_time) };
       });
     }
-    return this.trendDataCache
+    return this.trendDataCache;
   }
 
   private get domainX() {
@@ -322,10 +322,10 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
 
   createUtcDate(time: string): Date {
     const utcDate = moment.utc(time);
-    if (utcDate.isValid) {	    
-      return new Date(utcDate.year(), utcDate.month(), utcDate.date());	
-    } else {	
-      console.error('Not a valid date ' + time);	
-      return new Date();	
+    if (utcDate.isValid) {
+      return new Date(utcDate.year(), utcDate.month(), utcDate.date());
+    } else {
+      console.error('Not a valid date ' + time);
+      return new Date();
     }  }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -33,7 +33,6 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     private el: ElementRef,
     @Inject(DOCUMENT) private document: Document
   ) {}
-  trendDataCache = [];
 
   @Input() data = [];
 
@@ -46,6 +45,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   @Input() vbHeight = 300;
 
   @ViewChild('svg', { static: true }) svg;
+  
+  trendDataCache = [];
 
   get viewBox() {
     return `0 0 ${this.vbWidth} ${this.vbHeight}`;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -52,7 +52,7 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
   }
 
   private get trendData(): TrendData[] {
-    if (this.trendDataCache === undefined || this.trendDataCache.length === 0) {
+    if (this.trendDataCache.length === 0) {
       this.trendDataCache = this.data.map(d => {
         return { ...d, report_time: this.createUtcDate(d.report_time) };
       });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -327,5 +327,6 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     } else {
       console.error('Not a valid date ' + time);
       return new Date();
-    }  }
+    }
+  }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The page used to crash when we select the option **Last year/Last 3 month** from the dropdown present in the trend graph, every time we call `this.trendData` it uses to loop through each data present in `this.data`

In `get trendData()` we try to convert time which is in type string (**2020-09-21T23:59:59Z**) to type object (**Mon Sep 21 2020 00:00:00 GMT+0530 (India Standard Time)**)

Eg:- To draw a graph in d3 we are calling trendData 377 time’s ( I saw this when I console log in get tendData() ) for 10 day’s graph call is **377 * 10 = 3,770** and for one year data is **377 * 366 = 1,37,982** 

When we select 10 days in option
<img width="1422" alt="Screenshot 2020-12-22 at 7 28 30 PM" src="https://user-images.githubusercontent.com/47217471/102896953-46924280-448d-11eb-8d76-d32e84bfc042.png">

<img width="711" alt="Screenshot 2020-12-22 at 7 34 22 PM" src="https://user-images.githubusercontent.com/47217471/102897020-5d389980-448d-11eb-8b7f-e99dcdcea093.png">
 
When we select 1 year in option
<img width="1424" alt="Screenshot 2020-12-22 at 7 48 37 PM" src="https://user-images.githubusercontent.com/47217471/102897899-bf45ce80-448e-11eb-8bb7-07ee669c6235.png">


### :chains: Related Resources
https://github.com/chef/automate/issues/4353 
### :+1: Definition of Done
We try to loop only once and Cache in trendDataCache
So that we don’t have to loop once again (from the second time onwards, so we are avoiding to loop 366 Times)

Eg:- if `trendDataCache` is equal to Zero/no data is present in trendDataCache only then we try to convert time which is in type string (**2020-09-21T23:59:59Z**) to type object (**Mon Sep 21 2020 00:00:00 GMT+0530 (India Standard Time)**) for the second time we can make use of trendDataCache without looking through

To draw a graph in d3 we are calling trendData one time for 10 day’s graph call is **1 * 10 = 10** and for one year data is **1 * 366 = 366** 

https://user-images.githubusercontent.com/47217471/102895805-60cb2100-448b-11eb-8537-6c3e7121dc8a.mov



### :athletic_shoe: How to Build and Test the Change

```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command make serve
```
Then open automate-ui in browser goto **Compliance -> Report** You will find the trend Graph select the option **Last year/Last 3 month** from the dropdown present in the trend graph

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable