### PR TITLE
Allow nginx to start even if external automate upstream fails to resolve

### DIFF
--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -82,6 +82,8 @@
         return "{{cfg.external_automate.token}}";
     }
 
+    resolver local=on ipv6=off;
+    set $externalautomate {{cfg.external_automate.endpoint}};
     location ~ "^/organizations/([^/]+)/data-collector$" {
       set $request_org $1;
       access_by_lua_block { validator.validate("POST") }
@@ -98,9 +100,9 @@
       {{/if}}
 
       {{~#if cfg.external_automate.ssl_upstream }}
-      proxy_pass https://external-automate;
+      proxy_pass https://$externalautomate;
       {{else}}
-      proxy_pass http://external-automate;
+      proxy_pass http://$externalautomate;
       {{/if}}
     }
 
@@ -124,9 +126,9 @@
       {{/if}}
 
       {{~#if cfg.external_automate.ssl_upstream }}
-      proxy_pass https://external-automate;
+      proxy_pass https://$externalautomate;
       {{else}}
-      proxy_pass http://external-automate;
+      proxy_pass http://$externalautomate;
       {{/if}}
   }
 {{else}}

--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -82,7 +82,7 @@
         return "{{cfg.external_automate.token}}";
     }
 
-    resolver local=on ipv6=off;
+    resolver local=on;
     set $externalautomate {{cfg.external_automate.endpoint}};
     location ~ "^/organizations/([^/]+)/data-collector$" {
       set $request_org $1;

--- a/components/automate-cs-nginx/habitat/config/nginx.conf
+++ b/components/automate-cs-nginx/habitat/config/nginx.conf
@@ -84,10 +84,6 @@ http {
   }
 
 {{#if cfg.external_automate.enable}}
-  upstream external-automate {
-    server {{cfg.external_automate.endpoint}};
-    keepalive 8;
-  }
 {{else}}
   upstream automate-gateway {
 {{#eachAlive bind.automate-gateway.members as |member|}}


### PR DESCRIPTION
Also, the resolver config reads the resolvers from /etc/resolve and
queries every few minutes. I checked with wireshark to make sure it
doesn't happen for every request.

resolves: https://github.com/chef/chef-server/issues/2181

Co-authored-by: Prajakta Purohit <prajakta@chef.io>
Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
