### PR TITLE
Fix links

### DIFF
--- a/components/docs-chef-io/Makefile
+++ b/components/docs-chef-io/Makefile
@@ -11,6 +11,7 @@ preview_netlify: chef_web_docs
 	cp -R data/* chef-web-docs/_vendor/github.com/chef/automate/components/docs-chef-io/data
 	cp -R layouts/* chef-web-docs/_vendor/github.com/chef/automate/components/docs-chef-io/layouts
 	cp -R static/* chef-web-docs/_vendor/github.com/chef/automate/components/docs-chef-io/static
+	cp -R config.toml chef-web-docs/_vendor/github.com/chef/automate/components/docs-chef-io/
 	pushd chef-web-docs && make assets; hugo --buildFuture --gc --minify && popd
 
 serve: generate_swagger chef_web_docs

--- a/components/docs-chef-io/config.toml
+++ b/components/docs-chef-io/config.toml
@@ -1,0 +1,2 @@
+[params.automate]
+gh_path = "https://github.com/chef/automate/blob/master/components/docs-chef-io/content/"

--- a/components/docs-chef-io/content/automate/_index.md
+++ b/components/docs-chef-io/content/automate/_index.md
@@ -4,6 +4,8 @@ title = "Quick Start Demo"
 weight = 10
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Quick Start Demo"
@@ -11,8 +13,6 @@ draft = false
     identifier = "automate/getting_started/_index.md Quick Start Demo"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/_index.md)
 
 Hello and welcome to Chef Automate! This Quickstart guides you through the initial installation and trial activation.
 

--- a/components/docs-chef-io/content/automate/airgapped_installation.md
+++ b/components/docs-chef-io/content/automate/airgapped_installation.md
@@ -3,6 +3,8 @@ title = "Airgapped Installation"
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Airgapped Installation"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/getting_started/airgapped_installation.md Airgapped Installation"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/airgapped_installation.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/api.md
+++ b/components/docs-chef-io/content/automate/api.md
@@ -4,6 +4,8 @@ title = "Chef Automate API"
 date = 2019-03-06T17:25:30-07:00
 draft = false
 
+gh_repo = "automate"
+
 layout = "data-api"
 style_sheet = "/automate-api-styles.css"
 api_file_path = "/automate-api-docs/all-apis.swagger.json"
@@ -16,6 +18,4 @@ return_page = "/automate/"
     identifier = "automate/reference/api.md Chef Automate API"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/api.md)
 

--- a/components/docs-chef-io/content/automate/api_tokens.md
+++ b/components/docs-chef-io/content/automate/api_tokens.md
@@ -2,6 +2,8 @@
 title = "API Tokens"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "API Tokens"
@@ -9,8 +11,6 @@ draft = false
     parent = "automate/settings"
     weight = 80
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/api_tokens.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/applications_dashboard.md
+++ b/components/docs-chef-io/content/automate/applications_dashboard.md
@@ -3,6 +3,8 @@ title = "Applications Dashboard"
 
 date = 2019-10-18T18:54:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Applications Dashboard"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/applications/applications_dashboard.md Applications Dashboard"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/applications_dashboard.md)
 
 The Chef Automate *Applications* dashboard allows you to organize and display your applications data from Chef Habitat in an intuitive way.
 Chef Automate organizes data from the application and environment tags provided by the Chef Habitat supervisor.

--- a/components/docs-chef-io/content/automate/applications_dashboard.md
+++ b/components/docs-chef-io/content/automate/applications_dashboard.md
@@ -109,4 +109,4 @@ The default time for a node to report to Chef Automate is 5 minutes.
 
 Chef Habitat sends the health check messages every 30 seconds by default.
 Configure this setting using the `--health-check-interval` option with the `hab sup run` command.
-See the [Habitat CLI documentation](https://www.habitat.sh/docs/habitat-cli/#hab-sup-run) for more information.
+See the [Habitat CLI documentation]({{< relref "/habitat/habitat_cli#hab-sup-run" >}}) for more information.

--- a/components/docs-chef-io/content/automate/applications_setup.md
+++ b/components/docs-chef-io/content/automate/applications_setup.md
@@ -3,6 +3,8 @@ title = "Setting up the Applications Dashboard"
 
 date = 2019-10-18T18:54:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Setting up the Applications Dashboard"
@@ -11,7 +13,7 @@ draft = false
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/applications_setup.md)
+
 <!-- ## Health Checks
 
 To maximize the utility of the Chef Automate EAS Applications feature, it is recommended to implement meaningful health check hooks for your services.

--- a/components/docs-chef-io/content/automate/applications_setup.md
+++ b/components/docs-chef-io/content/automate/applications_setup.md
@@ -16,7 +16,7 @@ draft = false
 
 To maximize the utility of the Chef Automate EAS Applications feature, it is recommended to implement meaningful health check hooks for your services.
 When a health check hook returns a status other than "OK", Chef Automate will display the output of the hook along with the status, so it is recommended to include useful debugging information in the output of the health checks when returning a "critical", "warning", or "unknown" status result.
-Further information about writing Chef Habitat health check hooks can be found in the (https://www.Chef Habitat.sh/docs/reference/#related-article-runtime-settings "Chef Habitat documentation"). -->
+Further information about writing Chef Habitat health check hooks can be found in the https://docs.chef.io/habitat/application_lifecycle_hooks#health-check "Chef Habitat documentation". -->
 
 This Enterprise Application Stack (EAS) integration gives you immediate insight into the status of your Chef Habitat services, even when scaling out to large numbers of services.
 
@@ -47,7 +47,7 @@ For best results:
 
 For services that do not follow this layout, you should select environment and application names that help you find and filter the application data and are relevant to your typical job tasks.
 
-For more information on setting up Chef Habitat, see the Chef Habitat [Service Groups](https://www.habitat.sh/docs/using-habitat/#service-groups) documentation.
+For more information on setting up Chef Habitat, see the Chef Habitat [Service Groups]({{< relref "/habitat/about_services#service-group" >}}) documentation.
 
 ## Setting up the Applications Dashboard
 
@@ -73,7 +73,7 @@ hab sup run \
   --event-stream-token="API_TOKEN" \
 ```
 
-* [hab sup run](https://www.habitat.sh/docs/habitat-cli/#hab-sup-run) is the hab cli commant to start the Habitat supervisor.
+* [hab sup run]({{< relref "/habitat/habitat_cli#hab-sup-run" >}}) is the hab cli commant to start the Habitat supervisor.
 * `MY_APP` is the name of your application. Chef Automate groups services by application name in the Applications Dashboard
 * `MY_ENV` is the application environment for this supervisor. Chef Automate groups services by environment in the Applications Dashboard
 * `MY_SITE` describes the physical (for example, datacenter) or cloud-specific (for example, the AWS region) location where your services are deployed. The site field is a value filtering for services in the Applications Dashboard.
@@ -248,11 +248,10 @@ If you are using a certificate signed by a trusted certificate authority instead
 For more information, check out this further explanation on how to [configure Builder to authenticate via Chef Automate](https://github.com/habitat-sh/on-prem-builder).
 ## Related Resources
 
-For more information, see the [Chef Habitat documentation](https://www.habitat.sh/docs).
+For more information, see the [Chef Habitat documentation]({{< relref "/habitat" >}}).
 In particular, see the entries on:
 
-* [Chef Habitat Best Practices](https://www.habitat.sh/docs/best-practices/)
-* [Service Groups](https://www.habitat.sh/docs/using-habitat/#service-groups)
-* [Services](https://www.habitat.sh/docs/glossary/#glossary-services)
-* [Supervisor](https://www.habitat.sh/docs/glossary/#glossary-supervisor)
-* [Topology](https://www.habitat.sh/docs/glossary/#topology)
+* [Service Groups]({{< relref "/habitat/service_groups" >}})
+* [Services]({{< relref "/habitat/about_services" >}})
+* [Supervisor]({{< relref "/habitat/sup" >}})
+* [Topology]({{< relref "/habitat/about_services#topology" >}})

--- a/components/docs-chef-io/content/automate/architectural_overview.md
+++ b/components/docs-chef-io/content/automate/architectural_overview.md
@@ -2,6 +2,8 @@
 title = "Architecture"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Architecture"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/reference/architecture.md Architecture"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/architectural_overview.md)
 
 ## Automate 2 Architecture
 

--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -3,6 +3,8 @@ title = "Backup"
 
 date = 2018-03-26T15:27:52-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Backup"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/getting_started/backup.md Backup"
     weight = 70
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/backup.md)
 
 Backups are crucial for protecting your data from catastrophic loss and preparing a recovery procedure.
 The `chef-automate backup create` command creates a single backup that contains data for all products deployed with Chef Automate, including [Chef Infra Server]({{< ref "infra_server.md" >}}) and [Chef Habitat Builder on-prem]({{< ref "on_prem_builder.md" >}}).

--- a/components/docs-chef-io/content/automate/cli_chef_automate.md
+++ b/components/docs-chef-io/content/automate/cli_chef_automate.md
@@ -3,6 +3,8 @@ title = "chef-automate CLI"
 
 date = 2018-03-26T15:29:24-07:00
 draft = false
+
+gh_repo = "automate"
 toc_layout = "cli_chef_automate_toc"
 
 [menu]
@@ -12,8 +14,6 @@ toc_layout = "cli_chef_automate_toc"
     identifier = "automate/reference/cli_chef_automate.md chef-automate CLI"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/cli_chef_automate.md)
 
 ## Automate CLI Commands
 

--- a/components/docs-chef-io/content/automate/client_runs.md
+++ b/components/docs-chef-io/content/automate/client_runs.md
@@ -3,6 +3,8 @@ title = "Client Runs"
 
 date = 2018-03-26T16:01:58-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Client Runs"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/client_runs.md Client Runs"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/client_runs.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/configuration.md
+++ b/components/docs-chef-io/content/automate/configuration.md
@@ -3,6 +3,8 @@ title = "Configuration"
 
 date = 2018-05-08T18:54:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Configuration"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/configuring_automate/configuration.md Configuration"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/configuration.md)
 
 The `chef-automate` CLI provides commands to help you work with your existing Chef Automate configuration:
 

--- a/components/docs-chef-io/content/automate/configuration.md
+++ b/components/docs-chef-io/content/automate/configuration.md
@@ -42,7 +42,7 @@ Then run `chef-automate config patch </path/to/your-file.toml>` to deploy your c
 
 #### Install Channel
 
-Chef Automate consists of [Habitat](https://www.habitat.sh/) packages installed from a release channel.
+Chef Automate consists of [Habitat]({{< relref "habitat">}}) packages installed from a release channel.
 The default channel is `current`.
 
 #### Upgrade Strategy

--- a/components/docs-chef-io/content/automate/data_collection.md
+++ b/components/docs-chef-io/content/automate/data_collection.md
@@ -2,6 +2,8 @@
 title = "Data Collection"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Data Collection"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/configuring_automate/data_collection.md Data Collection"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/data_collection.md)
 
 # Audit Cookbook + Inspec + Automate 2 Versions Support Matrix
 

--- a/components/docs-chef-io/content/automate/data_lifecycle.md
+++ b/components/docs-chef-io/content/automate/data_lifecycle.md
@@ -2,6 +2,8 @@
 title = "Data Lifecycle"
 description = "Chef Automate Data Lifecycle: Data Management and Data Retention"
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Data Lifecycle"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/settings/data_lifecycle.md Data Lifecycle"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/data_lifecycle.md)
 
 Data Lifecycle manages the retention of events, service groups, Chef Infra Client runs, compliance reports and scans in Chef Automate.
 Chef Automate stores data from the ingest-service,event-feed-service, compliance-service and applications-service in Elasticsearch or PostgreSQL.

--- a/components/docs-chef-io/content/automate/datafeed.md
+++ b/components/docs-chef-io/content/automate/datafeed.md
@@ -3,6 +3,8 @@ title = "Data Feeds"
 date = 2020-05-05T13:19:02-07:00
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Data Feeds"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/settings/datafeed.md Data Feeds"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/datafeed.md)
 
 {{< note >}}
 Data Feed is a beta feature in active development. To enable Data Feed, first select anywhere on the Chef Automate interface and enter 'feat' to open the feature flags window and then toggle "Chef Automate Data Feed" to the "ON" position.

--- a/components/docs-chef-io/content/automate/desktop.md
+++ b/components/docs-chef-io/content/automate/desktop.md
@@ -3,6 +3,8 @@ title = "Desktop Dashboard"
 
 date = 2018-03-26T16:01:47-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Desktop Dashboard"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/desktop.md Desktop Dashboard"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/desktop.md)
 
 The Chef Automate _Desktop_ dashboard displays status information about all desktops connected to Chef Automate.
 Desktop information populates this dashboard after a Chef Infra Client run has executed.

--- a/components/docs-chef-io/content/automate/eas.md
+++ b/components/docs-chef-io/content/automate/eas.md
@@ -64,7 +64,7 @@ In most cases, artifacts have three possible channels: "unstable", "testing", an
 When you upload your artifact to Builder, Chef Habitat labels your application artifact with the `unstable` tag, which means that it is in the "unstable" channel.
 When you promote your application artifact to another channel, such as "test" or "stable", Chef Habitat applies the new tag and makes it available to the respective channel.
 You can apply more than one tag to a single artifact, for example, artifacts are often tagged for both the "unstable" and "test" channels.
-For more information, see the Chef Habitat [Continuous Deployment Using Channels](https://www.habitat.sh/docs/using-habitat/#continuous-deployment-using-channels) documentation.
+For more information, see the Chef Habitat [Continuous Deployment Using Channels]({{< relref "/habitat/pkg_promote#continuous-deployment-using-channels" >}}) documentation.
 
 _Deployment_ -
 Each instance of an artifact downloaded from a channel into an environment is called a deployment.
@@ -78,7 +78,7 @@ _Supervisor_ -
 The Supervisor is Chef Habitat's process manager, which means it controls the processes related to a package, including starting, monitoring, and updating services. Each Supervisor runs a single instance of a service.
 Each Supervisor in an environment subscribes to a channel, which means they watch for new versions of services promoted in that channel.
 Once a supervisor detects a new artifact in a channel, it deploys the new package into its own environment and updates all of the services for that service group.
-For more information about automated deployments, see the Chef Habitat [update-strategy](https://www.habitat.sh/docs/using-habitat/#update-strategy) documentation.
+For more information about automated deployments, see the Chef Habitat [update-strategy]({{< relref "/habitat/service_group_updates#configuring-an-update-strategy" >}}) documentation.
 
 _Service_ -
 A service is any single running instance of a Chef Habitat package running in an environment and managed by a Supervisor.

--- a/components/docs-chef-io/content/automate/eas.md
+++ b/components/docs-chef-io/content/automate/eas.md
@@ -3,6 +3,8 @@ title = "Chef EAS"
 
 date = 2019-10-18T18:54:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Chef EAS"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/applications/eas.md Chef EAS"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/eas.md)
 
 The Chef Enterprise Application Stack (EAS) allows organizations to automate infrastructure, security, and application delivery together, helping them deploy software quickly while maintaining compliance with industry regulations. Chef EAS helps teams drive efficiency and consistency for any application across multi-cloud and heterogeneous infrastructure.
 

--- a/components/docs-chef-io/content/automate/elasticsearch.md
+++ b/components/docs-chef-io/content/automate/elasticsearch.md
@@ -2,6 +2,8 @@
 title = "Elasticsearch"
 
 draft = true
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Elasticsearch"
@@ -10,4 +12,3 @@ draft = true
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/elasticsearch.md)

--- a/components/docs-chef-io/content/automate/event_feed.md
+++ b/components/docs-chef-io/content/automate/event_feed.md
@@ -3,6 +3,8 @@ title = "Event Feed"
 
 date = 2018-03-26T16:01:47-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Event Feed"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/event_feed.md Event Feed"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/event_feed.md)
 
 Use the _Event Feed_ for actionable insights and operational visibility.
 The _Event Feed_ shows the time of the event, its type, the object acted upon, the action, and the initiating action.

--- a/components/docs-chef-io/content/automate/flags.md
+++ b/components/docs-chef-io/content/automate/flags.md
@@ -2,6 +2,8 @@
 title = "Feature Flags"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Feature Flags"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/reference/flags.md Feature Flags"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/flags.md)
 
 Use the beta, lega, or feat flags to turn on or off beta, legacy, or in-development features.
 

--- a/components/docs-chef-io/content/automate/iam_actions.md
+++ b/components/docs-chef-io/content/automate/iam_actions.md
@@ -2,6 +2,8 @@
 title = "IAM Actions"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "IAM Actions"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/authorization/iam_actions.md IAM Actions"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/iam_actions.md)
 
 Reference the chart on this page when creating a *Role* to know which action grants access to what page in the browser.
 

--- a/components/docs-chef-io/content/automate/iam_v2_guide.md
+++ b/components/docs-chef-io/content/automate/iam_v2_guide.md
@@ -3,6 +3,8 @@ title = "IAM Users Guide"
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "IAM Users Guide"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/authorization/iam_v2_guide.md IAM Users Guide"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/iam_v2_guide.md)
 
 {{< note >}}
 This documentation covers Chef Automate's IAM feature in release 20200326170928 and later.

--- a/components/docs-chef-io/content/automate/iam_v2_overview.md
+++ b/components/docs-chef-io/content/automate/iam_v2_overview.md
@@ -2,13 +2,13 @@
 title = "IAM Overview"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     parent = "automate/authorization"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/iam_v2_overview.md)
 
 {{< note >}}
 This documentation covers Chef Automate's IAM feature in release 20200326170928 and later.

--- a/components/docs-chef-io/content/automate/infra_server.md
+++ b/components/docs-chef-io/content/automate/infra_server.md
@@ -4,6 +4,8 @@ title = "Install Chef Infra Server With Automate"
 date = 2020-02-11T14:24:00-08:00
 weight = 20
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Install Chef Infra Server With Automate"
@@ -11,8 +13,6 @@ draft = false
     identifier = "automate/getting_started/infra_server.md Install Chef Infra Server With Automate"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/infra_server.md)
 
 {{% warning %}}
 

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -3,6 +3,8 @@ title = "Installation Guide"
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Install Guide"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/getting_started/install.md Install Guide"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/install.md)
 
 Before beginning your installation, check the [System Requirements]({{< relref "system_requirements.md" >}}) for Chef Automate.
 

--- a/components/docs-chef-io/content/automate/ldap.md
+++ b/components/docs-chef-io/content/automate/ldap.md
@@ -3,6 +3,8 @@ title = "LDAP"
 
 date = 2018-05-11T09:27:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "LDAP"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/configuring_automate/ldap.md LDAP"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/ldap.md)
 
 ## Authentication via Existing Identity Management Systems
 

--- a/components/docs-chef-io/content/automate/log_management.md
+++ b/components/docs-chef-io/content/automate/log_management.md
@@ -3,6 +3,8 @@ title = "Log Management"
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Log Management"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/configuring_automate/log_management.md Log Management"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/log_management.md)
 
 Chef Automate 2.0 uses `systemd`. Log management is performed according to the configuration defined for the system service `journald`.
 

--- a/components/docs-chef-io/content/automate/migrate.md
+++ b/components/docs-chef-io/content/automate/migrate.md
@@ -2,6 +2,8 @@
 title = "Migrate from Chef Automate 1"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Migrate from Chef Automate 1"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/getting_started/migrate.md Migrate from Chef Automate 1"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/migrate.md)
 
 Chef Automate versions 1.0.0-1.8.96 reached end-of-life on December 31, 2019 and are no longer supported.
 For more information and for help upgrading your system, please contact your Chef account representative.

--- a/components/docs-chef-io/content/automate/migrate.md
+++ b/components/docs-chef-io/content/automate/migrate.md
@@ -25,7 +25,7 @@ The Chef Automate migration process performs the following steps, in order:
 
 1. Runs preflight checks to ensure the system is suitable for Chef Automate 2, your Chef Automate 1 installation can be migrated safely, and that the upgrade process will be able to migrate your data.
 1. Analyzes your Chef Automate 1 configuration files and migrates the relevant settings to a configuration file for Chef Automate 2. If incompatibilities are detected, the migration process fails and emits a description of the problem. You will have an opportunity to make any necessary changes to the generated Chef Automate 2 configuration.
-1. Downloads Chef Automate 2. Chef Automate 2 is distributed via [Habitat](https://www.habitat.sh/) packages that are installed early in the process to minimize the downtime required for the migration.
+1. Downloads Chef Automate 2. Chef Automate 2 is distributed via [Habitat]({{< relref "/habitat/">}}) packages that are installed early in the process to minimize the downtime required for the migration.
 1. Puts your Chef Automate 1 installation into maintenance mode, waits for queued data to be processed, and then backs up all Chef Automate 1 data. This ensures that data will not be lost in the migration process and that you will be able to recover to a working state should an unforeseen error occur.
 1. Creates a local snapshot of Chef Automate 1 data for import into Chef Automate 2.
 1. Shuts down Chef Automate 1.

--- a/components/docs-chef-io/content/automate/monitoring.md
+++ b/components/docs-chef-io/content/automate/monitoring.md
@@ -3,6 +3,8 @@ title = "Monitoring Chef Automate"
 
 date = 2019-10-28T14:44:28-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Monitoring Chef Automate"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/reference/monitoring.md Monitoring Chef Automate"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/monitoring.md)
 
 Use the authenticated https endpoint `/status` to monitor your Chef Automate installation.
 

--- a/components/docs-chef-io/content/automate/node_credentials.md
+++ b/components/docs-chef-io/content/automate/node_credentials.md
@@ -4,6 +4,8 @@ title = "Node Credentials"
 date = 2018-05-22T17:23:24-07:00
 weight = 20
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Node Credentials"
@@ -11,8 +13,6 @@ draft = false
     parent = "automate/settings"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/node_credentials.md)
 
 The Chef Automate Credentials page allows you to add, edit, and delete ``SSH``, ``WinRm``, and ``Sudo`` credentials for remotely access to your nodes.
 

--- a/components/docs-chef-io/content/automate/node_integrations.md
+++ b/components/docs-chef-io/content/automate/node_integrations.md
@@ -3,6 +3,8 @@ title = "Node Integrations"
 
 date = 2018-05-22T18:01:36-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Node Integrations"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/settings/node_integrations.md Node Integrations"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/node_integrations.md)
 
 Set up Chef Automate to detect and monitor the nodes in your AWS EC2 and Azure accounts by providing your credentials and creating a node manager. Chef Automate creates a node reference for each instance in your account. Associate your EC2 and Azure instances with ssh and WinRM credentials using tags--the values support wildcard matching--in your node manager. Run scan jobs with your node manager reference and you're suddenly running an `inspec exec` across your instances. Every two hours Chef Automate queries your AWS or Azure account to see the current state of all your nodes to determine if they are running, stopped, or terminated, and then updates Chef Automate accordingly. If the node manager finds an instance that used to be running and reachable but which no longer is (the node stopped, terminated, or is in a transition state), the node manager updates the status of that node in Chef Automate accordingly.
 

--- a/components/docs-chef-io/content/automate/nodes.md
+++ b/components/docs-chef-io/content/automate/nodes.md
@@ -2,6 +2,8 @@
 title = "Nodes API"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Nodes"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/compliance/nodes.md Nodes"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/nodes.md)
 
 ### Nodes
 

--- a/components/docs-chef-io/content/automate/notifications.md
+++ b/components/docs-chef-io/content/automate/notifications.md
@@ -3,6 +3,8 @@ title = "Notifications"
 
 date = 2018-05-18T13:19:02-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Notifications"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/settings/notifications.md Notifications"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/notifications.md)
 
 ## About Notifications
 

--- a/components/docs-chef-io/content/automate/on_prem_builder.md
+++ b/components/docs-chef-io/content/automate/on_prem_builder.md
@@ -5,6 +5,8 @@ date = 2019-11-19T14:10:15-08:00
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "Install Chef Habitat Builder On-prem"
@@ -12,8 +14,6 @@ draft = false
     identifier = "automate/getting_started/on_prem_builder.md Install Chef Habitat Builder On-prem"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/on_prem_builder.md)
 
 This guide details how to install Chef Automate and deploy Chef Habitat Builder on-prem together. Enterprise customers may wish to set up an on-premises Chef Habitat Builder depot to store Chef Habitat packages for use by their own Chef Habitat Studios and Supervisors.
 

--- a/components/docs-chef-io/content/automate/on_prem_builder.md
+++ b/components/docs-chef-io/content/automate/on_prem_builder.md
@@ -244,7 +244,7 @@ Once you are signed in to the Chef Habitat Builder UI, select the **New Origin**
 ## Access Chef Habitat Builder On-prem With Chef Habitat Command-Line Tools
 
 Use the `https://{{< example_fqdn "automate" >}}/bldr/v1` URL when accessing your Chef Habitat Builder installation with the Chef Habitat command-line tools.
-The Chef Habitat command-line tools recognize the [`HAB_BLDR_URL` environment variable](https://www.habitat.sh/docs/reference/), which you can set on the command line with:
+The Chef Habitat command-line tools recognize the [`HAB_BLDR_URL` environment variable]({{< relref "/habitat/environment_variables" >}}), which you can set on the command line with:
 
 ```bash
 export HAB_BLDR_URL=https://{{< example_fqdn "automate" >}}/bldr/v1/
@@ -252,7 +252,7 @@ export HAB_BLDR_URL=https://{{< example_fqdn "automate" >}}/bldr/v1/
 
 ## Access the Chef Habitat Builder On-prem REST API
 
-To access the [REST API](https://www.habitat.sh/docs/api/builder-api/) for your on-prem installation of Chef Habitat Builder, you must specify your Builder authentication token as a bearer token in your request's
+To access the [REST API]({{< relref "/habitat/builder_api" >}}) for your on-prem installation of Chef Habitat Builder, you must specify your Builder authentication token as a bearer token in your request's
 `Authorization` header.
 For example:
 
@@ -358,8 +358,8 @@ To finish up, return to your Chef Habitat Builder on-prem installation and view 
 
 ## Using Chef Habitat Builder
 
-Because you are using an on-prem installation of Chef Habitat Builder, you must specify the [Builder API endpoint of your installation]({{< ref "on_prem_builder.md#access-chef-habitat-builder-on-prem-with-habitat-command-line-tools" >}}) when following the [Habitat Builder documentation](https://www.habitat.sh/docs/using-builder/).
-This documentation covers [using origin keys](https://www.habitat.sh/docs/using-builder/#using-origin-secrets), [using origin secrets](https://www.habitat.sh/docs/using-builder/#using-origin-secrets), and [uploading and promoting packages](https://www.habitat.sh/docs/using-builder/#upload-and-promote-packages).
+Because you are using an on-prem installation of Chef Habitat Builder, you must specify the [Builder API endpoint of your installation]({{< ref "on_prem_builder.md#access-chef-habitat-builder-on-prem-with-habitat-command-line-tools" >}}) when following the [Habitat Builder documentation]({{< relref "/habitat/builder_overview" >}}).
+This documentation covers [using origin keys]({{< relref "/habitat/builder_origins#origin-keys" >}}), [using origin secrets]({{< relref "/habitat/builder_origins#origin-secrets" >}}), and [uploading and promoting packages]({{< relref "/habitat/builder_origin_packages" >}}).
 
 ## Operating Chef Habitat Builder
 

--- a/components/docs-chef-io/content/automate/policies.md
+++ b/components/docs-chef-io/content/automate/policies.md
@@ -2,6 +2,8 @@
 title = "Policies"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Policies"
@@ -9,8 +11,6 @@ draft = false
     parent = "automate/settings"
     weight = 90
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/policies.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/profiles.md
+++ b/components/docs-chef-io/content/automate/profiles.md
@@ -3,6 +3,8 @@ title = "Profiles"
 
 date = 2018-03-26T16:02:53-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Profiles"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/compliance/profiles.md Profiles"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/profiles.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/projects.md
+++ b/components/docs-chef-io/content/automate/projects.md
@@ -2,6 +2,8 @@
 title = "Projects"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Projects"
@@ -9,8 +11,6 @@ draft = false
     parent = "automate/settings"
     weight = 110
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/projects.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -3,6 +3,8 @@ title = "Reports"
 
 date = 2018-03-26T16:02:09-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Reports"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/compliance/reports.md Reports"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/reports.md)
 
 The _Reports_ page (Compliance > Reports) provides comprehensive insight into the compliance status of all scanned infrastructure.
 Scan results for audit cookbook configurations also appear in this view.

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -3,6 +3,8 @@ title = "Restore"
 
 date = 2018-03-26T15:27:52-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Restore"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/getting_started/restore.md Restore"
     weight = 80
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/restore.md)
 
 Restore Chef Automate from a [filesystem backup]({{< ref "restore.md#restore-from-a-filesystem-backup" >}}), an [Amazon S3 bucket backup]({{< ref "restore.md#restore-from-an-aws-s3-backup" >}}), or a [Google Cloud Storage (GCS) bucket backup]({{< ref "restore.md#restore-from-a-google-cloud-storage-backup" >}}).
 

--- a/components/docs-chef-io/content/automate/roles.md
+++ b/components/docs-chef-io/content/automate/roles.md
@@ -2,6 +2,8 @@
 title = "Roles"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Roles"
@@ -9,8 +11,6 @@ draft = false
     parent = "automate/settings"
     weight = 100
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/roles.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -3,6 +3,8 @@ title = "SAML"
 
 date = 2018-05-11T09:27:09+00:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "SAML"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/configuring_automate/saml.md SAML"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/saml.md)
 
 ## Authentication via Existing Identity Management Systems
 

--- a/components/docs-chef-io/content/automate/scan_jobs.md
+++ b/components/docs-chef-io/content/automate/scan_jobs.md
@@ -3,6 +3,8 @@ title = "Scan Jobs"
 
 date = 2018-03-26T16:02:35-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Scan Jobs"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/compliance/scan_jobs.md Scan Jobs"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/scan_jobs.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/servicenow_integration_install.md
+++ b/components/docs-chef-io/content/automate/servicenow_integration_install.md
@@ -3,6 +3,8 @@ title = "ServiceNow Integration"
 
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "ServiceNow Integration"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/reference/servicenow_integration_install.md ServiceNow Integration"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/servicenow_integration_install.md)
 
 This guide helps you set up a ServiceNow instance that creates incidents from Chef Automate failure notifications on failed Chef Infra Client runs and Compliance scans.
 

--- a/components/docs-chef-io/content/automate/system_requirements.md
+++ b/components/docs-chef-io/content/automate/system_requirements.md
@@ -4,6 +4,8 @@ title = "System Requirements"
 weight = 20
 draft = false
 
+gh_repo = "automate"
+
 [menu]
   [menu.automate]
     title = "System Requirements"
@@ -11,8 +13,6 @@ draft = false
     identifier = "automate/getting_started/system_requirements.md System Requirements"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/system_requirements.md)
 
 ## Hardware
 

--- a/components/docs-chef-io/content/automate/teams.md
+++ b/components/docs-chef-io/content/automate/teams.md
@@ -3,6 +3,8 @@ title = "Teams"
 
 date = 2018-05-16T16:03:13-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Teams"
@@ -10,8 +12,6 @@ draft = false
     parent = "automate/settings"
     weight = 70
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/teams.md)
 
 ## Overview
 

--- a/components/docs-chef-io/content/automate/telemetry.md
+++ b/components/docs-chef-io/content/automate/telemetry.md
@@ -2,6 +2,8 @@
 title = "Telemetry"
 
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Telemetry"
@@ -9,8 +11,6 @@ draft = false
     identifier = "automate/configuring_automate/telemetry.md Telemetry"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/telemetry.md)
 
 ### About Telemetry
 

--- a/components/docs-chef-io/content/automate/troubleshooting.md
+++ b/components/docs-chef-io/content/automate/troubleshooting.md
@@ -3,6 +3,8 @@ title = "Troubleshooting"
 
 date = 2018-05-15T17:27:57-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Troubleshooting"
@@ -10,8 +12,6 @@ draft = false
     identifier = "automate/troubleshooting.md Troubleshooting"
     weight = 100
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/troubleshooting.md)
 
 ## chef-automate CLI Errors
 

--- a/components/docs-chef-io/content/automate/users.md
+++ b/components/docs-chef-io/content/automate/users.md
@@ -3,6 +3,8 @@ title = "Users"
 
 date = 2018-05-16T16:03:13-07:00
 draft = false
+
+gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Users"
@@ -10,8 +12,6 @@ draft = false
     parent = "automate/settings"
     weight = 60
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/automate/blob/master/components/docs-chef-io/content/automate/users.md)
 
 ## Overview
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

This replaces links to pages in the old Hab docs site with links to the current Hab docs pages
This also replaces Edit on GitHub links with a partial that generates the GitHub page link.

### :chains: Related Resources

chef/chef-web-docs#2775

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
