### PR TITLE
Adjust merge base point for semgrep differential scan

### DIFF
--- a/.expeditor/buildkite/semgrep.sh
+++ b/.expeditor/buildkite/semgrep.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eou pipefail
+
+# usage: semgrep.sh $BUILDKITE_BRANCH $BUILDKITE_BUILD_URL $BUILDKITE_PULL_REQUEST_BASE_BRANCH
+
+echo "running in $(pwd)"
+
+# Env vars needed by semgrep-agent
+export SEMGREP_BRANCH=$1
+export SEMGREP_REPO_NAME=chef/automate
+# Activates links to buildkite builds in slack notification
+export SEMGREP_JOB_URL=$2
+# Activates links to git commits in slack notification
+export SEMGREP_REPO_URL=https://github.com/chef/automate
+
+BASELINE=$3
+MERGE_BASE=$(git merge-base "${BASELINE:-master}" HEAD)
+if [ "$SEMGREP_BRANCH" == "master" ] ; then
+  echo "build on master; using 'master~1' as base branch" && BASELINE=master~1
+elif [ "$SEMGREP_BRANCH" != "master" ] && [ -n "$BASELINE" ] ; then
+  echo "PR build on '$SEMGREP_BRANCH' branch; base is $MERGE_BASE (merge-base of '$BASELINE')" && BASELINE=$MERGE_BASE
+elif [ "$SEMGREP_BRANCH" != "master" ] && [ -z "$BASELINE" ] ; then
+  echo "manual build on '$SEMGREP_BRANCH' branch; using merge-base of master as base ($MERGE_BASE)" && BASELINE=$MERGE_BASE
+fi
+python -m semgrep_agent --publish-token "$SEMGREP_TOKEN" --publish-deployment "$SEMGREP_ID" --baseline-ref "$BASELINE"

--- a/.expeditor/buildkite/semgrep.sh
+++ b/.expeditor/buildkite/semgrep.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
 set -eou pipefail
 
-# usage: semgrep.sh $BUILDKITE_BRANCH $BUILDKITE_BUILD_URL $BUILDKITE_PULL_REQUEST_BASE_BRANCH
-
 echo "running in $(pwd)"
 
 # Env vars needed by semgrep-agent
-export SEMGREP_BRANCH=$1
+export SEMGREP_BRANCH=$BUILDKITE_BRANCH 
 export SEMGREP_REPO_NAME=chef/automate
 # Activates links to buildkite builds in slack notification
-export SEMGREP_JOB_URL=$2
+export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
 # Activates links to git commits in slack notification
 export SEMGREP_REPO_URL=https://github.com/chef/automate
 
-BASELINE=$3
+BASELINE=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
 MERGE_BASE=$(git merge-base "${BASELINE:-master}" HEAD)
 if [ "$SEMGREP_BRANCH" == "master" ] ; then
   echo "build on master; using 'master~1' as base branch" && BASELINE=master~1

--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -258,7 +258,7 @@ steps:
             - .expeditor/export_semgrep_token.sh
       - docker#v3.7.0:
           image: returntocorp/semgrep-agent:v1
-          propogate-environment: true
+          propagate-environment: true
           workdir: /go/src/github.com/chef/automate
           environment:
             - SEMGREP_TOKEN

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -115,18 +115,7 @@ steps:
 
   - label: ":semgrep: Security"
     command:
-      - echo "running in $(pwd)"
-      - export SEMGREP_BRANCH=$BUILDKITE_BRANCH
-      - export SEMGREP_REPO_NAME=chef/automate
-      # Activates links to buildkite builds in slack notification
-      - export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
-      # Activates links to git commits in slack notification
-      - export SEMGREP_REPO_URL=https://github.com/chef/automate
-      - export BASELINE=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-      - \[ "$BUILDKITE_BRANCH" != "master" \] && \[ -n "\$BASELINE" \] && echo "PR build on '$BUILDKITE_BRANCH' branch; base is '\$BASELINE'"
-      - \[ "$BUILDKITE_BRANCH" != "master" \] && \[ -z "\$BASELINE" \] && echo "manual build on '$BUILDKITE_BRANCH' branch; using master as base" && BASELINE=master
-      - \[ "$BUILDKITE_BRANCH" == "master" \] && echo "build on master; using 'master~1' as base branch" && BASELINE=master~1
-      - python -m semgrep_agent --publish-token "\$SEMGREP_TOKEN" --publish-deployment \$SEMGREP_ID --baseline-ref \$BASELINE
+      - .expeditor/buildkite/semgrep.sh "$BUILDKITE_BRANCH" "$BUILDKITE_BUILD_URL" "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
     timeout_in_minutes: 15
     expeditor:
       secrets: true

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -115,7 +115,7 @@ steps:
 
   - label: ":semgrep: Security"
     command:
