### PR TITLE
Fix rollout helpers for proto linting changes

### DIFF
--- a/.studio/config-mgmt-service
+++ b/.studio/config-mgmt-service
@@ -299,12 +299,12 @@ function config_mgmt_create_rollout() {
 
 function config_mgmt_send_to_create_rollout_pretty() {
   local response
-  response=$(config_mgmt_send_to_create_rollout_raw)
+  response=$(config_mgmt_send_to_create_rollout_raw 2>&1)
   success=$?
-  if [[ $success ]]; then
+  if [[ $success == 0 ]]; then
     echo "$response" | jq .
   else
-    echo "$response"
+    error "config_mgmt_send_to_create_rollout_raw failed: $response"
   fi
   return $success
 }
@@ -448,8 +448,8 @@ function config_mgmt_rollout_json_static() {
         "policy_revision_id": "111222333aaabbbccc",
         "policy_domain_url": "https://chef-server.example/organizations/example_org",
         "policy_domain_username": "bobo",
-        "scm_type": "GIT",
-        "scm_web_type": "GITHUB",
+        "scm_type": "SCM_TYPE_GIT",
+        "scm_web_type": "SCM_WEB_TYPE_GITHUB",
         "policy_scm_url": "git@github.com:chef/automate.git",
         "policy_scm_web_url": "https://github.com/chef/automate.git",
         "policy_scm_commit": "1ca3deb611fa1ab5bbf28cfb55179011e16d4a3e",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In #4255 we enabled the `ENUM_VALUE_PREFIX` lint rule in [buf](https://docs.buf.build). Because the rollout APIs are beta instead of final, we made the breaking change to conform the protos to the new lint rule instead of excepting them from the rule. This meant that callers of the API needed to changes to use the new enum values, but we didn't make that change in the studio helpers, so they broke. The base rollout document we use needs to be updated for the new enum values of the `scm_type` and `scm_web_type` fields.

### :chains: Related Resources

#4255

### :+1: Definition of Done

`config_mgmt_rollout_json | config_mgmt_send_to_create_rollout_pretty` and any similar usage, e.g., `config_mgmt_populate_rollouts` works.

### :athletic_shoe: How to Build and Test the Change

* restart your studio clean, or source the config-mgmt-service code
* start all services
* `config_mgmt_populate_rollouts`
* `config_mgmt_list_rollouts` should show rollouts created by the populate function

