### PR TITLE
Added UI improvements for server and org list.

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -99,10 +99,10 @@
           <chef-table>
             <chef-thead>
               <chef-tr>
-                <chef-th>Name</chef-th>
-                <chef-th>Admin</chef-th>
-                <chef-th>Projects</chef-th>
-                <chef-th class="three-dot-column"></chef-th>
+                <chef-th  class="no_border_th">Name</chef-th>
+                <chef-th class="no_border_th">Admin</chef-th>
+                <chef-th class="no_border_th">Projects</chef-th>
+                <chef-th class="three-dot-column no_border_th"></chef-th>
               </chef-tr>
             </chef-thead>
             <chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -99,10 +99,10 @@
           <chef-table>
             <chef-thead>
               <chef-tr>
-                <chef-th  class="no_border_th">Name</chef-th>
-                <chef-th class="no_border_th">Admin</chef-th>
-                <chef-th class="no_border_th">Projects</chef-th>
-                <chef-th class="three-dot-column no_border_th"></chef-th>
+                <chef-th  class="no-border-th">Name</chef-th>
+                <chef-th class="no-border-th">Admin</chef-th>
+                <chef-th class="no-border-th">Projects</chef-th>
+                <chef-th class="three-dot-column no-border-th"></chef-th>
               </chef-tr>
             </chef-thead>
             <chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -24,7 +24,7 @@ chef-toolbar {
     float: right;
     width: 150px;
     height: 36px;
-    top: 268px; 
+    top: 268px;
     background: #3864F2;
     border-radius: 4px;
   }
@@ -142,12 +142,10 @@ chef-table {
     text-decoration: underline;
   }
 
-  .no_border_th
- {
-  border: none;
-  font-size: 12px;
-  //border-left: none;
-}
+  .no_border_th {
+    border: none;
+    font-size: 12px;
+  }
 }
 
 chef-loading-spinner {

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -15,13 +15,45 @@ chef-toolbar {
     position: absolute;
     right: 0;
   }
+
+  chef-button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px 16px;
+    float: right;
+    width: 150px;
+    height: 36px;
+    top: 268px; 
+    background: #3864F2;
+    border-radius: 4px;
+  }
 }
 
 chef-tab-selector {
   chef-option {
-    margin-right: 16px;
+    margin-right: 4px;
     color: $chef-primary-dark;
   }
+
+  ::ng-deep .selected {
+    background-color: #F3F6F8;
+  }
+
+  ::ng-deep .selected::before {
+    height: 4px;
+    background-color: #3864F2;
+  }
+
+  chef-option:focus {
+    outline: none;
+  }
+
+  ::ng-deep chef-option::before {
+    height: 4px;
+    background-color: #E7E9E9;
+  }
+
 }
 
 form {
@@ -109,6 +141,13 @@ chef-table {
     cursor: pointer;
     text-decoration: underline;
   }
+
+  .no_border_th
+ {
+  border: none;
+  font-size: 12px;
+  //border-left: none;
+}
 }
 
 chef-loading-spinner {

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -142,7 +142,7 @@ chef-table {
     text-decoration: underline;
   }
 
-  .no_border_th {
+  .no-border-th {
     border: none;
     font-size: 12px;
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -22,9 +22,6 @@ chef-toolbar {
     align-items: center;
     padding: 8px 16px;
     float: right;
-    width: 150px;
-    height: 36px;
-    top: 268px;
     background: #3864F2;
     border-radius: 4px;
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -36,11 +36,11 @@
         <chef-table>
           <chef-thead>
             <chef-tr>
-              <chef-th  class="no_border_th">Name</chef-th>
-              <chef-th class="no_border_th">FQDN</chef-th>
-              <chef-th class="no_border_th">IP Address</chef-th>
-              <chef-th class="no_border_th">No Of Orgs</chef-th>
-              <chef-th class="three-dot-column  no_border_th"></chef-th>
+              <chef-th  class="no-border-th">Name</chef-th>
+              <chef-th class="no-border-th">FQDN</chef-th>
+              <chef-th class="no-border-th">IP Address</chef-th>
+              <chef-th class="no-border-th">No Of Orgs</chef-th>
+              <chef-th class="three-dot-column  no-border-th"></chef-th>
             </chef-tr>
           </chef-thead>
           <chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.html
@@ -36,11 +36,11 @@
         <chef-table>
           <chef-thead>
             <chef-tr>
-              <chef-th>Name</chef-th>
-              <chef-th>FQDN</chef-th>
-              <chef-th>IP Address</chef-th>
-              <chef-th>No Of Orgs</chef-th>
-              <chef-th class="three-dot-column"></chef-th>
+              <chef-th  class="no_border_th">Name</chef-th>
+              <chef-th class="no_border_th">FQDN</chef-th>
+              <chef-th class="no_border_th">IP Address</chef-th>
+              <chef-th class="no_border_th">No Of Orgs</chef-th>
+              <chef-th class="three-dot-column  no_border_th"></chef-th>
             </chef-tr>
           </chef-thead>
           <chef-tbody>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
@@ -1,0 +1,25 @@
+@import "~styles/variables";
+
+chef-table {
+
+  .no_border_th {
+    border: none;
+    font-size: 12px;
+  }
+}
+chef-toolbar {
+
+  chef-button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 8px 16px;
+    float: right;
+    width: 150px;
+    height: 36px;
+    top: 268px; 
+    background: #3864F2;
+    border-radius: 4px;
+  }
+
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
@@ -2,7 +2,7 @@
 
 chef-table {
 
-  .no_border_th {
+  .no-border-th {
     border: none;
     font-size: 12px;
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.scss
@@ -7,6 +7,7 @@ chef-table {
     font-size: 12px;
   }
 }
+
 chef-toolbar {
 
   chef-button {
@@ -17,7 +18,7 @@ chef-toolbar {
     float: right;
     width: 150px;
     height: 36px;
-    top: 268px; 
+    top: 268px;
     background: #3864F2;
     border-radius: 4px;
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -19,7 +19,8 @@ import { ChefSorters } from 'app/helpers/auth/sorter';
 
 @Component({
   selector: 'app-chef-servers-list',
-  templateUrl: './chef-servers-list.component.html'
+  templateUrl: './chef-servers-list.component.html',
+  styleUrls: ['./chef-servers-list.component.scss']
 })
 export class ChefServersListComponent implements OnInit, OnDestroy {
   public loading$: Observable<boolean>;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
new UI for the Server and Orgs list pages for read-only views 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#4713 
### :+1: Definition of Done
1. Removed the border of the Server and org List Table.
2. Added the background colour for Active option.
3. Increased the height of the selected Active Blue Line.
4. Aligned Create Buttons to Right of Server and org.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
![orgTab](https://user-images.githubusercontent.com/61003053/107629609-645b7700-6c88-11eb-9a9a-b4703aeccf76.png)
![serverTab](https://user-images.githubusercontent.com/61003053/107629613-658ca400-6c88-11eb-93fd-6011f4bef4e8.png)
