### PR TITLE
Fix workflow build

### DIFF
--- a/components/automate-workflow-server/rebar.config
+++ b/components/automate-workflow-server/rebar.config
@@ -94,8 +94,9 @@
         {eunit_sugar, ".*",
          {git, "https://github.com/xenolinguist/eunit_sugar", {branch, "master"}}},
 
+	%% The latest versions of parse_trans no longer work erlang 18
         {parse_trans, ".*",
-         {git, "https://github.com/uwiger/parse_trans.git", {branch, "master"}}},
+         {git, "https://github.com/uwiger/parse_trans.git", {tag, "3.3.1"}}},
 
         {eunit_formatters, ".*",
          {git, "https://github.com/seancribbs/eunit_formatters.git", {branch, "master"}}},


### PR DESCRIPTION
Looks like erlang 18 is no longer supported by parse_trans since
https://github.com/uwiger/parse_trans/commit/91f02431e0205df21c2cbfa2de5881b522ef3ff5