### PR TITLE
Update notification for acceptance promotion/pass 2

### DIFF
--- a/.expeditor/announce-acceptance.sh
+++ b/.expeditor/announce-acceptance.sh
@@ -2,12 +2,13 @@
 
 # Get current sha, then find the one right after that via the ancestry-path; that is where we start.
 current_sha=$(curl https://packages.chef.io/manifests/current/automate/latest.json 2>/dev/null | jq -r '.git_sha');
-current_date=$(git log -1 --pretty=%cI "$(git rev-list --ancestry-path "$current_sha"..HEAD | tail -1)")
+# date renders as e.g. "2021-01-27T10:16:58+00:00" so we need to urlencode the plus sign
+current_date=$(git log -1 --pretty=%cI "$(git rev-list --ancestry-path "$current_sha"..HEAD | tail -1)" | sed -e s/\+/%2B/)
 
 # Get the date of the latest acceptance sha and add one second to it, otherwise it does not appear in the list!
 acceptance_sha=$(curl https://packages.chef.io/manifests/acceptance/automate/latest.json 2>/dev/null | jq -r '.git_sha');
 acceptance_date_tmp=$(git log -1 --pretty=%cI "$acceptance_sha")
-acceptance_date=$(date -d "$acceptance_date_tmp + 1 second" '+%Y-%m-%dT%H:%M:%S%z')
+acceptance_date=$(date -d "$acceptance_date_tmp + 1 second" '+%Y-%m-%dT%H:%M:%S%z' | sed -e s/\+/%2B/)
 
 read -r -d '' message <<EOF
 <!here> Automate has been promoted from \`dev\` to \`acceptance\` :successful:


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

The revised acceptance-announcement script is almost working--but the URL comes out wrong due to the date formats. Need to convert, e.g., "2021-01-27T10:16:58+00:00" to "2021-01-27T10:16:58%2B00:00".

### :chains: Related Resources
#4600 

### :+1: Definition of Done
Upon promoting to acceptance the slack message reads like this, with the plus sign in the dates URL-encodeed.
```
@here Automate has been promoted from dev to acceptance :successful:
List of changes by commit: https://github.com/chef/automate/compare/76612f53b101daffb1badb252b6de186594dbcba...3b5a3ab507b37f5b44f7da548f27f9a901776020
List of changes by PR: https://github.com/chef/automate/pulls?q=is%3Apr+is%3Amerged+sort%3Acreated-asc+closed%3A2021-01-27T10:16:58%2B00:00..2021-01-29T16:11:07%2B0000
. . .
```
### :athletic_shoe: How to Build and Test the Change
Need the automate repo present on a Linux box, then change the final line to just `echo $message`... that's a lot of setup, though, so the easier way is just to promote to acceptance. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA