### PR TITLE
Encrypt secrets that are put in the secrets store

### DIFF
--- a/components/automate-cli/cmd/chef-automate/bootstrap.go
+++ b/components/automate-cli/cmd/chef-automate/bootstrap.go
@@ -177,6 +177,10 @@ func runBootstrapBundleUnpack(cmd *cobra.Command, args []string) error {
 	secretStore := secrets.NewDiskStore(
 		secretStorePath, uid, gid)
 
+	if err := secretStore.Initialize(); err != nil {
+		return errors.Wrap(err, "could not initialize secret store")
+	}
+
 	b := bootstrapbundle.NewCreator(
 		secretStore,
 		bootstrapbundle.WithRootDir(bootstrapBundleCmdFlags.rootDir))

--- a/components/automate-deployment/habitat/plan.sh
+++ b/components/automate-deployment/habitat/plan.sh
@@ -19,7 +19,7 @@ pkg_deps=(
   core/net-tools
   core/procps-ng
   core/util-linux
-  chef/automate-platform-tools
+  "${local_platform_tools_origin:-chef}/automate-platform-tools"
   core/bash
   core/cacerts # fetching manifest over HTTPS
   core/certstrap

--- a/lib/secrets/encrypt.go
+++ b/lib/secrets/encrypt.go
@@ -1,0 +1,148 @@
+package secrets
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/hex"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/pkg/errors"
+)
+
+// SecretKeyJSON secret json structure thats required to write and read
+// to the encrypted secret file
+type SecretKeyJSON struct {
+	Algorithm  string               `json:"algorithm"`
+	IV         initializationVector `json:"iv"`
+	Ciphertext ciphertext           `json:"ciphertext"`
+}
+
+type secretStoreKey struct {
+	keyData rawBytes
+}
+
+func (d *diskStore) keyPath() string {
+	return filepath.Join(d.basePath, "key")
+}
+
+func (d *diskStore) keyExists() (bool, error) {
+	return fileutils.PathExists(d.keyPath())
+}
+
+func (d *diskStore) ensureKey() (secretStoreKey, error) {
+	exists, err := d.keyExists()
+	if err != nil {
+		return secretStoreKey{}, err
+	}
+
+	if exists {
+		// If the key is already created, we will not recreate it
+		return d.loadKey()
+	}
+
+	// Generate a 32 byte random key for AES
+	rb, err := randomBytes(32)
+	if err != nil {
+		return secretStoreKey{}, err
+	}
+
+	// Serialize the key. In our serialized form, it it represented
+	// with hex encoding
+	serializedKey, err := rb.MarshalText()
+	if err != nil {
+		return secretStoreKey{}, err
+	}
+
+	// creating path to store the secret key
+	s := bytes.NewReader(serializedKey)
+
+	// writing the key to a file
+	err = fileutils.AtomicWrite(d.keyPath(), s,
+		fileutils.WithAtomicWriteFileMode(0700),
+		fileutils.WithAtomicWriteChown(d.ownerUid, d.ownerGid),
+	)
+	if err != nil {
+		return secretStoreKey{}, errors.Wrap(err, "could not write secret to disk")
+	}
+
+	return secretStoreKey{
+		keyData: rb,
+	}, nil
+}
+
+func (d *diskStore) loadKey() (secretStoreKey, error) {
+	key, err := ioutil.ReadFile(d.keyPath())
+	if err != nil {
+		return secretStoreKey{}, err
+	}
+	rb := rawBytes{}
+	if err := rb.UnmarshalText(key); err != nil {
+		return secretStoreKey{}, err
+	}
+	return secretStoreKey{
+		keyData: rb,
+	}, nil
+}
+
+func (key secretStoreKey) encrypt(plaintext []byte) (initializationVector, ciphertext, error) {
+	block, err := aes.NewCipher(key.keyData)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error creating cipher block during encryption")
+	}
+	iv, err := randomBytes(block.BlockSize())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not generate random iv for encryption")
+	}
+	stream := cipher.NewCTR(block, iv)
+	ct := make([]byte, len(plaintext))
+	stream.XORKeyStream(ct, plaintext)
+
+	return iv, ct, nil
+}
+
+func (key secretStoreKey) decrypt(iv initializationVector, ct ciphertext) ([]byte, error) {
+	block, err := aes.NewCipher(key.keyData)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to covert secret key to block")
+	}
+	stream := cipher.NewCTR(block, iv)
+	plain := make([]byte, len(ct))
+	stream.XORKeyStream(plain, ct)
+
+	return plain, nil
+}
+
+type rawBytes []byte
+
+func randomBytes(numBytes int) (rawBytes, error) {
+	rb := make([]byte, numBytes)
+	if _, err := rand.Read(rb); err != nil {
+		return nil, errors.Wrap(err, "failed to read random data while generating random bytes")
+	}
+	return rb, nil
+}
+
+func (rb *rawBytes) UnmarshalText(text []byte) error {
+	b := make([]byte, hex.DecodedLen(len(text)))
+	_, err := hex.Decode(b, text)
+	if err != nil {
+		return err
+	}
+	*rb = b
+	return nil
+}
+
+func (rb rawBytes) MarshalText() ([]byte, error) {
+	if rb == nil {
+		return []byte(""), nil
+	}
+	strVal := hex.EncodeToString(rb)
+	return []byte(strVal), nil
+}
+
+type ciphertext = rawBytes
+type initializationVector = rawBytes

