### PR TITLE
Add Integration Testing for the Notifications Service

### DIFF
--- a/.studio/notifications-service
+++ b/.studio/notifications-service
@@ -105,10 +105,8 @@ document "notifications_update_component" <<DOC
   Warning: this does not work for new files. If you create a new file run rebuild components/notifications-service
 DOC
 function notifications_update_component() {
-  component_path=$(hab pkg path "$HAB_ORIGIN"/notifications-service 2> /dev/null)
-  if [[ $? -ne 0 ]]; then
-    component_path=$(hab pkg path chef/notifications-service 2> /dev/null)
-    if [[ $? -ne 0 ]]; then
+  if ! component_path=$(hab pkg path "$HAB_ORIGIN"/notifications-service 2> /dev/null); then 
+    if ! component_path=$(hab pkg path chef/notifications-service 2> /dev/null); then
       error "Could not find notifications-service deployed under either your origin ($HAB_ORIGIN) or chef origin."
       error "Deploy A2 and try again."
       return 1
@@ -117,12 +115,12 @@ function notifications_update_component() {
 
   elixir_install
 
-  pushd /src/components/notifications-service/server >/dev/null
+  pushd /src/components/notifications-service/server >/dev/null || return 1
     mix local.hex --force
     mix local.rebar --force
     MIX_ENV=habitat mix "do" deps.get, compile
     returnStatus=$?
-  popd >/dev/null
+  popd >/dev/null || return 1
 
   if [[ $returnStatus == 0 ]]; then
     log_line "reload the notifications-service binary."

--- a/.studio/notifications-service
+++ b/.studio/notifications-service
@@ -38,6 +38,14 @@ function notifications_lint() {
   return $EXIT_CODE
 }
 
+document "notifications_integration" <<DOC
+  run the notifications service's integration tests
+DOC
+function notifications_integration() {
+  check_if_deployinate_started || return 1;
+  A2_SVC_NAME="notifications-service" A2_SVC_PATH="/hab/svc/notifications-service" go_test "github.com/chef/automate/components/notifications-service/integration_test"
+}
+
 document "notifications_compile_protobuf" <<DOC
   create the protobuf files for the notifications-service and notifications-client.
   This was copied from both of the components Make files.

--- a/components/notifications-service/integration_test/notification_receiver_test.go
+++ b/components/notifications-service/integration_test/notification_receiver_test.go
@@ -1,0 +1,110 @@
+package integration_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// notificationReceiver is an HTTP server that accepts notification posts from
+// the notifications-service. We use it to verify that the
+// notifications-service sends correctly formatted notifications in response to
+// events. It's a small wrapper around the httptest library.
+// The HTTP server listens on a random port each time you start it. Use the
+// SlackURL(), etc. functions to get a useable URL.
+type notificationReceiver struct {
+	server *httptest.Server
+	posts  chan *notificationPost
+}
+
+// notificationPost contains data from requests made by the notifications
+// service to the notificationReceiver server. Add any fields you need to
+// verify the notifications-service's behavior
+type notificationPost struct {
+	URL               string
+	BodyBytes         []byte
+	BasicAuthUsed     bool
+	BasicAuthUsername string
+	BasicAuthPassword string
+}
+
+func newTestServer() *notificationReceiver {
+	n := notificationReceiver{
+		posts: make(chan *notificationPost),
+	}
+
+	n.server = httptest.NewServer(n.httpHandler())
+	return &n
+}
+
+func (n *notificationReceiver) Close() {
+	n.server.Close()
+	close(n.posts)
+}
+
+func (n *notificationReceiver) SlackURL() string {
+	return fmt.Sprintf("%s/slackalert/", n.server.URL)
+}
+
+func (n *notificationReceiver) ServiceNowURL() string {
+	return fmt.Sprintf("%s/servicenowalert/", n.server.URL)
+}
+
+func (n *notificationReceiver) WebhookURL() string {
+	return fmt.Sprintf("%s/webhookalert/", n.server.URL)
+}
+
+func (n *notificationReceiver) GetLastPost() *notificationPost {
+	return <-n.posts
+}
+
+// CheckForPost: Check if there is a post in the posts channel, and return it
+// if it's there.  This is here to make negative tests (i.e., you expect no
+// alert to be sent) more robust and easier to debug. You assert that this
+// function returns nil and if it's not nil, testify will tell you a bit about
+// the value you did get.
+//
+// It sleeps for 1 second because notifications-service sends notifications
+// async and there's no good way to synchronize on the absence of a message.
+func (n *notificationReceiver) CheckForPost() *notificationPost {
+	var p *notificationPost
+	time.Sleep(1 * time.Second)
+	select {
+	case p = <-n.posts:
+		return p
+	default:
+		return p
+	}
+}
+
+func (n *notificationReceiver) httpHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		//fmt.Printf("Test server recvd request: %s %s\n", r.Method, r.URL)
+
+		if r.Method == "POST" {
+			bodyBytes, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				fmt.Printf("[TEST SERVER] READ ERROR: %s\n", err)
+				return
+			}
+			//fmt.Printf("Body: \n%s\n----\n", bodyBytes)
+
+			// posts channel is synchronous (unbuffered). We desire to have synchronous
+			// behavior in the test but not block this server forever if a test forgets
+			// to read from the channel. So do the send in a goroutine
+			go func() {
+				p := &notificationPost{
+					URL:       r.URL.String(),
+					BodyBytes: bodyBytes,
+				}
+				p.BasicAuthUsername, p.BasicAuthPassword, p.BasicAuthUsed = r.BasicAuth()
+
+				n.posts <- p
+			}()
+		}
+
+		fmt.Fprintln(w, "PONG")
+	}
+}

