### PR TITLE
add metadata to every page in docs.chef.io/automate

### DIFF
--- a/components/docs-chef-io/content/automate/_index.md
+++ b/components/docs-chef-io/content/automate/_index.md
@@ -1,10 +1,11 @@
 +++
 title = "Quick Start Demo"
-
 weight = 10
 draft = false
-
 gh_repo = "automate"
+
+[cascade]
+  product = ["automate"]
 
 [menu]
   [menu.automate]


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

This adds product metadata to every page in docs.chef.io/automate/

We can use the [cascade parameter](https://gohugo.io/content-management/front-matter#front-matter-cascade) key in `content/automate/_index.md` to add a product value to every page docs.chef.io/automate/ so we can facet search results by that product

chef/chef-web-docs#2878

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
