### PR TITLE
[infra-proxy-read-only] fixed the scroll bar for the infra create org modal

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -2,81 +2,79 @@
   <h2 slot="title">Add Chef Organization</h2>
   <div class="flex-container">
     <form [formGroup]="createForm">
-      <div class="scrollable-form-div">
-        <div class="input-margin">
-          <chef-form-field>
-            <label>
-              <span class="label">Name <span aria-hidden="true">*</span></span>
-              <input chefInput name="name" formControlName="name" type="text" (keyup)="handleNameInput($event)" data-cy="org-name" autocomplete="off">
-            </label>
-            <chef-error
-              *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
-              Display Name is required.
-            </chef-error>
-          </chef-form-field>
-          <span class="detail light">Don't worry, organization names can be changed later.</span>
+      <div class="input-margin">
+        <chef-form-field>
+          <label>
+            <span class="label">Name <span aria-hidden="true">*</span></span>
+            <input chefInput name="name" formControlName="name" type="text" (keyup)="handleNameInput($event)" data-cy="org-name" autocomplete="off">
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
+            Display Name is required.
+          </chef-error>
+        </chef-form-field>
+        <span class="detail light">Don't worry, organization names can be changed later.</span>
+      </div>
+      <div *ngIf="modifyID" class="id-margin">
+        <chef-form-field>
+          <label>
+            <span class="label">ID <span aria-hidden="true">*</span></span>
+            <input chefInput formControlName="id" type="text" (keyup)="handleInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
+          </label>
+          <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
+            ID must be 64 characters or less.
+          </chef-error>
+          <chef-error *ngIf="createForm.get('id').hasError('required') && createForm.get('id').dirty">
+            ID is required.
+          </chef-error>
+          <chef-error *ngIf="createForm.get('id').hasError('pattern') && createForm.get('id').dirty">
+            Only lowercase letters, numbers, hyphens, and underscores are allowed.
+          </chef-error>
+          <chef-error *ngIf="conflictError">
+            Organization ID "{{createForm.get('id').value}}" already exists.
+          </chef-error>
+        </chef-form-field>
+        <span class="detail light">Organization IDs are unique, permanent, and cannot be changed later.</span>
+      </div>
+      <div *ngIf="!modifyID" class="id-margin">
+        <div id="id-fields">
+          <span class="key-label">ID:&nbsp;</span>
+          <span data-cy="id-label">{{ this.createForm?.value.id }}</span>
         </div>
