### PR TITLE
[infra-proxy-read-only] fixed the console error on cookbook details content tab

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -46,7 +46,7 @@
             <div *ngIf="!contentLoading">
               <h2 class="item-heading">{{ activeContentName }}</h2>
               <div class="item-content">
-                <chef-snippet [code]="urlContent?.content"></chef-snippet>
+                <chef-snippet [code]="contentData"></chef-snippet>
               </div>
             </div>
           </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -54,6 +54,7 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
   public defaultContent: SubMenu;
   public contentUrl: string;
   public urlContent;
+  public contentData: string;
   public activeContentName: string;
   public listItem = [
     'attributes',
@@ -198,6 +199,7 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
         this.urlContent = fileContent;
         this.contentTabLoading = false;
         this.contentLoading = false;
+        this.contentData = this.urlContent.content.toString();
       });
   }
 


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
While click on content tab getting console error
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/4631
### :+1: Definition of Done
I have added changes to fix the console error for the cookbook details content tab. 
### :athletic_shoe: How to Build and Test the Change
if you have sample data for the infra servers than
```
go to >> infrastructure tab >> click on Chef server on left side navigation bar >> click to any server where you can see the list of orgs >> click to any of org >> where you can see the multiple tabs (the first tab is cookbooks) >> see the list of cookbooks >> click to any of cookbook >> you can see the 2 tabs content tab and details tab >> click to the content tab and open the browser console.
```