### PR TITLE
Notifications Rewrite: Service Stub

### DIFF
--- a/components/notifications-service2/.gitignore
+++ b/components/notifications-service2/.gitignore
@@ -1,0 +1,1 @@
+cmd/notifications-service/notifications-service

--- a/components/notifications-service2/cmd/notifications-service/commands/root.go
+++ b/components/notifications-service2/cmd/notifications-service/commands/root.go
@@ -16,8 +16,6 @@ func RootCmd() *cobra.Command {
 	return r
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := RootCmd().Execute(); err != nil {
 		log.Error(err)

--- a/components/notifications-service2/cmd/notifications-service/commands/root.go
+++ b/components/notifications-service2/cmd/notifications-service/commands/root.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func RootCmd() *cobra.Command {
+	r := &cobra.Command{
+		Use:   "applications-service",
+		Short: "Chef Automate Applications Service",
+	}
+	r.AddCommand(newServeCommand())
+	return r
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd().Execute(); err != nil {
+		log.Error(err)
+		os.Exit(-1)
+	}
+}

--- a/components/notifications-service2/cmd/notifications-service/commands/serve.go
+++ b/components/notifications-service2/cmd/notifications-service/commands/serve.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/chef/automate/components/automate-deployment/pkg/toml"
+	"github.com/chef/automate/components/notifications-service2/pkg/config"
 	"github.com/spf13/cobra"
 )
 
@@ -29,17 +31,15 @@ func newServeCommand() *cobra.Command {
 }
 
 func runServeCommand(cmd *cobra.Command, args []string) error {
+	c, err := config.FromFile(serveCmdFlags.configFile)
+	if err != nil {
+		return err
+	}
 	for {
 		fmt.Println("hello from notifications-service2")
+		s, _ := toml.Marshal(c)
+		fmt.Println(string(s))
 		time.Sleep(5 * time.Second)
 	}
-	// Tasks:
-	// - implement config. parse the toml file
-	// - load our service certs
-	// - connect to postgres
-	// - migrate database to be identical to elixir version, but use the golang migrator.
-	//   - fresh install case
-	//   - upgrade case
-	// - start the gRPC server
 	return nil
 }

--- a/components/notifications-service2/cmd/notifications-service/commands/serve.go
+++ b/components/notifications-service2/cmd/notifications-service/commands/serve.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type serveCmdFlagSet struct {
+	configFile string
+}
+
+var serveCmdFlags serveCmdFlagSet
+
+func newServeCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "serve",
+		Short: "Run notifications-service server",
+		RunE:  runServeCommand,
+	}
+	c.PersistentFlags().StringVar(
+		&serveCmdFlags.configFile,
+		"config",
+		"",
+		"path to config file",
+	)
+	return c
+}
+
+func runServeCommand(cmd *cobra.Command, args []string) error {
+	for {
+		fmt.Println("hello from notifications-service2")
+		time.Sleep(5 * time.Second)
+	}
+	// Tasks:
+	// - implement config. parse the toml file
+	// - load our service certs
+	// - connect to postgres
+	// - migrate database to be identical to elixir version, but use the golang migrator.
+	//   - fresh install case
+	//   - upgrade case
+	// - start the gRPC server
+	return nil
+}

--- a/components/notifications-service2/cmd/notifications-service/notifications-service.go
+++ b/components/notifications-service2/cmd/notifications-service/notifications-service.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/chef/automate/components/notifications-service2/cmd/notifications-service/commands"
+
+func main() {
+	commands.Execute()
+}

--- a/components/notifications-service2/habitat/config/config.toml
+++ b/components/notifications-service2/habitat/config/config.toml
@@ -4,10 +4,6 @@ port = {{cfg.service.port}}
 external_fqdn = "{{cfg.service.external_fqdn}}"
 log_level = "{{cfg.log.level}}"
 
