### PR TITLE
Jamie/d3 version 6 changes

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
@@ -389,21 +389,23 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
 
     svg.select('.zoom-slider-button.start')
       .call(d3.drag()
-        .on('start', () => { this.dragStarted(); })
-        .on('drag', (e) => { this.dragStartSlider(e); })
-        .on('end', () => { this.dragEnded('start'); }));
+        .on('start', () => this.dragStarted())
+        .on('drag', (e) => this.dragStartSlider(e))
+        .on('end', () => this.dragEnded('start'))
+        );
     svg.select('.zoom-slider-button.end')
       .call(d3.drag()
-        .on('start', () => { this.dragStarted(); })
-        .on('drag', (e) => { this.dragEndSlider(e); })
-        .on('end', () => { this.dragEnded('end'); }));
+        .on('start', () => this.dragStarted())
+        .on('drag', (e) => this.dragEndSlider(e))
+        .on('end', () => this.dragEnded('end'))
+        );
   }
 
   dragStarted() {
     this.sliderWidth = this.getComponentWidth();
   }
 
-  dragStartSlider(e) {
+  dragStartSlider(e: DragEvent) {
     const positionPercentage = e.x / this.sliderWidth * 100;
 
     // Checks to see if the start slider is about to bump into the end slider
@@ -417,7 +419,7 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
     }
   }
 
-  dragEndSlider(e) {
+  dragEndSlider(e: DragEvent) {
     const positionPercentage = e.x / this.sliderWidth * 100;
 
     // Checks to see if the end slider is about to bump into the start slider

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.ts
@@ -390,12 +390,12 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
     svg.select('.zoom-slider-button.start')
       .call(d3.drag()
         .on('start', () => { this.dragStarted(); })
-        .on('drag', () => { this.dragStartSlider(); })
+        .on('drag', (e) => { this.dragStartSlider(e); })
         .on('end', () => { this.dragEnded('start'); }));
     svg.select('.zoom-slider-button.end')
       .call(d3.drag()
         .on('start', () => { this.dragStarted(); })
-        .on('drag', () => { this.dragEndSlider(); })
+        .on('drag', (e) => { this.dragEndSlider(e); })
         .on('end', () => { this.dragEnded('end'); }));
   }
 
@@ -403,8 +403,8 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
     this.sliderWidth = this.getComponentWidth();
   }
 