--- a/lib/secrets/encrypt_test.go
+++ b/lib/secrets/encrypt_test.go
@@ -1,0 +1,27 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretStoreKey(t *testing.T) {
+	keyData, err := randomBytes(32)
+	require.NoError(t, err)
+	k := secretStoreKey{
+		keyData: keyData,
+	}
+
+	plaintext, err := randomBytes(1477)
+	require.NoError(t, err)
+	iv, ct, err := k.encrypt(plaintext)
+	require.NoError(t, err)
+	require.Len(t, iv, 16)
+	require.Len(t, ct, 1477)
+	require.NotEqual(t, plaintext, ct)
+
+	pt, err := k.decrypt(iv, ct)
+	require.NoError(t, err)
+	require.Equal(t, []byte(plaintext), pt)
+}

--- a/lib/secrets/secrets.go
+++ b/lib/secrets/secrets.go
@@ -241,7 +241,7 @@ func (d *diskStore) SetSecret(secret SecretName, data []byte) error {
 
 	if err := fileutils.AtomicWrite(secretPath, bytes.NewReader(buf.Bytes()),
 		fileutils.WithAtomicWriteFileMode(0700),
-		fileutils.WithAtomicWriteChown(d.ownerGid, d.ownerGid),
+		fileutils.WithAtomicWriteChown(d.ownerUid, d.ownerGid),
 	); err != nil {
 		return errors.Wrap(err, "error writing the secret file")
 	}

--- a/lib/secrets/secrets.go
+++ b/lib/secrets/secrets.go
@@ -7,10 +7,9 @@ package secrets
 
 import (
 	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/chef/automate/lib/user"
-	"github.com/chef/toml"
 )
 
 // Commonly used secrets names. When accessing this library from
@@ -37,14 +35,6 @@ var BifrostSuperuserIDName = SecretName{
 type SecretName struct {
 	Group string
 	Name  string
-}
-
-// SecretKeyToml secret toml structure thats required to write and read
-// to the encrypted secret file
-type SecretKeyToml struct {
-	Algorithm  string `toml:"algorithm"`
-	IV         string `toml:"iv"`
-	Ciphertext string `toml:"ciphertext"`
 }
 
 // SecretNameFromString returns parses the string according to the
@@ -110,7 +100,7 @@ const (
 	DefaultDiskStoreDataOwner = "hab"
 
 	// SecretFileExtension is the extension name for the encrypted secrets file
-	SecretFileExtension = ".enc.toml"
+	SecretFileExtension = ".enc"
 )
 
 func NewDiskStoreReader(basePath string) SecretsReader {
@@ -162,15 +152,8 @@ func (d *diskStore) Initialize() error {
 	}
 
 	// creates encryption key if it does not exist
-	keyExists, err := keyExists(d.basePath)
-	if err != nil {
-		return err
-	}
-	if !keyExists {
-		_, err := d.createEncryptionKey()
-		if err != nil {
-			return err
-		}
+	if _, err := d.ensureKey(); err != nil {
+		return errors.Wrap(err, "could not create encryption key")
 	}
 
 	return nil
@@ -184,14 +167,13 @@ func (d *diskStore) Exists(secret SecretName) (bool, error) {
 		return false, err
 	}
 	if encryptedExists {
-		return encryptedExists, nil
+		return true, nil
 	}
 	path := filepath.Join(d.basePath, secret.Group, secret.Name)
 	return fileutils.PathExists(path)
 }
 
 func (d *diskStore) GetSecret(secret SecretName) ([]byte, error) {
-
 	// checks if the encrypted secret exists
 	pathToEncryptedSecret := filepath.Join(d.basePath, secret.Group, addSecretFileExtension(secret.Name))
 	encryptedSecretExists, err := fileutils.PathExists(pathToEncryptedSecret)
@@ -199,16 +181,21 @@ func (d *diskStore) GetSecret(secret SecretName) ([]byte, error) {
 		return nil, errors.Wrap(err, "unexpected error while checking if encrypted file exists (secret may not have been generated yet)")
 	}
 	if encryptedSecretExists {
-		value, err := ioutil.ReadFile(pathToEncryptedSecret)
+		sktJSON := SecretKeyJSON{}
+		data, err := ioutil.ReadFile(pathToEncryptedSecret)
 		if err != nil {
 			return nil, errors.Wrap(err, "unexpected error while reading encrypted secret data")
 		}
-		// decrypts and returns the secret value
-		ret, err := getDecryptedData(d.basePath, value)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not decrypt secret with existing key")
+
+		if err := json.Unmarshal(data, &sktJSON); err != nil {
+			return nil, errors.Wrap(err, "unexpected error while reading encrypted secret data")
 		}
-		return ret, err
+
+		secretKey, err := d.loadKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load secret key")
+		}
+		return secretKey.decrypt(sktJSON.IV, sktJSON.Ciphertext)
 	}
 
 	// else return unencrypted secret
@@ -221,58 +208,45 @@ func (d *diskStore) GetSecret(secret SecretName) ([]byte, error) {
 }
 
 func (d *diskStore) SetSecret(secret SecretName, data []byte) error {
+	secretKey, err := d.loadKey()
+	if err != nil {
+		return errors.Wrap(err, "failed to load secret key")
+	}
+
 	parentDir := filepath.Join(d.basePath, secret.Group)
 	secretPath := filepath.Join(parentDir, addSecretFileExtension(secret.Name))
-	err := os.MkdirAll(parentDir, 0700)
-	if err != nil {
+
+	if err := os.MkdirAll(parentDir, 0700); err != nil {
 		return errors.Wrap(err, "could not create directory for secrets data")
 	}
-	err = os.Chown(parentDir, d.ownerUid, d.ownerGid)
-	if err != nil {
+
+	if err := os.Chown(parentDir, d.ownerUid, d.ownerGid); err != nil {
 		return errors.Wrap(err, "could not chown directory for secrets data")
 	}
 
-	// creates encrypted data from input data
-	encryptedData, iv, err := getEncryptedData(data, d.basePath)
+	iv, ct, err := secretKey.encrypt(data)
 	if err != nil {
 		return err
 	}
 
-	// writes as toml file
-	err = writeToml("AES256 CTR mode", hex.EncodeToString(iv), hex.EncodeToString(encryptedData), secretPath, d.ownerUid, d.ownerGid)
-	if err != nil {
-		return errors.Wrap(err, "could not write secrets data to disk")
+	buf := new(bytes.Buffer)
+
+	if err := json.NewEncoder(buf).Encode(SecretKeyJSON{
+		Algorithm:  "AES256 CTR mode",
+		IV:         iv,
+		Ciphertext: ct,
+	}); err != nil {
+		return errors.Wrap(err, "failed to encode struct SecretKeyJSON data to json")
+	}
+
+	if err := fileutils.AtomicWrite(secretPath, bytes.NewReader(buf.Bytes()),
+		fileutils.WithAtomicWriteFileMode(0700),
+		fileutils.WithAtomicWriteChown(d.ownerGid, d.ownerGid),
+	); err != nil {
+		return errors.Wrap(err, "error writing the secret file")
 	}
 
 	return nil
-}
-
-// Creates the Key used for the secret values' encryption
-// we generate a random byte array of 32 bytes required for the AES256 encryption
-// save the key to a file named key in base path and sets owner
-// returns the key
-func (d *diskStore) createEncryptionKey() ([]byte, error) {
-	secretKey, err := GenerateRandomBytes(32)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not generate random secret for encryption")
-	}
-
-	// creating path to store the secret key
-	secretKeyPath := filepath.Join(d.basePath, "key")
-	s := bytes.NewReader(secretKey)
-
-	// writing the key to a file
-	err = fileutils.AtomicWrite(secretKeyPath, s, fileutils.WithAtomicWriteFileMode(0700))
-	if err != nil {
-		return nil, errors.Wrap(err, "could not write secret to disk")
-	}
-
-	// TODO(ssd) 2018-08-20: Should this be an option we can pass to AtomicWrite?
-	err = os.Chown(secretKeyPath, d.ownerUid, d.ownerGid)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not chown secrets data")
-	}
-	return secretKey, nil
 }
 
 // GenerateRandomBytes generates the requested number of ASCII bytes
@@ -311,122 +285,6 @@ func PrepareSSHPrivateKey(keyContent string) (string, error) {
 		return "", errors.New("Failed to write inspec private key " + keyPath.Name() + ": " + err.Error())
 	}
 	return keyPath.Name(), nil
-}
-
-// checks if encryption key exists or not
-func keyExists(basePath string) (bool, error) {
-	path := filepath.Join(basePath, "key")
-	return fileutils.PathExists(path)
-}
-
-// Takes in key and the data
-// Uses AES256 CTR mode for encryption
-// returns the ciphertext, iv and error
-func encrypt(key []byte, value []byte) ([]byte, []byte, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error creating cipher block during encryption")
-	}
-	iv, err := GenerateRandomBytes(block.BlockSize())
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not generate random iv for encryption")
-	}
-	stream := cipher.NewCTR(block, iv)
-	ciphertext := make([]byte, len(value))
-	stream.XORKeyStream(ciphertext, value)
-	return ciphertext, iv, nil
-}
-
-// decrpting the cipher for ctr mode
-// returns the data and error
-func decrypt(block cipher.Block, ciphertext []byte, iv []byte) []byte {
-	stream := cipher.NewCTR(block, iv)
-	plain := make([]byte, len(ciphertext))
-	stream.XORKeyStream(plain, ciphertext)
-	return plain
-}
-
-// function used to write the secret values to given file in toml format
-// also sets the owner for that file
-// stores the name of the algorithm , iv and the ciphertext
-func writeToml(algorithm string, iv string, ciphertext string, path string, ownerUID int, ownerGID int) error {
-	secretData := SecretKeyToml{
-		Algorithm:  algorithm,
-		IV:         iv,
-		Ciphertext: ciphertext,
-	}
-
-	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(secretData); err != nil {
-		return errors.Wrap(err, "failed to encode struct SecretKeyToml data to toml")
-	}
-
-	err := fileutils.AtomicWrite(path, bytes.NewReader(buf.Bytes()), fileutils.WithAtomicWriteFileMode(0700))
-	if err != nil {
-		return errors.Wrap(err, "error writing the secret file")
-	}
-
-	// TODO(ssd) 2018-08-20: Should this be an option we can pass to AtomicWrite?
-	err = os.Chown(path, ownerUID, ownerGID)
-	if err != nil {
-		return errors.Wrap(err, "could not chown secrets data")
-	}
-	return nil
-}
-
-// takes in the secret value and encrypts it
-// return encrypted cipher, iv and error
-func getEncryptedData(data []byte, basePath string) ([]byte, []byte, error) {
-	// we create the encryption key if it doesnot exist
-	var secretKey []byte
-	keyExists, err := keyExists(basePath)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !keyExists {
-		return nil, nil, errors.New("Could not find the encryption key")
-	}
-	path := filepath.Join(basePath, "key")
-	secretKey, err = ioutil.ReadFile(path)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not read secrets key (unexpected error)")
-	}
-	encryptedData, iv, err := encrypt(secretKey, data)
-	if err != nil {
-		return nil, nil, err
-	}
-	return encryptedData, iv, nil
-}
-
-// gets the secret from the toml file and decrypts the file contents
-// returns the decrypted data or error
-func getDecryptedData(basePath string, data []byte) ([]byte, error) {
-	keyPath := filepath.Join(basePath, "key")
-	key, err := ioutil.ReadFile(keyPath)
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to covert secret key to block")
-	}
-	var secretData SecretKeyToml
-	_, err = toml.Decode(string(data), &secretData)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshal data from secret toml file")
-	}
-
-	// coverts ciphertext to byte from hex
-	dcdCipher, err := hex.DecodeString(secretData.Ciphertext)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode secret ciphertext value while reading from file")
-	}
-
-	// coverts iv to byte from hex
-	dcdIv, err := hex.DecodeString(secretData.IV)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to decode iv value while reading from file")
-	}
-
-	decrypted := decrypt(block, dcdCipher, dcdIv)
-	return decrypted, nil
 }
 
 func addSecretFileExtension(name string) string {

--- a/lib/secrets/secrets_helpers_test.go
+++ b/lib/secrets/secrets_helpers_test.go
@@ -1,0 +1,19 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalers(t *testing.T) {
+	iv := initializationVector{0xff, 0xee, 0x0d, 0x00}
+	v, err := iv.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, []byte("ffee0d00"), v)
+
+	iv2 := initializationVector{}
+	err = iv2.UnmarshalText([]byte("ffee0d00"))
+	require.NoError(t, err)
+	require.Equal(t, iv, iv2)
+}

--- a/lib/secrets/secrets_test.go
+++ b/lib/secrets/secrets_test.go
@@ -109,7 +109,7 @@ func TestDiskSecretStore(t *testing.T) {
 
 	// checks if GetSecret method is able to read old unencrypted secrets
 	t.Run("Able to read preexisting unencrypted secrets", func(t *testing.T) {
-		testSecretName := secrets.SecretName{"test", "test-secret-2"}
+		testSecretName := secrets.SecretName{"test", "test-secret-3"}
 		testSecretContent := []byte("this-is-a-secret")
 
 		// creates group directory with owner permissions


### PR DESCRIPTION
This modifies the secrets store/secrets helper utilities to encrypt secrets that are stored on disk. Any existing secret data will not be encrypted unless it is modified. This is fine, as all existing data is generated and uses the secret helpers to share that data between services.

The reason we are doing this is be able to store customer provided secrets in non plaintext. We will take the secrets that are provided in the config and place them in the secret store encrypted.

This is not a user facing change.
This does not provide any sort of security, as the key is stored on next to the secrets on disk.