--- a/components/notifications-service/integration_test/notification_test.go
+++ b/components/notifications-service/integration_test/notification_test.go
@@ -1,0 +1,1207 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chef/automate/api/external/common/query"
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/components/notifications-client/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const exampleURL = "https://slack.example"
+
+var (
+	// timestamps for sample data. Use semi-static values so we can match them
+	// exactly in test assertions
+	startTime = time.Now().UTC().Add(-5 * time.Minute).Round(time.Second)
+	endTime   = time.Now().UTC().Round(time.Second)
+)
+
+// Test Matrix for Notifications:
+// 4 Event Types:
+//	 Rule_CCRFailure        Rule_Event = 0
+//	 Rule_CCRSuccess        Rule_Event = 1
+//	 Rule_ComplianceFailure Rule_Event = 2
+//	 Rule_ComplianceSuccess Rule_Event = 3
+//
+// 3 Alert types (plus additional behaviors within):
+// * slack
+//   * 1 failed compliance control
+//   * > 1 failed control in one profile
+//   * failures in multiple profiles
+// * webhook
+// * servicenow
+//
+// Dispatch Scenarios:
+// * when there are no rules, no alerts are sent
+// * when there are rules but the event types don't match, no alerts are sent
+// * when there is one rule with a matching event type, one alert is sent
+// * when there are multiple rules matching the event type multiple alerts are sent
+//
+// Prefiltering:
+// * alerts are never sent for CCR Success or ComplianceSuccess
+// * alerts are never sent if there are no critical control failures in compliance failure
+// NOTE: there's a critical controls only setting on the service now alert type
+// but this cannot possibly do anything because the prefilter would discard the event first.
+
+func TestNotificationDispatchWithNoRules(t *testing.T) {
+	t.Run("with no rules, no alerts are sent", func(t *testing.T) {
+		err := suite.DeleteEverything()
+		require.NoError(t, err)
+
+		_, err = suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+
+		_, err = suite.Client.Notify(ctx, ccrSuccessEvent())
+		require.NoError(t, err)
+
+		_, err = suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+
+		_, err = suite.Client.Notify(ctx, complianceSuccessEvent())
+		require.NoError(t, err)
+	})
+}
+
+func TestNotificationDispatchWithOneSlackAlertRuleForAllEvents(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	// NOTE: the elixir notifications service caches the rules and refreshes them
+	// every 5s, which means we have to wait that long for the rules to take
+	// effect before we test their behavior. To speed things up, we group tests
+	// that can share the same alert rules state.
+	addRules(t,
+		slackAlertRuleFor(api.Rule_CCRFailure, ts.SlackURL()),
+		slackAlertRuleFor(api.Rule_ComplianceFailure, ts.SlackURL()),
+		// Success events are unsupported, which we test for below
+		slackAlertRuleFor(api.Rule_ComplianceSuccess, ts.SlackURL()),
+		slackAlertRuleFor(api.Rule_CCRSuccess, ts.SlackURL()),
+	)
+
+	t.Run("no alerts are sent for CCRSuccess, they are always filtered", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrSuccessEvent())
+		require.NoError(t, err)
+		post := ts.CheckForPost()
+		assert.Nil(t, post)
+	})
+
+	t.Run("no alerts are sent for ComplianceSuccess, they are always filtered", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceSuccessEvent())
+		require.NoError(t, err)
+		post := ts.CheckForPost()
+		assert.Nil(t, post)
+	})
+
+	t.Run("CCRFailure alerts are sent to the Slack URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+
+	t.Run("CCRFailure alerts are properly formatted", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		var actual SlackMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+		assert.Equal(t, "Chef Automate", actual.Username)
+		assert.Equal(t, "<https://automate.example/nodes/0/runs/1|Chef client run failure on chefnode.example>\n", actual.Text)
+		assert.Equal(t, "https://docs.chef.io/images/chef-icon.png", actual.IconURL)
+		require.Len(t, actual.Attachments, 1)
+		attach := actual.Attachments[0]
+		assert.Equal(t, "Example Exception Occurs\n```Error: Chef::ExampleException\nMessage: EXAMPLE EXCEPTION MESSAGE\n(cookbook_example::recipe_example line 13)\nFile: recipe_example\nLine: 13```", attach.Text)
+		assert.Equal(t, "", attach.Pretext)
+		assert.Equal(t, []string{"text"}, attach.MarkdownIn)
+		assert.Equal(t, "Chef client run failed on chefnode.example", attach.Fallback)
+		assert.Equal(t, "warning", attach.Color)
+		assert.Len(t, attach.Fields, 2)
+		expectedField1 := &SlackAttachmentField{
+			Value: "chefnode.example",
+			Title: "Node",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField1)
+		expectedField2 := &SlackAttachmentField{
+			Value: "cookbook_example::recipe_example",
+			Title: "Cookbook::Recipe",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField2)
+	})
+
+	t.Run("ComplianceFailure alerts are sent to the Slack URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+	})
+
+	// The formatter for compliance failures behaves differently if there are
+	// 1 vs. 2+ failed profiles
+	// 1 vs. 2+ failed controls
+	// It examines the fields in the data to find critical failed controls as
+	// here:
+	// https://github.com/chef/automate/blob/5b457d40fb8ec494d69678bc595c264ca4b9bf94/components/notifications-service/server/lib/formatters/utils.ex#L27
+	t.Run("ComplianceFailure alerts are formatted correctly when one control fails", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		var actual SlackMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+		assert.Equal(t, "Chef Automate", actual.Username)
+		assert.Equal(t, "<https://chefautomate.example/compliance_failure/0|InSpec found a critical control failure on node chefnode.example>", actual.Text)
+		assert.Equal(t, "https://docs.chef.io/images/chef-icon.png", actual.IconURL)
+		require.Len(t, actual.Attachments, 1)
+		attach := actual.Attachments[0]
+		assert.Equal(t, "```EXAMPLE CONTROL FAILED MESSAGE```\n", attach.Text)
+		assert.Equal(t, "", attach.Pretext)
+		assert.Equal(t, []string{"text", "pretext"}, attach.MarkdownIn)
+		assert.Equal(t, "InSpec critical control failure on node chefnode.example.\nEXAMPLE CONTROL FAILED MESSAGE", attach.Fallback)
+		assert.Equal(t, "warning", attach.Color)
+		assert.Len(t, attach.Fields, 3)
+		expectedField1 := &SlackAttachmentField{
+			Value: "Example Control::Simulated Failure",
+			Title: "Control ID::Title",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField1)
+		expectedField2 := &SlackAttachmentField{
+			Value: "Example Profile",
+			Title: "Profile",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField2)
+		expectedField3 := &SlackAttachmentField{
+			Value: "chefnode.example",
+			Title: "Node",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField3)
+	})
+	t.Run("ComplianceFailure alerts are formatted correctly when N > 1 controls fail in one profile", func(t *testing.T) {
+		event := complianceFailureEvent()
+		cf := event.GetComplianceFailure()
+		cf.TestTotals.Failed = 2
+		cf.TestTotals.Critical = 2
+		cf.TestTotals.CriticalFailed = 2
+		profile := cf.FailedProfiles[0]
+		profile.Stats.NumTests = 2
+		profile.Stats.NumFailedTests = 2
+
+		failedControl2 := &api.Profile_Control{
+			Id:     "Example Control",
+			Impact: 7.7,
+			Title:  "Simulated Failure 2",
+			Desc:   "An example control from an integration_test (2)",
+			Stats: &api.Profile_Control_ResultTotals{
+				NumTests:        2,
+				NumFailedTests:  1,
+				NumSkippedTests: 0,
+				NumPassedTests:  1,
+			},
+			FailedResults: []*api.Profile_Control_Result{
+				&api.Profile_Control_Result{
+					Status:   "failed",
+					CodeDesc: "not good",
+					Message:  "EXAMPLE CONTROL FAILED MESSAGE TWO",
+				},
+			},
+		}
+
+		profile.FailedControls = append(profile.FailedControls, failedControl2)
+
+		_, err := suite.Client.Notify(ctx, event)
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		// fmt.Println(string(postData.BodyBytes))
+
+		var actual SlackMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+		assert.Equal(t, "Chef Automate", actual.Username)
+		assert.Equal(t, "<https://chefautomate.example/compliance_failure/0|InSpec found a critical control failure on node chefnode.example>", actual.Text)
+		assert.Equal(t, "https://docs.chef.io/images/chef-icon.png", actual.IconURL)
+		require.Len(t, actual.Attachments, 1)
+		attach := actual.Attachments[0]
+		assert.Equal(t, "```2 of 4 tests failed. View in Chef Automate for full details.```\n", attach.Text)
+		assert.Equal(t, "", attach.Pretext)
+		assert.Equal(t, []string{"text", "pretext"}, attach.MarkdownIn)
+		assert.Equal(t, "InSpec critical control failure on node chefnode.example.\n2 of 4 tests failed. View in Chef Automate for full details.", attach.Fallback)
+		assert.Equal(t, "warning", attach.Color)
+
+		assert.Len(t, attach.Fields, 3)
+		expectedField1 := &SlackAttachmentField{
+			Value: "Multiple",
+			Title: "Control ID::Title",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField1)
+		expectedField2 := &SlackAttachmentField{
+			Value: "Example Profile",
+			Title: "Profile",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField2)
+		expectedField3 := &SlackAttachmentField{
+			Value: "chefnode.example",
+			Title: "Node",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField3)
+	})
+	t.Run("ComplianceFailure alerts are formatted correctly when N > 1 controls fail in M > 1 profiles", func(t *testing.T) {
+		event := complianceFailureEvent()
+		cf := event.GetComplianceFailure()
+		cf.TestTotals.Failed = 2
+		cf.TestTotals.Critical = 2
+		cf.TestTotals.CriticalFailed = 2
+
+		failedProfile2 := &api.Profile{
+			Name:  "Example Profile 2",
+			Title: "Example Profile 2",
+			Stats: &api.Profile_ControlTotals{
+				NumTests:        1,
+				NumFailedTests:  1,
+				NumSkippedTests: 0,
+				NumPassedTests:  0,
+			},
+			FailedControls: []*api.Profile_Control{
+				&api.Profile_Control{
+					Id:     "Example Control in Profile 2",
+					Impact: 7.5,
+					Title:  "Simulated Failure in Profile 2",
+					Desc:   "An example control from an integration_test (2)",
+					Stats: &api.Profile_Control_ResultTotals{
+						NumTests:        2,
+						NumFailedTests:  1,
+						NumSkippedTests: 0,
+						NumPassedTests:  1,
+					},
+					FailedResults: []*api.Profile_Control_Result{
+						&api.Profile_Control_Result{
+							Status:   "failed",
+							CodeDesc: "not good",
+							Message:  "EXAMPLE CONTROL FAILED MESSAGE (2)",
+						},
+					},
+				},
+			},
+		}
+		cf.FailedProfiles = append(cf.FailedProfiles, failedProfile2)
+
+		_, err := suite.Client.Notify(ctx, event)
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		// fmt.Println(string(postData.BodyBytes))
+
+		var actual SlackMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+		assert.Equal(t, "Chef Automate", actual.Username)
+		assert.Equal(t, "<https://chefautomate.example/compliance_failure/0|InSpec found a critical control failure on node chefnode.example>", actual.Text)
+		assert.Equal(t, "https://docs.chef.io/images/chef-icon.png", actual.IconURL)
+		require.Len(t, actual.Attachments, 1)
+		attach := actual.Attachments[0]
+		assert.Equal(t, "```2 of 4 tests failed. View in Chef Automate for full details.```\n", attach.Text)
+		assert.Equal(t, "", attach.Pretext)
+		assert.Equal(t, []string{"text", "pretext"}, attach.MarkdownIn)
+		assert.Equal(t, "InSpec critical control failure on node chefnode.example.\n2 of 4 tests failed. View in Chef Automate for full details.", attach.Fallback)
+		assert.Equal(t, "warning", attach.Color)
+
+		assert.Len(t, attach.Fields, 3)
+		expectedField1 := &SlackAttachmentField{
+			Value: "Multiple",
+			Title: "Control ID::Title",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField1)
+		expectedField2 := &SlackAttachmentField{
+			Value: "Multiple",
+			Title: "Profile",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField2)
+		expectedField3 := &SlackAttachmentField{
+			Value: "chefnode.example",
+			Title: "Node",
+			Short: false,
+		}
+		assert.Contains(t, attach.Fields, expectedField3)
+	})
+}
+
+func TestNotificationDispatchWithOneServiceNowAlertRuleForAllEvents(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	// NOTE: the elixir notifications service caches the rules and refreshes them
+	// every 5s, which means we have to wait that long for the rules to take
+	// effect before we test their behavior. To speed things up, we group tests
+	// that can share the same alert rules state.
+	addRules(t,
+		serviceNowAlertRuleFor(api.Rule_CCRFailure, ts.ServiceNowURL(), ""),
+		serviceNowAlertRuleFor(api.Rule_ComplianceFailure, ts.ServiceNowURL(), ""),
+		// Success events are unsupported, which we test for below
+		serviceNowAlertRuleFor(api.Rule_ComplianceSuccess, ts.ServiceNowURL(), ""),
+		serviceNowAlertRuleFor(api.Rule_CCRSuccess, ts.ServiceNowURL(), ""),
+	)
+
+	t.Run("CCRFailure alerts are sent to the ServiceNow URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+
+	t.Run("CCRFailure alerts are formatted properly", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		//fmt.Println(string(postData.BodyBytes))
+
+		var actual ServiceNowMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "converge_failure", actual.Type)
+		assert.Equal(t, "chefnode.example", actual.NodeName)
+		// AutomateFQDN is populated from the A2 config, so it could be anything.
+		// In the hab studio, it should be a2-dev.test
+		assert.NotEmpty(t, actual.AutomateFQDN)
+		assert.Equal(t, "https://automate.example/nodes/0/runs/1", actual.AutomateFailureURL)
+		assert.Equal(t, "cookbook_example", actual.Cookbook)
+		expectedFailureSnippet :=
+			`Chef client run failure on [https://automate.example/nodes/0] chefnode.example : https://automate.example/nodes/0/runs/1
+Example Exception Occurs
+EXAMPLE EXCEPTION MESSAGE
+(cookbook_example::recipe_example line 13) 
+`
+		assert.Equal(t, expectedFailureSnippet, actual.FailureSnippet)
+		assert.Equal(t, "Example Exception Occurs", actual.ExceptionTitle)
+		assert.Equal(t, "EXAMPLE EXCEPTION MESSAGE\n(cookbook_example::recipe_example line 13)", actual.ExceptionMessage)
+		expectedBT := []string{"/path/to/recipe_example.rb: 42", "/path/to/recipe_example.rb: 23"}
+		assert.Equal(t, expectedBT, actual.ExceptionBacktrace)
+		// NOTE: the string values of the time will be different because of how the
+		// floating point value of the fractional seconds is converted to a string
+		// in different programming languages. E.g., trying to compare the strings
+		// can result in something like this:
+		// 		expected: "2021-01-29T19:11:09Z"
+		// 		actual  : "2021-01-29T19:11:09.000000Z"
+		// We can verify the time objects are the same, though.
+		actualStartTime, err := time.Parse(time.RFC3339Nano, actual.StartTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, startTime, actualStartTime)
+
+		actualEndTime, err := time.Parse(time.RFC3339Nano, actual.EndTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, endTime, actualEndTime)
+
+		actualTimestamp, err := time.Parse(time.RFC3339Nano, actual.EndTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, endTime, actualTimestamp)
+	})
+	t.Run("ComplianceFailure alerts are sent to the ServiceNow URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+	t.Run("ComplianceFailure alerts are formatted properly", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		//fmt.Println(string(postData.BodyBytes))
+
+		var actual ServiceNowComplianceFailureMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "compliance_failure", actual.Type)
+		assert.Equal(t, "chefnode.example", actual.NodeName)
+		assert.Equal(t, "11111111-2222-3333-4444-555555555555", actual.NodeUUID)
+		assert.Equal(t, "0", actual.InspecVersion)
+		// AutomateFQDN is populated from the A2 config, so it could be anything.
+		// In the hab studio, it should be a2-dev.test
+		assert.NotEmpty(t, actual.AutomateFQDN)
+		assert.Equal(t, "https://chefautomate.example/compliance_failure/0", actual.AutomateFailureURL)
+		expectedFailureSnippet := "InSpec found a control failure on [chefnode.example](https://chefautomate.example/compliance_failure/0)"
+		assert.Equal(t, expectedFailureSnippet, actual.FailureSnippet)
+		// NOTE: the string values of the time will be different because of how the
+		// floating point value of the fractional seconds is converted to a string
+		// in different programming languages. E.g., trying to compare the strings
+		// can result in something like this:
+		// 		expected: "2021-01-29T19:11:09Z"
+		// 		actual  : "2021-01-29T19:11:09.000000Z"
+		// We can verify the time objects are the same, though.
+		actualEndTime, err := time.Parse(time.RFC3339Nano, actual.EndTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, endTime, actualEndTime)
+
+		actualTimestamp, err := time.Parse(time.RFC3339Nano, actual.TimestampUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, startTime, actualTimestamp)
+
+		assert.Equal(t, 1, actual.TotalNumberOfTests)
+		assert.Equal(t, 0, actual.TotalNumberOfSkippedTests)
+		assert.Equal(t, 0, actual.TotalNumberOfPassedTests)
+		assert.Equal(t, 1, actual.TotalNumberOfFailedTests)
+		assert.Equal(t, 1, actual.NumberOfFailedCriticalTests)
+		assert.Equal(t, 1, actual.NumberOfCriticalTests)
+
+		require.Len(t, actual.FailedCriticalProfiles, 1)
+		profileActual := actual.FailedCriticalProfiles[0]
+
+		assert.Equal(t, "Example Profile", profileActual.Name)
+		assert.Equal(t, "Example Profile", profileActual.Title)
+		assert.Equal(t, "An example profile for integration testing", profileActual.Summary)
+		assert.Equal(t, "5.23.42", profileActual.Version)
+		assert.Equal(t, "123abc", profileActual.SHA256)
+		assert.Equal(t, "automate@chef.io", profileActual.Maintainer)
+		assert.Equal(t, "Apache 2.0", profileActual.License)
+		assert.Equal(t, "Chef Software, Inc.", profileActual.Copyright)
+		assert.Equal(t, "legal@chef.io", profileActual.CopyrightEmail)
+		assert.Equal(t, 1, profileActual.NumberOfControls)
+
+		require.Len(t, profileActual.Supports, 1)
+		supportsActual := profileActual.Supports[0]
+		assert.Equal(t, "84", supportsActual.Release)
+		assert.Equal(t, "plan9", supportsActual.OSName)
+		assert.Equal(t, "Esoterica", supportsActual.OSFamily)
+		assert.Equal(t, "99", supportsActual.InSpec)
+
+		require.Len(t, profileActual.Attributes, 1)
+		attrActual := profileActual.Attributes[0]
+
+		assert.Equal(t, "example_attr", attrActual.Name)
+		assert.Equal(t, "example attribute in an integration test", attrActual.Options.Description)
+
+		require.Len(t, profileActual.Controls, 1)
+		controlActual := profileActual.Controls[0]
+
+		assert.Equal(t, "Example Control", controlActual.ID)
+		assert.Equal(t, "Simulated Failure", controlActual.Title)
+		assert.Equal(t, "An example control from an integration_test", controlActual.Desc)
+		assert.Equal(t, "failed", controlActual.Status)
+		assert.Equal(t, "halt -p", controlActual.Code)
+		assert.Equal(t, 2, controlActual.NumberOfTests)
+		assert.Equal(t, 1, controlActual.NumberOfFailedTests)
+		assert.Equal(t, 7.5, controlActual.Impact)
+
+		assert.Equal(t, "example_profile.rb", controlActual.SourceLocation.Ref)
+		assert.Equal(t, 5, controlActual.SourceLocation.Line)
+
+		require.Len(t, controlActual.Refs, 1)
+		refsActual := controlActual.Refs[0]
+		assert.Equal(t, "http://compliancerules.example.net", refsActual.URL)
+		assert.Equal(t, "http://compliancerules.example", refsActual.URI)
+
+		require.Len(t, controlActual.Results, 1)
+		resultActual := controlActual.Results[0]
+
+		assert.Equal(t, "failed", resultActual.Status)
+		assert.Equal(t, "EXAMPLE CONTROL FAILED MESSAGE", resultActual.Message)
+		assert.Equal(t, "example skip message", resultActual.SkipMessage)
+		assert.Equal(t, "not good", resultActual.CodeDesc)
+		assert.Equal(t, 3.5, resultActual.RunTime)
+
+		resultStartTime, err := time.Parse(time.RFC3339Nano, resultActual.StartTime)
+		assert.NoError(t, err)
+		assert.Equal(t, startTime, resultStartTime)
+
+	})
+}
+
+func TestNotificationDispatchWithOneServiceNowAlertRuleWithASecretID(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	sres, err := suite.SecretsClient.Create(ctx, &secrets.Secret{
+		Id:   "integration_test_secret_id",
+		Name: "integration_test_secret_id",
+		Type: "service_now",
+		Data: []*query.Kv{
+			&query.Kv{Key: "username", Value: "integration_test_username_secretstore"},
+			&query.Kv{Key: "password", Value: "integration_test_password_secretstore"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, sres.Id)
+
+	secretID := sres.Id
+	defer func() {
+		suite.SecretsClient.Delete(ctx, &secrets.Id{Id: secretID})
+	}()
+
+	// NOTE: the elixir notifications service caches the rules and refreshes them
+	// every 5s, which means we have to wait that long for the rules to take
+	// effect before we test their behavior. To speed things up, we group tests
+	// that can share the same alert rules state.
+	addRules(t,
+		serviceNowAlertRuleFor(api.Rule_CCRFailure, ts.ServiceNowURL(), secretID),
+		serviceNowAlertRuleFor(api.Rule_ComplianceFailure, ts.ServiceNowURL(), secretID),
+	)
+
+	t.Run("CCRFailure alerts are sent to the ServiceNow URL with the secret username+password", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+		assert.True(t, postData.BasicAuthUsed)
+		assert.Equal(t, "integration_test_username_secretstore", postData.BasicAuthUsername)
+		assert.Equal(t, "integration_test_password_secretstore", postData.BasicAuthPassword)
+	})
+
+	t.Run("ComplianceFailure alerts are sent to the ServiceNow URL with the secret username+password", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+		assert.True(t, postData.BasicAuthUsed)
+		assert.Equal(t, "integration_test_username_secretstore", postData.BasicAuthUsername)
+		assert.Equal(t, "integration_test_password_secretstore", postData.BasicAuthPassword)
+	})
+}
+
+func TestNotificationDispatchWithOneWebhookAlertRuleForAllEvents(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	// NOTE: the elixir notifications service caches the rules and refreshes them
+	// every 5s, which means we have to wait that long for the rules to take
+	// effect before we test their behavior. To speed things up, we group tests
+	// that can share the same alert rules state.
+	addRules(t,
+		webhookAlertRuleFor(api.Rule_CCRFailure, ts.WebhookURL()),
+		webhookAlertRuleFor(api.Rule_ComplianceFailure, ts.WebhookURL()),
+		// Success events are unsupported, which we test for below
+		webhookAlertRuleFor(api.Rule_ComplianceSuccess, ts.WebhookURL()),
+		webhookAlertRuleFor(api.Rule_CCRSuccess, ts.WebhookURL()),
+	)
+
+	t.Run("CCRFailure alerts are sent to the Webhook URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+
+	t.Run("CCRFailure alerts are formatted properly", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		//fmt.Println(string(postData.BodyBytes))
+
+		var actual WebhookMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "converge_failure", actual.Type)
+		assert.Equal(t, "chefnode.example", actual.NodeName)
+
+		expectedSnippet := "Chef client run failure on [https://automate.example/nodes/0] chefnode.example : https://automate.example/nodes/0/runs/1\nExample Exception Occurs\nEXAMPLE EXCEPTION MESSAGE\n(cookbook_example::recipe_example line 13) \n"
+		assert.Equal(t, expectedSnippet, actual.FailureSnippet)
+		assert.Equal(t, "Example Exception Occurs", actual.ExceptionTitle)
+		assert.Equal(t, "EXAMPLE EXCEPTION MESSAGE\n(cookbook_example::recipe_example line 13)", actual.ExceptionMessage)
+
+		expectedBT := []string{
+			"/path/to/recipe_example.rb: 42",
+			"/path/to/recipe_example.rb: 23",
+		}
+		assert.Equal(t, expectedBT, actual.ExceptionBacktrace)
+		assert.NotEmpty(t, actual.AutomateFQDN)
+		assert.Equal(t, "https://automate.example/nodes/0/runs/1", actual.AutomateFailureURL)
+
+		actualStartTime, err := time.Parse(time.RFC3339Nano, actual.StartTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, startTime, actualStartTime)
+
+		actualEndTime, err := time.Parse(time.RFC3339Nano, actual.EndTimeUTC)
+		assert.NoError(t, err)
+		assert.Equal(t, endTime, actualEndTime)
+	})
+
+	t.Run("ComplianceFailure alerts are sent to the Webhook URL", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+	t.Run("ComplianceFailure alerts are formatted properly", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, complianceFailureEvent())
+		require.NoError(t, err)
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		// uncomment to see the message the service sent
+		//fmt.Println(string(postData.BodyBytes))
+
+		var actual WebhookComplianceFailureMessage
+		err = json.Unmarshal(postData.BodyBytes, &actual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "compliance_failure", actual.Type)
+		assert.Equal(t, "chefnode.example", actual.NodeName)
+		assert.Equal(t, "11111111-2222-3333-4444-555555555555", actual.NodeUUID)
+		assert.Equal(t, "0", actual.InspecVersion)
+		// AutomateFQDN is populated from the A2 config, so it could be anything.
+		// In the hab studio, it should be a2-dev.test
+		assert.NotEmpty(t, actual.AutomateFQDN)
+		assert.Equal(t, "https://chefautomate.example/compliance_failure/0", actual.AutomateFailureURL)
+		expectedFailureSnippet := "InSpec found a critical control failure on [chefnode.example](https://chefautomate.example/compliance_failure/0)"
+		assert.Equal(t, expectedFailureSnippet, actual.FailureSnippet)
+
+		assert.Equal(t, 1, actual.TotalNumberOfTests)
+		assert.Equal(t, 0, actual.TotalNumberOfSkippedTests)
+		assert.Equal(t, 0, actual.TotalNumberOfPassedTests)
+		assert.Equal(t, 1, actual.TotalNumberOfFailedTests)
+		assert.Equal(t, 1, actual.NumberOfFailedCriticalTests)
+		assert.Equal(t, 1, actual.NumberOfCriticalTests)
+
+		require.Len(t, actual.FailedCriticalProfiles, 1)
+		profileActual := actual.FailedCriticalProfiles[0]
+
+		assert.Equal(t, "Example Profile", profileActual.Name)
+		assert.Equal(t, "Example Profile", profileActual.Title)
+		assert.Equal(t, "An example profile for integration testing", profileActual.Summary)
+		assert.Equal(t, "5.23.42", profileActual.Version)
+		assert.Equal(t, "123abc", profileActual.SHA256)
+		assert.Equal(t, "automate@chef.io", profileActual.Maintainer)
+		assert.Equal(t, "Apache 2.0", profileActual.License)
+		assert.Equal(t, "Chef Software, Inc.", profileActual.Copyright)
+		assert.Equal(t, "legal@chef.io", profileActual.CopyrightEmail)
+		assert.Equal(t, 1, profileActual.NumberOfControls)
+
+		require.Len(t, profileActual.Supports, 1)
+		supportsActual := profileActual.Supports[0]
+		assert.Equal(t, "84", supportsActual.Release)
+		assert.Equal(t, "plan9", supportsActual.OSName)
+		assert.Equal(t, "Esoterica", supportsActual.OSFamily)
+		assert.Equal(t, "99", supportsActual.InSpec)
+
+		require.Len(t, profileActual.Attributes, 1)
+		attrActual := profileActual.Attributes[0]
+
+		assert.Equal(t, "example_attr", attrActual.Name)
+		assert.Equal(t, "example attribute in an integration test", attrActual.Options.Description)
+
+		require.Len(t, profileActual.Controls, 1)
+		controlActual := profileActual.Controls[0]
+
+		assert.Equal(t, "Example Control", controlActual.ID)
+		assert.Equal(t, "Simulated Failure", controlActual.Title)
+		assert.Equal(t, "An example control from an integration_test", controlActual.Desc)
+		assert.Equal(t, "failed", controlActual.Status)
+		assert.Equal(t, "halt -p", controlActual.Code)
+		assert.Equal(t, 2, controlActual.NumberOfTests)
+		assert.Equal(t, 1, controlActual.NumberOfFailedTests)
+		assert.Equal(t, 7.5, controlActual.Impact)
+
+		assert.Equal(t, "example_profile.rb", controlActual.SourceLocation.Ref)
+		assert.Equal(t, 5, controlActual.SourceLocation.Line)
+
+		require.Len(t, controlActual.Refs, 1)
+		refsActual := controlActual.Refs[0]
+		assert.Equal(t, "http://compliancerules.example.net", refsActual.URL)
+		assert.Equal(t, "http://compliancerules.example", refsActual.URI)
+
+		require.Len(t, controlActual.Results, 1)
+		resultActual := controlActual.Results[0]
+
+		assert.Equal(t, "failed", resultActual.Status)
+		assert.Equal(t, "EXAMPLE CONTROL FAILED MESSAGE", resultActual.Message)
+		assert.Equal(t, "example skip message", resultActual.SkipMessage)
+		assert.Equal(t, "not good", resultActual.CodeDesc)
+		assert.Equal(t, 3.5, resultActual.RunTime)
+
+		resultStartTime, err := time.Parse(time.RFC3339Nano, resultActual.StartTime)
+		assert.NoError(t, err)
+		assert.Equal(t, startTime, resultStartTime)
+	})
+}
+
+func TestNotificationDispatchWithMultipleDestinations(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	addRules(t,
+		slackAlertRuleFor(api.Rule_CCRFailure, ts.SlackURL()),
+		slackAlertRuleFor(api.Rule_ComplianceFailure, ts.SlackURL()),
+		serviceNowAlertRuleFor(api.Rule_CCRFailure, ts.ServiceNowURL(), ""),
+		serviceNowAlertRuleFor(api.Rule_ComplianceFailure, ts.ServiceNowURL(), ""),
+		webhookAlertRuleFor(api.Rule_CCRFailure, ts.WebhookURL()),
+		webhookAlertRuleFor(api.Rule_ComplianceFailure, ts.WebhookURL()),
+	)
+	t.Run("a CCR failure sends one alert to each destination", func(t *testing.T) {
+		_, err := suite.Client.Notify(ctx, ccrFailureEvent())
+		require.NoError(t, err)
+		actualURLPaths := make(map[string]bool)
+		for i := 0; i < 3; i++ {
+			postData := ts.GetLastPost()
+			assert.NotNil(t, postData)
+			actualURLPaths[postData.URL] = true
+		}
+		expectedURLPaths := map[string]bool{
+			"/slackalert/":      true,
+			"/servicenowalert/": true,
+			"/webhookalert/":    true,
+		}
+
+		assert.Equal(t, expectedURLPaths, actualURLPaths)
+
+	})
+	t.Run("a compliance failure sends one alert to each destination", func(t *testing.T) {
+	})
+}
+
+func addRules(t *testing.T, rules ...*api.Rule) {
+	for _, r := range rules {
+		createResponse, err := suite.Client.AddRule(ctx, r)
+		require.NoError(t, err)
+		require.Equal(t, api.RuleAddResponse_ADDED, createResponse.Code)
+	}
+	// elixir implementation keeps a cache of the rules which it refreshes every 5s
+	time.Sleep(6 * time.Second)
+}
+
+func slackAlertRuleFor(re api.Rule_Event, url string) *api.Rule {
+	return &api.Rule{
+		Event: re,
+		Name:  fmt.Sprintf("SlackAlert_%s", re),
+		Action: &api.Rule_SlackAlert{
+			SlackAlert: &api.SlackAlert{
+				Url: url,
+			},
+		},
+	}
+}
+
+func serviceNowAlertRuleFor(re api.Rule_Event, url, secretID string) *api.Rule {
+	return &api.Rule{
+		Event: re,
+		Name:  fmt.Sprintf("ServiceNowAlert_%s", re),
+		Action: &api.Rule_ServiceNowAlert{
+			ServiceNowAlert: &api.ServiceNowAlert{
+				Url:      url,
+				SecretId: secretID,
+			},
+		},
+	}
+}
+
+func webhookAlertRuleFor(re api.Rule_Event, url string) *api.Rule {
+	return &api.Rule{
+		Event: re,
+		Name:  fmt.Sprintf("WebhookAlert_%s", re),
+		Action: &api.Rule_WebhookAlert{
+			WebhookAlert: &api.WebhookAlert{
+				Url: url,
+			},
+		},
+	}
+}
+
+func ccrFailureEvent() *api.Event {
+	return &api.Event{
+		Id: newEventID(),
+		Event: &api.Event_CCRFailure{
+			CCRFailure: &api.CCRFailure{
+				RunId:    "0",
+				RunUrl:   "https://automate.example/nodes/0/runs/1",
+				NodeName: "chefnode.example",
+				NodeUrl:  "https://automate.example/nodes/0",
+				Cookbook: "cookbook_example",
+				Recipe:   "recipe_example",
+				Exception: &api.ExceptionInfo{
+					Title: "Example Exception Occurs",
+					Class: "Chef::ExampleException",
+					Msg:   "EXAMPLE EXCEPTION MESSAGE\n(cookbook_example::recipe_example line 13)",
+					Backtrace: []string{
+						"/path/to/recipe_example.rb: 42",
+						"/path/to/recipe_example.rb: 23",
+					},
+				},
+				Time: &api.TimeInfo{
+					StartTime: startTime.Format(time.RFC3339),
+					EndTime:   endTime.Format(time.RFC3339),
+				},
+				Timestamp: endTime.Format(time.RFC3339),
+			},
+		},
+	}
+}
+
+func ccrSuccessEvent() *api.Event {
+	return &api.Event{
+		Id: newEventID(),
+		Event: &api.Event_CCRSuccess{
+			CCRSuccess: &api.CCRSuccess{},
+		},
+	}
+}
+
+func complianceFailureEvent() *api.Event {
+	return &api.Event{
+		Id: newEventID(),
+		Event: &api.Event_ComplianceFailure{
+			ComplianceFailure: &api.ComplianceFailure{
+				Id:            "0",
+				NodeName:      "chefnode.example",
+				NodeId:        "11111111-2222-3333-4444-555555555555",
+				InspecVersion: "0",
+				EndTime:       endTime.Format(time.RFC3339),
+				Timestamp:     startTime.Format(time.RFC3339),
+				ComplianceUrl: "https://chefautomate.example/compliance_failure/0",
+				TestTotals: &api.ComplianceFailure_ControlTotals{
+					Skipped:        0,
+					Passed:         0,
+					Failed:         1,
+					Critical:       1,
+					CriticalFailed: 1,
+				},
+				FailedProfiles: []*api.Profile{
+					&api.Profile{
+						Name:           "Example Profile",
+						Title:          "Example Profile",
+						Version:        "5.23.42",
+						Summary:        "An example profile for integration testing",
+						Maintainer:     "automate@chef.io",
+						Copyright:      "Chef Software, Inc.",
+						CopyrightEmail: "legal@chef.io",
+						License:        "Apache 2.0",
+						Sha256:         "123abc",
+						Supports: []*api.PlatformSupport{
+							&api.PlatformSupport{
+								Inspec:   "99",
+								OsName:   "plan9",
+								OsFamily: "Esoterica",
+								Release:  "84",
+							},
+						},
+						Attributes: []*api.Profile_Attribute{
+							&api.Profile_Attribute{
+								Name: "example_attr",
+								Options: &api.Profile_Attribute_Options{
+									Description: "example attribute in an integration test",
+								},
+							},
+						},
+						Stats: &api.Profile_ControlTotals{
+							NumTests:        1,
+							NumFailedTests:  1,
+							NumSkippedTests: 0,
+							NumPassedTests:  0,
+						},
+						FailedControls: []*api.Profile_Control{
+							&api.Profile_Control{
+								Id:     "Example Control",
+								Impact: 7.5,
+								Title:  "Simulated Failure",
+								Desc:   "An example control from an integration_test",
+								Refs: []*api.Refs{
+									&api.Refs{Uri: "http://compliancerules.example", Url: "http://compliancerules.example.net"},
+								},
+								Code:           "halt -p",
+								SourceLocation: &api.SourceLocation{Ref: "example_profile.rb", Line: 5},
+								Stats: &api.Profile_Control_ResultTotals{
+									NumTests:        2,
+									NumFailedTests:  1,
+									NumSkippedTests: 0,
+									NumPassedTests:  1,
+								},
+								FailedResults: []*api.Profile_Control_Result{
+									&api.Profile_Control_Result{
+										Status:      "failed",
+										CodeDesc:    "not good",
+										Message:     "EXAMPLE CONTROL FAILED MESSAGE",
+										SkipMessage: "example skip message",
+										StartTime:   startTime.Format(time.RFC3339),
+										RunTime:     3.5,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func complianceSuccessEvent() *api.Event {
+	return &api.Event{
+		Id: newEventID(),
+		Event: &api.Event_ComplianceSuccess{
+			ComplianceSuccess: &api.ComplianceSuccess{},
+		},
+	}
+}
+
+func newEventID() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+type SlackMessage struct {
+	Username    string             `json:"username"`
+	Text        string             `json:"text"`
+	IconURL     string             `json:"icon_url"`
+	Attachments []*SlackAttachment `json:"attachments"`
+}
+
+type SlackAttachment struct {
+	Text       string                  `json:"text"`
+	Pretext    string                  `json:"pretext"`
+	MarkdownIn []string                `json:"mrkdwn_in"`
+	Fallback   string                  `json:"fallback"`
+	Color      string                  `json:"color"`
+	Fields     []*SlackAttachmentField `json:"fields"`
+}
+
+type SlackAttachmentField struct {
+	Value string `json:"value"`
+	Title string `json:"title"`
+	Short bool   `json:"short"`
+}
+
+type ServiceNowMessage struct {
+	Type               string   `json:"type"`
+	NodeName           string   `json:"node_name"`
+	AutomateFQDN       string   `json:"automate_fqdn"`
+	AutomateFailureURL string   `json:"automate_failure_url"`
+	TimestampUTC       string   `json:"timestamp_utc"`
+	StartTimeUTC       string   `json:"start_time_utc"`
+	EndTimeUTC         string   `json:"end_time_utc"`
+	FailureSnippet     string   `json:"failure_snippet"`
+	ExceptionTitle     string   `json:"exception_title"`
+	ExceptionMessage   string   `json:"exception_message"`
+	Cookbook           string   `json:"cookbook"`
+	ExceptionBacktrace []string `json:"exception_backtrace"`
+}
+
+type ServiceNowComplianceFailureMessage struct {
+	Type                        string                     `json:"type"`
+	NodeName                    string                     `json:"node_name"`
+	NodeUUID                    string                     `json:"node_uuid"`
+	InspecVersion               string                     `json:"inspec_version"`
+	AutomateFQDN                string                     `json:"automate_fqdn"`
+	AutomateFailureURL          string                     `json:"automate_failure_url"`
+	TotalNumberOfTests          int                        `json:"total_number_of_tests"`
+	TotalNumberOfSkippedTests   int                        `json:"total_number_of_skipped_tests"`
+	TotalNumberOfPassedTests    int                        `json:"total_number_of_passed_tests"`
+	TotalNumberOfFailedTests    int                        `json:"total_number_of_failed_tests"`
+	NumberOfFailedCriticalTests int                        `json:"number_of_failed_critical_tests"`
+	NumberOfCriticalTests       int                        `json:"number_of_critical_tests"`
+	FailureSnippet              string                     `json:"failure_snippet"`
+	FailedCriticalProfiles      []*ServiceNowFailedProfile `json:"failed_critical_profiles"`
+	TimestampUTC                string                     `json:"timestamp_utc"`
+	EndTimeUTC                  string                     `json:"end_time_utc"`
+}
+
+type ServiceNowFailedProfile struct {
+	Name             string                              `json:"name"`
+	Title            string                              `json:"title"`
+	Summary          string                              `json:"summary"`
+	Version          string                              `json:"version"`
+	Maintainer       string                              `json:"maintainer"`
+	License          string                              `json:"license"`
+	Copyright        string                              `json:"copyright"`
+	CopyrightEmail   string                              `json:"copyright_email"`
+	SHA256           string                              `json:"sha256"`
+	NumberOfControls int                                 `json:"number_of_controls"`
+	Supports         []*ServiceNowFailedProfilePlatform  `json:"supports"`
+	Controls         []*ServiceNowFailedControl          `json:"controls"`
+	Attributes       []*ServiceNowFailedProfileAttribute `json:"attributes"`
+}
+
+type ServiceNowFailedProfilePlatform struct {
+	InSpec   string `json:"inspec"`
+	OSName   string `json:"os_name"`
+	OSFamily string `json:"os_family"`
+	Release  string `json:"release"`
+}
+
+type ServiceNowFailedProfileAttribute struct {
+	Name    string                                   `json:"name"`
+	Options *ServiceNowFailedProfileAttributeOptions `json:"options"`
+}
+
+type ServiceNowFailedProfileAttributeOptions struct {
+	Description string `json:"description"`
+}
+
+type ServiceNowFailedControl struct {
+	ID                  string                                 `json:"id"`
+	Title               string                                 `json:"title"`
+	Desc                string                                 `json:"desc"`
+	Status              string                                 `json:"status"`
+	Impact              float64                                `json:"impact"`
+	NumberOfTests       int                                    `json:"number_of_tests"`
+	NumberOfFailedTests int                                    `json:"number_of_failed_tests"`
+	SourceLocation      *ServiceNowFailedControlSourceLocation `json:"source_location"`
+	Code                string                                 `json:"code"`
+	Refs                []*ServiceNowFailedControlRefs         `json:"refs"`
+	Results             []*ServiceNowResult                    `json:"results"`
+}
+
+type ServiceNowFailedControlSourceLocation struct {
+	Ref  string `json:"ref"`
+	Line int    `json:"line"`
+}
+
+type ServiceNowFailedControlRefs struct {
+	URI string `json:"uri"`
+	URL string `json:"url"`
+}
+
+type ServiceNowResult struct {
+	Status      string  `json:"status"`
+	Message     string  `json:"message"`
+	SkipMessage string  `json:"skip_message"`
+	CodeDesc    string  `json:"code_desc"`
+	RunTime     float64 `json:"run_time"`
+	StartTime   string  `json:"start_time"`
+}
+
+type WebhookMessage struct {
+	Type               string   `json:"type"`
+	NodeName           string   `json:"node_name"`
+	FailureSnippet     string   `json:"failure_snippet"`
+	ExceptionTitle     string   `json:"exception_title"`
+	ExceptionMessage   string   `json:"exception_message"`
+	ExceptionBacktrace []string `json:"exception_backtrace"`
+	AutomateFQDN       string   `json:"automate_fqdn"`
+	AutomateFailureURL string   `json:"automate_failure_url"`
+	StartTimeUTC       string   `json:"start_time_utc"`
+	EndTimeUTC         string   `json:"end_time_utc"`
+}
+
+type WebhookComplianceFailureMessage struct {
+	Type                        string                  `json:"type"`
+	NodeName                    string                  `json:"node_name"`
+	NodeUUID                    string                  `json:"node_uuid"`
+	InspecVersion               string                  `json:"inspec_version"`
+	AutomateFQDN                string                  `json:"automate_fqdn"`
+	AutomateFailureURL          string                  `json:"automate_failure_url"`
+	TotalNumberOfTests          int                     `json:"total_number_of_tests"`
+	TotalNumberOfSkippedTests   int                     `json:"total_number_of_skipped_tests"`
+	TotalNumberOfPassedTests    int                     `json:"total_number_of_passed_tests"`
+	TotalNumberOfFailedTests    int                     `json:"total_number_of_failed_tests"`
+	NumberOfFailedCriticalTests int                     `json:"number_of_failed_critical_tests"`
+	NumberOfCriticalTests       int                     `json:"number_of_critical_tests"`
+	FailureSnippet              string                  `json:"failure_snippet"`
+	FailedCriticalProfiles      []*WebhookFailedProfile `json:"failed_critical_profiles"`
+}
+
+type WebhookFailedProfile struct {
+	Name             string                           `json:"name"`
+	Title            string                           `json:"title"`
+	Summary          string                           `json:"summary"`
+	Version          string                           `json:"version"`
+	Maintainer       string                           `json:"maintainer"`
+	License          string                           `json:"license"`
+	Copyright        string                           `json:"copyright"`
+	CopyrightEmail   string                           `json:"copyright_email"`
+	SHA256           string                           `json:"sha256"`
+	NumberOfControls int                              `json:"number_of_controls"`
+	Supports         []*WebhookFailedProfilePlatform  `json:"supports"`
+	Controls         []*WebhookFailedControl          `json:"controls"`
+	Attributes       []*WebhookFailedProfileAttribute `json:"attributes"`
+}
+
+type WebhookFailedProfilePlatform struct {
+	InSpec   string `json:"inspec"`
+	OSName   string `json:"os_name"`
+	OSFamily string `json:"os_family"`
+	Release  string `json:"release"`
+}
+
+type WebhookFailedProfileAttribute struct {
+	Name    string                                `json:"name"`
+	Options *WebhookFailedProfileAttributeOptions `json:"options"`
+}
+
+type WebhookFailedProfileAttributeOptions struct {
+	Description string `json:"description"`
+}
+
+type WebhookFailedControl struct {
+	ID                  string                              `json:"id"`
+	Title               string                              `json:"title"`
+	Desc                string                              `json:"desc"`
+	Status              string                              `json:"status"`
+	Impact              float64                             `json:"impact"`
+	NumberOfTests       int                                 `json:"number_of_tests"`
+	NumberOfFailedTests int                                 `json:"number_of_failed_tests"`
+	SourceLocation      *WebhookFailedControlSourceLocation `json:"source_location"`
+	Code                string                              `json:"code"`
+	Refs                []*WebhookFailedControlRefs         `json:"refs"`
+	Results             []*WebhookResult                    `json:"results"`
+}
+
+type WebhookFailedControlSourceLocation struct {
+	Ref  string `json:"ref"`
+	Line int    `json:"line"`
+}
+
+type WebhookFailedControlRefs struct {
+	URI string `json:"uri"`
+	URL string `json:"url"`
+}
+
+type WebhookResult struct {
+	Status      string  `json:"status"`
+	Message     string  `json:"message"`
+	SkipMessage string  `json:"skip_message"`
+	CodeDesc    string  `json:"code_desc"`
+	RunTime     float64 `json:"run_time"`
+	StartTime   string  `json:"start_time"`
+}

--- a/components/notifications-service/integration_test/rules_crud_test.go
+++ b/components/notifications-service/integration_test/rules_crud_test.go
@@ -1,105 +1,14 @@
 package integration_test
 
 import (
-	"context"
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	deploymentConst "github.com/chef/automate/components/automate-deployment/pkg/constants"
 	"github.com/chef/automate/components/notifications-client/api"
-	"github.com/chef/automate/lib/grpc/secureconn"
 	"github.com/chef/automate/lib/pcmp/passert"
-	"github.com/chef/automate/lib/tls/certs"
 )
-
-var (
-	suite = &Suite{}
-	ctx   = context.Background()
-)
-
-type Suite struct {
-	Client api.NotificationsClient
-}
-
-func (s *Suite) GlobalSetup() error {
-	// Sometimes in local dev we do partial deployments with just a few services,
-	// but the deployment-service should always be there. Using deployment's
-	// certs should always work.
-	deploymentCerts := certs.TLSConfig{
-		CertPath:       deploymentConst.CertPath,
-		KeyPath:        deploymentConst.KeyPath,
-		RootCACertPath: deploymentConst.RootCertPath,
-	}
-	certData, err := deploymentCerts.ReadCerts()
-	if err != nil {
-		return err
-	}
-
-	mutTLSFactory := secureconn.NewFactory(*certData)
-	grpcEndpoint, err := mutTLSFactory.Dial("notifications-service", "localhost:10125")
-	if err != nil {
-		return err
-	}
-
-	s.Client = api.NewNotificationsClient(grpcEndpoint)
-
-	return s.DeleteEverything()
-}
-
-func (s *Suite) GlobalTeardown() error {
-	return s.DeleteEverything()
-}
-
-func (s *Suite) DeleteEverything() error {
-	ruleList, err := s.Client.ListRules(ctx, &api.Empty{})
-	if err != nil {
-		return err
-	}
-	for _, r := range ruleList.Rules {
-		_, err := s.Client.DeleteRule(ctx, &api.RuleIdentifier{Id: r.Id})
-		if err != nil {
-			return nil
-		}
-	}
-	return nil
-}
-
-// TestMain allow us to run a setup before running our tests and also
-// teardown everything after we have finished testing.
-//
-// (Check out 'suite_test.go')
-//
-// => Docs: https://golang.org/pkg/testing/#hdr-Main
-func TestMain(m *testing.M) {
-	// Global Setup hook: Here is where you can initialize anythings you need
-	// for your tests to run
-	err := suite.GlobalSetup()
-	if err != nil {
-		fmt.Println("Test suite failed during GlobalSetup")
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	// Execute the test suite and record the exit code
-	exitCode := m.Run()
-
-	// Teardown hook: It says it all
-	err = suite.GlobalTeardown()
-	if err != nil {
-		fmt.Println("Test suite failed during GlobalTeardown")
-		fmt.Println(err)
-		if exitCode != 0 {
-			os.Exit(2)
-		}
-	}
-
-	// call with result of m.Run()
-	os.Exit(exitCode)
-}
 
 /*
 	API Endpoints to Test:

--- a/components/notifications-service/integration_test/rules_crud_test.go
+++ b/components/notifications-service/integration_test/rules_crud_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/chef/automate/lib/pcmp/passert"
 )
 
-/*
-	API Endpoints to Test:
-
-	* rpc Notify(Event) returns (Response);
-	* rpc ValidateWebhook(URLValidationRequest) returns (URLValidationResponse);
-		}
-*/
-
 func TestGetVersion(t *testing.T) {
 	res, err := suite.Client.Version(ctx, &api.VersionRequest{})
 	require.NoError(t, err)
@@ -337,9 +329,11 @@ func TestUpdateRuleValidation(t *testing.T) {
 		updatedRule.Name = "TestAddRule_validations_unique"
 		response, err := suite.Client.UpdateRule(ctx, updatedRule)
 		require.NoError(t, err)
-		// TODO: the elixir implementation does not check for this case so it
-		// returns an internal error when the db request fails on the key constraint.
-		// This should be changed so the server detects the duplicate
+		// NOTE: the elixir implementation does not check for the case that an
+		// update would violate the uniqueness constraint on the name column, so it
+		// returns an internal error when the db request fails on the contstraint
+		// violation. This is a bug, but we don't plan to change the behavior until
+		// after the elixir implementation is replaced.
 		assert.NotEqual(t, api.RuleUpdateResponse_OK, response.Code)
 		//assert.Equal(t, api.RuleUpdateResponse_DUPLICATE_NAME, response.Code)
 		//assert.Contains(t, response.Messages, "A rule with this name already exists")

--- a/components/notifications-service/integration_test/service_test.go
+++ b/components/notifications-service/integration_test/service_test.go
@@ -1,0 +1,506 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	deploymentConst "github.com/chef/automate/components/automate-deployment/pkg/constants"
+	"github.com/chef/automate/components/notifications-client/api"
+	"github.com/chef/automate/lib/grpc/secureconn"
+	"github.com/chef/automate/lib/pcmp/passert"
+	"github.com/chef/automate/lib/tls/certs"
+)
+
+var (
+	suite = &Suite{}
+	ctx   = context.Background()
+)
+
+type Suite struct {
+	Client api.NotificationsClient
+}
+
+func (s *Suite) GlobalSetup() error {
+	// Sometimes in local dev we do partial deployments with just a few services,
+	// but the deployment-service should always be there. Using deployment's
+	// certs should always work.
+	deploymentCerts := certs.TLSConfig{
+		CertPath:       deploymentConst.CertPath,
+		KeyPath:        deploymentConst.KeyPath,
+		RootCACertPath: deploymentConst.RootCertPath,
+	}
+	certData, err := deploymentCerts.ReadCerts()
+	if err != nil {
+		return err
+	}
+
+	mutTLSFactory := secureconn.NewFactory(*certData)
+	grpcEndpoint, err := mutTLSFactory.Dial("notifications-service", "localhost:10125")
+	if err != nil {
+		return err
+	}
+
+	s.Client = api.NewNotificationsClient(grpcEndpoint)
+
+	return s.DeleteEverything()
+}
+
+func (s *Suite) GlobalTeardown() error {
+	return s.DeleteEverything()
+}
+
+func (s *Suite) DeleteEverything() error {
+	ruleList, err := s.Client.ListRules(ctx, &api.Empty{})
+	if err != nil {
+		return err
+	}
+	for _, r := range ruleList.Rules {
+		_, err := s.Client.DeleteRule(ctx, &api.RuleIdentifier{Id: r.Id})
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+// TestMain allow us to run a setup before running our tests and also
+// teardown everything after we have finished testing.
+//
+// (Check out 'suite_test.go')
+//
+// => Docs: https://golang.org/pkg/testing/#hdr-Main
+func TestMain(m *testing.M) {
+	// Global Setup hook: Here is where you can initialize anythings you need
+	// for your tests to run
+	err := suite.GlobalSetup()
+	if err != nil {
+		fmt.Println("Test suite failed during GlobalSetup")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Execute the test suite and record the exit code
+	exitCode := m.Run()
+
+	// Teardown hook: It says it all
+	err = suite.GlobalTeardown()
+	if err != nil {
+		fmt.Println("Test suite failed during GlobalTeardown")
+		fmt.Println(err)
+		if exitCode != 0 {
+			os.Exit(2)
+		}
+	}
+
+	// call with result of m.Run()
+	os.Exit(exitCode)
+}
+
+/*
+	API Endpoints to Test:
+
+	* rpc Notify(Event) returns (Response);
+	* rpc ValidateWebhook(URLValidationRequest) returns (URLValidationResponse);
+		}
+*/
+
+func TestGetVersion(t *testing.T) {
+	res, err := suite.Client.Version(ctx, &api.VersionRequest{})
+	require.NoError(t, err)
+	// In local dev the version string changes to include extra information (in
+	// the elixir notifications service). Allow any non-empty string here to be
+	// less brittle.
+	assert.NotEmpty(t, res.Version)
+}
+
+func TestGetRule(t *testing.T) {
+	err := suite.DeleteEverything()
+	assert.NoError(t, err)
+
+	t.Run("returns not found when requesting a rule that doesn't exist", func(t *testing.T) {
+		res, err := suite.Client.GetRule(ctx, &api.RuleIdentifier{Id: "42"})
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleGetResponse_NOT_FOUND, res.Code)
+		assert.Empty(t, res.Rule)
+	})
+
+	t.Run("returns the rule when the rule exists", func(t *testing.T) {
+		rule := validRule("TestGetRule_success_01")
+		createResponse, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		require.NotEmpty(t, createResponse.Id)
+
+		res, err := suite.Client.GetRule(ctx, &api.RuleIdentifier{Id: createResponse.Id})
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleGetResponse_OK, res.Code)
+
+		rule.Id = createResponse.Id
+		passert.Equal(t, rule, res.Rule)
+	})
+}
+
+func TestListRules(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	t.Run("Returns an empty list when no rules exist", func(t *testing.T) {
+		ruleList, err := suite.Client.ListRules(ctx, &api.Empty{})
+		require.NoError(t, err)
+		assert.Empty(t, ruleList.Rules)
+	})
+
+	t.Run("Returns the rules when rules exist", func(t *testing.T) {
+		expectedRuleNames := []string{"TestListRules_success_01", "TestListRules_success_02"}
+		for _, name := range expectedRuleNames {
+			_, err := suite.Client.AddRule(ctx, validRule(name))
+			require.NoError(t, err)
+		}
+
+		ruleList, err := suite.Client.ListRules(ctx, &api.Empty{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, ruleList.Rules)
+		actualRuleNames := []string{}
+		for _, r := range ruleList.Rules {
+			actualRuleNames = append(actualRuleNames, r.Name)
+		}
+		assert.ElementsMatch(t, expectedRuleNames, actualRuleNames)
+	})
+}
+
+func TestAddRuleSuccessCase(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	t.Run("valid rule returns a successful response", func(t *testing.T) {
+		rule := validRule("TestAddRule_success_01")
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, response.Code)
+		assert.NotEmpty(t, response.Id)
+		passert.Equal(t, rule, response.Rule)
+	})
+
+}
+
+func TestAddRuleValidations(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	t.Run("the Id field must be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_Id")
+		rule.Id = "43"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "Rule ID may not be included in an add-rule request")
+	})
+
+	t.Run("the Name field must not be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_Name")
+		rule.Name = ""
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "Rule name must be supplied.")
+	})
+
+	t.Run("the Name must be unique", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_unique")
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, response.Code)
+		assert.NotEmpty(t, response.Id)
+
+		response, err = suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_DUPLICATE_NAME, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A rule with this name already exists")
+	})
+
+	t.Run("the Action field must not be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_Action")
+		rule.Action = nil
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "Action must be set.")
+	})
+
+	t.Run("the URL in a SlackAlert action must not be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_SlackAlertURL")
+		rule.GetSlackAlert().Url = ""
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a SlackAlert action must include the protocol/scheme", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_SlackAlertURL")
+		rule.GetSlackAlert().Url = "example.com"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a SlackAlert action must include the hostname", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_SlackAlertURL")
+		rule.GetSlackAlert().Url = "https://"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+
+	t.Run("the URL in a WebhookAlert action must not be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_WebhookAlertURL")
+		rule.Action = validWebhook()
+		rule.GetWebhookAlert().Url = ""
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a WebhookAlert action must include the protocol/scheme", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_WebhookAlertURL")
+		rule.Action = validWebhook()
+		rule.GetWebhookAlert().Url = "example.com"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a WebhookAlert action must include the hostname", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_WebhookAlertURL")
+		rule.Action = validWebhook()
+		rule.GetWebhookAlert().Url = "https://"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+
+	t.Run("the URL in a ServiceNowAlert action must not be empty", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_ServiceNowAlertURL")
+		rule.Action = validServiceNowAlert()
+		rule.GetServiceNowAlert().Url = ""
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a ServiceNowAlert action must include the protocol/scheme", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_ServiceNowAlertURL")
+		rule.Action = validServiceNowAlert()
+		rule.GetServiceNowAlert().Url = "example.com"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+	t.Run("the URL in a ServiceNowAlert action must include the hostname", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_ServiceNowAlertURL")
+		rule.Action = validServiceNowAlert()
+		rule.GetServiceNowAlert().Url = "https://"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "A valid action URL must be supplied")
+	})
+
+	t.Run("Multiple error messages are returned when multiple validation rules are not satisfied", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_MuliInvalid")
+		rule.Action = nil
+		rule.Name = ""
+		rule.Id = "42"
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_VALIDATION_ERROR, response.Code)
+		assert.Empty(t, response.Id)
+		assert.Contains(t, response.Messages, "Action must be set.")
+		assert.Contains(t, response.Messages, "Rule name must be supplied.")
+		assert.Contains(t, response.Messages, "Rule ID may not be included in an add-rule request")
+	})
+
+	// NOTE: this is a test of a validation that doesn't exist
+	// NOTE: it's unclear to me if this behavior is correct. It's how the
+	// original elixir implementation behaves.
+	t.Run("the SecretId in a ServiceNowAlert action can be blank", func(t *testing.T) {
+		rule := validRule("TestAddRule_validations_ServiceNowAlert_SecretId")
+		rule.Action = validServiceNowAlert()
+		rule.GetServiceNowAlert().SecretId = ""
+		response, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, response.Code)
+		assert.NotEmpty(t, response.Id)
+		assert.Empty(t, response.Messages)
+	})
+
+}
+
+func TestUpdateRuleSuccess(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	t.Run("valid rule returns a successful response", func(t *testing.T) {
+		rule := validRule("TestAddRule_success_01")
+		createResponse, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, createResponse.Code)
+
+		rule.Id = createResponse.Id
+		rule.GetSlackAlert().Url = "https://newurl.example"
+		response, err := suite.Client.UpdateRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Empty(t, response.Messages)
+		assert.Equal(t, api.RuleUpdateResponse_OK, response.Code)
+	})
+
+	t.Run("update can modify the rule name", func(t *testing.T) {
+		rule := validRule("TestAddRule_success_02")
+		createResponse, err := suite.Client.AddRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, createResponse.Code)
+
+		rule.Id = createResponse.Id
+		rule.Name = "TestAddRule_success_02_updated_value"
+		response, err := suite.Client.UpdateRule(ctx, rule)
+		require.NoError(t, err)
+		assert.Empty(t, response.Messages)
+		assert.Equal(t, api.RuleUpdateResponse_OK, response.Code)
+	})
+
+}
+
+func TestUpdateRuleValidation(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ruleToCreate := validRule("TestUpdateRule_validations")
+	created, err := suite.Client.AddRule(ctx, ruleToCreate)
+	require.NoError(t, err)
+	createdRule := created.Rule
+	createdRule.Id = created.Id
+
+	t.Run("the Id field must not be empty", func(t *testing.T) {
+		updatedRule := copyRule(createdRule)
+		updatedRule.Id = ""
+		response, err := suite.Client.UpdateRule(ctx, updatedRule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleUpdateResponse_VALIDATION_ERROR, response.Code)
+		assert.Contains(t, response.Messages, "Rule ID must be included from the rule being modified")
+	})
+
+	t.Run("the Name field must not be empty", func(t *testing.T) {
+		updatedRule := copyRule(createdRule)
+		updatedRule.Name = ""
+		response, err := suite.Client.UpdateRule(ctx, updatedRule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleUpdateResponse_VALIDATION_ERROR, response.Code)
+		assert.Contains(t, response.Messages, "Rule name must be supplied.")
+	})
+
+	t.Run("the Name must be unique", func(t *testing.T) {
+		rule2 := validRule("TestAddRule_validations_unique")
+		res, err := suite.Client.AddRule(ctx, rule2)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleAddResponse_ADDED, res.Code)
+		assert.NotEmpty(t, res.Id)
+
+		updatedRule := copyRule(createdRule)
+		updatedRule.Name = "TestAddRule_validations_unique"
+		response, err := suite.Client.UpdateRule(ctx, updatedRule)
+		require.NoError(t, err)
+		// TODO: the elixir implementation does not check for this case so it
+		// returns an internal error when the db request fails on the key constraint.
+		// This should be changed so the server detects the duplicate
+		assert.NotEqual(t, api.RuleUpdateResponse_OK, response.Code)
+		//assert.Equal(t, api.RuleUpdateResponse_DUPLICATE_NAME, response.Code)
+		//assert.Contains(t, response.Messages, "A rule with this name already exists")
+	})
+
+	t.Run("the Action field must not be empty", func(t *testing.T) {
+		updatedRule := copyRule(createdRule)
+		updatedRule.Action = nil
+		response, err := suite.Client.UpdateRule(ctx, updatedRule)
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleUpdateResponse_VALIDATION_ERROR, response.Code)
+		assert.Contains(t, response.Messages, "Action must be set.")
+	})
+
+	// NOTE: UpdateRule is expected to apply the same validations to the actions
+	// as AddRule does. We don't explicitly test those because it's repetitive
+}
+
+func TestDeleteRule(t *testing.T) {
+	err := suite.DeleteEverything()
+	require.NoError(t, err)
+
+	ruleToCreate := validRule("TestUpdateRule_validations")
+	created, err := suite.Client.AddRule(ctx, ruleToCreate)
+	require.NoError(t, err)
+
+	t.Run("deleting an existing rule succeeds", func(t *testing.T) {
+		response, err := suite.Client.DeleteRule(ctx, &api.RuleIdentifier{Id: created.Id})
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleDeleteResponse_DELETED, response.Code)
+	})
+
+	t.Run("deleting a rule that doesn't exist returns an error", func(t *testing.T) {
+		response, err := suite.Client.DeleteRule(ctx, &api.RuleIdentifier{Id: "5"})
+		require.NoError(t, err)
+		assert.Equal(t, api.RuleDeleteResponse_NOT_FOUND, response.Code)
+	})
+}
+
+func copyRule(r *api.Rule) *api.Rule {
+	// NOTE: shallow copy. This will work as long as you only modify r2 by
+	// assigning a new value for a field.
+	r2 := *r
+	return &r2
+}
+
+func validRule(name string) *api.Rule {
+	return &api.Rule{
+		Event: api.Rule_CCRFailure,
+		Name:  name,
+		Action: &api.Rule_SlackAlert{
+			SlackAlert: &api.SlackAlert{
+				Url: "https://slack.example",
+			},
+		},
+	}
+}
+
+func validWebhook() *api.Rule_WebhookAlert {
+	return &api.Rule_WebhookAlert{
+		WebhookAlert: &api.WebhookAlert{Url: "https://webhook.example"},
+	}
+}
+
+func validServiceNowAlert() *api.Rule_ServiceNowAlert {
+	return &api.Rule_ServiceNowAlert{
+		ServiceNowAlert: &api.ServiceNowAlert{
+			Url:                  "https://servicenow.example",
+			SecretId:             "supersecret",
+			CriticalControlsOnly: false,
+		},
+	}
+}