-## TODO: is this needed?
-# export CACHE_TIMEOUT_MS_EVENT_RULE="{{cfg.cache.event_rule_timeout_ms}}"
-# export EVENT_DEDUP_WINDOW_SECONDS="{{cfg.service.dedup_window_seconds}}"
-
 [postgres]
 database = "{{cfg.storage.database}}"
 schema_path = "{{pkg.path}}/schema"

--- a/components/notifications-service2/habitat/config/config.toml
+++ b/components/notifications-service2/habitat/config/config.toml
@@ -1,6 +1,8 @@
 [service]
-external_fqdn = "{{cfg.service.external_fqdn}}"
+host = "127.0.0.1"
 port = {{cfg.service.port}}
+external_fqdn = "{{cfg.service.external_fqdn}}"
+log_level = "{{cfg.log.level}}"
 
 ## TODO: is this needed?
 # export CACHE_TIMEOUT_MS_EVENT_RULE="{{cfg.cache.event_rule_timeout_ms}}"

--- a/components/notifications-service2/habitat/config/config.toml
+++ b/components/notifications-service2/habitat/config/config.toml
@@ -1,0 +1,28 @@
+[service]
+external_fqdn = "{{cfg.service.external_fqdn}}"
+port = {{cfg.service.port}}
+
+## TODO: is this needed?
+# export CACHE_TIMEOUT_MS_EVENT_RULE="{{cfg.cache.event_rule_timeout_ms}}"
+# export EVENT_DEDUP_WINDOW_SECONDS="{{cfg.service.dedup_window_seconds}}"
+
+[postgres]
+database = "{{cfg.storage.database}}"
+schema_path = "{{pkg.path}}/schema"
+max_open_conns = {{cfg.storage.max_open_conns}}
+max_idle_conns = {{cfg.storage.max_idle_conns}}
+
+[secrets]
+{{~#eachAlive bind.secrets-service.members as |secrets|}}
+  {{~#if @last}}
+host = "{{secrets.cfg.host}}"
+port = "{{secrets.cfg.port}}"
+  {{~/if}}
+{{~/eachAlive}}
+
+
+[tls]
+cert_path = "{{pkg.svc_config_path}}/service.crt"
+key_path = "{{pkg.svc_config_path}}/service.key"
+root_ca_path ="{{pkg.svc_config_path}}/root_ca.crt"
+

--- a/components/notifications-service2/habitat/config/init_proxy
+++ b/components/notifications-service2/habitat/config/init_proxy
@@ -1,0 +1,9 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+exec 2>&1
+
+{{ #if cfg.proxy.connection_string ~}}
+export https_proxy="{{cfg.proxy.connection_string}}"
+export http_proxy="{{cfg.proxy.connection_string}}"
+export no_proxy="{{cfg.proxy.no_proxy_string}}"
+{{ /if ~ }}

--- a/components/notifications-service2/habitat/default.toml
+++ b/components/notifications-service2/habitat/default.toml
@@ -1,0 +1,17 @@
+[mlsa]
+accept = false
+
+[service]
+external_fqdn="http://localhost"
+host = "localhost"
+port = 4001
+
+# How long in seconds must pass before we consider
+# an inbound event with the same id and type as not a duplicate
+dedup_window_seconds = 300
+
+[storage]
+user = "notifications"
+
+[cache]
+event_rule_timeout_ms = 5000

--- a/components/notifications-service2/habitat/default.toml
+++ b/components/notifications-service2/habitat/default.toml
@@ -4,17 +4,10 @@ accept = false
 [service]
 external_fqdn="http://localhost"
 host = "localhost"
-port = 4001
-
-# How long in seconds must pass before we consider
-# an inbound event with the same id and type as not a duplicate
-dedup_window_seconds = 300
+port = 10125
 
 [storage]
 database = "notifications_service"
 max_open_conns = 10
 max_idle_conns = 10
 
-
-[cache]
-event_rule_timeout_ms = 5000

--- a/components/notifications-service2/habitat/default.toml
+++ b/components/notifications-service2/habitat/default.toml
@@ -11,7 +11,10 @@ port = 4001
 dedup_window_seconds = 300
 
 [storage]
-user = "notifications"
+database = "notifications_service"
+max_open_conns = 10
+max_idle_conns = 10
+
 
 [cache]
 event_rule_timeout_ms = 5000

--- a/components/notifications-service2/habitat/hooks/init
+++ b/components/notifications-service2/habitat/hooks/init
@@ -1,0 +1,11 @@
+# *** WARNING ***
+# Please put potentially long-running and/or complex operations in the run hook rather
+# than the init hook until the issue described in
+#
+# https://github.com/habitat-sh/habitat/issues/1973
+#
+# has been resolved.
+# Currently, the Habitat `init` and `health_check` hooks run directly from the main loop
+# of the Habitat supervisor. If these hooks hang or take too long to run, they can block
+# execution of the supervisor.
+#

--- a/components/notifications-service2/habitat/hooks/run
+++ b/components/notifications-service2/habitat/hooks/run
@@ -1,0 +1,15 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+set -e
+
+exec 2>&1
+
+# Call the script to block until user accepts the MLSA via the package's config
+{{pkgPathFor "chef/mlsa"}}/bin/accept {{cfg.mlsa.accept}}
+
+pg-helper ensure-service-database "notifications_service"
+pg-helper create-extension "notifications_service" "pgcrypto"
+
+source {{pkg.svc_config_path}}/init_proxy
+
+exec "notifications-service" "serve" "--config" "{{pkg.svc_config_path}}/config.toml"

--- a/components/notifications-service2/habitat/plan.sh
+++ b/components/notifications-service2/habitat/plan.sh
@@ -29,21 +29,6 @@ pkg_binds=(
 pkg_bin_dirs=(bin)
 pkg_lib_dirs=(lib)
 
-# The service files and directories
-# NOTE: this has nothing to do with habitat. It is used for
-#       determining when a build is stale in the studiorc
-pkg_srcs=(
-  server/lib
-  server/priv
-  server/rel
-  server/config.exs
-  server/Makefile
-  server/mix.exs
-  server/mix.lock
-
-  # TODO: VERSION should be in this list
-)
-
 pkg_scaffolding="${local_scaffolding_origin:-chef}/automate-scaffolding-go"
 scaffolding_go_base_path=github.com/chef
 scaffolding_go_repo_name=automate
@@ -55,10 +40,10 @@ scaffolding_go_binary_list=(
   "${scaffolding_go_import_path}/cmd/${pkg_name}"
 )
 
-## . scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_name}/components/${pkg_name}"
-## . scaffolding_go_binary_list=(
-## .   "${scaffolding_go_import_path}/cmd/${pkg_name}"
-## . )
+##  scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_name}/components/${pkg_name}"
+##  scaffolding_go_binary_list=(
+##    "${scaffolding_go_import_path}/cmd/${pkg_name}"
+##  )
 
 do_install() {
   do_default_install
@@ -71,5 +56,4 @@ do_install() {
 do_strip() {
   return 0
 }
-
 

--- a/components/notifications-service2/habitat/plan.sh
+++ b/components/notifications-service2/habitat/plan.sh
@@ -1,0 +1,75 @@
+# NOTE/TODO: remove this when we cut over the packages
+chef_automate_dev_only_pkg=true
+
+pkg_name=notifications-service
+pkg_description="Chef Automate Notifications Service"
+pkg_origin=chef
+pkg_version="2.0.0"
+pkg_maintainer="Chef Software Inc. <support@chef.io>"
+pkg_license=('Chef-MLSA')
+pkg_upstream_url="http://github.com/chef/automate"
+
+
+pkg_deps=(
+  chef/mlsa
+  ${local_platform_tools_origin:-chef}/automate-platform-tools
+)
+
+pkg_exports=(
+  [port]=service.port
+)
+
+pkg_exposes=(port)
+
+pkg_binds=(
+  [automate-pg-gateway]="port"
+  [pg-sidecar-service]="port"
+  [secrets-service]="port"
+)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+# The service files and directories
+# NOTE: this has nothing to do with habitat. It is used for
+#       determining when a build is stale in the studiorc
+pkg_srcs=(
+  server/lib
+  server/priv
+  server/rel
+  server/config.exs
+  server/Makefile
+  server/mix.exs
+  server/mix.lock
+
+  # TODO: VERSION should be in this list
+)
+
+pkg_scaffolding="${local_scaffolding_origin:-chef}/automate-scaffolding-go"
+scaffolding_go_base_path=github.com/chef
+scaffolding_go_repo_name=automate
+
+# NOTE/TODO: This references the temporary name/path components/notifications-service2
+# when we cut over, this needs to be changed to the commented version below
+scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_name}/components/notifications-service2"
+scaffolding_go_binary_list=(
+  "${scaffolding_go_import_path}/cmd/${pkg_name}"
+)
+
+## . scaffolding_go_import_path="${scaffolding_go_base_path}/${scaffolding_go_repo_name}/components/${pkg_name}"
+## . scaffolding_go_binary_list=(
+## .   "${scaffolding_go_import_path}/cmd/${pkg_name}"
+## . )
+
+do_install() {
+  do_default_install
+
+  build_line "Copying schema sql files"
+  mkdir "${pkg_prefix}/schema"
+  cp -r pkg/storage/postgres/schema/sql/* "${pkg_prefix}/schema"
+}
+
+do_strip() {
+  return 0
+}
+
+

--- a/components/notifications-service2/package.meta
+++ b/components/notifications-service2/package.meta
@@ -1,0 +1,4 @@
+{
+  "name": "chef/notifications-service",
+  "uses_platform_scaffolding": true
+}

--- a/components/notifications-service2/pkg/config/service.go
+++ b/components/notifications-service2/pkg/config/service.go
@@ -43,7 +43,7 @@ type Secrets struct {
 // certs), sets derived config and populates global state (e.g., log level,
 // etc.)
 func FromFile(path string) (*Notifications, error) {
-	n, err := marshalFromFile(path)
+	n, err := MarshalFromFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func FromFile(path string) (*Notifications, error) {
 	if err := n.SetLogLevel(); err != nil {
 		return nil, err
 	}
-	if err := n.readCerts(); err != nil {
+	if err := n.ReadCerts(); err != nil {
 		return nil, err
 	}
 
 	return n, nil
 }
 
-func marshalFromFile(path string) (*Notifications, error) {
+func MarshalFromFile(path string) (*Notifications, error) {
 	viper.SetConfigFile(path)
 
 	err := viper.ReadInConfig()
@@ -94,7 +94,7 @@ func (n *Notifications) SetLogLevel() error {
 	return n.Service.SetLogLevel()
 }
 
-func (n *Notifications) readCerts() error {
+func (n *Notifications) ReadCerts() error {
 	certs, err := n.TLSConfig.ReadCerts()
 	if err != nil {
 		return err

--- a/components/notifications-service2/pkg/config/service.go
+++ b/components/notifications-service2/pkg/config/service.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	platform_config "github.com/chef/automate/lib/platform/config"
+	"github.com/chef/automate/lib/tls/certs"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+const DefaultLogLevel = "info"
+
+type Notifications struct {
+	Service   *Service            `mapstructure:"service" toml:"service"`
+	Postgres  *Postgres           `mapstructure:"postgres" toml:"postgres"`
+	Secrets   *Secrets            `mapstructure:"secrets" toml:"secrets"`
+	TLSConfig *certs.TLSConfig    `mapstructure:"tls" toml:"tls"`
+	Certs     *certs.ServiceCerts `mapstructure:"-" toml:"-"`
+}
+
+type Service struct {
+	ExternalFQDN string `mapstructure:"external_fqdn" toml:"external_fqdn"`
+	Host         string `mapstructure:"host" toml:"host"`
+	Port         int    `mapstructure:"port" toml:"port"`
+	LogLevel     string `mapstructure:"log_level" toml:"log_level"`
+}
+
+type Postgres struct {
+	URI          string `mapstructure:"uri" toml:"uri"`
+	Database     string `mapstructure:"database" toml:"database"`
+	SchemaPath   string `mapstructure:"schema_path" toml:"schema_path"`
+	MaxOpenConns int    `mapstructure:"max_open_conns" toml:"max_open_conns"`
+	MaxIdleConns int    `mapstructure:"max_idle_conns" toml:"max_idle_conns"`
+}
+
+type Secrets struct {
+	Host string `mapstructure:"host" toml:"host"`
+	Port int    `mapstructure:"port" toml:"port"`
+}
+
+// FromFile loads the config from the given path, load referenced files (e.g.,
+// certs), sets derived config and populates global state (e.g., log level,
+// etc.)
+func FromFile(path string) (*Notifications, error) {
+	n, err := marshalFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := n.FixupPGURI(); err != nil {
+		return nil, err
+	}
+	if err := n.SetLogLevel(); err != nil {
+		return nil, err
+	}
+	if err := n.readCerts(); err != nil {
+		return nil, err
+	}
+
+	return n, nil
+}
+
+func marshalFromFile(path string) (*Notifications, error) {
+	viper.SetConfigFile(path)
+
+	err := viper.ReadInConfig()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read config file at path %q", path)
+	}
+
+	log.WithFields(log.Fields{"file": viper.ConfigFileUsed()}).Info("Using config file")
+
+	n := &Notifications{}
+	if err := viper.Unmarshal(n); err != nil {
+		return nil, errors.Wrapf(err, "could not parse config file at path %q", path)
+	}
+
+	return n, nil
+}
+
+func (n *Notifications) FixupPGURI() error {
+	if n.Postgres.URI != "" {
+		return nil
+	}
+	pgURI, err := platform_config.PGURIFromEnvironment(n.Postgres.Database)
+	if err != nil {
+		return errors.Wrapf(err, "PGURIFromEnvironment failed for database %q", n.Postgres.Database)
+	}
+	n.Postgres.URI = pgURI
+	return nil
+}
+
+func (n *Notifications) SetLogLevel() error {
+	return n.Service.SetLogLevel()
+}
+
+func (n *Notifications) readCerts() error {
+	certs, err := n.TLSConfig.ReadCerts()
+	if err != nil {
+		return err
+	}
+	n.Certs = certs
+	return nil
+}
+
+func (s *Service) SetLogLevel() error {
+	desiredLevelStr := s.LogLevel
+	if desiredLevelStr == "" {
+		desiredLevelStr = DefaultLogLevel
+	}
+
+	desiredLevel, err := log.ParseLevel(desiredLevelStr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse log level string %q", desiredLevel)
+	}
+
+	log.SetLevel(desiredLevel)
+	return nil
+}

--- a/components/notifications-service2/pkg/config/service_test.go
+++ b/components/notifications-service2/pkg/config/service_test.go
@@ -49,7 +49,7 @@ func TestConfigMarshaling(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	unmarshaled, err := marshalFromFile(f.Name())
+	unmarshaled, err := MarshalFromFile(f.Name())
 	require.NoError(t, err)
 	assert.Equal(t, original, unmarshaled)
 }
@@ -96,7 +96,7 @@ func TestConfigReadCerts(t *testing.T) {
 			RootCACertPath: "/src/dev/certs/Chef_Automate_FAKE_Dev.crt",
 		},
 	}
-	err := nValid.readCerts()
+	err := nValid.ReadCerts()
 	require.NoError(t, err)
 
 }

--- a/components/notifications-service2/pkg/config/service_test.go
+++ b/components/notifications-service2/pkg/config/service_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/chef/automate/components/automate-deployment/pkg/toml"
+	"github.com/chef/automate/lib/tls/certs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigMarshaling(t *testing.T) {
+	original := &Notifications{
+		Service: &Service{
+			ExternalFQDN: "automate-fe.example",
+			Host:         "localhost",
+			Port:         1234,
+			LogLevel:     "debug",
+		},
+		Postgres: &Postgres{
+			URI:          "postgresql://notifications@127.0.0.1:10145/notifications_service?opts=vals",
+			Database:     "notifications_service",
+			SchemaPath:   "/hab/pkgs/example/notifications-service/2.0.0/20210204232203/schema",
+			MaxOpenConns: 15,
+			MaxIdleConns: 17,
+		},
+		Secrets: &Secrets{
+			Host: "secrets.example",
+			Port: 4567,
+		},
+		TLSConfig: &certs.TLSConfig{
+			CertPath:       "/hab/svc/notifications-service/config/service.crt",
+			KeyPath:        "/hab/svc/notifications-service/config/service.key",
+			RootCACertPath: "/hab/svc/notifications-service/config/root_ca.crt",
+		},
+	}
+	configBytes, err := toml.Marshal(original)
+	require.NoError(t, err)
+
+	f, err := ioutil.TempFile("", "notifications_service_config_test*.toml")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.Write(configBytes)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+
+	unmarshaled, err := marshalFromFile(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, original, unmarshaled)
+}
+
+func TestConfigLogLevel(t *testing.T) {
+	levelBeforeTest := log.GetLevel()
+	defer log.SetLevel(levelBeforeTest)
+
+	validLogLevels := []string{
+		"trace",
+		"debug",
+		"info",
+		"error",
+		"warning",
+		"fatal",
+		"panic",
+	}
+	for _, levelToSet := range validLogLevels {
+		n := &Notifications{
+			Service: &Service{
+				LogLevel: levelToSet,
+			},
+		}
+		err := n.SetLogLevel()
+		require.NoError(t, err)
+		assert.Equal(t, levelToSet, log.GetLevel().String())
+	}
+
+	nInvalid := &Notifications{
+		Service: &Service{
+			LogLevel: "bork",
+		},
+	}
+
+	err := nInvalid.SetLogLevel()
+	require.Error(t, err)
+}
+
+func TestConfigReadCerts(t *testing.T) {
+	nValid := &Notifications{
+		TLSConfig: &certs.TLSConfig{
+			CertPath:       "/src/dev/certs/notifications-service.crt",
+			KeyPath:        "/src/dev/certs/notifications-service.key",
+			RootCACertPath: "/src/dev/certs/Chef_Automate_FAKE_Dev.crt",
+		},
+	}
+	err := nValid.readCerts()
+	require.NoError(t, err)
+
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We are rewriting the notifications service in go to align better with our engineering capabilities.

This change creates a `notifications-service2` component in the source tree. It can be compiled and packaged manually, but is hidden from pipeline builds using the `dev_only` option in the habitat `plan.sh` (the `automate-ui-devproxy` uses the same mechanism).

The `notifications-service2` is missing most of the functionality that it will eventually have/need. Currently it only implements configuration file loading. When run as a service it prints its config to the logs in a loop. This is a first step towards implementing the infrastructural components of the new notifications service.

### :athletic_shoe: How to Build and Test the Change

In a fresh habitat studio, `start_all_services`. Then run `build components/notifications-service2/ && sl`. The service should build without error and then get picked up by the deployment service. In the log output you will see the running configuration for the service.

The unit tests for the config package can be run by `cd /src/components/notifications-service2` and `go test -v pkg/config/*go`
