### PR TITLE
[infra-proxy-read-only] On server update show the top notification

### DIFF
--- a/components/automate-ui/src/app/entities/servers/server.effects.ts
+++ b/components/automate-ui/src/app/entities/servers/server.effects.ts
@@ -114,6 +114,14 @@ export class ServerEffects {
           observableOf(new UpdateServerFailure(error))))));
 
   @Effect()
+  updateOrgSuccess$ = this.actions$.pipe(
+      ofType(ServerActionTypes.UPDATE_SUCCESS),
+      map(({ payload: { server } }: UpdateServerSuccess) => new CreateNotification({
+      type: Type.info,
+      message: `Updated server ${server.name}.`
+    })));
+
+  @Effect()
   updateServerFailure$ = this.actions$.pipe(
     ofType(ServerActionTypes.UPDATE_FAILURE),
     map(({ payload }: UpdateServerFailure) => {


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
When the user updating the server details then a success notification on the top section does not appear.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/4639
### :+1: Definition of Done
I have added changes to show the success notification on top
### :athletic_shoe: How to Build and Test the Change
if you have sample data for the infra servers than
go to >> infrastructure tab >> click on Chef server on left side navigation bar >> click to any server where you can see the second tab details
If the user trying to update the details then a success notification is showing.
### :camera: Screenshots, if applicable
![server_update_notification](https://user-images.githubusercontent.com/12297653/105578206-73938700-5da4-11eb-9b5f-fe5f239e5a8a.png)
