### PR TITLE
[WIP] Extend export report API to support xml format

### DIFF
--- a/components/compliance-service/reporting/util/xml.go
+++ b/components/compliance-service/reporting/util/xml.go
@@ -1,0 +1,133 @@
+package util
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	reportingapi "github.com/chef/automate/api/interservice/compliance/reporting"
+)
+
+type xmlFields struct {
+	XMLName          xml.Name  `xml:"Node"`
+	ID               string    `xml:"ID,omitempty"`
+	NodeID           string    `xml:"NodeID,omitempty"`
+	NodeName         string    `xml:"NodeName,omitempty"`
+	EndTime          int64     `xml:"EndTime>Seconds,omitempty"`
+	Platform         Platform  `xml:"Platform,omitempty"`
+	Environment      string    `xml:"Environment,omitempty"`
+	IPAddress        string    `xml:"IPAddress,omitempty"`
+	FQDN             string    `xml:"FQDN,omitempty"`
+	Profiles         []Profile `xml:"Profiles,omitempty"`
+	Version          string    `xml:"Version,omitempty"`
+	ChefServer       string    `xml:"ChefServer,omitempty"`
+	ChefOrganization string    `xml:"ChefOrganization,omitempty"`
+}
+
+// Platform detail
+type Platform struct {
+	Name    string `xml:"Platform>Name,omitempty"`
+	Release string `xml:"Platform>Release,omitempty"`
+	Full    string `xml:"Platform>Full,omitempty"`
+}
+
+// Profile detail
+type Profile struct {
+	Name      string    `xml:"Profile>Name,omitempty"`
+	Title     string    `xml:"Profile>Title,omitempty"`
+	Version   string    `xml:"Profile>Version,omitempty"`
+	Summary   string    `xml:"Profile>Summary,omitempty"`
+	Controles []Control `xml:"Profile>Controles,omitempty"`
+}
+
+// Control detail
+type Control struct {
+	ID                  string   `xml:"Control>ID,omitempty"`
+	Title               string   `xml:"Control>Title,omitempty"`
+	Impact              float32  `xml:"Control>Impact,omitempty"`
+	Waived              string   `xml:"Waived,omitempty"`
+	WaiverJustification string   `xml:"Waiver>Justification,omitempty"`
+	WaiverExpiration    string   `xml:"Waiver>Expiration,omitempty"`
+	Results             []Result `xml:"Results,omitempty"`
+}
+
+// Result detail
+type Result struct {
+	Status          string  `xml:"Result>Status,omitempty"`
+	RunTime         float32 `xml:"Result>RunTime,omitempty"`
+	CodeDescription string  `xml:"Result>CodeDescription,omitempty"`
+	Message         string  `xml:"Result>Message,omitempty"`
+	SkipMessage     string  `xml:"Result>SkipMessage,omitempty"`
+}
+
+// ReportToXML converts a report to its XML representation as a string
+func ReportToXML(report *reportingapi.Report) ([]byte, error) {
+	if report == nil {
+		return []byte{}, fmt.Errorf("Received an empty report to be converted to XML")
+	}
+
+	exportProfiles := make([]Profile, len(report.Profiles))
+
+	for i, profile := range report.Profiles {
+		exportControls := make([]Control, len(profile.Controls))
+
+		for j, control := range profile.Controls {
+			exportResults := make([]Result, len(control.Results))
+
+			for k, result := range control.Results {
+				exportResults[k] = Result{
+					Status:          result.Status,
+					RunTime:         result.RunTime,
+					CodeDescription: result.CodeDesc,
+					Message:         result.Message,
+					SkipMessage:     result.SkipMessage,
+				}
+			} // End of results loop
+
+			exportControls[j] = Control{
+				ID:                  control.Id,
+				Title:               control.Title,
+				Impact:              control.Impact,
+				Waived:              control.WaivedStr,
+				WaiverJustification: control.WaiverData.GetJustification(),
+				WaiverExpiration:    control.WaiverData.GetExpirationDate(),
+				Results:             exportResults,
+			}
+		} // End of controls loop
+
+		exportProfiles[i] = Profile{
+			Name:      profile.Name,
+			Title:     profile.Title,
+			Version:   profile.Version,
+			Summary:   profile.Summary,
+			Controles: exportControls,
+		}
+	} // End of profiles loop
+
+	xF := xmlFields{
+		ID:       report.Id,
+		NodeID:   report.NodeId,
+		NodeName: report.NodeName,
+		EndTime:  report.EndTime.GetSeconds(),
+
+		Platform: Platform{
+			Name:    report.GetPlatform().GetName(),
+			Release: report.GetPlatform().GetRelease(),
+			Full:    report.GetPlatform().GetFull(),
+		},
+
+		Environment:      report.Environment,
+		IPAddress:        report.Ipaddress,
+		FQDN:             report.Fqdn,
+		Profiles:         exportProfiles,
+		Version:          report.Version,
+		ChefServer:       report.ChefServer,
+		ChefOrganization: report.ChefOrganization,
+	}
+
+	content, err := xml.MarshalIndent(xF, "  ", "    ")
+	if err != nil {
+		return []byte{}, fmt.Errorf("Failed to marshal XML report: %+v", err)
+	}
+
+	return content, nil
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
- As of now we have two supported formats `JSON` & `CSV` to download the compliance report.
- This PR is for supporting the xml format to download the report.

### :chains: Related Resources
Fixes: #1880 

### :+1: Definition of Done
- Export compliance report in XML format.

### :athletic_shoe: How to Build and Test the Change

- `rebuild components/compliance-service/`
- `chef_load_compliance_nodes`
- hit export API with `type: xml`:

```
curl -sSkH "api-token: $(get_admin_token)" -X POST https://a2-dev.test/api/v0/compliance/reporting/export -d '{"type": "xml"}'
```

Response:

```
<Node>
      <ID>42838336-cec8-4ba5-9da2-e87a52bc082b</ID>
      <NodeID>8470e194-8f68-49ff-a61f-6a47670ff00a</NodeID>
      <NodeName>node1</NodeName>
      <EndTime>
          <Seconds>1608197927</Seconds>
      </EndTime>
      <Platform>
          <Platform>
              <Name>ubuntu</Name>
              <Release>16.04</Release>
              <Full>ubuntu 16.04</Full>
          </Platform>
      </Platform>
      <Environment>_default</Environment>
      <IPAddress>10.0.2.15</IPAddress>
      <FQDN>node1.test</FQDN>
      <Profiles>
          <Profile>
              <Name>ssl-baseline</Name>
              <Title>DevSec SSL/TLS Baseline</Title>
              <Version>1.6.3</Version>
              <Summary>Ensures a secure configuration for TCP ports</Summary>
              <Controles>
                  <Control>
                      <ID>au-anon</ID>
                      <Title>Disable ANON as AU from all exposed SSL/TLS ports and versions.</Title>
                      <Impact>0.5</Impact>
                  </Control>
                  <Waived>no</Waived>
                  <Waiver></Waiver>
                  <Results>
                      <Result>
                          <Status>skipped</Status>
                          <RunTime>3.032e-06</RunTime>
                          <CodeDescription>No-op</CodeDescription>
                          <SkipMessage>Skipped control due to only_if condition.</SkipMessage>
                      </Result>
                  </Results>
              </Controles>
              <Controles>
                  <Control>
                      <ID>au-export</ID>
                      <Title>Disable EXPORT as AU from all exposed SSL/TLS ports and versions.</Title>
                      <Impact>0.5</Impact>
                  </Control>
                  <Waived>no</Waived>
                  <Waiver></Waiver>
                  <Results>
                      <Result>
                          <Status>skipped</Status>
                          <RunTime>2.847e-06</RunTime>
                          <CodeDescription>No-op</CodeDescription>
                          <SkipMessage>Skipped control due to only_if condition.</SkipMessage>
                      </Result>
                  </Results>
              </Controles>
          </Profile>
      </Profiles>
      <Version>4.24.8</Version>
      <ChefServer>chef-server.test</ChefServer>
      <ChefOrganization>4thcoffee</ChefOrganization>


```

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>