--- a/components/notifications-service/integration_test/suite_test.go
+++ b/components/notifications-service/integration_test/suite_test.go
@@ -1,0 +1,100 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	deploymentConst "github.com/chef/automate/components/automate-deployment/pkg/constants"
+	"github.com/chef/automate/components/notifications-client/api"
+	"github.com/chef/automate/lib/grpc/secureconn"
+	"github.com/chef/automate/lib/tls/certs"
+)
+
+var (
+	suite = &Suite{}
+	ctx   = context.Background()
+)
+
+// Suite holds any global state needed for the test run and implements
+// GlobalSetup and GlobalTeardown methods.
+type Suite struct {
+	Client api.NotificationsClient
+}
+
+func (s *Suite) GlobalSetup() error {
+	// Sometimes in local dev we do partial deployments with just a few services,
+	// but the deployment-service should always be there. Using deployment's
+	// certs should always work.
+	deploymentCerts := certs.TLSConfig{
+		CertPath:       deploymentConst.CertPath,
+		KeyPath:        deploymentConst.KeyPath,
+		RootCACertPath: deploymentConst.RootCertPath,
+	}
+	certData, err := deploymentCerts.ReadCerts()
+	if err != nil {
+		return err
+	}
+
+	mutTLSFactory := secureconn.NewFactory(*certData)
+	grpcEndpoint, err := mutTLSFactory.Dial("notifications-service", "localhost:10125")
+	if err != nil {
+		return err
+	}
+
+	s.Client = api.NewNotificationsClient(grpcEndpoint)
+
+	return s.DeleteEverything()
+}
+
+func (s *Suite) GlobalTeardown() error {
+	return s.DeleteEverything()
+}
+
+func (s *Suite) DeleteEverything() error {
+	ruleList, err := s.Client.ListRules(ctx, &api.Empty{})
+	if err != nil {
+		return err
+	}
+	for _, r := range ruleList.Rules {
+		_, err := s.Client.DeleteRule(ctx, &api.RuleIdentifier{Id: r.Id})
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+// TestMain allow us to run a setup before running our tests and also
+// teardown everything after we have finished testing.
+//
+// (Check out 'suite_test.go')
+//
+// => Docs: https://golang.org/pkg/testing/#hdr-Main
+func TestMain(m *testing.M) {
+	// Global Setup hook: Here is where you can initialize anythings you need
+	// for your tests to run
+	err := suite.GlobalSetup()
+	if err != nil {
+		fmt.Println("Test suite failed during GlobalSetup")
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Execute the test suite and record the exit code
+	exitCode := m.Run()
+
+	// Teardown hook: It says it all
+	err = suite.GlobalTeardown()
+	if err != nil {
+		fmt.Println("Test suite failed during GlobalTeardown")
+		fmt.Println(err)
+		if exitCode != 0 {
+			os.Exit(2)
+		}
+	}
+
+	// call with result of m.Run()
+	os.Exit(exitCode)
+}

--- a/components/notifications-service/integration_test/webhook_validator_test.go
+++ b/components/notifications-service/integration_test/webhook_validator_test.go
@@ -1,0 +1,133 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/chef/automate/api/external/common/query"
+	"github.com/chef/automate/api/external/secrets"
+	"github.com/chef/automate/components/notifications-client/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhookValidator(t *testing.T) {
+	t.Run("with a malformed URL, the webhook validator returns an 'invalid URL' response", func(t *testing.T) {
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url:         "malformed_URL_input",
+			Credentials: &api.URLValidationRequest_None{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_INVALID_URL, res.Code)
+	})
+
+	t.Run("with a URL for a service that isn't running, the webhook validator returns an error", func(t *testing.T) {
+		ts := newTestServer()
+		// Note this is closed immediately instead of defered, so the server will be down.
+		ts.Close()
+
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url:         ts.SlackURL(),
+			Credentials: &api.URLValidationRequest_None{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_ERROR, res.Code)
+	})
+
+	t.Run("with a valid URL and no credentials, the webhook validator succeeds", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.Close()
+
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url:         ts.SlackURL(),
+			Credentials: &api.URLValidationRequest_None{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_OK, res.Code)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+	})
+
+	t.Run("with a valid URL and username/password creds, the webhook validator succeeds", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.Close()
+
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url: ts.SlackURL(),
+			Credentials: &api.URLValidationRequest_UsernamePassword{
+				UsernamePassword: &api.UsernamePassword{
+					Username: "integration_test_username",
+					Password: "integration_test_password",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_OK, res.Code)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+
+		assert.True(t, postData.BasicAuthUsed)
+		assert.Equal(t, "integration_test_username", postData.BasicAuthUsername)
+		assert.Equal(t, "integration_test_password", postData.BasicAuthPassword)
+	})
+
+	t.Run("with a valid URL and secret ID creds, and the secret ID **IS NOT** in the secrets store, the webhook validator succeeds", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.Close()
+
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url: ts.SlackURL(),
+			Credentials: &api.URLValidationRequest_SecretId{
+				SecretId: &api.SecretId{
+					Id: "integration_test_secret_id_NOEXIST",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_OK, res.Code)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+		assert.False(t, postData.BasicAuthUsed)
+	})
+
+	t.Run("with a valid URL and secret ID creds, and the secret ID **IS** in the secrets store, the webhook validator succeeds", func(t *testing.T) {
+		ts := newTestServer()
+		defer ts.Close()
+
+		sres, err := suite.SecretsClient.Create(ctx, &secrets.Secret{
+			Id:   "integration_test_secret_id",
+			Name: "integration_test_secret_id",
+			Type: "service_now",
+			Data: []*query.Kv{
+				&query.Kv{Key: "username", Value: "integration_test_username_secretstore"},
+				&query.Kv{Key: "password", Value: "integration_test_password_secretstore"},
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, sres.Id)
+
+		secretID := sres.Id
+		defer func() {
+			suite.SecretsClient.Delete(ctx, &secrets.Id{Id: secretID})
+		}()
+
+		res, err := suite.Client.ValidateWebhook(ctx, &api.URLValidationRequest{
+			Url: ts.SlackURL(),
+			Credentials: &api.URLValidationRequest_SecretId{
+				SecretId: &api.SecretId{
+					Id: secretID,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, api.URLValidationResponse_OK, res.Code)
+
+		postData := ts.GetLastPost()
+		assert.NotNil(t, postData)
+		assert.True(t, postData.BasicAuthUsed)
+		assert.Equal(t, "integration_test_username_secretstore", postData.BasicAuthUsername)
+		assert.Equal(t, "integration_test_password_secretstore", postData.BasicAuthPassword)
+	})
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Create a full integration test suite for the notifications service in go. Everything is tested via external interface. This enables reimplementing the notifications-service while maintaining API stability.

NOTE: click the "Load Large Diff" button for `components/notifications-service/integration_test/notification_test.go`, that's most of the action in this PR.

No work is done to run this test suite in Ci yet. It will make sense to do so once we've created the reimplementation of the notifications-service.

This suite will probably need some adaption to work against the new implementation of the notifications-service. That will be done when there is a new implementation to adapt to.

### :athletic_shoe: How to Build and Test the Change

In a fresh studio (if not fresh, source the `.studio` files):
* start all services
* run `notifications_integration` or `A2_SVC_NAME="notifications-service" A2_SVC_PATH="/hab/svc/notifications-service" go test -v "github.com/chef/automate/components/notifications-service/integration_test" -count 1`
