### PR TITLE
In Services sidebar, Limit page-picker to 5 pages max displayed at once

### DIFF
--- a/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
+++ b/components/automate-ui/src/app/page-components/services-sidebar/services-sidebar.component.html
@@ -161,6 +161,7 @@
       [total]="totalServices"
       [perPage]="pageSize"
       [page]="currentPage"
+      [maxSelectablePages]="5"
       (pageChanged)="updatePageNumber($event)">
     </app-page-picker>
   </div>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The page-picker component was breaking out of its container when longer than 5 pages.  This branch constrains the number of pages to 5 pages max displayed at a time.

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/4504

### :+1: Definition of Done
The page picker no longer breaks out of its container

### :athletic_shoe: How to Build and Test the Change
in Automate root: `hab studio enter` then `build components/automate-ui-devproxy && start_all_services`
in automate-ui: 'make serve'

in hab studio run 
```
for i in {1..3}; do applications_populate_database; done
```
... which will take ~30 seconds to complete.
Navigate to https://a2-dev.test/applications/service-groups
In the Filter Bar, Filter on application: demo
Click on the first result in the list so that it displays in the sidebar
scroll sidebar to bottom so that you can see the page-picker component

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Before:
<img width="1547" alt="Applications Pagination needs fixing" src="https://user-images.githubusercontent.com/16737484/103244412-c39c3c80-4911-11eb-84ec-e5956c8e441f.png">

After:
<img width="1368" alt="Page limited to max 3" src="https://user-images.githubusercontent.com/16737484/103244408-c0a14c00-4911-11eb-954c-c549fb9c8888.png">
