### PR TITLE
added download button to get full details report of particular node

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -275,7 +275,7 @@
               <chef-icon>cloud_download</chef-icon>
             </chef-button>
             <chef-dropdown class="dropdown" [visible]="downloadOptsVisible">
-              <chef-click-outside  omit="dropdown-toggle">
+              <chef-click-outside omit="dropdown-toggle">
                 <chef-button tertiary (click)="onDownloadNodeReport('json')">JSON</chef-button>
                 <chef-button tertiary (click)="onDownloadNodeReport('csv')">CSV</chef-button>
               </chef-click-outside>
@@ -323,12 +323,12 @@
       title="download-title"
       [visible]="downloadStatusVisible"
       (closeModal)="hideDownloadStatus()">
-      <ng-container *ngIf="downloadInProgress">
-        <h2 id="download-report" class="display4" slot="title">Downloading report...</h2>
-      </ng-container>
-      <ng-container *ngIf="downloadFailed">
-        <h2 id="download-failed" class="display4" slot="title">Download failed.</h2>
-      </ng-container>
+        <ng-container *ngIf="downloadInProgress">
+          <h2 id="download-report" class="display4" slot="title">Downloading report...</h2>
+        </ng-container>
+        <ng-container *ngIf="downloadFailed">
+          <h2 id="download-failed" class="display4" slot="title">Download failed.</h2>
+        </ng-container>
       <chef-loading-spinner *ngIf="downloadInProgress" size="50"></chef-loading-spinner>
     </chef-modal>
       <chef-loading-spinner *ngIf="reportLoading" size="100"></chef-loading-spinner>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -270,6 +270,17 @@
             <h2 class="display4"><strong>Scan history for node:</strong></h2>
             <p>{{ activeReport?.node_name }}</p>
           </div>
+          <div class="download-report">
+            <chef-button class="dropdown-toggle" secondary (click)="toggleDownloadDropdown()" >
+              <chef-icon>cloud_download</chef-icon>
+            </chef-button>
+            <chef-dropdown class="dropdown" [visible]="downloadOptsVisible">
+              <chef-click-outside  omit="dropdown-toggle">
+                <chef-button tertiary (click)="onDownloadNodeReport('json')">JSON</chef-button>
+                <chef-button tertiary (click)="onDownloadNodeReport('csv')">CSV</chef-button>
+              </chef-click-outside>
+            </chef-dropdown>
+          </div>
           <chef-button secondary (click)="onHistoryCloseClick($event)">
             <chef-icon>close</chef-icon>
           </chef-button>
@@ -307,7 +318,19 @@
           </div>
         </div>
       </chef-side-panel>
-
+      <chef-modal
+      id="download-modal"
+      title="download-title"
+      [visible]="downloadStatusVisible"
+      (closeModal)="hideDownloadStatus()">
+      <ng-container *ngIf="downloadInProgress">
+        <h2 id="download-report" class="display4" slot="title">Downloading report...</h2>
+      </ng-container>
+      <ng-container *ngIf="downloadFailed">
+        <h2 id="download-failed" class="display4" slot="title">Download failed.</h2>
+      </ng-container>
+      <chef-loading-spinner *ngIf="downloadInProgress" size="50"></chef-loading-spinner>
+    </chef-modal>
       <chef-loading-spinner *ngIf="reportLoading" size="100"></chef-loading-spinner>
     </main>
   </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.spec.ts
@@ -7,7 +7,7 @@ import { NgrxStateAtom, runtimeChecks, ngrxReducers } from 'app/ngrx.reducers';
 import { CookieModule } from 'ngx-cookie';
 import { ReportingNodeComponent } from './reporting-node.component';
 import { ChefSessionService } from 'app/services/chef-session/chef-session.service';
-import { of as observableOf } from 'rxjs';
+import { Observable, of as observableOf } from 'rxjs';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { StatsService, ReportQueryService, ScanResultsService } from '../../shared/reporting';
 import { DatetimePipe } from 'app/pipes/datetime.pipe';
@@ -145,6 +145,13 @@ describe('ReportingNodeComponent', () => {
         {id: 2, status: 'skipped'},
         {id: 5, status: 'skipped'}
       ]);
+    });
+  });
+  describe('onDownloadNodeReport', () => {
+    it('calls downloadReport with correct format type', () => {
+      spyOn(statsService, 'downloadNodeReport').and.returnValue(new Observable(() => {}));
+      component.onDownloadNodeReport('json');
+      expect(statsService.downloadNodeReport).toHaveBeenCalledWith('json', jasmine.any(Object));
     });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -248,6 +248,5 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.statsService.downloadNodeReport(fileFormat, reportQuery).pipe(
       finalize(onComplete))
       .subscribe(onNext, onError);
-
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -245,7 +245,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
     this.downloadList = [filename];
     this.showDownloadStatus();
-    this.statsService.downloaNodeReport(format, reportQuery).pipe(
+    this.statsService.downloadNodeReport(format, reportQuery).pipe(
       finalize(onComplete))
       .subscribe(onNext, onError);
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { StatsService, ReportCollection } from '../../shared/reporting/stats.service';
+import { StatsService, ReportCollection, reportFormat } from '../../shared/reporting/stats.service';
 import { Subject, Observable } from 'rxjs';
 import { ReportQueryService, ReturnParams, ReportQuery } from '../../shared/reporting/report-query.service';
 import * as moment from 'moment/moment';
@@ -220,24 +220,24 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.downloadFailed = false;
   }
 
-  showDownloadStatus() {
+  private showDownloadStatus() {
     this.downloadStatusVisible = true;
     this.downloadInProgress = true;
     this.downloadFailed = false;
   }
 
-  onDownloadNodeReport(format) {
+  onDownloadNodeReport(fileFormat: reportFormat) {
     this.downloadOptsVisible = false;
     const id: string = this.route.snapshot.params['id'];
     const reportQuery = this.reportQueryService.getReportQuery();
     reportQuery.filters = reportQuery.filters.concat([{type: {name: 'node_id'}, value: {id}}]);
-    const filename = `${reportQuery.endDate.format('YYYY-M-D')}.${format}`;
+    const filename = `${reportQuery.endDate.format('YYYY-M-D')}.${fileFormat}`;
 
     const onComplete = () => this.downloadInProgress = false;
     const onError = _e => this.downloadFailed = true;
     const types = { 'json': 'application/json', 'csv': 'text/csv' };
     const onNext = data => {
-      const type = types[format];
+      const type = types[fileFormat];
       const blob = new Blob([data], { type });
       saveAs(blob, filename);
       this.hideDownloadStatus();
@@ -245,7 +245,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
     this.downloadList = [filename];
     this.showDownloadStatus();
-    this.statsService.downloadNodeReport(format, reportQuery).pipe(
+    this.statsService.downloadNodeReport(fileFormat, reportQuery).pipe(
       finalize(onComplete))
       .subscribe(onNext, onError);
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -31,10 +31,10 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   totalReports = 0;
   firstReportIsLoaded = false;
   downloadList: Array<string> = [];
-  downloadOptsVisible: boolean = false;
-  downloadStatusVisible: boolean;
-  downloadInProgress: boolean;
-  downloadFailed: boolean;
+  downloadOptsVisible = false;
+  downloadStatusVisible = false;
+  downloadInProgress = false;
+  downloadFailed = false;
   openControls = {};
 
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
@@ -210,7 +210,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
         this.activeReport = Object.assign(report, data);
       });
   }
-  
+
   toggleDownloadDropdown() {
     this.downloadOptsVisible = !this.downloadOptsVisible;
   }

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -226,6 +226,17 @@ export class StatsService {
     return this.httpClient.post(url, body, { responseType: 'text' });
   }
 
+  downloaNodeReport(format: string, reportQuery: ReportQuery): Observable<string> {
+    const url = `${CC_API_URL}/reporting/node/export`;
+
+        // for export, we want to send the start_time as the beg of day of end time
+    // so we find the endtime in the filters, and then set start time to beg of that day
+    reportQuery.startDate = moment.utc(reportQuery.endDate).startOf('day');
+
+    const body = { type: format, filters: this.formatFilters(reportQuery) };
+    return this.httpClient.post(url, body, { responseType: 'text' });
+  }
+
   getSingleReport(reportID: string, reportQuery: ReportQuery): Observable<any> {
     const url = `${CC_API_URL}/reporting/reports/id/${reportID}`;
     const formatted = this.formatFilters(reportQuery);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -226,7 +226,7 @@ export class StatsService {
     return this.httpClient.post(url, body, { responseType: 'text' });
   }
 
-  downloaNodeReport(format: string, reportQuery: ReportQuery): Observable<string> {
+  downloadNodeReport(format: string, reportQuery: ReportQuery): Observable<string> {
     const url = `${CC_API_URL}/reporting/node/export`;
 
         // for export, we want to send the start_time as the beg of day of end time

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -17,7 +17,7 @@ export interface DateRange {
 }
 
 export type ControlStatus = 'passed' | 'failed' | 'waived' | 'skipped';
-
+export type reportFormat = 'json' | 'csv';
 export class ReportCollection {
   reports: any[];
   totalReports: number;
@@ -226,14 +226,12 @@ export class StatsService {
     return this.httpClient.post(url, body, { responseType: 'text' });
   }
 
-  downloadNodeReport(format: string, reportQuery: ReportQuery): Observable<string> {
+  downloadNodeReport(fileFormat: reportFormat, reportQuery: ReportQuery): Observable<string> {
     const url = `${CC_API_URL}/reporting/node/export`;
 
-        // for export, we want to send the start_time as the beg of day of end time
-    // so we find the endtime in the filters, and then set start time to beg of that day
     reportQuery.startDate = moment.utc(reportQuery.endDate).startOf('day');
 
-    const body = { type: format, filters: this.formatFilters(reportQuery) };
+    const body = { type: fileFormat, filters: this.formatFilters(reportQuery) };
     return this.httpClient.post(url, body, { responseType: 'text' });
   }
 


### PR DESCRIPTION
Signed-off-by: Shaik Mudassir <47217471+shaik80@users.noreply.github.com>

### :nut_and_bolt: Description: What code changed, and why?
Added a button to download historical reports on compliance node details with file format option
### :chains: Related Resources
https://github.com/chef/automate/issues/4344
### :+1: Definition of Done
Added download report button including option(JSON and CSV) plus  pop-up downloading Status model and also written unit test for download report function
### :athletic_shoe: How to Build and Test the Change

```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command make serve
```
Before testing please follow steps from https://github.com/chef/automate/pull/2378

 open automate-ui in browser goto **Compliance -> Report ->  Nodes** select any node then click on **Scan History** to download report of that particular node

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="1920" alt="Screenshot 2021-01-04 at 7 11 10 PM" src="https://user-images.githubusercontent.com/47217471/103541908-22d5f000-4ec2-11eb-9e6b-700f934b22e1.png">