### PR TITLE
revert compliance profiles to 20210113170230

### DIFF
--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -46,7 +46,7 @@ else
   # WARNING: chef/automate-compliance-profiles is managed by Expeditor
   # See .expeditor/update-compliance-profiles.sh for details
   pkg_deps+=(
-      chef/automate-compliance-profiles/1.0.0/20210210220805
+      chef/automate-compliance-profiles/1.0.0/20210113170230
   )
 fi
 


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

The compliance profile needs to be reverted from 20210210220805 to 20210113170230

### :chains: Related Resources

### :+1: Definition of Done

The compliance profile should have the profiles associated only for 20210113170230

### :athletic_shoe: How to Build and Test the Change

Deploy Automate 
Click on the profiles tab and check the profiles list available.

### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
