### PR TITLE
Move secrets from config to secret store

### DIFF
--- a/components/automate-deployment/pkg/server/automate_config.go
+++ b/components/automate-deployment/pkg/server/automate_config.go
@@ -85,7 +85,7 @@ func (s *server) PatchAutomateConfig(ctx context.Context,
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
 
-		if err = s.deployment.ReplaceUserOverrideConfig(existingCopy); err != nil {
+		if err = s.deployment.ReplaceUserOverrideConfig(existingCopy, s.secretStore); err != nil {
 			return status.Error(codes.Internal, err.Error())
 		}
 
@@ -129,7 +129,7 @@ func (s *server) SetAutomateConfig(ctx context.Context,
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
 
-		if err = s.deployment.ReplaceUserOverrideConfig(req.Config); err != nil {
+		if err = s.deployment.ReplaceUserOverrideConfig(req.Config, s.secretStore); err != nil {
 			return status.Error(codes.Internal, err.Error())
 		}
 
@@ -221,7 +221,7 @@ func (s *server) updateUserOverrideConfigFromRestoreBackupRequest(req *api.Resto
 		return status.Error(codes.InvalidArgument, errors.Wrap(err, "updating config").Error())
 	}
 
-	if err = s.deployment.ReplaceUserOverrideConfig(cfg); err != nil {
+	if err = s.deployment.ReplaceUserOverrideConfig(cfg, s.secretStore); err != nil {
 		return status.Error(codes.Internal, errors.Wrap(err, "replacing config").Error())
 	}
 

--- a/components/automate-deployment/pkg/server/server_test.go
+++ b/components/automate-deployment/pkg/server/server_test.go
@@ -55,7 +55,7 @@ func testServer(t target.Target) server {
 	c.Deployment.V1.Svc.AdminUser.Password = w.String("ponies")
 
 	d, _ := deployment.CreateDeployment()
-	d.UpdateWithUserOverrideConfig(c)
+	d.UpdateWithUserOverrideConfig(c, nil)
 	d.SetTarget(t)
 
 	return server{deployment: d, ensureStatusInterval: time.Nanosecond}

--- a/components/automate-dex/habitat/config/ldap_bind_password
+++ b/components/automate-dex/habitat/config/ldap_bind_password
@@ -1,6 +1,0 @@
-{{~#if cfg.connectors.ldap}}
-{{~toJson cfg.connectors.ldap.bind_password}}
-{{~/if}}
-{{~#if cfg.connectors.msad_ldap}}
-{{~toJson cfg.connectors.msad_ldap.bind_password}}
-{{~/if}}

--- a/components/automate-dex/habitat/config/run_environment.sh
+++ b/components/automate-dex/habitat/config/run_environment.sh
@@ -1,9 +1,9 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 {{~#if cfg.connectors.ldap}}
 export LDAP_BINDDN=$(sed 's/^\"\(.*\)\"$/\1/' {{pkg.svc_config_path}}/ldap_bind_dn)
-export LDAP_BINDPW=$(sed 's/^\"\(.*\)\"$/\1/' {{pkg.svc_config_path}}/ldap_bind_password)
+export LDAP_BINDPW=$(secrets-helper show userconfig.ldap_password || echo "")
 {{~/if}}
 {{~#if cfg.connectors.msad_ldap}}
 export LDAP_BINDDN=$(sed 's/^\"\(.*\)\"$/\1/' {{pkg.svc_config_path}}/ldap_bind_dn)
-export LDAP_BINDPW=$(sed 's/^\"\(.*\)\"$/\1/' {{pkg.svc_config_path}}/ldap_bind_password)
+export LDAP_BINDPW=$(secrets-helper show userconfig.msad_password || echo "")
 {{~/if}}

--- a/components/automate-dex/habitat/hooks/run
+++ b/components/automate-dex/habitat/hooks/run
@@ -21,4 +21,8 @@ pg-helper create-extension "{{cfg.storage.database}}" "pgcrypto"
 # cleanup static path
 rm -rf "{{pkg.svc_static_path}}/web"
 
-exec dex serve {{pkg.svc_var_path}}/etc/config.yml
+exec secrets-helper exec \
+  --watch \
+  --optional-secret userconfig.ldap_password \
+  --optional-secret userconfig.msad_password \
+  -- dex serve {{pkg.svc_var_path}}/etc/config.yml

--- a/lib/secrets/secrets.go
+++ b/lib/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -35,6 +36,10 @@ var BifrostSuperuserIDName = SecretName{
 type SecretName struct {
 	Group string
 	Name  string
+}
+
+func (s SecretName) String() string {
+	return fmt.Sprintf("%s.%s", s.Group, s.Name)
 }
 
 // SecretNameFromString returns parses the string according to the


### PR DESCRIPTION
Move secrets stored in the config to the secret store.

Added a watch mode the secrets-helper exec. When run with this flag, the
we run the requested executable as a child process. If any of the
watched secrets change, the child process is killed. This will make sure changes
to secrets still get picked up automatically. I've kept it simple for now. It polls the secrets
instead of using anything like inotify.

To run this:
- rebuild components/automate-platform-tools
- export local_platform_tools_origin=YOURORIGIN
- rebuild components/automate-deployment
- rebuild components/automate-dex

You can use the following config to patch automate:
```
[dex.v1.sys.connectors.ldap]
host = "ldap.localhost"
bind_dn = "uid=service_account,dc=example,dc=local"
bind_password = "testpassword3"
insecure_no_ssl = true
username_attr = "cn"
user_id_attr = "uid"
base_user_search_dn = "cn=users,dc=example,dc=local"
```

That's not a working ldap configuration, but it will be accepted (it may take 15 seconds). You can check that dex starts with `LDAP_PASSWORD=testpassword3` by looking at `/proc/PID/environ`

Better test would be to setup ldap for real