### PR TITLE
Fix docs symlink

### DIFF
--- a/docs
+++ b/docs
@@ -1,1 +1,1 @@
-./components/automate-chef-io/content/docs
+components/docs-chef-io/content/automate/


### PR DESCRIPTION
docs symlink was pointing at a folder that didn't exist. Looks like things have been moved to components/docs-chef-io