### PR TITLE
Increasing timeout for post-promote pipeline

### DIFF
--- a/.expeditor/post-promote.pipeline.yml
+++ b/.expeditor/post-promote.pipeline.yml
@@ -1,6 +1,9 @@
 steps:
   - command:
       - .expeditor/upload-files.sh
+    # ruby dependencies themselves are > 7 minutes
+    # so increasing from default of 10 minutes here
+    timeout_in_minutes: 15
     label: "Manifest and CLI Upload"
     concurrency: 1
     concurrency_group: chef-automate-master/deploy/$CHANNEL


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

ruby dependencies themselves are > 7 minutes so increasing from default of 10 minutes here

### :chains: Related Resources
NA

### :+1: Definition of Done
Retries not needed for post-promote in buildkite.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
