### PR TITLE
Re-sync with changes to AWS region list

### DIFF
--- a/components/nodemanager-service/tests/mgrtesthelpers/mgr-test-helpers.go
+++ b/components/nodemanager-service/tests/mgrtesthelpers/mgr-test-helpers.go
@@ -24,6 +24,7 @@ const (
 var AWSRegionsList = []string{
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ap-northeast-3",
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Apparently AWS has added a new region, which broke our integration tests.

```
    TestAWSEC2SearchNodeFields: aws_ec2_nodes_integration_test.go:103: 
        	Error Trace:	aws_ec2_nodes_integration_test.go:103
        	Error:      	Not equal: 
        	            	expected: []string{"ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
        	            	actual  : []string{"ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,5 @@
        	            	-([]string) (len=16) {
        	            	+([]string) (len=17) {
        	            	  (string) (len=14) "ap-northeast-1",
        	            	  (string) (len=14) "ap-northeast-2",
        	            	+ (string) (len=14) "ap-northeast-3",
        	            	  (string) (len=10) "ap-south-1",
        	Test:       	TestAWSEC2SearchNodeFields
```

### :chains: Related Resources

### :+1: Definition of Done
`nodemanager-integration` Buildkite task now passes.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