-  dragStartSlider() {
-    const positionPercentage = d3.event.x / this.sliderWidth * 100;
+  dragStartSlider(e) {
+    const positionPercentage = e.x / this.sliderWidth * 100;
 
     // Checks to see if the start slider is about to bump into the end slider
     if (this.endSliderPosition - positionPercentage >= this.sliderGrid) {
@@ -417,8 +417,8 @@ export class EventFeedGuitarStringsComponent implements OnInit, OnChanges {
     }
   }
 
-  dragEndSlider() {
-    const positionPercentage = d3.event.x / this.sliderWidth * 100;
+  dragEndSlider(e) {
+    const positionPercentage = e.x / this.sliderWidth * 100;
 
     // Checks to see if the end slider is about to bump into the start slider
     if (positionPercentage - this.sliderGrid >= this.startSliderPosition) {

--- a/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.ts
+++ b/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.ts
@@ -229,22 +229,12 @@ export class SimpleLineGraphComponent implements OnChanges, OnInit {
       // add class to rotate labels when more than comfortable to fit in space
       .classed('turnt', () => this.xData.length > 7)
 
-      .on('mouseenter', (e) => {
-        this.handleHover(e);
-      })
-      .on('mouseout', () => {
-        this.AllDeactivate();
-      })
+      .on('mouseenter', e => this.handleHover(e))
+      .on('mouseout', () => this.AllDeactivate())
       // focus styles
-      .on('focus', (e) => {
-        this.handleHover(e);
-      })
-      .on('focusout', () => {
-        this.AllDeactivate();
-      })
-      .on('click', (e) => {
-        this.handleClick(e);
-      });
+      .on('focus', e => this.handleHover(e))
+      .on('focusout', () => this.AllDeactivate())
+      .on('click', e => this.handleClick(e));
   }
 
   private formatLabels(daysAgo: number): string {
@@ -301,13 +291,13 @@ export class SimpleLineGraphComponent implements OnChanges, OnInit {
       .remove();
   }
 
-  private handleHover(d3Event: d3.Event): void {
-    const num = this.getHoveredElement(d3Event);
+  private handleHover(e: MouseEvent): void {
+    const num = this.getHoveredElement(e);
     d3.selectAll(`.elem-${num}`).classed('active', true);
   }
 
-  private handleClick(d3Event: d3.Event): void {
-    const num = this.getHoveredElement(d3Event);
+  private handleClick(e: MouseEvent): void {
+    const num = this.getHoveredElement(e);
     const isAlreadyLocked = d3.selectAll(`.elem-${num}`).classed('lock');
     if (isAlreadyLocked) {
       d3.selectAll(`.elem-${num}`).classed('lock', false);
@@ -319,8 +309,8 @@ export class SimpleLineGraphComponent implements OnChanges, OnInit {
     }
   }
 
-  private getHoveredElement(d3Event: d3.Event): string {
-    const classes = d3.select(d3Event.target).attr('class');
+  private getHoveredElement(e: MouseEvent): string {
+    const classes = d3.select(e.target).attr('class');
     const match = classes.match(/elem-([0-9]{1,2})/g)[0];
     const num = match.split('-')[1];
     return num;

--- a/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.ts
+++ b/components/automate-ui/src/app/page-components/simple-line-graph/simple-line-graph.component.ts
@@ -229,21 +229,21 @@ export class SimpleLineGraphComponent implements OnChanges, OnInit {
       // add class to rotate labels when more than comfortable to fit in space
       .classed('turnt', () => this.xData.length > 7)
 
-      .on('mouseenter', () => {
-        this.handleHover(d3.event);
+      .on('mouseenter', (e) => {
+        this.handleHover(e);
       })
       .on('mouseout', () => {
         this.AllDeactivate();
       })
       // focus styles
-      .on('focus', () => {
-        this.handleHover(d3.event);
+      .on('focus', (e) => {
+        this.handleHover(e);
       })
       .on('focusout', () => {
         this.AllDeactivate();
       })
-      .on('click', () => {
-        this.handleClick(d3.event);
+      .on('click', (e) => {
+        this.handleClick(e);
       });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
With the d3's upgrade to version 6, there were some changes in how events are handled.  This branch updates the events that were broken as a result of the upgrade.
d3 migration guide - events : https://observablehq.com/@d3/d3v6-migration-guide#events

### :chains: Related Resources
Introduced the upgrade to d3 version 6: https://github.com/chef/automate/pull/4499

### :+1: Definition of Done
Breaking changes from d3 version 6 are resolved in our codebase
1. Event feed range slider
2. Desktop Check in History Line graph

### :athletic_shoe: How to Build and Test the Change
pre: Make sure you have pulled the newest version of master which includes the upgrade to Angular 11
pre: npm install if this is your first time on a master than includes Angular 11 upgrade

in hab studio: `build components/automate-ui-devproxy && start_all_services`
in Automate/components/automate-ui: `make serve`

Load up some events in the event feed by running 
in hab studio: `chef_load_actions`
Navigate to https://a2-dev.test/dashboards/event-feed
move the date range sliders and check that they work as expected and there are no errors in the console

Navigate to https://a2-dev.test/desktop
View the Check in History Graph
Hover over dates in the X axis, change date range, click on dates
All should work as expected and carry no messages in the console

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Fixed Components:

1. Event feed range slider
<img width="861" alt="Screen Shot 2020-12-29 at 2 17 55 PM" src="https://user-images.githubusercontent.com/16737484/103317720-d9c4fe00-49e0-11eb-8045-c6bbe78968cf.png">

2. Desktop Check in History Line graph
<img width="930" alt="Screen Shot 2020-12-29 at 2 17 45 PM" src="https://user-images.githubusercontent.com/16737484/103317727-df224880-49e0-11eb-8f4e-902455e3bb9d.png">

