### PR TITLE
Infra proxy nodes list UI

### DIFF
--- a/components/automate-ui/src/app/app.module.ts
+++ b/components/automate-ui/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { DataBagsRequests } from './entities/data-bags/data-bags.requests';
 import { DesktopRequests } from './entities/desktop/desktop.requests';
 import { DestinationRequests } from './entities/destinations/destination.requests';
 import { EnvironmentRequests } from './entities/environments/environment.requests';
+import { InfraNodeRequests } from './entities/infra-nodes/infra-nodes.requests';
 import { InfraRoleRequests } from './entities/infra-roles/infra-role.requests';
 import { JobRequests } from './entities/jobs/job.requests';
 import { LicenseStatusRequests } from './entities/license/license.requests';
@@ -313,6 +314,7 @@ import { WelcomeModalComponent } from './page-components/welcome-modal/welcome-m
       useClass: HttpClientAuthInterceptor,
       multi: true
     },
+    InfraNodeRequests,
     InfraRoleRequests,
     JobRequests,
     LayoutSidebarService,

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.actions.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.actions.ts
@@ -1,0 +1,37 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Action } from '@ngrx/store';
+
+import { InfraNode } from './infra-nodes.model';
+
+export enum NodeActionTypes {
+  GET_ALL = 'NODES::GET_ALL',
+  GET_ALL_SUCCESS = 'NODES::GET_ALL::SUCCESS',
+  GET_ALL_FAILURE = 'NODES::GET_ALL::FAILURE'
+}
+
+export class GetNodes implements Action {
+  readonly type = NodeActionTypes.GET_ALL;
+
+  constructor(public payload: { server_id: string, org_id: string }) { }
+}
+
+export interface NodesSuccessPayload {
+  nodes: InfraNode[];
+}
+
+export class GetNodesSuccess implements Action {
+  readonly type = NodeActionTypes.GET_ALL_SUCCESS;
+
+  constructor(public payload: NodesSuccessPayload) { }
+}
+
+export class GetNodesFailure implements Action {
+  readonly type = NodeActionTypes.GET_ALL_FAILURE;
+
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+export type NodeActions =
+  | GetNodes
+  | GetNodesSuccess
+  | GetNodesFailure;

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.effects.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.effects.ts
@@ -16,14 +16,14 @@ import {
 } from './infra-nodes.actions';
 
 import {
-  NodeRequests
+  InfraNodeRequests
 } from './infra-nodes.requests';
 
 @Injectable()
 export class InfraNodeEffects {
   constructor(
     private actions$: Actions,
-    private requests: NodeRequests
+    private requests: InfraNodeRequests
   ) { }
 
   @Effect()

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.effects.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.effects.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import { of as observableOf } from 'rxjs';
+import { catchError, mergeMap, map } from 'rxjs/operators';
+
+import { CreateNotification } from 'app/entities/notifications/notification.actions';
+import { Type } from 'app/entities/notifications/notification.model';
+
+import {
+  GetNodes,
+  GetNodesSuccess,
+  NodesSuccessPayload,
+  GetNodesFailure,
+  NodeActionTypes
+} from './infra-nodes.actions';
+
+import {
+  NodeRequests
+} from './infra-nodes.requests';
+
+@Injectable()
+export class InfraNodeEffects {
+  constructor(
+    private actions$: Actions,
+    private requests: NodeRequests
+  ) { }
+
+  @Effect()
+  getNodes$ = this.actions$.pipe(
+      ofType(NodeActionTypes.GET_ALL),
+      mergeMap(({ payload: { server_id, org_id } }: GetNodes) =>
+        this.requests.getNodes(server_id, org_id).pipe(
+          map((resp: NodesSuccessPayload) => new GetNodesSuccess(resp)),
+          catchError(
+            (error: HttpErrorResponse) => observableOf(new GetNodesFailure(error)
+            )))));
+
+  @Effect()
+  getNodesFailure$ = this.actions$.pipe(
+      ofType(NodeActionTypes.GET_ALL_FAILURE),
+      map(({ payload }: GetNodesFailure) => {
+        const msg = payload.error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not get nodes: ${msg || payload.error}`
+        });
+      }));
+
+}

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.model.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.model.ts
@@ -1,0 +1,11 @@
+export interface InfraNode {
+    id: string;
+    name: string;
+    fqdn: string;
+    ip_address: string;
+    check_in: string;
+    uptime: string;
+    platform: string;
+    environment: string;
+    policy_group: string;
+}

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.reducer.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.reducer.ts
@@ -1,0 +1,43 @@
+import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+import { set, pipe } from 'lodash/fp';
+
+import { EntityStatus } from 'app/entities/entities';
+import { NodeActionTypes, NodeActions } from './infra-nodes.actions';
+import { InfraNode } from './infra-nodes.model';
+
+export interface InfraNodeEntityState extends EntityState<InfraNode> {
+  nodesStatus: EntityStatus;
+  getAllStatus: EntityStatus;
+}
+
+const GET_ALL_STATUS = 'getAllStatus';
+
+export const nodeEntityAdapter: EntityAdapter<InfraNode> = createEntityAdapter<InfraNode>();
+
+export const InfraNodeEntityInitialState: InfraNodeEntityState =
+  nodeEntityAdapter.getInitialState(<InfraNodeEntityState>{
+    getAllStatus: EntityStatus.notLoaded
+  });
+
+export function infraNodeEntityReducer(
+  state: InfraNodeEntityState = InfraNodeEntityInitialState,
+  action: NodeActions): InfraNodeEntityState {
+
+  switch (action.type) {
+    case NodeActionTypes.GET_ALL:
+      return set(GET_ALL_STATUS, EntityStatus.loading, nodeEntityAdapter.removeAll(state));
+
+    case NodeActionTypes.GET_ALL_SUCCESS:
+      return pipe(
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        (nodeEntityAdapter.setAll(action.payload.nodes, state)) as InfraNodeEntityState;
+
+    case NodeActionTypes.GET_ALL_FAILURE:
+      return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    default:
+      return state;
+  }
+}
+
+export const getEntityById = (id: string) => (state: InfraNodeEntityState) => state.entities[id];

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.requests.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.requests.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment as env } from 'environments/environment';
+import { NodesSuccessPayload } from './infra-nodes.actions';
+import { InterceptorSkipHeader } from 'app/services/http/http-client-auth.interceptor';
+
+@Injectable()
+export class NodeRequests {
+
+  constructor(private http: HttpClient) { }
+
+  public getNodes(server_id: string, org_id: string):
+  Observable<NodesSuccessPayload> {
+    const headers = new HttpHeaders().set(InterceptorSkipHeader, '');
+    return this.http.get<NodesSuccessPayload>(
+      `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/nodes`, {headers});
+  }
+
+}

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.requests.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.requests.ts
@@ -6,7 +6,7 @@ import { NodesSuccessPayload } from './infra-nodes.actions';
 import { InterceptorSkipHeader } from 'app/services/http/http-client-auth.interceptor';
 
 @Injectable()
-export class NodeRequests {
+export class InfraNodeRequests {
 
   constructor(private http: HttpClient) { }
 

--- a/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.selectors.ts
+++ b/components/automate-ui/src/app/entities/infra-nodes/infra-nodes.selectors.ts
@@ -1,0 +1,19 @@
+import { createSelector, createFeatureSelector } from '@ngrx/store';
+import { InfraNodeEntityState, nodeEntityAdapter } from './infra-nodes.reducer';
+
+export const infraNodeState = createFeatureSelector<InfraNodeEntityState>('infraNodes');
+
+export const {
+  selectAll: allInfraNodes,
+  selectEntities: nodeEntities
+} = nodeEntityAdapter.getSelectors(infraNodeState);
+
+export const getAllStatus = createSelector(
+  infraNodeState,
+  (state) => state.getAllStatus
+);
+
+export const infraNodeStatus = createSelector(
+  infraNodeState,
+  (state) => state.nodesStatus
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.html
@@ -1,0 +1,30 @@
+<section class="infra-nodes">
+  <chef-loading-spinner *ngIf="nodesListLoading" size="50"></chef-loading-spinner>
+  <app-empty-state *ngIf="authFailure" moduleTitle="nodes" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
+  <ng-container *ngIf="!nodesListLoading && !authFailure">
+    <chef-table>
+      <chef-thead>
+        <chef-tr>
+          <chef-th>Node Name</chef-th>
+          <chef-th>Platform</chef-th>
+          <chef-th>FQDN</chef-th>
+          <chef-th>IP Address</chef-th>
+          <chef-th>Uptime</chef-th>
+          <chef-th>Last Check-In</chef-th>
+          <chef-th>Environment</chef-th>
+        </chef-tr>
+      </chef-thead>
+      <chef-tbody>
+        <chef-tr *ngFor="let node of nodes">
+          <chef-td>{{ node.name }}</chef-td>
+          <chef-td>{{ node.platform }}</chef-td>
+          <chef-td>{{ node.fqdn }}</chef-td>
+          <chef-td>{{ node.ip_address }}</chef-td>
+          <chef-td>{{ node.uptime }}</chef-td>
+          <chef-td>{{ node.check_in }}</chef-td>
+          <chef-td>{{ node.environment }}</chef-td>
+        </chef-tr>
+      </chef-tbody>
+    </chef-table>
+  </ng-container>
+</section>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.scss
@@ -1,0 +1,35 @@
+@import "~styles/variables";
+
+thead {
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  color: $chef-primary-dark;
+}
+
+th {
+  text-align: left;
+  padding: 0px;
+}
+
+tbody > .detail-row {
+  padding-top: 0px;
+  padding-bottom: 15px;
+}
+
+chef-table-new {
+  .controls {
+    text-align: right;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+
+chef-loading-spinner {
+  display: block;
+  margin: 100px auto;
+  width: 100px;
+  z-index: 199;
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.spec.ts
@@ -1,0 +1,57 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { InfraNodesComponent } from './infra-nodes.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MockComponent } from 'ng2-mock-component';
+import { StoreModule } from '@ngrx/store';
+import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
+import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
+
+describe('InfraNodesComponent', () => {
+  let component: InfraNodesComponent;
+  let fixture: ComponentFixture<InfraNodesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        MockComponent({ selector: 'a', inputs: ['routerLink'] }),
+        MockComponent({ selector: 'chef-heading' }),
+        MockComponent({ selector: 'chef-icon' }),
+        MockComponent({ selector: 'chef-loading-spinner' }),
+        MockComponent({ selector: 'chef-page-header' }),
+        MockComponent({ selector: 'chef-subheading' }),
+        MockComponent({ selector: 'chef-toolbar' }),
+        MockComponent({ selector: 'chef-table' }),
+        MockComponent({ selector: 'chef-thead' }),
+        MockComponent({ selector: 'chef-tbody' }),
+        MockComponent({ selector: 'chef-tr' }),
+        MockComponent({ selector: 'chef-th' }),
+        MockComponent({ selector: 'chef-td' }),
+        MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({ selector: 'mat-select' }),
+        MockComponent({ selector: 'mat-option' }),
+        InfraNodesComponent
+      ],
+      providers: [
+        FeatureFlagsService
+      ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        StoreModule.forRoot(ngrxReducers, { runtimeChecks })
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InfraNodesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { InfraNodesComponent } from './infra-nodes.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -11,7 +11,7 @@ describe('InfraNodesComponent', () => {
   let component: InfraNodesComponent;
   let fixture: ComponentFixture<InfraNodesComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.ts
@@ -1,0 +1,69 @@
+import { Component, Input, OnInit, OnDestroy, EventEmitter, Output } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { isNil } from 'lodash/fp';
+
+import { NgrxStateAtom } from 'app/ngrx.reducers';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { EntityStatus } from 'app/entities/entities';
+import { GetNodes } from 'app/entities/infra-nodes/infra-nodes.actions';
+import { InfraNode } from 'app/entities/infra-nodes/infra-nodes.model';
+import {
+  allInfraNodes,
+  getAllStatus as getAllNodesForOrgStatus
+} from 'app/entities/infra-nodes/infra-nodes.selectors';
+
+
+@Component({
+  selector: 'app-infra-nodes',
+  templateUrl: './infra-nodes.component.html',
+  styleUrls: ['./infra-nodes.component.scss']
+})
+
+export class InfraNodesComponent implements OnInit, OnDestroy {
+  @Input() serverId: string;
+  @Input() orgId: string;
+  @Output() resetKeyRedirection = new EventEmitter<boolean>();
+
+  private isDestroyed = new Subject<boolean>();
+  public nodes: InfraNode[] = [];
+  public nodesListLoading = true;
+  public authFailure = false;
+
+  constructor(
+    private store: Store<NgrxStateAtom>,
+    private layoutFacade: LayoutFacadeService
+  ) { }
+
+  ngOnInit() {
+    this.layoutFacade.showSidebar(Sidebar.Infrastructure);
+
+    this.store.dispatch(new GetNodes({
+      server_id: this.serverId, org_id: this.orgId
+    }));
+
+    combineLatest([
+      this.store.select(getAllNodesForOrgStatus),
+      this.store.select(allInfraNodes)
+    ]).pipe(takeUntil(this.isDestroyed))
+    .subscribe(([ getNodesSt, allInfraNodesState]) => {
+      if (getNodesSt === EntityStatus.loadingSuccess && !isNil(allInfraNodesState)) {
+        this.nodes = allInfraNodesState;
+        this.nodesListLoading = false;
+      } else if (getNodesSt === EntityStatus.loadingFailure) {
+        this.nodesListLoading = false;
+        this.authFailure = true;
+      }
+    });
+  }
+
+  resetKeyTabRedirection(resetLink: boolean) {
+    this.resetKeyRedirection.emit(resetLink);
+  }
+
+  ngOnDestroy(): void {
+    this.isDestroyed.next(true);
+    this.isDestroyed.complete();
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-proxy.module.ts
@@ -17,6 +17,7 @@ import { DataBagsDetailsComponent } from './data-bags-details/data-bags-details.
 import { DataBagsListComponent } from './data-bags-list/data-bags-list.component';
 import { EnvironmentsComponent } from './environments/environments.component';
 import { EnvironmentDetailsComponent } from './environment-details/environment-details.component';
+import { InfraNodesComponent } from './infra-nodes/infra-nodes.component';
 import { InfraRolesComponent } from './infra-roles/infra-roles.component';
 import { InfraRoleDetailsComponent } from './infra-role-details/infra-role-details.component';
 import { JsonTreeTableComponent } from './json-tree-table/json-tree-table.component';
@@ -43,6 +44,7 @@ import { EmptyStateComponent } from './empty-state/empty-state.component';
     EnvironmentsComponent,
     EnvironmentDetailsComponent,
     JsonTreeTableComponent,
+    InfraNodesComponent,
     InfraRolesComponent,
     InfraRoleDetailsComponent,
     OrgDetailsComponent,

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -45,6 +45,9 @@
           <app-tab tabTitle="Policyfiles" #policyFiles_tab  [active]="policyFilesTab">
             <app-policy-files *ngIf="policyFiles_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-policy-files>
           </app-tab>
+          <app-tab tabTitle="Nodes" #nodes_tab  [active]="nodesTab">
+            <app-infra-nodes *ngIf="nodes_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-infra-nodes>
+          </app-tab>
           <app-tab tabTitle="Details" #details_tab [active]="false">
             <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
           </app-tab>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -33,6 +33,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
   public environmentsTab = false;
   public resetKeyTab = false;
   public rolesTab = false;
+  public nodesTab = false;
   public dataBagsTab = false;
   public clientsTab = false;
   public policyFilesTab = false;
@@ -63,6 +64,9 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         } else if (path.includes('data-bags')) {
           this.resetTabs();
           this.dataBagsTab = true;
+        } else if (path.includes('nodes')) {
+          this.resetTabs();
+          this.nodesTab = true;
         } else if (path.includes('cookbooks')) {
           this.resetTabs();
           this.cookbooksTab = true;
@@ -137,9 +141,12 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
         this.policyFilesTab = true;
         break;
       case 6:
-        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'orgEdit');
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'nodes');
         break;
       case 7:
+        this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'orgEdit');
+        break;
+      case 8:
         this.telemetryService.track(ORG_DETAILS_TAB_NAME, 'resetkey');
         break;
     }
@@ -160,6 +167,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
     this.policyFilesTab = false;
     this.resetKeyTab = false;
     this.clientsTab = false;
+    this.nodesTab = false;
   }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/ngrx.effects.ts
+++ b/components/automate-ui/src/app/ngrx.effects.ts
@@ -20,6 +20,7 @@ import { DesktopEffects } from './entities/desktop/desktop.effects';
 import { DestinationEffects } from './entities/destinations/destination.effects';
 import { EnvironmentEffects } from './entities/environments/environment.effects';
 import { EventFeedEffects } from './services/event-feed/event-feed.effects';
+import { InfraNodeEffects } from './entities/infra-nodes/infra-nodes.effects';
 import { InfraRoleEffects } from './entities/infra-roles/infra-role.effects';
 import { JobEffects } from './entities/jobs/job.effects';
 import { LicenseStatusEffects } from './entities/license/license.effects';
@@ -63,6 +64,7 @@ import { UserPermEffects } from './entities/userperms/userperms.effects';
       DestinationEffects,
       EnvironmentEffects,
       EventFeedEffects,
+      InfraNodeEffects,
       InfraRoleEffects,
       JobEffects,
       LicenseStatusEffects,

--- a/components/automate-ui/src/app/ngrx.reducers.ts
+++ b/components/automate-ui/src/app/ngrx.reducers.ts
@@ -24,6 +24,7 @@ import * as dataBagItemDetailsEntity from './entities/data-bags/data-bag-item-de
 import * as desktopEntity from './entities/desktop/desktop.reducer';
 import * as environmentEntity from './entities/environments/environment.reducer';
 import * as environmentDetailsEntity from './entities/environments/environment-details.reducer';
+import * as infraNodeEntity from './entities/infra-nodes/infra-nodes.reducer';
 import * as infraRoleEntity from './entities/infra-roles/infra-role.reducer';
 import * as infraRoleDetailsEntity from './entities/infra-roles/infra-role-details.reducer';
 import * as integrationsAdd from './pages/integrations/add/integration-add.reducer';
@@ -96,6 +97,7 @@ export interface NgrxStateAtom {
   destinations: destinationEntity.DestinationEntityState;
   environments: environmentEntity.EnvironmentEntityState;
   environmentDetails: environmentDetailsEntity.EnvironmentDetailsEntityState;
+  infraNodes: infraNodeEntity.InfraNodeEntityState;
   infraRoles: infraRoleEntity.InfraRoleEntityState;
   infraRoleDetails: infraRoleDetailsEntity.InfraRoleDetailsEntityState;
   jobs: jobEntity.JobEntityState;
@@ -221,6 +223,7 @@ export const defaultInitialState = {
   destinations: destinationEntity.DestinationEntityInitialState,
   environments: environmentEntity.EnvironmentEntityInitialState,
   environmentDetails: environmentDetailsEntity.EnvironmentEntityInitialState,
+  infraNodes: infraNodeEntity.InfraNodeEntityInitialState,
   infraRoles: infraRoleEntity.InfraRoleEntityInitialState,
   infraRoleDetails: infraRoleDetailsEntity.InfraRoleEntityInitialState,
   jobs: jobEntity.JobEntityInitialState,
@@ -283,6 +286,7 @@ export const ngrxReducers = {
   destinations: destinationEntity.destinationEntityReducer,
   environments: environmentEntity.environmentEntityReducer,
   environmentDetails: environmentDetailsEntity.environmentDetailsEntityReducer,
+  infraNodes: infraNodeEntity.infraNodeEntityReducer,
   infraRoles: infraRoleEntity.infraRoleEntityReducer,
   infraRoleDetails: infraRoleDetailsEntity.infraRoleDetailsEntityReducer,
   jobs: jobEntity.jobEntityReducer,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
we need to show the list of the infra proxy nodes under the org details.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/4371
### :+1: Definition of Done
Added nodes tabs for the org where we can show the list of the infra proxy nodes.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

$npm run serve:hab
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![infra-nodes](https://user-images.githubusercontent.com/12297653/104295258-372f7380-54e6-11eb-87ac-32039569704b.png)
