### PR TITLE
[nginx] data-collector and compliance if configured should forward to the automate instance instead of localhost

### DIFF
--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -87,6 +87,7 @@
     location ~ "^/organizations/([^/]+)/data-collector$" {
       set $request_org $1;
       access_by_lua_block { validator.validate("POST") }
+      proxy_set_header Host $proxy_host;
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
       rewrite ^ /data-collector/v0/ break;
@@ -113,6 +114,7 @@
     location ~ (?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) {
       set $request_org $1;
       access_by_lua_block { validator.validate("GET") }
+      proxy_set_header Host $proxy_host;
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
       rewrite ^(?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) /api/v0/compliance/profiles/$2$3 break;


### PR DESCRIPTION
resolves: https://github.com/chef/chef-server/issues/1862

Co-authored-by: Jay Mundrawala <jmundrawala@chef.io>
Signed-off-by: Prajakta Purohit <prajakta@chef.io>