-        <div *ngIf="modifyID" class="id-margin">
-          <chef-form-field>
-            <label>
-              <span class="label">ID <span aria-hidden="true">*</span></span>
-              <input chefInput formControlName="id" type="text" (keyup)="handleInput($event)" id="id-input" data-cy="create-id" autocomplete="off"/>
-            </label>
-            <chef-error *ngIf="createForm.get('id').hasError('maxlength') && createForm.get('id').dirty">
-              ID must be 64 characters or less.
-            </chef-error>
-            <chef-error *ngIf="createForm.get('id').hasError('required') && createForm.get('id').dirty">
-              ID is required.
-            </chef-error>
-            <chef-error *ngIf="createForm.get('id').hasError('pattern') && createForm.get('id').dirty">
-              Only lowercase letters, numbers, hyphens, and underscores are allowed.
-            </chef-error>
-            <chef-error *ngIf="conflictError">
-              Organization ID "{{createForm.get('id').value}}" already exists.
-            </chef-error>
-          </chef-form-field>
-          <span class="detail light">Organization IDs are unique, permanent, and cannot be changed later.</span>
-        </div>
-        <div *ngIf="!modifyID" class="id-margin">
-          <div id="id-fields">
-            <span class="key-label">ID:&nbsp;</span>
-            <span data-cy="id-label">{{ this.createForm?.value.id }}</span>
-          </div>
-          <chef-toolbar>
-            <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
-          </chef-toolbar>
-        </div>
-        <div class="input-margin">
-          <app-projects-dropdown
-            [checkedProjectIDs]="checkedProjectIDs"
-            (onDropdownClosing)="onProjectDropdownClosing($event)"
-            [projectsUpdated]="projectsUpdatedEvent">
-          </app-projects-dropdown>
-        </div>
-        <div class="input-margin">
-          <chef-form-field>
-            <label>
-              <span class="label">Admin User <span aria-hidden="true">*</span></span>
-              <input chefInput name="admin_user" formControlName="admin_user" type="text" id="admin-input" data-cy="admin-user" autocomplete="off">
-            </label>
-            <chef-error
-              *ngIf="(createForm.get('admin_user').hasError('required') || createForm.get('admin_user').hasError('pattern')) && createForm.get('admin_user').dirty">
-              Admin user is required.
-            </chef-error>
-          </chef-form-field>
-        </div>
-        <div class="input-margin">
-          <chef-form-field>
-            <label>
-              <span class="label">Admin Key <span aria-hidden="true">*</span></span>
-              <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" placeholder="-----BEGIN RSA PRIVATE KEY -----" autofocus></textarea>
-            </label>
-            <chef-error
-              *ngIf="(createForm.get('admin_key').hasError('required') || createForm.get('admin_key').hasError('pattern')) && createForm.get('admin_key').dirty">
-              Admin key is required.
-            </chef-error>
-          </chef-form-field>
-        </div>
+        <chef-toolbar>
+          <chef-button tertiary (click)="modifyID = true" id="edit-button-object-modal" data-cy="edit-button">Edit ID</chef-button>
+        </chef-toolbar>
+      </div>
+      <div class="input-margin">
+        <app-projects-dropdown
+          [checkedProjectIDs]="checkedProjectIDs"
+          (onDropdownClosing)="onProjectDropdownClosing($event)"
+          [projectsUpdated]="projectsUpdatedEvent">
+        </app-projects-dropdown>
+      </div>
+      <div class="input-margin">
+        <chef-form-field>
+          <label>
+            <span class="label">Admin User <span aria-hidden="true">*</span></span>
+            <input chefInput name="admin_user" formControlName="admin_user" type="text" id="admin-input" data-cy="admin-user" autocomplete="off">
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('admin_user').hasError('required') || createForm.get('admin_user').hasError('pattern')) && createForm.get('admin_user').dirty">
+            Admin user is required.
+          </chef-error>
+        </chef-form-field>
+      </div>
+      <div class="input-margin">
+        <chef-form-field>
+          <label>
+            <span class="label">Admin Key <span aria-hidden="true">*</span></span>
+            <textarea chefInput name="admin_key" id="admin_key" formControlName="admin_key" cols="54" rows="10" placeholder="-----BEGIN RSA PRIVATE KEY -----" autofocus></textarea>
+          </label>
+          <chef-error
+            *ngIf="(createForm.get('admin_key').hasError('required') || createForm.get('admin_key').hasError('pattern')) && createForm.get('admin_key').dirty">
+            Admin key is required.
+          </chef-error>
+        </chef-form-field>
       </div>
       <div id="button-org">
         <chef-button [disabled]="!createForm?.valid || creating || conflictError"  primary id="create-org-modal-btn" (click)="createServerOrg()">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -59,7 +59,7 @@ chef-modal {
 }
 
 chef-modal ::ng-deep .modal {
-  height: 82%;
+  height: 90%;
   overflow-x: hidden;
 }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.scss
@@ -39,13 +39,6 @@ chef-modal {
           font-weight: bold;
         }
       }
-
-      .scrollable-form-div {
-        height: calc(100vh - 220px);
-        overflow-y: scroll;
-        padding-right: 90px;
-        margin-left: 100px;
-      }
     }
 
     #button-org {
@@ -63,4 +56,19 @@ chef-modal {
       height: 45px;
     }
   }
+}
+
+chef-modal ::ng-deep .modal {
+  height: 82%;
+  overflow-x: hidden;
+}
+
+chef-modal ::ng-deep .modal::-webkit-scrollbar {
+  width: 12px;
+  background-color: #F5F5F5;
+}
+
+chef-modal ::ng-deep .modal::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background-color: #CCC;
 }


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
Create org modal scroll bar is the same as other modal scroll bars.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/4623
### :+1: Definition of Done
I have added CSS changes to fix the create org modal scroll bar.
### :athletic_shoe: How to Build and Test the Change
To load sample data:
- Load data into the infra views using `infra_service_load_sample_data` in hab studio (ref: [adding_test_data](https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md))
- Enable the Chef Infra Server Views in the magic menu by typing **feat** anywhere in the automate ui

if you have sample data for the infra servers than 
go to >>  infrastructure tab >> click on Chef server on left side navigation bar >> click to any server where you can see the button `add chef organization` 
### :camera: Screenshots, if applicable
**before fix** 
![org-modal-scrollbar](https://user-images.githubusercontent.com/12297653/105577112-a5edb600-5d9d-11eb-8b77-d03e51320354.png)
**after fix**
![org-modal-scrollbar-fixed](https://user-images.githubusercontent.com/12297653/105577114-a7b77980-5d9d-11eb-94e7-1cf16a80479c.png)
