### PR TITLE
Resync secrets script with releng vault changes

### DIFF
--- a/scripts/get_secrets.sh
+++ b/scripts/get_secrets.sh
@@ -5,8 +5,9 @@ error() {
     echo "$*" >&2
 }
 
-export VAULT_ADDR=${VAULT_ADDR:-https://vault.chef.co:8200}
+export VAULT_ADDR=${VAULT_ADDR:-https://vault.es.chef.co}
 export VAULT_CACERT=""
+export VAULT_NAMESPACE=releng
 CHEF_USERNAME=${CHEF_USERNAME:-unknown}
 STUDIO_TYPE=${STUDIO_TYPE:-none}
 
@@ -41,12 +42,13 @@ fi
 
 echo "Using VAULT_ADDR=$VAULT_ADDR"
 echo "Using VAULT_CACERT=$VAULT_CACERT"
+echo "Using VAULT_NAMESPACE=$VAULT_NAMESPACE"
 echo "Using CHEF_USERNAME=$CHEF_USERNAME"
 
 if [[ ! -f "$HOME/.vault-token" ]]; then
     echo "No cached token found. Attempting to log in."
     echo "Please enter your Chef password:"
-    vault login -method=okta username="$CHEF_USERNAME"
+    vault login -method=okta -namespace="$VAULT_NAMESPACE" username="$CHEF_USERNAME"
 else
     echo "Cached token found at $HOME/.vault-token, skipping login"
 fi

--- a/scripts/get_secrets.sh
+++ b/scripts/get_secrets.sh
@@ -51,7 +51,7 @@ echo "Using CHEF_USERNAME=$CHEF_USERNAME"
 if [[ ! -f "$HOME/.vault-token" ]]; then
     echo "No cached token found. Attempting to log in."
     echo "Please enter your Chef password:"
-    vault login -method=okta -namespace="$VAULT_NAMESPACE" username="$CHEF_USERNAME"
+    vault login -method=okta username="$CHEF_USERNAME"
 else
     echo "Cached token found at $HOME/.vault-token, skipping login"
 fi

--- a/scripts/get_secrets.sh
+++ b/scripts/get_secrets.sh
@@ -5,6 +5,9 @@ error() {
     echo "$*" >&2
 }
 
+# typical usage (inside hab studio) -- supply your username to the script:
+#     [19][default:/src:0]#  CHEF_USERNAME=msorens ./scripts/get_secrets.sh
+
 export VAULT_ADDR=${VAULT_ADDR:-https://vault.es.chef.co}
 export VAULT_CACERT=""
 export VAULT_NAMESPACE=releng
@@ -59,7 +62,7 @@ vault kv get -field=license secret/a2/license > dev/license.jwt
 # A1 license
 vault kv get -field=license secret/a2/delivery_license | base64 --decode >components/automate-deployment/a1-migration/delivery.license
 
-# Automate acceptence env secrets
+# Automate acceptance env secrets
 target_host=$(vault kv get -field=data secret/a2/testing/target_host)
 target_user=$(vault kv get -field=data secret/a2/testing/target_user)
 target_key=$(vault kv get -field=data secret/a2/testing/target_key)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Several weeks ago the releng team migrated to a new vault enterprise cluster, but that was a breaking change that needs the changes in this PR for the `get-secrets` script (for internal developer use) to function.

### :chains: Related Resources
NA

### :+1: Definition of Done
 * get-secrets does not report an authentication error.
 * get-secrets populates three files (see script) with data from the vault.

### :athletic_shoe: How to Build and Test the Change
Connect to the VPN.
Run `CHEF_USERNAME=msorens ./scripts/get_secrets.sh` substituting your Chef username instead of mine.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
