### PR TITLE
fixed issue in trend graph and pie chart

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
@@ -80,16 +80,20 @@ export class OverviewFailuresComponent implements OnChanges, OnDestroy {
     const update = this.bubbleSelection.merge(enter);
     const exit = this.bubbleSelection.exit();
 
-    const mouseover = (_d, i, ns) => {
+    const mouseover = (event) => {
+      const ns = d3.select(event.currentTarget).nodes();
+      const i = ns.indexOf(event.currentTarget);
       d3.selectAll(ns.filter(n => n !== ns[i])).transition()
         .style('opacity', 0.5);
     };
-    const mouseout = (_d, _i, ns) => {
+    const mouseout = (event) => {
+      const ns = d3.select(event.currentTarget).nodes();
       d3.selectAll(ns).transition()
         .style('opacity', 1);
     };
 
-    enter.on('click', (node) => {
+    enter.on('click', (_d, node) => {
+      console.log(node.data)
       this.itemSelected.next(node.data);
     });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-failures/overview-failures.component.ts
@@ -93,7 +93,6 @@ export class OverviewFailuresComponent implements OnChanges, OnDestroy {
     };
 
     enter.on('click', (_d, node) => {
-      console.log(node.data)
       this.itemSelected.next(node.data);
     });
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/overview-trend/overview-trend.component.ts
@@ -229,8 +229,8 @@ export class OverviewTrendComponent implements OnChanges, OnDestroy  {
     enter.append('rect')
       .attr('class', 'dot-group-bg');
 
-    enter.on('click', (line) => {
-      this.dateSelected.next(moment(line.report_time).format('YYYY-MM-DD'));
+    enter.on('click', (_d, i) => {
+      this.dateSelected.next(moment(i.report_time).format('YYYY-MM-DD'));
     });
 
     update.select('.dot-group-tick')


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
- Clicking on a date in trend graph is not loading data for that date.
- Clicking on the pie chart does not open the reports page

Issue was caused due to the recent changes in d3 version from 5.16.0 to 6.3.1
According to the migration guide [click here](https://observablehq.com/@d3/d3v6-migration-guide)
``` ts
// any pattern like this
selection.on("click", function(d, i, e) {
    console.log(d, i, e);
  })
// should be replaced by:
selection.on("click", function(event, d) {
  const e = selection.nodes();
  const i = e.indexOf(this);
  console.log(d, i, e);
})
```
I have made the changes in overview-failure component and overview-trend component.
Could not find any other places this pattern was not followed.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#4515 
### :+1: Definition of Done
- open the compliance tab
- clicking on a date in the trend chart should load data for that date
- clicking on the piechart should open the reports page
### :athletic_shoe: How to Build and Test the Change
inside habitat studio:
- `start_all_services`
- load data using `load_compliance_reports`

In the browser
- open a2-dev.test
- clicking on a date in the trend chart should load data for that date
- clicking on the piechart should open the reports page
### :white_check_mark: Checklist

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] Tests added/updated?
- [X] Docs added/updated?
- [X] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
<img width="1626" alt="Screenshot 2021-01-08 at 9 13 05 PM" src="https://user-images.githubusercontent.com/59958706/104034044-5ed8c000-51f6-11eb-9bca-98c86843dc43.png">
<img width="1626" alt="Screenshot 2021-01-08 at 9 13 15 PM" src="https://user-images.githubusercontent.com/59958706/104034051-613b1a00-51f6-11eb-9679-6dc6e3bd61d3.png">
