### PR TITLE
Doc update on how to add resolvers for PG and ES gateways

### DIFF
--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -179,12 +179,12 @@ Name Servers can be added in two ways:
   1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the Elastic search nodes, the nameservers can be added to the `config.toml` file.
   ```toml
   [esgateway.v1.sys.ngx.main.resolvers]
-    nameservers = ["127.0.0.53:52"]
+    nameservers = ["127.0.0.53:53"]
   ```
   2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file 
   ```toml
   [esgateway.v1.sys.ngx.main.resolvers]
-    enable_system_resolvers = true
+    enable_system_nameservers = true
   ```
 
 In case both the options are set, the preference will be given to the nameserver IPs over the system nameserver entries 
@@ -347,7 +347,7 @@ Name Servers can be added in two ways:
   [pg_gateway.v1.sys.resolvers]
     # Multiple resolvers can be specified by
     # adding the resolvers in the list.
-    nameservers = ["127.0.0.53:52"]
+    nameservers = ["127.0.0.53:53"]
   ```
   2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file
   ```toml

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -173,25 +173,26 @@ Because externally-deployed Elasticsearch nodes will not have access to Chef Aut
 
 ##### Adding Resolvers for Elasticsearch
 
-In case you want to resolve the elastic search node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
+In case you want to resolve the Elasticsearch node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
 
 Name Servers can be added in two ways:
 
-1. **Add nameserver IPs:** Add the nameservers to the `config.toml` file to resolve the Elasticsearch nodes.
+1. **Add nameserver IPs:** Add the nameservers to your `config.toml` file to resolve the Elasticsearch nodes.
 
-    ```toml
-    [esgateway.v1.sys.ngx.main.resolvers]
-      nameservers = ["192.0.2.0:24", "198.51.100.0:24"]
-    ```
+  ```toml
+  [esgateway.v1.sys.ngx.main.resolvers]
+    # Multiple resolvers can be specified by adding the resolvers in the list.
+    nameservers = ["192.0.2.0:24", "198.51.100.0:24"]
+  ```
 
-1. **Set system DNS entries:** To use existing system nameserver entries from the `/etc/resolv.conf` file, add the following setting to the `config.toml`.
+1. **Set system DNS entries:** To use existing system nameserver entries from `/etc/resolv.conf`, add the following setting to `config.toml`:
 
-    ```toml
-    [esgateway.v1.sys.ngx.main.resolvers]
-      enable_system_nameservers = true
-    ```
+  ```toml
+  [esgateway.v1.sys.ngx.main.resolvers]
+    enable_system_nameservers = true
+  ```
 
-`nameserver` IP takes precedence over the `system_nameserver` if both configurations are set.
+If both options are set, nameserver IPs takes precedence over the system nameserver entries.
 
 Apply the changes:
 
@@ -199,11 +200,11 @@ Apply the changes:
 sudo chef-automate config patch config.toml
 ````
 
-Restore the default configuration or modify the configuration:
+If you wish to reset to the default configuration or to modify the configuration:
 
 1. Run `chef-automate config show config.toml`.
-1. Open the `config.toml` and remove the `esgateway.v1.sys.ngx.main.resolvers` configuration or change the values.
-1. Run `chef-automate config set config.toml` to apply your updated configuration.
+1. Open `config.toml` and remove the `esgateway.v1.sys.ngx.main.resolvers` configuration or change the values.
+1. Run `chef-automate config set config.toml` to apply your changes.
 
 ##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
@@ -346,28 +347,35 @@ enable = true
 
 ##### Adding Resolvers for PostgreSQL Database
 
-In case you want to resolve the postgresql cluster node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
+In case you want to resolve the PostgreSQL cluster node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
 
 Name Servers can be added in two ways:
-  1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the PostgreSQL nodes, the nameservers can be added to the `config.toml` file.
+
+1. **Add nameserver IPs:** If you are aware of the nameservers which should resolve the PostgreSQL nodes, the nameservers can be added to your `config.toml` file.
+
   ```toml
   [pg_gateway.v1.sys.resolvers]
-    # Multiple resolvers can be specified by
-    # adding the resolvers in the list.
+    # Multiple resolvers can be specified by adding the resolvers in the list.
     nameservers = ["127.0.0.53:53"]
   ```
-  2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file
+
+1. **Set system DNS entries:** To use existing system nameserver entries from `/etc/resolv.conf`, add the following setting to `config.toml`:
+
   ```toml
   [pg_gateway.v1.sys.resolvers]
     enable_system_nameservers = false
   ```
-In case both the options are set, the preference will be given to the nameserver IPs over the system nameserver entries.
 
