### PR TITLE
Jamie / Downgrade AJV package

### DIFF
--- a/components/automate-ui/README.md
+++ b/components/automate-ui/README.md
@@ -57,8 +57,7 @@ While it is problematic to document this information due to the maintenance burd
 
 ### Package ajv: ^6.9.1
 
-Updating to ajv 7 requires ajv-keywords 4, they are similar but actually have
-different docs, which should be thoroughly checked before updating.
+Updating to from ajv version 6 to 7 requires ajv-keywords 4.  Ajv versions 6 and 7 are similar, however they contain different docs, which should be thoroughly checked before updating.
 
 ### Package immutable: ^3.8.2
 

--- a/components/automate-ui/README.md
+++ b/components/automate-ui/README.md
@@ -55,29 +55,34 @@ Certain packages in package.json are constrained for the reasons detailed here.
 At any future moment though, the reasons for constraint here could be invalidated, so this should be updated as needed when package.json is updated.
 While it is problematic to document this information due to the maintenance burden, the value of having this in one place outweighs that burden.
 
-### Packages @ngrx/* =10.1.0
+### Package ajv: ^6.9.1
 
-awaiting the release of ngrx 11.  Until then, we will get incompatible peer dependencies if we try to update to latest.
-
-### Package karma: ^5.1.1
-
-"@angular-devkit/build-angular" has an incompatible peer dependency to Karma which requires ~5.1.0.
-
-### Package typescript: ^4.0.5
-
-"@angular-devkit/build-angular" has an incompatible peer dependency to typescript which requires ~4.0.0
-
-### Package jwt-decode: ^2.2.0
-
-Newer versions of jwt_decode introduce a new import format, which is breaking some of our testing.
+Updating to ajv 7 requires ajv-keywords 4, they are similar but actually have
+different docs, which should be thoroughly checked before updating.
 
 ### Package immutable: ^3.8.2
 
 Reason: Later releases are release candidates; should only be using production-releases.
 
+### Package jwt-decode: ^2.2.0
+
+Newer versions of jwt_decode introduce a new import format, which is breaking some of our testing.
+
+### Package karma: ^5.1.1
+
+"@angular-devkit/build-angular" has an incompatible peer dependency to Karma which requires ~5.1.0.
+
+### Packages @ngrx/*: =10.1.0
+
+awaiting the release of ngrx 11.  Until then, we will get incompatible peer dependencies if we try to update to latest.
+
 ### Package rrule: =2.4.1
 
 Per https://github.com/chef/automate/pull/1867, future versions have made a breaking change so it breaks our code base.
+
+### Package typescript: ^4.0.5
+
+"@angular-devkit/build-angular" has an incompatible peer dependency to typescript which requires ~4.0.0
 
 ### Package zone.js: ^0.10.3
 

--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -2597,23 +2597,15 @@
       }
     },
     "ajv": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.2.tgz",
-      "integrity": "sha512-qIaxO9RXjaXyO21tJr0EvwPcZa49m64GcXCU8ZrLjCAlFyMuOcPpI560So4A11M1WsKslJYIXn6jSyG5P0xIeg==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
-      },
-      "dependencies": {
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
       }
     },
     "ajv-errors": {
@@ -6903,9 +6895,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
       }
@@ -12260,12 +12252,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -76,7 +76,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "^2.0.8",
     "@types/lodash": "^4.14.166",
-    "ajv": "^7.0.2",
+    "ajv": "^6.9.1",
     "angular2-template-loader": "^0.6.2",
     "axe-webdriverjs": "^2.3.0",
     "codelyzer": "^6.0.0",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Upgrading to ajv 7 requires ajv-keywords 4.  This can be added to a separate upgrade of packages that can be completed in the next few months along with other packages that are still catching up to the Angular 11 upgrade.

### :chains: Related Resources
Angular 11 upgrade: https://github.com/chef/automate/pull/4499

### :+1: Definition of Done
Warning is no longer showing an incompatible peer dependency after `npm install`

### :athletic_shoe: How to Build and Test the Change
running `ng build` should produce no warning related to the package `ajv`

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
