### PR TITLE
Add convenience target for semgrep

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -32,3 +32,4 @@ coverage/
 *.pb.*.go
 *.bindata.go
 *.spec.ts
+modernizr-custom.js

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,12 @@ semgrep-all: ## runs full semgrep but filters out the insignificant issues repor
 
 semgrep-legacy: ## runs full semgrep including findings for existing issues that are not significant
 	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS); fi
+
+
+# For exploring new rulesets before integrating with CI.
+# For convenience, this uses all the ignores from Makefile.common_go and automate-ui/Makefile.
+# Ruleset choices come from https://semgrep.dev/explore.
+# Example: `make semgrep-test/rc2-bug-scan`
+SEMGREP_IGNORE := --exclude third_party --exclude *_test.go --exclude *.pb.go --exclude *.pb.*.go --exclude *.bindata.go --exclude *.spec.ts --exclude coverage --exclude modernizr-custom.js
+semgrep-test/%:
+	semgrep --config "p/$(@F)" $(SEMGREP_IGNORE)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ revendor: ## revendor dependencies in protovendor/ and update .bldr.toml with de
 	@scripts/revendor.sh
 
 semgrep: ## runs differential semgrep, checking only changes in the current PR, just as is done in Buildkite
-	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS) --baseline-ref  $(shell git merge-base master head); fi
+	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS) --baseline-ref  $(shell git merge-base master HEAD); fi
 
 semgrep-all: ## runs full semgrep but filters out the insignificant issues reported by semgrep-legacy; this is what runs nightly in Buildkite
 	@if [[ -z "${SEMGREP_TOKEN}" || -z "${SEMGREP_ID}" ]]; then echo $(SEMGREP_MSG); else docker run -it --rm --init $(DOCKER_PARAMS) $(SEMGREP_NIGHTLY_REPO) $(SEMGREP_CONTAINER) python $(SEMGREP_COMMON_PARAMS); fi

--- a/components/automate-ui/Makefile
+++ b/components/automate-ui/Makefile
@@ -11,7 +11,7 @@ NG_CMD := npm run ng --
 REPOROOT=../..
 
 # Semgrep by default respects .gitignore; these are additive:
-SEMGREP_IGNORE := --exclude *.spec.ts --exclude coverage
+SEMGREP_IGNORE := --exclude *.spec.ts --exclude coverage --exclude modernizr-custom.js
 SEMGREP_CONFIG := https://semgrep.dev/p/r2c-ci
 
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add convenience target for semgrep for exploring new rulesets before integrating with CI. Ruleset choices come from https://semgrep.dev/explore. 

Usage is:
```
make semgrep-test/<ruleset-name>
```

Example:
```
make semgrep-test/rc2-bug-scan
```

### :chains: Related Resources

### :+1: Definition of Done
Can run `make semgrep-test/<ruleset-name>` from the repo root.

### :athletic_shoe: How to Build and Test the Change
Can run `make semgrep-test/rc2-bug-scan` (or any other ruleset) from the Automate repo root.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA