### PR TITLE
Fix segfault during migration of secrets

### DIFF
--- a/components/automate-deployment/pkg/deployment/deployment.go
+++ b/components/automate-deployment/pkg/deployment/deployment.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -88,9 +89,13 @@ func newDeploymentFromUserOverrideConfig(config *dc.AutomateConfig) (*Deployment
 }
 
 func (d *Deployment) MoveSecretsToSecretStore(secretStore secrets.SecretStore) error {
+	if secretStore == nil || reflect.ValueOf(secretStore).IsNil() {
+		return nil
+	}
 	if d.userOverrideConfig != nil {
 		d.userOverrideConfig.PullSecretsFromConfig()
 	}
+
 	if d.Config != nil {
 		secretsFromConfig := d.Config.PullSecretsFromConfig()
 		for secret, val := range secretsFromConfig {

--- a/components/automate-deployment/pkg/deployment/deployment_test.go
+++ b/components/automate-deployment/pkg/deployment/deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	dc "github.com/chef/automate/api/config/deployment"
 	w "github.com/chef/automate/api/config/shared/wrappers"
@@ -100,4 +101,11 @@ func TestSetInstalledExpectations(t *testing.T) {
 	err := deployment.SetInstalledExpectations([]string{"local-user-service"})
 	assert.Nil(t, err)
 	assert.Equal(t, svc.DeploymentState, Installed)
+}
+
+func TestMoveSecretsToSecretStoreWithNilValue(t *testing.T) {
+	config := dc.NewAutomateConfig()
+	deployment, _ := CreateDeploymentWithUserOverrideConfig(config)
+	err := deployment.MoveSecretsToSecretStore(nil)
+	require.NoError(t, err)
 }

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1012,17 +1012,17 @@ func StartServer(config *Config) error {
 	defer database.Close()
 	server.deploymentStore = boltdb.NewDeploymentStore(database)
 
+	err = server.initSecretStore()
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize secret store")
+	}
+
 	err = server.initDeploymentFromDB()
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize deployment")
 	}
 
 	maybeResetHabPath(server)
-
-	err = server.initSecretStore()
-	if err != nil {
-		return errors.Wrap(err, "failed to initialize secret store")
-	}
 
 	certs, _, err := server.readOrGenDeploymentServiceCerts()
 	if err != nil {
@@ -1396,6 +1396,7 @@ func (s *server) initDeploymentFromDB() error {
 // runConfigMigrations does any necessary config migrations in the current config version
 func (s *server) runConfigMigrations(d *deployment.Deployment) {
 	c := d.GetUserOverrideConfigForPersistence()
+
 	if c == nil {
 		return
 	}


### PR DESCRIPTION
Users who have secrets configured prior to last release (20210116...)
are stuck in a crash loop for deployment-service. The issue is that the
secrets store is being initialized too late in the process. This change
initializes it sooner. If a nil secrets store is provided, the code now
ignores it and moves on.

The release plan:
Deployment service will not be able to fix itself in this case. Customers who have already upgraded will need to follow the following steps after we promote the fix:
```
# Install the latest deployment service
hab pkg install chef/deployment-service/0.1.0/$NEW_VERSION
# Tell habitat that it must load the new version
sed -i -e 's|chef/deployment-service/0.1.0/20210116174651|chef/deployment-service/0.1.0/$NEW_VERSION|g' /hab/sup/default/specs/deployment-service.spec
# Tell automate its time to upgrade
chef-automate upgrade run
```