### PR TITLE
PG: Ignore comments on extensions when restoring

### DIFF
--- a/lib/platform/pg/exporter.go
+++ b/lib/platform/pg/exporter.go
@@ -295,7 +295,7 @@ func (db DatabaseExporter) buildSQLTOC(pgBackupFile string, filters []string) (f
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
 			txt := scanner.Text()
-			if !isIncompatibleTOCLine(txt) {
+			if !IsIncompatibleTOCLine(txt) {
 				_, err := fmt.Fprintln(pgListFile, txt)
 				if err != nil {
 					errChan <- err
@@ -340,7 +340,7 @@ func (db DatabaseExporter) buildSQLTOC(pgBackupFile string, filters []string) (f
 //
 // If using the habitat dev studio, you can access the postgresql CLI tools via
 // `hab pkg exec core/postgresql-client COMMAND`
-func isIncompatibleTOCLine(line string) bool {
+func IsIncompatibleTOCLine(line string) bool {
 	// I think this refers to a TOC line like this:
 	//   4; 2615 2200 SCHEMA - public automate
 	if strings.Contains(line, "2615 2200") {

--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -338,4 +338,39 @@ func TestImport(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("it filters items from the TOC that cannot be imported", func(t *testing.T) {
+		rejectedTOCLines := []string{
+			"4; 2615 2200 SCHEMA - public automate",
+			"2215; 0 0 COMMENT - EXTENSION plpgsql ",
+			"2216; 0 0 COMMENT - EXTENSION pgcrypto ",
+		}
+
+		for _, line := range rejectedTOCLines {
+			assert.True(t, pg.IsIncompatibleTOCLine(line), "line %q should return true for IsIncompatibleTOCLine()", line)
+		}
+
+		acceptedTOCLines := []string{
+			"2213; 1262 17864 DATABASE - notifications_service notifications",
+			"2214; 0 0 COMMENT - SCHEMA public automate",
+			"1; 3079 12415 EXTENSION - plpgsql ",
+			"2; 3079 18164 EXTENSION - pgcrypto ",
+			"600; 1247 21250 TYPE public rule_action notifications",
+			"597; 1247 21238 TYPE public rule_event notifications",
+			"237; 1255 21273 FUNCTION public log_and_clean_event(character varying, public.rule_event, smallint) notifications",
+			"188; 1259 21309 TABLE public processed_events notifications",
+			"187; 1259 21299 TABLE public rules notifications",
+			"186; 1259 21286 TABLE public schema_migrations notifications",
+			"2207; 0 21309 TABLE DATA public processed_events notifications",
+			"2206; 0 21299 TABLE DATA public rules notifications",
+			"2205; 0 21286 TABLE DATA public schema_migrations notifications",
+			"2087; 2606 21314 CONSTRAINT public processed_events processed_events_pkey notifications",
+			"2083; 2606 21308 CONSTRAINT public rules rules_name_key notifications",
+			"2085; 2606 21306 CONSTRAINT public rules rules_pkey notifications",
+			"2081; 2606 21290 CONSTRAINT public schema_migrations schema_migrations_pkey notifications",
+		}
+
+		for _, line := range acceptedTOCLines {
+			assert.False(t, pg.IsIncompatibleTOCLine(line), "line %q should return false for IsIncompatibleTOCLine()", line)
+		}
+	})
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A customer is experiencing errors attempting to restore a postures database using AWS RDS. The pertinent part of the error is like this (there are other errors for other extensions) `could not execute query: ERROR:  must be owner of extension pgcrypto\n    Command was: COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';`.

This error happens because in AWS RDS, the superuser is actually quite limited. If you start an interactive database session manually with an RDS instance, you can see that `COMMENT ON EXTENSION ...` commands won't work.

To fix the restore issue, we want to avoid attempting to restore these comments, as they do not affect functionality. [`pg_dump` version 12.x](https://www.postgresql.org/docs/12/app-pgdump.html) and [`pg_restore` version 12.x](https://www.postgresql.org/docs/12/app-pgrestore.html) support a `--no-comments` filter, but we are on version 9.6.11, which does not have this feature. Instead we must implement similar functionality by analyzing the TOC of the pg dump files and excluding the entries that we wish to ignore.

In the process of adding to it, I was able to extract existing functionality that filters the TOC before restore to a unit-test-able form. It would be ideal to add backup and restore of a system with external data stores to our acceptance procedure or automated pipelines, but that is a more involved effort.

### :chains: Related Resources

https://github.com/chef/customer-bugs/issues/303

### :+1: Definition of Done

Can restore backups to a new database when using AWS RDS.

### :athletic_shoe: How to Build and Test the Change

This one is hard to test! @balkarsinghkang set up a cluster to repro this following the instructions here: https://github.com/chef-cft/chef-examples/blob/master/examples/a2-aws-backends/a2-aws-backends.md Once the cluster is up, create a backup and get the ID of it. Then you need to attempt a restore to a NEW RDS database, using a patch config, something like `chef-automate backup restore BACKUP_URI --patch-config config.toml`. This will fail with the bug we are fixing, with something like this in the logs:

```
Jan 28 17:47:55 ip-10-100-101-111 hab[9622]: deployment-service.default(O): time="2021-01-28T17:47:55Z" level=error msg="Failed to restore synchronous operations" backup_id=20210128174154 error="failed to import database dump from authz-service/pg_data/chef_authz_service.fc: error importing database \"chef_authz_service\": failed to import SQL file from \"stdin\", stderr: pg_restore: [archiver (db)] Error while PROCESSING TOC:\npg_restore: [archiver (db)] Error from TOC entry 3357; 0 0 COMMENT EXTENSION pgcrypto \npg_restore: [archiver (db)] could not execute query: ERROR:  must be owner of extension pgcrypto\n    Command was: COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';\n\n\n\npg_restore: [archiver (db)] Error from TOC entry 3358; 0 0 COMMENT EXTENSION \"uuid-ossp\" \npg_restore: [archiver (db)] could not execute query: ERROR:  must be owner of extension uuid-ossp\n    Command was: COMMENT ON EXTENSION \"uuid-ossp\" IS 'generate universally unique identifiers (UUIDs)';\n\n\n\nWARNING: errors ignored on restore: 2\n: exit status 1" restore_id=20210128174459
Jan 28 17:47:55 ip-10-100-101-111 hab[9622]: deployment-service.default(O): time="2021-01-28T17:47:55Z" level=error msg="Failed to restore services" backup_id=20210128174154 error="failed to import database dump from authz-service/pg_data/chef_authz_service.fc: error importing database \"chef_authz_service\": failed to import SQL file from \"stdin\", stderr: pg_restore: [archiver (db)] Error while PROCESSING TOC:\npg_restore: [archiver (db)] Error from TOC entry 3357; 0 0 COMMENT EXTENSION pgcrypto \npg_restore: [archiver (db)] could not execute query: ERROR:  must be owner of extension pgcrypto\n    Command was: COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';\n\n\n\npg_restore: [archiver (db)] Error from TOC entry 3358; 0 0 COMMENT EXTENSION \"uuid-ossp\" \npg_restore: [archiver (db)] could not execute query: ERROR:  must be owner of extension uuid-ossp\n    Command was: COMMENT ON EXTENSION \"uuid-ossp\" IS 'generate universally unique identifiers (UUIDs)';\n\n\n\nWARNING: errors ignored on restore: 2\n: exit status 1" restore_id=20210128174459
```

To see this change work, you need to build the deployment service locally and then copy it over to your test machine. From there you need to cache all of the automate component artifacts. I did `for p in $(ls -d -1 chef/*); do hab pkg download --channel current --download-directory /root/hartifacts/ $p; done` and then ended up moving all the `.hart` files over to `/hab/cache/artifacts/`. Copy also your custom deployment service to `/hab/cache/artifacts/`. From there, you can run this command to do the restore:

```
chef-automate backup restore s3://balkar/backups/automate/20210218183956 --patch-config config.toml --override-origin YOURORIGIN --hartifacts /hab/cache/artifacts/ --skip-preflight --upgrade
```


