### PR TITLE
Fix ha chef-server test

### DIFF
--- a/integration/tests/ha_chef_server.sh
+++ b/integration/tests/ha_chef_server.sh
@@ -90,7 +90,8 @@ org({:name => "pedant_testorg_#{chef_server_uid}",
 
 # You MUST specify the address of the server the API requests will be
 # sent to.  Only specify protocol, hostname, and port.
-chef_server "https://localhost:443"
+chef_server "https://localhost"
+base_resource_url "https://localhost:443"
 
 # SSL protocol version to use for secure communications
 # with the load balancer

--- a/integration/tests/ha_chef_server.sh
+++ b/integration/tests/ha_chef_server.sh
@@ -90,7 +90,7 @@ org({:name => "pedant_testorg_#{chef_server_uid}",
 
 # You MUST specify the address of the server the API requests will be
 # sent to.  Only specify protocol, hostname, and port.
-chef_server "https://localhost"
+chef_server "https://localhost:443"
 
 # SSL protocol version to use for secure communications
 # with the load balancer


### PR DESCRIPTION
The test is complaining that the its getting back a port in the uri.
This should pacify it:

Likely due to https://github.com/chef/chef-server/pull/2096

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>