### PR TITLE
Modify nginx_jdomain repo

### DIFF
--- a/components/automate-es-gateway/habitat/config/nginx.conf
+++ b/components/automate-es-gateway/habitat/config/nginx.conf
@@ -1,7 +1,7 @@
 daemon off;
 pid {{ pkg.svc_var_path }}/pid;
 worker_processes {{ cfg.ngx.main.worker_processes }};
-error_log {{ cfg.ngx.main.error_log }} {{ cfg.logger.level }};
+error_log {{ cfg.ngx.main.error_log }} {{ cfg.log.level }};
 
 events {
   worker_connections {{cfg.ngx.events.worker_connections}};

--- a/components/automate-es-gateway/habitat/plan.sh
+++ b/components/automate-es-gateway/habitat/plan.sh
@@ -11,10 +11,10 @@ pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 
 
-jdomain_version="1.1.5"
-jdomain_filename="ngx_upstream_jdomain-${jdomain_version}.tar.gz"
-jdomain_source="https://github.com/nicholaschiasson/ngx_upstream_jdomain/archive/${jdomain_version}.tar.gz"
-jdomain_shasum=e7346dac41d473ea02995b7626bd0660115538c2c784dfe683e235c58dbc2c2c
+jdomain_version="master"
+jdomain_filename="ngx_upstream_jdomain-master.tar.gz"
+jdomain_source="https://github.com/wdaike/ngx_upstream_jdomain/archive/master.tar.gz"
+jdomain_shasum=3e7bedcddedf26d82da214d299e4cbee7605ac85a04ff3415c6b85de4f5a4ed5
 
 nginx_version="1.19.2"
 pkg_source="https://nginx.org/download/nginx-${nginx_version}.tar.gz"

--- a/components/automate-es-gateway/habitat/plan.sh
+++ b/components/automate-es-gateway/habitat/plan.sh
@@ -12,8 +12,8 @@ pkg_upstream_url="https://www.chef.io/automate"
 
 
 jdomain_version="master"
-jdomain_filename="ngx_upstream_jdomain-master.tar.gz"
-jdomain_source="https://github.com/wdaike/ngx_upstream_jdomain/archive/master.tar.gz"
+jdomain_filename="ngx_upstream_jdomain-${jdomain_version}.tar.gz"
+jdomain_source="https://github.com/wdaike/ngx_upstream_jdomain/archive/${jdomain_version}.tar.gz"
 jdomain_shasum=3e7bedcddedf26d82da214d299e4cbee7605ac85a04ff3415c6b85de4f5a4ed5
 
 nginx_version="1.19.2"


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

[nginx_upstream_jdomain](https://github.com/nicholaschiasson/ngx_upstream_jdomain) was introduced in `20201230192246` release to handle dynamic resolution of the hostnames based on the local `/etc/resolv.conf`.
This helps in resolving and connecting to nodes in ES cluster managed by cloud providers where change of IP address because of change of a parameter in a cluster is expected.
A very common such use case is with AWS ES.

Although the change worked for such a cluster with master nodes but it failed to resolve IP in case of clusters with no master nodes and only data nodes. 

This results in Automate Compliance/Infrastructure pages returning no data or unresponsive.

This is because the nginx jdomain module added has a bug which stops it from resolving the IP address in a regular interval.
This change considers the [wdaike nginx jdomain](https://github.com/wdaike/ngx_upstream_jdomain) module which was originally written.

### :chains: Related Resources

[4751](https://github.com/chef/automate/issues/4751)

### :+1: Definition of Done

The change in the ES cluster which can trigger a blue/green deployment and assigning of new IP addresses to the data nodes should not cause Automate to stop fetching ES data from the cluster.

### :athletic_shoe: How to Build and Test the Change

1. Deploy Automate on EC2 instance
2. Setup AWS ES cluster. Look up for [test-cluster](https://us-west-2.console.aws.amazon.com/es/home?region=us-west-2#domain:resource=nab-test-cluster;action=dashboard;tab=undefined)
3. Make sure both of these are in the same VPC and subnet
4. Should be able to access Automate Web page and look around compliance tab
5. Modify the number of data nodes. This should take the ES cluster to **Processing** state from **Active**
6. Once the ES cluster is **Active**, check back on Compliance tab and see if it is working fine.
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