-The changes will be reflected after you run:
-```shell
+If both options are set, nameserver IPs takes precedence over the system nameserver entries.
+
+Apply the changes:
+
+```bash
 sudo chef-automate config patch config.toml
 ````
-In order to reset back to the default configuration or modify the configuration, follow these steps:
+
+If you wish to reset to the default configuration or to modify the configuration:
+
 1. Run `chef-automate config show config.toml`.
-2. Edit `config.toml` to replace/edit the `pg_gateway.v1.sys.resolvers` section with the configuration values.
-3. Run `chef-automate config set config.toml` to set your updated configuration.
+1. Edit `config.toml` to replace/edit the `pg_gateway.v1.sys.resolvers` section with the configuration values.
+1. Run `chef-automate config set config.toml` to apply your changes.

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -173,32 +173,39 @@ Because externally-deployed Elasticsearch nodes will not have access to Chef Aut
 
 ##### Adding Resolvers for Elasticsearch
 
-In case you want to resolve the elastic search node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration. 
+In case you want to resolve the elastic search node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
 
 Name Servers can be added in two ways:
-  1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the Elastic search nodes, the nameservers can be added to the `config.toml` file.
-  ```toml
-  [esgateway.v1.sys.ngx.main.resolvers]
-    nameservers = ["127.0.0.53:53"]
-  ```
-  2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file 
-  ```toml
-  [esgateway.v1.sys.ngx.main.resolvers]
-    enable_system_nameservers = true
-  ```
 
-In case both the options are set, the preference will be given to the nameserver IPs over the system nameserver entries 
+1. **Add nameserver IPs:** Add the nameservers to the `config.toml` file to resolve the Elasticsearch nodes.
 
-The changes will be reflected after you run:
-```shell
+    ```toml
+    [esgateway.v1.sys.ngx.main.resolvers]
+      nameservers = ["192.0.2.0:24", "198.51.100.0:24"]
+    ```
+
+1. **Set system DNS entries:** To use existing system nameserver entries from the `/etc/resolv.conf` file, add the following setting to the `config.toml`.
+
+    ```toml
+    [esgateway.v1.sys.ngx.main.resolvers]
+      enable_system_nameservers = true
+    ```
+
+`nameserver` IP takes precedence over the `system_nameserver` if both configurations are set.
+
+Apply the changes:
+
+```bash
 sudo chef-automate config patch config.toml
 ````
-In order to reset back to the default configuration or modify the configuration, follow these steps:
-1. Run `chef-automate config show config.toml`.
-2. Edit `config.toml` to replace/edit the `esgateway.v1.sys.ngx.main.resolvers` section with the configuration values.
-3. Run `chef-automate config set config.toml` to set your updated configuration.
 
-  ##### Backup Externally-Deployed Elasticsearch to Local Filesystem
+Restore the default configuration or modify the configuration:
+
+1. Run `chef-automate config show config.toml`.
+1. Open the `config.toml` and remove the `esgateway.v1.sys.ngx.main.resolvers` configuration or change the values.
+1. Run `chef-automate config set config.toml` to apply your updated configuration.
+
+##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
 To configure local filesystem backups of Chef Automate data stored in an externally-deployed Elasticsearch cluster:
 
@@ -339,7 +346,7 @@ enable = true
 
 ##### Adding Resolvers for PostgreSQL Database
 
-In case you want to resolve the postgresql cluster node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration. 
+In case you want to resolve the postgresql cluster node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.
 
 Name Servers can be added in two ways:
   1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the PostgreSQL nodes, the nameservers can be added to the `config.toml` file.

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -171,7 +171,34 @@ Add the following to your config.toml:
 
 Because externally-deployed Elasticsearch nodes will not have access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
 
-##### Backup Externally-Deployed Elasticsearch to Local Filesystem
+##### Adding Resolvers for Elasticsearch
+
+In case you want to resolve the elastic search node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration. 
+
+Name Servers can be added in two ways:
+  1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the Elastic search nodes, the nameservers can be added to the `config.toml` file.
+  ```toml
+  [esgateway.v1.sys.ngx.main.resolvers]
+    nameservers = ["127.0.0.53:52"]
+  ```
+  2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file 
+  ```toml
+  [esgateway.v1.sys.ngx.main.resolvers]
+    enable_system_resolvers = true
+  ```
+
+In case both the options are set, the preference will be given to the nameserver IPs over the system nameserver entries 
+
+The changes will be reflected after you run:
+```shell
+sudo chef-automate config patch config.toml
+````
+In order to reset back to the default configuration or modify the configuration, follow these steps:
+1. Run `chef-automate config show config.toml`.
+2. Edit `config.toml` to replace/edit the `esgateway.v1.sys.ngx.main.resolvers` section with the configuration values.
+3. Run `chef-automate config set config.toml` to set your updated configuration.
+
+  ##### Backup Externally-Deployed Elasticsearch to Local Filesystem
 
 To configure local filesystem backups of Chef Automate data stored in an externally-deployed Elasticsearch cluster:
 
@@ -309,3 +336,31 @@ password = "<dbuser password>"
 [global.v1.external.postgresql.backup]
 enable = true
 ```
