### PR TITLE
Clarify three Buildkite scenarios for semgrep

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -128,8 +128,6 @@ steps:
       - \[ "$BUILDKITE_BRANCH" == "master" \] && echo "build on master; using 'master~1' as base branch" && BASELINE=master~1
       - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \$BASELINE
     timeout_in_minutes: 15
-    # TODO: soft_fail until confirming this works when run on master (after being merged)
-    soft_fail: true
     expeditor:
       secrets: true
     plugins:

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -122,12 +122,12 @@ steps:
       - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
       # Activates links to git commits in slack notification
       - export SEMGREP_REPO_URL=https://github.com/chef/automate
-      - echo "branch=[$BUILDKITE_BRANCH], PR base branch=[$BUILDKITE_PULL_REQUEST_BASE_BRANCH]"
       - export BASELINE=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-      - \[ "$BUILDKITE_BRANCH" != "master" \] && \[ -z "$BASELINE" \] && echo "manual build; using 'master' as base branch" && BASELINE=master
+      - \[ "$BUILDKITE_BRANCH" != "master" \] && \[ -n "\$BASELINE" \] && echo "PR build on '$BUILDKITE_BRANCH' branch; base is '\$BASELINE'"
+      - \[ "$BUILDKITE_BRANCH" != "master" \] && \[ -z "\$BASELINE" \] && echo "manual build on '$BUILDKITE_BRANCH' branch; using master as base" && BASELINE=master
       - \[ "$BUILDKITE_BRANCH" == "master" \] && echo "build on master; using 'master~1' as base branch" && BASELINE=master~1
       - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \$BASELINE
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     # TODO: soft_fail until confirming this works when run on master (after being merged)
     soft_fail: true
     expeditor:


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Straightened out the details and the messaging for the three possible build scenarios.

Also, in my last PR (#4596) I was testing the behavior when merging to master, and that worked as expected, so now removing the soft-fail safe guard.

#### Manual build

This is an explicitly created build via the "New Build" button in Buildkite, outside of a PR.
In our environment, this should almost always be on a working branch that derived from master; we rely on that fact to set the base branch to "master" for the differential semgrep scan (1). Points (2) and (3) show the differential scan in action--it picks up only the 9 files in the 7 commits on the target branch.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/6817500/104828988-e7251980-5823-11eb-9ced-e39da61ffd50.png">

#### PR build

This is the same run inside a PR, kicked off automatically by Buildkite, as you can tell from (1).
This will actually accommodate PRs derived from any branch, not just master, though in this case
it is derived from master. 
You see the same commits (2) and the same number of files (3) as in the manual build.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/6817500/104829055-aed20b00-5824-11eb-9623-b3f3466cb0fa.png">

#### Merge build

When we merge a PR, Buildkite re-runs all tasks and tests on master. For the automate repository,
all PRs are forced to use the squash-and-merge policy, which means there will be exactly one new commit added to master. We rely on that fact to set the base for the differential scan to the commit just preceding this new commit (1). You can see the results of the squash at (2), where there is now just a single commit, but (3) confirms that there are still the same 9 files, as there should be.

<img width="601" alt="image" src="https://user-images.githubusercontent.com/6817500/104829098-3586e800-5825-11eb-86b8-fe7559b57950.png">

### :chains: Related Resources
#4395 -- introduce semgrep
#4430 -- migrate to semgrep-agent
#4596 -- update makefile and buildkite semgrep tasks

### :+1: Definition of Done
Any of the 3 build scenarios run the same semgrep differential scan and clearly spell that out in the output log.

### :athletic_shoe: How to Build and Test the Change
(1) Open a PR to see a PR build.
(2) Manually create a new build in Buildkite to see a manual build.
(3) Merge a PR to see a merge build.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA