### PR TITLE
Set data_collector to true only if external automate or local automate is enabled.

### DIFF
--- a/api/config/erchef/config_request.go
+++ b/api/config/erchef/config_request.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	ac "github.com/chef/automate/api/config/shared"
+	config "github.com/chef/automate/api/config/shared"
 	w "github.com/chef/automate/api/config/shared/wrappers"
+	"github.com/chef/automate/lib/stringutils"
 )
 
 // NewConfigRequest returns a new instance of ConfigRequest with zero values.
@@ -143,4 +145,12 @@ func (c *ConfigRequest) PrepareSystemConfig(creds *ac.TLSCredentials) (ac.Prepar
 	c.V1.Sys.Tls = creds
 
 	return c.V1.Sys, nil
+}
+
+func (c *ConfigRequest) ConfigureProduct(productConfig *config.ProductConfig) {
+	if len(productConfig.Products) > 0 {
+		if !c.V1.Sys.GetExternalAutomate().GetEnable().GetValue() && !stringutils.SliceContains(productConfig.Products, "automate") {
+			c.V1.Sys.DataCollector.Enabled = w.Bool(false)
+		}
+	}
 }

--- a/api/config/erchef/config_request_test.go
+++ b/api/config/erchef/config_request_test.go
@@ -3,11 +3,42 @@ package erchef
 import (
 	"testing"
 
+	"github.com/chef/automate/api/config/shared"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	w "github.com/chef/automate/api/config/shared/wrappers"
 )
 
 func TestValidateConfigRequestValid(t *testing.T) {
 	c := NewConfigRequest()
 	err := c.Validate()
 	assert.Nil(t, err)
+}
+
+func TestDataCollector(t *testing.T) {
+	t.Run("enabled when External Automate is enabled and Internal Automate is disabled", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.V1.Sys.ExternalAutomate = &shared.External_Automate{
+			Enable: w.Bool(true),
+		}
+		c.ConfigureProduct(&shared.ProductConfig{
+			Products: []string{"chef-server"},
+		})
+		require.True(t, c.V1.Sys.GetDataCollector().GetEnabled().GetValue())
+	})
+	t.Run("enabled when External Automate is disabled and Internal Automate is enabled", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.ConfigureProduct(&shared.ProductConfig{
+			Products: []string{"automate", "chef-server"},
+		})
+		require.True(t, c.V1.Sys.GetDataCollector().GetEnabled().GetValue())
+	})
+	t.Run("disabled when External Automate is disabled and Internal Automate is disabled", func(t *testing.T) {
+		c := DefaultConfigRequest()
+		c.ConfigureProduct(&shared.ProductConfig{
+			Products: []string{"chef-server"},
+		})
+		require.False(t, c.V1.Sys.GetDataCollector().GetEnabled().GetValue())
+	})
 }

--- a/integration/tests/chef_server_only.sh
+++ b/integration/tests/chef_server_only.sh
@@ -16,12 +16,6 @@ source .studio/chef-server-collection
 
 do_create_config() {
     do_create_config_default
-
-    #shellcheck disable=SC2154
-    cat <<EOF >> "$test_config_path"
-[erchef.v1.sys.data_collector]
-enabled = false
-EOF
 }
 
 do_deploy() {


### PR DESCRIPTION
Currently chef-server will not come up if automate is disabled in the dev vm.

This happens because data-collector is set to true(enable) by default. This change makes it such that data-collector will be enabled only if external or internal automate are enabled.

Co-authored-by: Jay Mundrawala <jmundrawala@chef.io>
Signed-off-by: Prajakta Purohit <prajakta@chef.io>