### PR TITLE
Wire up full semgrep to run nightly

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -232,3 +232,34 @@ steps:
       executor:
         linux:
           privileged: true
+
+  - label: ":semgrep: Semgrep"
+    command:
+      - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
+      # This is actually a fictitious repo name for the nightly run to allow attaching
+      # a different semgrep policy to the run.
+      # The Chef-nightly policy (https://semgrep.dev/manage/policy/chef-nightly)
+      # excludes a few rules from the main policy to produce less noisy output,
+      # ignoring legacy issues that are of no consequence and do not need to be addressed.
+      - export SEMGREP_REPO_NAME=chef/automate-nightly
+      # Activates links to buildkite builds in slack notification
+      - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
+      # Activates links to git commits in slack notification
+      - export SEMGREP_REPO_URL=https://github.com/chef/automate
+      - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID
+    timeout_in_minutes: 20
+    soft_fail: true
+    expeditor:
+      secrets: true
+    plugins:
+      # Temporary workaround per @tduffield; do not propagate this solution too much!
+      - chef/step-hook#v0.1.1:
+          pre-command:
+            - .expeditor/export_semgrep_token.sh
+      - docker#v3.7.0:
+          image: returntocorp/semgrep-agent:v1
+          propogate-environment: true
+          workdir: /go/src/github.com/chef/automate
+          environment:
+            - SEMGREP_TOKEN
+            - SEMGREP_ID


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Adding in a full run of semgrep in the evening run. During PRs, semgrep does only a differential scan, reviewing just the files in the current PR. This is just a way to keep tabs on any on-going technical debt.

### :chains: Related Resources
NA

### :+1: Definition of Done
New Buildkite task for semgrep in the nightly build.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA