### PR TITLE
Remove advice to call CS

### DIFF
--- a/components/docs-chef-io/content/automate/data_lifecycle.md
+++ b/components/docs-chef-io/content/automate/data_lifecycle.md
@@ -16,13 +16,6 @@ Data Lifecycle manages the retention of events, service groups, Chef Infra Clien
 Chef Automate stores data from the ingest-service,event-feed-service, compliance-service and applications-service in Elasticsearch or PostgreSQL.
 Over time, you may wish to remove that data from Chef Automate by using the data lifecycle settings.
 
-{{% warning %}}
-Note: Chef Automate data retention processes changed in 20191129172405.
-The [upgrade documentation]({{< ref "install/#upgrades" >}}) covers configuring your system to install new Chef Automate versions.
-For guidance, contact your customer support agent.
-You can also use the [previous data retention documentation](https://github.com/chef/automate/blob/20191104205453/components/automate-chef-io/content/docs/configuration.md#data-retention) for help with configuring data retention on older Chef Automate installations.
-{{% /warning %}}
-
 ## Data Lifecycle UI
 
 Navigate to _Settings_ > _Data Lifecycle_ and adjust any settings you would like to change. After making changes, use the **Save Changes** button to apply your changes.

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -133,11 +133,8 @@ and retry opening Chef Automate in your browser.
 
 ### Configuring External Data Stores
 
-You can configure Chef Automate to use PostgreSQL and Elasticsearch clusters that are not
-deployed via Chef Automate itself. The directions provided below are intended for use only
-during initial deployment of Chef Automate. Please reach out to a Customer Support or
-Customer Success representative for assistance with migrating from a standalone
-installation of Chef Automate to one using externally-deployed data stores.
+You can configure Chef Automate to use PostgreSQL and Elasticsearch clusters that are not deployed via Chef Automate itself.
+The directions provided below are intended for use only during initial deployment of Chef Automate.
 
 #### Configuring External Elasticsearch
 


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

We fixed a few issues that used to be tricky. This PR removes advice to contact customer support from the Automate docs, except for in the doc about migrating from A1 to A2.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
