### PR TITLE
Fix test anomaly due to February

### DIFF
--- a/components/config-mgmt-service/integration_test/count_missing_node_durations_test.go
+++ b/components/config-mgmt-service/integration_test/count_missing_node_durations_test.go
@@ -61,7 +61,8 @@ func TestMissingNodeRangeCounts(t *testing.T) {
 				},
 				{
 					// checked in within 1 month but not 2 week. Counted in the 3d, 1w, and 2w buckets only
-					Checkin: time.Now().AddDate(0, 0, -28),
+					// Keep this under the number of days of ANY month, i.e. strictly less than 28 days!
+					Checkin: time.Now().AddDate(0, 0, -27),
 				},
 				{
 					// checked in within 3 month but not 1 month. Counted in the 3d, 1w, 2w, 1m buckets only


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fix failing integration test:
```
FAIL: TestMissingNodeRangeCounts (0.72s)
    --- FAIL: TestMissingNodeRangeCounts/normal_case (0.14s)
        count_missing_node_durations_test.go:343:
            	Error Trace:	count_missing_node_durations_test.go:343
            	Error:      	Not equal:
            	            	expected: 2
            	            	actual  : 3
            	Test:       	TestMissingNodeRangeCounts/normal_case
```

I am not able to test locally, so I will see shortly if my theory is correct after Buildkite runs.
The gist of the "normal case" test is to collect some node checkins into various time buckets specified by this set of expectations:
```
expectedResponse: []*response.CountedDuration{
	{ Duration: "3d", Count:    11, },
	{ Duration: "1w", Count:    8, },
	{ Duration: "2w", Count:    6, },
	{ Duration: "1M", Count:    2, },
	{ Duration: "3M", Count:    1, },
},
```
Each bucket records nodes that have not checked in for at least that many units. For example, a node checking in after 4 days would be counted in the 3-day ("3d") bucket tally but no others. A node checking in after 8 days would be counted in both the 3d bucket and the 1w bucket. The problem was that for the 1M (1 month) bucket, we were getting 3 instead of 2, due to the line of code I changed (which was previously exactly 28 days ago). Since the month just completed, February 2021, has 28 days, that bumped the 1-month tally by an extra count. By reducing that to 27, it is guaranteed never to add a month.

### :chains: Related Resources
NA

### :+1: Definition of Done
Buildkite task `config-mgmt-service` now passes.

### :athletic_shoe: How to Build and Test the Change
NA

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA