### PR TITLE
Enable HA Chef Server test

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -623,15 +623,15 @@ steps:
         linux:
           privileged: true
 
-  #- label: "ha chef server"
-    #command:
-      #- integration/run_test integration/tests/ha_chef_server.sh
-    #timeout_in_minutes: 35
-    #expeditor:
-      #executor:
-        #linux:
-          #single-use: true
-          #privileged: true
+  - label: "ha chef server"
+    command:
+      - integration/run_test integration/tests/ha_chef_server.sh
+    timeout_in_minutes: 35
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
 
   - label: "workflow"
     command:

--- a/integration/tests/ha_chef_server.sh
+++ b/integration/tests/ha_chef_server.sh
@@ -90,7 +90,9 @@ org({:name => "pedant_testorg_#{chef_server_uid}",
 
 # You MUST specify the address of the server the API requests will be
 # sent to.  Only specify protocol, hostname, and port.
-chef_server "https://localhost"
+chef_server "https://localhost:443"
+base_resource_url "https://localhost:443"
+explicit_port_url true
 
 # SSL protocol version to use for secure communications
 # with the load balancer


### PR DESCRIPTION
the chef server tests are now passing the port as part of the host header. When erchef is configured to use the host header, it doesn't strip out the port if its passed via the host header even if its a default port. This change tells pedant to expect the port in the response URIs.