### PR TITLE
Add PopulateSecretsFromEnvironment for loading config

### DIFF
--- a/api/config/deployment/automate_config.go
+++ b/api/config/deployment/automate_config.go
@@ -69,7 +69,7 @@ func (c *AutomateConfig) PopulateSecretsFromEnvironment() {
 				v = (reflectVal.Interface()).(a2conf.A2ServiceConfig)
 				isNew = true
 			} else {
-				v = (f.Elem().Interface()).(a2conf.A2ServiceConfig)
+				v = (f.Interface()).(a2conf.A2ServiceConfig)
 			}
 			for _, secret := range v.ListSecrets() {
 				if v.GetSecret(secret.Name) == nil {

--- a/api/config/deployment/automate_config.go
+++ b/api/config/deployment/automate_config.go
@@ -56,7 +56,7 @@ func LoadUserOverrideConfigFile(file string, options ...AutomateConfigOpt) (*Aut
 
 func (c *AutomateConfig) PopulateSecretsFromEnvironment() {
 	a2ServiceConfigType := reflect.TypeOf((*a2conf.A2ServiceConfig)(nil)).Elem()
-	a := reflect.ValueOf(c)
+	a := reflect.ValueOf(c).Elem()
 	for i := 0; i < a.NumField(); i++ {
 		f := a.Field(i)
 


### PR DESCRIPTION
PopulateSecretsFromEnvironment will attempt to read any missing config that are sercret from environment variables. These will eventually be removed from the config and stored in an encrypted place