### PR TITLE
Remove rebase-on-the-fly in PRs

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,25 +15,6 @@ git fetch origin master
 # Fetch the git tags to see if that addresses the weird smart build behavior for Habitat
 git fetch --tags --force
 
-# Rebase onto current master to ensure this PR is closer to what happens when it's merged.
-# Only do this if it's actually a branch (i.e. a PR or a manually created build), not a
-# post-merge CI run of master.
-if [[ "$BUILDKITE_BRANCH" != "master" ]]; then
-  git config user.email "you@example.com" # these are needed for the rebase attempt
-  git config user.name "Your Name"
-  master=$(git show-ref -s --abbrev origin/master)
-  pr_head=$(git show-ref -s --abbrev HEAD)
-  github="https://github.com/chef/automate/commit/"
-  if git rebase origin/master >/dev/null; then
-    buildkite-agent annotate --style success --context "rebase-pr-branch-${master}" \
-      "Rebased onto master ([${master}](${github}${master}))."
-  else
-    git rebase --abort
-    buildkite-agent annotate --style warning --context "rebase-pr-branch-${master}" \
-      "Couldn't rebase onto master ([${master}](${github}${master})), building PR HEAD ([${pr_head}](${github}${pr_head}))."
-  fi
-fi
-
 # Count retries as BK annotations; don't make all jobs explode if the script
 # is removed.
 [[ -x "scripts/count_retries.sh" ]] && scripts/count_retries.sh

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -119,6 +119,7 @@ steps:
     - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
     - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
     - export SEMGREP_REPO_NAME=chef/automate
+    - export SEMGREP_REPO_URL=https://github.com/chef/automate
     - echo "branch=[$BUILDKITE_BRANCH], PR base branch=[$BUILDKITE_PULL_REQUEST_BASE_BRANCH]"
     - \[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" \] && echo "manual build; using 'master' as base branch"
     - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -138,7 +138,6 @@ steps:
           environment:
             - SEMGREP_TOKEN
             - SEMGREP_ID
-    soft_fail: true
 
   # Wait for the build to complete before starting anything below this
   # directive. All tests below this wait either require build assets

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -116,9 +116,11 @@ steps:
   - label: ":semgrep: Security"
     command:
     - echo "running in $(pwd)"
-    - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
     - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
     - export SEMGREP_REPO_NAME=chef/automate
+    # Activates links to buildkite builds in slack notification
+    - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
+    # Activates links to git commits in slack notification
     - export SEMGREP_REPO_URL=https://github.com/chef/automate
     - echo "branch=[$BUILDKITE_BRANCH], PR base branch=[$BUILDKITE_PULL_REQUEST_BASE_BRANCH]"
     - \[ -z "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" \] && echo "manual build; using 'master' as base branch"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

While this was useful to have during periods of heavy development, the PR traffic is now much reduced so it is OK to change this back to the way almost every other Chef repo works.

The motivation for this was for tools (like semgrep) that want to tie notifications to specific commit links and that could not be done with the on-the-fly rebase.

### :chains: Related Resources
NA

### :+1: Definition of Done
(a) Build still runs fine.
(b) Slack notifications for semgrep have active links to the github commit pinpointing the failure.

### :athletic_shoe: How to Build and Test the Change

Easier just to show it:
Buildkite fails the semgrep task, that produces a notification in slack, and clicking on the SHA opens up a window in GitHub:
![2020-12-17_14-54-42 (1)](https://user-images.githubusercontent.com/6817500/102554470-c8dbca80-4079-11eb-878e-dc4d0d5f1a6a.gif)

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
