### PR TITLE
Unlock staging area nightly in case of stall

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,6 +18,9 @@ schedules:
   - name: cleanup_abandoned_a2_instances
     description: Cleanup abandoned a2instances
     cronline: "0 1 * * *" # every day at 1am
+  - name: unlock_staging_area_in_case_of_stall
+    description: Unlock staging area in case of stall
+    cronline: "0 2 * * *" # every day at 2am
 
 # These are our Buildkite pipelines where deploys take place
 pipelines:
@@ -166,3 +169,9 @@ subscriptions:
   - workload: schedule_triggered:{{agent_id}}:cleanup_abandoned_a2_instances:*
     actions:
       - bash:.expeditor/cleanup-abandoned-a2-instances.sh
+  - workload: schedule_triggered:{{agent_id}}:unlock_staging_area_in_case_of_stall:*
+    actions:
+      - unlock_staging_area:post_merge:
+          post_commit: true
+          always_run: true
+ 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Prior to this, the only time the staging area got unlocked was upon completion of the habitat build.
However, as we saw in December, the habitat build stalled completely (it never ran) for about 4 weeks.

### :chains: Related Resources
NA

### :+1: Definition of Done
Staging area is always unlocked once per day in case other pipelines get stalled.

### :athletic_shoe: How to Build and Test the Change
?? Not sure

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