+
+##### Adding Resolvers for PostgreSQL Database
+
+In case you want to resolve the postgresql cluster node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration. 
+
+Name Servers can be added in two ways:
+  1. **Adding the nameserver IPs:** If you are awae of the nameservers which shoud resolve the PostgreSQL nodes, the nameservers can be added to the `config.toml` file.
+  ```toml
+  [pg_gateway.v1.sys.resolvers]
+    # Multiple resolvers can be specified by
+    # adding the resolvers in the list.
+    nameservers = ["127.0.0.53:52"]
+  ```
+  2. **Using system DNS entries:** If you want to use the system nameserver entries in `/etc/resolv.conf` file, that can be done by adding the following entries in `config.toml` file
+  ```toml
+  [pg_gateway.v1.sys.resolvers]
+    enable_system_nameservers = false
+  ```
+In case both the options are set, the preference will be given to the nameserver IPs over the system nameserver entries.
+
+The changes will be reflected after you run:
+```shell
+sudo chef-automate config patch config.toml
+````
+In order to reset back to the default configuration or modify the configuration, follow these steps:
+1. Run `chef-automate config show config.toml`.
+2. Edit `config.toml` to replace/edit the `pg_gateway.v1.sys.resolvers` section with the configuration values.
+3. Run `chef-automate config set config.toml` to set your updated configuration.

--- a/components/docs-chef-io/static/automate-api-docs/all-apis.swagger.json
+++ b/components/docs-chef-io/static/automate-api-docs/all-apis.swagger.json
@@ -4695,6 +4695,44 @@
         }
       }
     },
+    "/api/v0/infra/servers/{server_id}/orgs/{org_id}/nodes": {
+      "get": {
+        "tags": [
+          "InfraProxy"
+        ],
+        "operationId": "InfraProxy_GetNodes",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Chef Infra Server ID.",
+            "name": "server_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Chef organization ID.",
+            "name": "org_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Nodes"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "schema": {
+              "$ref": "#/definitions/grpc.gateway.runtime.Error"
+            }
+          }
+        }
+      }
+    },
     "/api/v0/infra/servers/{server_id}/orgs/{org_id}/nodes/{name}": {
       "put": {
         "tags": [
@@ -5090,28 +5128,6 @@
             "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/chef.automate.api.infra_proxy.response.Role"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response",
-            "schema": {
-              "$ref": "#/definitions/grpc.gateway.runtime.Error"
-            }
-          }
-        }
-      }
-    },
-    "/api/v0/infra/version": {
-      "get": {
-        "tags": [
-          "InfraProxy"
-        ],
-        "operationId": "InfraProxy_GetVersion",
-        "responses": {
-          "200": {
-            "description": "A successful response.",
-            "schema": {
-              "$ref": "#/definitions/chef.automate.api.common.version.VersionInfo"
             }
           },
           "default": {
@@ -16344,8 +16360,16 @@
           "description": "Node environment name.",
           "type": "string"
         },
+        "fqdn": {
+          "description": "Node FQDN.",
+          "type": "string"
+        },
         "id": {
           "description": "Node ID.",
+          "type": "string"
+        },
+        "ip_address": {
+          "description": "Node IP address.",
           "type": "string"
         },
         "name": {
@@ -16363,6 +16387,18 @@
         "uptime": {
           "description": "Node uptime.",
           "type": "string"
+        }
+      }
+    },
+    "chef.automate.api.infra_proxy.response.Nodes": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "description": "Node list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/chef.automate.api.infra_proxy.response.NodeAttribute"
+          }
         }
       }
     },


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

The PR here https://github.com/chef/automate/pull/4486 allows automate to now resolve the Postgres cluster and Elasticsearch nodes using resolvers. The resolvers can be set in the `config.toml` by the users.

The changes document how to configure resolvers in case of external PG or ES.

### :chains: Related Resources

Updated install.md file to add sections:

1. ADDING RESOLVERS FOR ELASTICSEARCH
2. ADDING RESOLVERS FOR POSTGRESQL DATABASE

### :+1: Definition of Done

The document should have the sections mentioned above with the details of the configuration.

### :athletic_shoe: How to Build and Test the Change

1. Pull the code
2. `make serve`
3. The updated document should be shown in http://localhost:1313/automate/install/

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