-      - .expeditor/buildkite/semgrep.sh "$BUILDKITE_BRANCH" "$BUILDKITE_BUILD_URL" "$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+      - .expeditor/buildkite/semgrep.sh
     timeout_in_minutes: 15
     expeditor:
       secrets: true
@@ -126,7 +126,7 @@ steps:
             - .expeditor/export_semgrep_token.sh
       - docker#v3.7.0:
           image: returntocorp/semgrep-agent:v1
-          propogate-environment: true
+          propagate-environment: true
           workdir: /go/src/github.com/chef/automate
           environment:
             - SEMGREP_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ revendor: ## revendor dependencies in protovendor/ and update .bldr.toml with de
 	@scripts/revendor.sh
 
 semgrep: ## runs differential semgrep, checking only changes in the current PR, just as is done in Buildkite
-	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS) --baseline-ref master; fi
+	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS) --baseline-ref  $(shell git merge-base master head); fi
 
 semgrep-all: ## runs full semgrep but filters out the insignificant issues reported by semgrep-legacy; this is what runs nightly in Buildkite
 	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_NIGHTLY_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS); fi


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Two days ago semgrep reported a finding (via slack notification) for 2 different PRs regarding an error in the same file (components/automate-deployment/pkg/server/reconfigure_handler.go). Since semgrep runs in differential mode--scanning files only in the current PR--this was quite surprising, because that file was touched in neither of those PRs!

The finding was this:
```
chef/automate – 1 new issues
4d668b0 Use search query interface
err-todo from dgryski.semgrep-go
– components/automate-deployment/pkg/server/reconfigure_handler.go:33
Scanned yesterday at 7:53 PM
```
The finding would be perfectly valid if that file was included in the PR but, as I said, it was not. What made that more peculiar was that if I were to run a full (non-differential) scan, that particular rule will report findings on about a dozen files, not just that one file. 

So what was unique about that file? It turns out that that file had been touched on master AFTER the PRs in question had split off of master. (Ironically, that file had been _deleted_ on master, so semgrep was actually reporting a finding on a file that no longer existed!)

So what was actually the problem?
The differential scan was comparing the tip of the current branch to the tip of master, rather than comparing the tip of the current branch to the point where it split off of master (the _merge base_ point). Thus, from the point of view of the PR, that deleted file had actually been _added_, which is why it was scanned and reported by semgrep.

This PR, then, changes the differential scan to compare the tip of the current branch to the _merge base_ point.

### :chains: Related Resources
#4597

### :+1: Definition of Done
Semgrep only reports findings in files that are actually in the current PR rather than including findings from files that have been merged to master since the current branch split off of master.

Also, the output logging will display an information line in one of these three formats shown:

BEFORE:
```
# Trigger a build manually:
manual build on 'ms/semgrep-base-adjust' branch; using master as base

# Trigger a build by pushing to an open PR:
PR build on 'ms/semgrep-base-adjust' branch; base is 'master'

# Trigger a build by merging to master:
build on master; using 'master~1' as base branch    
```

AFTER:
```
# Trigger a build manually:
manual build on 'ms/semgrep-base-adjust' branch;
      using merge-base of master as base (22545b9d39d4a575e21e7c738a63076fb178cff6)

# Trigger a build by pushing to an open PR:
PR build on 'ms/semgrep-base-adjust' branch;
      base is 22545b9d39d4a575e21e7c738a63076fb178cff6 (merge-base of 'master')

# Trigger a build by merging to master:
build on master; using 'master~1' as base branch
```

### :athletic_shoe: How to Build and Test the Change
 - Checkout the commit on master (dbd81bd) just before the commit that deleted reconfigure_handler.go (a053722). 
 - Start a new branch there, and copy the files from this PR onto that branch.
 - Push the branch to GitHub.
 - Manually start a new build in Buildkite (https://buildkite.com/chef/chef-automate-master-verify-private/builds/15441#9d6d5456-3f2d-4daf-9d47-3782bd1d17d5)
 - Observe that the semgrep task completes successfully. 

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA