### PR TITLE
Update notification for acceptance promotion

### DIFF
--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -21,5 +21,4 @@ Next steps:
 (3) Perform general acceptance testing: https://a2-acceptance.cd.chef.co/.
 EOF
 
-echo $message
-# post_slack_message "a2-release-coordinate" "$message"
+post_slack_message "a2-release-coordinate" "$message"

--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -6,9 +6,8 @@ current_date=$(git log -1 --pretty=%cI "$(git rev-list --ancestry-path "$current
 
 # Get the date of the latest acceptance sha and add one second to it, otherwise it does not appear in the list!
 acceptance_sha=$(curl https://packages.chef.io/manifests/acceptance/automate/latest.json 2>/dev/null | jq -r '.git_sha');
-# TODO: need recipe to add one second to acceptance_date for linux. This works on macOS:
-acceptance_date_tmp=$(git log -1 --pretty=%cI $acceptance_sha | sed -e 's/T/ /' -e 's/-..:..//')
-acceptance_date=$(date -j -v '+1S'  -f '%Y-%m-%d %H:%M:%S' "$acceptance_date_tmp"  '+%Y-%m-%dT%H:%M:%S%z')
+acceptance_date_tmp=$(git log -1 --pretty=%cI "$acceptance_sha")
+acceptance_date=$(date -d "$acceptance_date_tmp + 1 second" '+%Y-%m-%dT%H:%M:%S%z')
 
 read -r -d '' message <<EOF
 <!here> Automate has been promoted from \`dev\` to \`acceptance\` :successful:

--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 
-current=$(curl https://packages.chef.io/manifests/current/automate/latest.json 2>/dev/null | jq -r '.git_sha');
-acceptance=$(curl https://packages.chef.io/manifests/acceptance/automate/latest.json 2>/dev/null | jq -r '.git_sha');
+# Get current sha, then find the one right after that via the ancestry-path; that is where we start.
+current_sha=$(curl https://packages.chef.io/manifests/current/automate/latest.json 2>/dev/null | jq -r '.git_sha');
+current_date=$(git log -1 --pretty=%cI "$(git rev-list --ancestry-path "$current_sha"..HEAD | tail -1)")
+
+# Get the date of the latest acceptance sha and add one second to it, otherwise it does not appear in the list!
+acceptance_sha=$(curl https://packages.chef.io/manifests/acceptance/automate/latest.json 2>/dev/null | jq -r '.git_sha');
+# TODO: need recipe to add one second to acceptance_date for linux. This works on macOS:
+acceptance_date_tmp=$(git log -1 --pretty=%cI $acceptance_sha | sed -e 's/T/ /' -e 's/-..:..//')
+acceptance_date=$(date -j -v '+1S'  -f '%Y-%m-%d %H:%M:%S' "$acceptance_date_tmp"  '+%Y-%m-%dT%H:%M:%S%z')
 
 read -r -d '' message <<EOF
-<!here> :success: A2 has been promoted from \`dev\` to \`acceptance\` :success:
+<!here> Automate has been promoted from \`dev\` to \`acceptance\` :successful:
 
-The list of changes can be found here: https://github.com/chef/automate/compare/${current}...${acceptance}
+List of changes by commit: https://github.com/chef/automate/compare/${current_sha}...${acceptance_sha}
+List of changes by PR: https://github.com/chef/automate/pulls?q=is%3Apr+is%3Amerged+sort%3Acreated-asc+closed%3A${current_date}..${acceptance_date}
 
-Please take your time to fill out the release notes by *EOD WEDNESDAY*: https://github.com/chef/automate/wiki/Pending-Release-Notes
+Next steps:
+(1) Review any PRs you have authored in the PR list above and mark with one of the 'acceptance:*' labels in GitHub.
+(2) Add an entry for any customer-facing or other impactful PRs you have authored to the release notes: https://github.com/chef/automate/wiki/Pending-Release-Notes.
+(3) Perform general acceptance testing: https://a2-acceptance.cd.chef.co/.
 EOF
 
-post_slack_message "a2-release-coordinate" "$message"
+echo $message
+# post_slack_message "a2-release-coordinate" "$message"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Previously an acceptance notification (in the `#a2-release-notification` slack channel) looked like this:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/6817500/105117829-10db7c00-5a82-11eb-995e-36dbe5d80e1d.png">

This PR makes the following changes:
(1) Besides showing the commits in the release it also shows the PRs in the release. This is the view directly used by developers to tag PRs with acceptance testing status.
(2) Previously the only action item listed was to update release notes; this PR has expanded that to the three required action items.

### What's Interesting in this PR?

Learn a technique for testing something that is inherently difficult to test or testable only indirectly by using "masking commits".

### :chains: Related Resources
NA

### :+1: Definition of Done

Not sure if there is a way to actually trigger the slack notification for testing purposes, so I am stating this from a "raw" perspective, examining output of the affected script directly.

This is the "raw" output, corresponding to the nice picture above, showing what the output looked like before this PR (I have only added line breaks for readability):
```
<!here> :success: A2 has been promoted from `dev` to `acceptance` :success:
The list of changes can be found here:
https://github.com/chef/automate/compare/b8a1825ff0badb9534cfb4fa1623faa984ac469c...b78e0562e97e77098061452c06682add49828990
Please take your time to fill out the release notes by *EOD WEDNESDAY*: 
https://github.com/chef/automate/wiki/Pending-Release-Notes
```
And here is the output from this PR (run on a Mac, again with added line breaks):
```
<!here> Automate has been promoted from `dev` to `acceptance` :successful:
List of changes by commit:
https://github.com/chef/automate/compare/b8a1825ff0badb9534cfb4fa1623faa984ac469c...b78e0562e97e77098061452c06682add49828990
List of changes by PR:
https://github.com/chef/automate/pulls?q=is%3Apr+is%3Amerged+sort%3Acreated-asc+closed%3A2021-01-14T15:51:51-08:00..2021-01-16T09:42:28-0800
Next steps:
(1) Review any PRs you have authored in the PR list above and mark with one of the 'acceptance:*' labels in GitHub.
(2) Add an entry for any customer-facing or other impactful PRs you have authored to the release notes: https://github.com/chef/automate/wiki/Pending-Release-Notes.
(3) Perform general acceptance testing: https://a2-acceptance.cd.chef.co/.
```
### :athletic_shoe: How to Build and Test the Change

The script normally runs a `post_slack_message` command which exists only during a CI run.
So to test, we are going to swap in an `echo` in place of that command.
First, check out the branch.
Next, you will rollback a commit or two to reveal code for testing.
* On a Mac, run `git reset HEAD~2`.
* On a Linux box, run `git reset HEAD~1`.
Then, from the automate repository root, run .expeditor/announce-acceptance.sh on the command line. 

The output should match what you see above.
Open those URLs in your browser to confirm the results are correct.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA