### PR TITLE
Fixes test failure and hab infra_server_load_test_data

### DIFF
--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -17,11 +17,11 @@ DOC
 function infra_service_integration() {
   check_if_deployinate_started || return 1;
   export CONTAINER_HOSTNAME=localhost
-  Setup local chef server
-  loads data which resides in dev-docs/adding-data/infra/chef-repo
+  # Setup local chef server
+  # loads data which resides in dev-docs/adding-data/infra/chef-repo
   infra_service_load_chef_repo
   log_line "Started loading chef repo..."
-  A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test -v "github.com/chef/automate/components/infra-proxy-service/integration_test"
+  A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test "github.com/chef/automate/components/infra-proxy-service/integration_test"
   log_line "Finished loading chef repo..."
 }
 

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -17,11 +17,26 @@ DOC
 function infra_service_integration() {
   check_if_deployinate_started || return 1;
   export CONTAINER_HOSTNAME=localhost
-  # Setup local chef server
-  # loads data which resides in dev-docs/adding-data/infra/chef-repo
+  Setup local chef server
+  loads data which resides in dev-docs/adding-data/infra/chef-repo
   infra_service_load_chef_repo
-  A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test "github.com/chef/automate/components/infra-proxy-service/integration_test"
+  log_line "Started loading chef repo..."
+  A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test -v "github.com/chef/automate/components/infra-proxy-service/integration_test"
+  log_line "Finished loading chef repo..."
 }
+
+document "infra_service_load_test_data" <<DOC
+  run the infra service's integration tests
+DOC
+function infra_service_load_test_data() {
+  check_if_deployinate_started || return 1;
+  log_line "Started loading infra service test data..."
+  INFRA_SERVER_ID="$1" INFRA_SERVER_ORG_ID="$2" TOTAL_RECORDS="$3" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test "github.com/chef/automate/components/infra-proxy-service/integration_test"
+  log_line $INFRA_SERVER_ID
+  log_line $INFRA_SERVER_ORG_ID
+  log_line "Finished loading infra service test data"
+}
+
 
 document "infra_service_load_sample_data" <<DOC
   Before running this command make sure either run 'start_infra_proxy_service' or 'start_all_services'

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -31,9 +31,7 @@ DOC
 function infra_service_load_test_data() {
   check_if_deployinate_started || return 1;
   log_line "Started loading infra service test data..."
-  INFRA_SERVER_ID="$1" INFRA_SERVER_ORG_ID="$2" TOTAL_RECORDS="$3" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test "github.com/chef/automate/components/infra-proxy-service/integration_test"
-  log_line $INFRA_SERVER_ID
-  log_line $INFRA_SERVER_ORG_ID
+  INFRA_SERVER_ID="$1" INFRA_SERVER_ORG_ID="$2" TOTAL_RECORDS="$3" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test -v "github.com/chef/automate/components/infra-proxy-service/integration_test"
   log_line "Finished loading infra service test data"
 }
 

--- a/.studio/infra-proxy-service
+++ b/.studio/infra-proxy-service
@@ -12,7 +12,7 @@ function start_infra_proxy_service() {
 }
 
 document "infra_service_integration" <<DOC
-  run the infra service's integration tests
+  run the infra service's integration tests.
 DOC
 function infra_service_integration() {
   check_if_deployinate_started || return 1;
@@ -26,12 +26,41 @@ function infra_service_integration() {
 }
 
 document "infra_service_load_test_data" <<DOC
-  run the infra service's integration tests
+  run the infra service's integration tests with data.
+
+  1. -N No of records Default: 10
+  2. -S Chef Infra Server ID Default: local-dev
+  3. -O Chef organization ID Default: test-org
+
+  Example:
+  -----------------------------
+  infra_service_load_test_data -N 100 -S SERVER_ID -O ORG_ID
 DOC
 function infra_service_load_test_data() {
+  local OPTIND opt
+  local records=10
+  local infra_server_id="local-dev"
+  local infra_org_id="test-org"
+  while getopts ":N:S:O:" opt; do
+    case $opt in
+      N) records="$OPTARG"
+      ;;
+      S) infra_server_id="$OPTARG"
+      ;;
+      O) infra_org_id="$OPTARG"
+      ;;
+      \?) echo "Invalid option -$OPTARG" >&2
+      ;;
+      : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+    esac
+  done
+  shift $((OPTIND -1))
   check_if_deployinate_started || return 1;
   log_line "Started loading infra service test data..."
-  INFRA_SERVER_ID="$1" INFRA_SERVER_ORG_ID="$2" TOTAL_RECORDS="$3" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test -v "github.com/chef/automate/components/infra-proxy-service/integration_test"
+
+  TOTAL_RECORDS="$records" INFRA_SERVER_ID="$infra_server_id" INFRA_SERVER_ORG_ID="$infra_org_id" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go_test "github.com/chef/automate/components/infra-proxy-service/integration_test"
   log_line "Finished loading infra service test data"
 }
 

--- a/components/infra-proxy-service/integration_test/clients_test.go
+++ b/components/infra-proxy-service/integration_test/clients_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -15,7 +14,6 @@ func TestGetClients(t *testing.T) {
 	// Pre-populated that has been added by scripts
 	// Validating the clients search based on these records.
 	// rpc GetClients (request.Clients) returns (response.Clients)
-	ctx := context.Background()
 	req := &request.Clients{
 		ServerId: autoDeployedChefServerID,
 		OrgId:    autoDeployedChefOrganizationID,
@@ -150,7 +148,6 @@ func TestGetClients(t *testing.T) {
 }
 
 func TestGetClient(t *testing.T) {
-	ctx := context.Background()
 	// rpc GetClient (request.Client) returns (response.Client)
 	name := fmt.Sprintf("chef-load-%d", time.Now().Nanosecond())
 	createReq := &request.CreateClient{
@@ -178,7 +175,6 @@ func TestGetClient(t *testing.T) {
 func TestResetClient(t *testing.T) {
 	// rpc ResetClient (request.ClientKey) returns (response.ResetClient)
 	name := fmt.Sprintf("client-%d", time.Now().Nanosecond())
-	ctx := context.Background()
 	req := &request.CreateClient{
 		ServerId:  autoDeployedChefServerID,
 		OrgId:     autoDeployedChefOrganizationID,
@@ -199,4 +195,24 @@ func TestResetClient(t *testing.T) {
 	assert.Equal(t, res.GetName(), resetRes.GetName())
 	// The old private key must not match with the reset private key
 	assert.NotEqual(t, res.GetClientKey().GetPrivateKey(), resetRes.GetClientKey().GetPrivateKey())
+}
+
+// Add client records
+func addClients(n int) int {
+	total := 0
+	for i := 0; i < n; i++ {
+		req := &request.CreateClient{
+			ServerId:  autoDeployedChefServerID,
+			OrgId:     autoDeployedChefOrganizationID,
+			Name:      fmt.Sprintf("chef-load-client-%d", time.Now().Nanosecond()),
+			CreateKey: true,
+		}
+		_, err := infraProxy.CreateClient(ctx, req)
+
+		if err == nil {
+			total++
+		}
+	}
+
+	return total
 }

--- a/components/infra-proxy-service/integration_test/databags_test.go
+++ b/components/infra-proxy-service/integration_test/databags_test.go
@@ -18,12 +18,10 @@ func TestGetDatabags(t *testing.T) {
 	// Pre-populated that has been added by scripts
 	// Validating the data bags search based on these records.
 	// rpc GetDataBags (request.DataBags) returns (response.DataBags)
-	ctx := context.Background()
 	req := &request.DataBags{
 		ServerId: autoDeployedChefServerID,
 		OrgId:    autoDeployedChefOrganizationID,
 	}
-
 	res, err := infraProxy.GetDataBags(ctx, req)
 	assert.NoError(t, err)
 	existingTotal := len(res.DataBags)
@@ -39,12 +37,11 @@ func TestGetDatabags(t *testing.T) {
 	assert.NotNil(t, dataBag)
 
 	fetchRes, err := infraProxy.GetDataBags(ctx, req)
+	assert.NoError(t, err)
 	assert.Equal(t, existingTotal+1, len(fetchRes.DataBags))
 }
 
 func TestGetDatabagItems(t *testing.T) {
-	ctx := context.Background()
-
 	// Add a data bag
 	dataBagName := fmt.Sprintf("data-bag-%d", time.Now().Nanosecond())
 	dataBag, err := infraProxy.CreateDataBag(ctx, &request.CreateDataBag{
@@ -78,7 +75,7 @@ func TestGetDatabagItems(t *testing.T) {
 			Name:     dataBagName,
 			Data: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
+					"id":   &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
 					"key1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key1-%d", time.Now().Nanosecond())}},
 					"key2": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key2-%d", time.Now().Nanosecond())}},
 				},
@@ -328,7 +325,7 @@ func TestCreateDatabagItem(t *testing.T) {
 }
 
 // Adds data bag with items records
-func addDatabagsWithItems(ctx context.Context, n int) int {
+func addDatabagsWithItems(n int) int {
 	total := 0
 	for i := 0; i < 10; i++ {
 		dataBagName := fmt.Sprintf("data-bag-%d", time.Now().Nanosecond())
@@ -339,7 +336,7 @@ func addDatabagsWithItems(ctx context.Context, n int) int {
 		})
 
 		if err == nil {
-			addDataBagItems(ctx, dataBagName, n)
+			addDataBagItems(dataBagName, n)
 			total++
 		}
 	}
@@ -348,7 +345,7 @@ func addDatabagsWithItems(ctx context.Context, n int) int {
 }
 
 // Adds data bag items records
-func addDataBagItems(ctx context.Context, dabaBagName string, n int) int {
+func addDataBagItems(dabaBagName string, n int) int {
 	total := 0
 	for i := 0; i < n; i++ {
 		itemId := fmt.Sprintf("item-%d", time.Now().Nanosecond())
@@ -358,7 +355,9 @@ func addDataBagItems(ctx context.Context, dabaBagName string, n int) int {
 			Name:     dabaBagName,
 			Data: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
+					"id":   &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
+					"key1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key1-%d", time.Now().Nanosecond())}},
+					"key2": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key2-%d", time.Now().Nanosecond())}},
 				},
 			},
 		}

--- a/components/infra-proxy-service/integration_test/databags_test.go
+++ b/components/infra-proxy-service/integration_test/databags_test.go
@@ -70,9 +70,6 @@ func TestGetDatabagItems(t *testing.T) {
 		assert.Equal(t, 0, int(res.GetTotal()))
 	})
 
-	//Adds data bag items records
-	addDataBagItems(ctx, dataBagName, 10)
-
 	t.Run("items list with a per_page search param", func(t *testing.T) {
 		itemId := fmt.Sprintf("item-%d", time.Now().Nanosecond())
 		createReq := &request.CreateDataBagItem{
@@ -82,6 +79,8 @@ func TestGetDatabagItems(t *testing.T) {
 			Data: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
+					"key1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key1-%d", time.Now().Nanosecond())}},
+					"key2": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: fmt.Sprintf("key2-%d", time.Now().Nanosecond())}},
 				},
 			},
 		}
@@ -326,6 +325,26 @@ func TestCreateDatabagItem(t *testing.T) {
 		require.Contains(t, err.Error(), errMsg)
 		grpctest.AssertCode(t, codes.InvalidArgument, err)
 	})
+}
+
+// Adds data bag with items records
+func addDatabagsWithItems(ctx context.Context, n int) int {
+	total := 0
+	for i := 0; i < 10; i++ {
+		dataBagName := fmt.Sprintf("data-bag-%d", time.Now().Nanosecond())
+		_, err := infraProxy.CreateDataBag(ctx, &request.CreateDataBag{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     dataBagName,
+		})
+
+		if err == nil {
+			addDataBagItems(ctx, dataBagName, n)
+			total++
+		}
+	}
+
+	return total
 }
 
 // Adds data bag items records

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -109,7 +109,6 @@ func TestGetEnvironments(t *testing.T) {
 
 func TestGetEnvironment(t *testing.T) {
 	// rpc GetEnvironment (request.Environment) returns (response.Environment)
-	ctx := context.Background()
 	t.Run("when the environment exists, return the environment successfully", func(t *testing.T) {
 		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
 		creReq := &request.CreateEnvironment{
@@ -147,7 +146,6 @@ func TestGetEnvironment(t *testing.T) {
 
 func TestCreateEnvironment(t *testing.T) {
 	// rpc GetEnvironment (request.Environment) returns (response.Environment)
-	ctx := context.Background()
 	t.Run("when a valid environment is submitted, creates the new environment successfully", func(t *testing.T) {
 		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
 		req := &request.CreateEnvironment{
@@ -211,7 +209,6 @@ func TestCreateEnvironment(t *testing.T) {
 
 func TestUpdateEnvironment(t *testing.T) {
 	// rpc UpdateEnvironment (request.UpdateEnvironment) returns (response.Environment)
-	ctx := context.Background()
 	t.Run("when a valid environment is submitted, updates the environment successfully", func(t *testing.T) {
 		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
 		req := &request.CreateEnvironment{
@@ -264,7 +261,6 @@ func TestUpdateEnvironment(t *testing.T) {
 
 func TestDeleteEnvironment(t *testing.T) {
 	// rpc DeleteEnvironment (request.Environment) returns (response.Environment)
-	ctx := context.Background()
 	t.Run("when a valid environment is submitted, deletes the environment successfully", func(t *testing.T) {
 		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
 		req := &request.CreateEnvironment{

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -89,8 +89,18 @@ func TestGetEnvironments(t *testing.T) {
 	})
 
 	t.Run("Environments list with a valid query search param", func(t *testing.T) {
+		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
+		createReq := &request.CreateEnvironment{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     name,
+		}
+		env, err := infraProxy.CreateEnvironment(ctx, createReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, env)
+
 		req.SearchQuery = &request.SearchQuery{
-			Q:       "name:_default",
+			Q:       fmt.Sprintf("name:%s", name),
 			Page:    0,
 			PerPage: 5,
 		}
@@ -99,7 +109,7 @@ func TestGetEnvironments(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, 0, int(res.Page))
 		assert.Equal(t, 1, int(res.Total))
-		assert.Equal(t, "_default", res.Environments[0].GetName())
+		assert.Equal(t, name, res.Environments[0].GetName())
 	})
 
 }

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -15,11 +14,6 @@ import (
 
 func TestGetEnvironments(t *testing.T) {
 	// rpc GetEnvironments (request.Environments) returns (response.Environments)
-	ctx := context.Background()
-
-	// Adds environments
-	addEnvironments(ctx, 10)
-
 	req := &request.Environments{
 		ServerId: autoDeployedChefServerID,
 		OrgId:    autoDeployedChefOrganizationID,
@@ -111,7 +105,6 @@ func TestGetEnvironments(t *testing.T) {
 		assert.Equal(t, 1, int(res.Total))
 		assert.Equal(t, name, res.Environments[0].GetName())
 	})
-
 }
 
 func TestGetEnvironment(t *testing.T) {
@@ -304,7 +297,7 @@ func TestDeleteEnvironment(t *testing.T) {
 }
 
 // Adds environments records
-func addEnvironments(ctx context.Context, n int) int {
+func addEnvironments(n int) int {
 	total := 0
 	for i := 0; i < n; i++ {
 		req := &request.CreateEnvironment{

--- a/components/infra-proxy-service/integration_test/global_test.go
+++ b/components/infra-proxy-service/integration_test/global_test.go
@@ -2,13 +2,15 @@ package integration_test
 
 import (
 	"os"
+	"strconv"
 	"testing"
 )
 
 // Global variables
 var (
-	autoDeployedChefServerID       = "local-dev"
-	autoDeployedChefOrganizationID = "test-org"
+	autoDeployedChefServerID       = getEnv("INFRA_SERVER_ID", "local-dev")
+	autoDeployedChefOrganizationID = getEnv("INFRA_SERVER_ORG_ID", "test-org")
+	totalRecords, _                  = strconv.Atoi(getEnv("TOTAL_RECORDS", "10"))
 	cFile                          = "/src/components/infra-proxy-service/dev/config"
 	// This suite variable will be available for every single test as long as they
 	// belong to the 'integration_test' package.
@@ -30,4 +32,11 @@ func TestMain(m *testing.M) {
 
 	// call with result of m.Run()
 	os.Exit(exitCode)
+}
+
+func getEnv(key, fallback string) string {
+    if value, ok := os.LookupEnv(key); ok {
+        return value
+    }
+    return fallback
 }

--- a/components/infra-proxy-service/integration_test/global_test.go
+++ b/components/infra-proxy-service/integration_test/global_test.go
@@ -34,8 +34,10 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// getEnv fetches the ENV variable with fallback default values. 
 func getEnv(key, fallback string) string {
-    if value, ok := os.LookupEnv(key); ok {
+	value := os.Getenv(key)
+    if value != "" {
         return value
     }
     return fallback

--- a/components/infra-proxy-service/integration_test/nodes_test.go
+++ b/components/infra-proxy-service/integration_test/nodes_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestGetNode(t *testing.T) {
+	t.Log("test.....................................")
+	t.Log(autoDeployedChefServerID)
+	t.Log(autoDeployedChefOrganizationID)
+	t.Log(totalRecords)
 	ctx := context.Background()
 	t.Run("when the node exists, return the node successfully", func(t *testing.T) {
 		name := fmt.Sprintf("node-%d", time.Now().Nanosecond())

--- a/components/infra-proxy-service/integration_test/nodes_test.go
+++ b/components/infra-proxy-service/integration_test/nodes_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -14,14 +13,8 @@ import (
 )
 
 func TestGetNode(t *testing.T) {
-	t.Log("test.....................................")
-	t.Log(autoDeployedChefServerID)
-	t.Log(autoDeployedChefOrganizationID)
-	t.Log(totalRecords)
-	ctx := context.Background()
 	t.Run("when the node exists, return the node successfully", func(t *testing.T) {
 		name := fmt.Sprintf("node-%d", time.Now().Nanosecond())
-
 		reqNode := &request.NodeDetails{
 			ServerId: autoDeployedChefServerID,
 			OrgId:    autoDeployedChefOrganizationID,
@@ -60,7 +53,6 @@ func TestGetNode(t *testing.T) {
 }
 
 func TestUpdateNodeTags(t *testing.T) {
-	ctx := context.Background()
 	t.Run("when add, adds values to the current group of tags", func(t *testing.T) {
 		name := fmt.Sprintf("node-%d", time.Now().Nanosecond())
 		reqNode := &request.NodeDetails{

--- a/components/infra-proxy-service/integration_test/roles_test.go
+++ b/components/infra-proxy-service/integration_test/roles_test.go
@@ -89,8 +89,19 @@ func TestGetRoles(t *testing.T) {
 	})
 
 	t.Run("Roles list with a valid query search param", func(t *testing.T) {
+		name := fmt.Sprintf("chef-load-role-%d", time.Now().Nanosecond())
+		createReq := &request.CreateRole{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "auto generated role",
+		}
+	    role, err := infraProxy.CreateRole(ctx, createReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, role)
+
 		req.SearchQuery = &request.SearchQuery{
-			Q:       "name:starter",
+			Q:       fmt.Sprintf("name:%s", name),
 			Page:    0,
 			PerPage: 5,
 		}
@@ -99,7 +110,7 @@ func TestGetRoles(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, 0, int(res.Page))
 		assert.Equal(t, 1, int(res.Total))
-		assert.Equal(t, "starter", res.Roles[0].GetName())
+		assert.Equal(t, name, res.Roles[0].GetName())
 	})
 }
 

--- a/components/infra-proxy-service/integration_test/roles_test.go
+++ b/components/infra-proxy-service/integration_test/roles_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -14,11 +13,6 @@ func TestGetRoles(t *testing.T) {
 	// Pre-populated that has been added by scripts
 	// Validating the roles search based on these records.
 	// rpc GetRoles (request.Roles) returns (response.Roles)
-	ctx := context.Background()
-
-	//Adds roles
-	addRoles(ctx, 10)
-
 	req := &request.Roles{
 		ServerId: autoDeployedChefServerID,
 		OrgId:    autoDeployedChefOrganizationID,
@@ -96,7 +90,7 @@ func TestGetRoles(t *testing.T) {
 			Name:        name,
 			Description: "auto generated role",
 		}
-	    role, err := infraProxy.CreateRole(ctx, createReq)
+		role, err := infraProxy.CreateRole(ctx, createReq)
 		assert.NoError(t, err)
 		assert.NotNil(t, role)
 
@@ -115,7 +109,7 @@ func TestGetRoles(t *testing.T) {
 }
 
 // Adds roles records
-func addRoles(ctx context.Context, n int) int {
+func addRoles(n int) int {
 	total := 0
 	for i := 0; i < n; i++ {
 		req := &request.CreateRole{

--- a/components/infra-proxy-service/integration_test/suite_test.go
+++ b/components/infra-proxy-service/integration_test/suite_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"context"
+
 	"github.com/chef/automate/components/infra-proxy-service/config"
 	"github.com/chef/automate/components/infra-proxy-service/server"
 )
@@ -14,6 +16,7 @@ var (
 	// res, err := infraProxy.GetOrgs(ctx, &req)
 	// ```
 	infraProxy *server.Server
+	ctx        = context.Background()
 )
 
 type Suite struct{}
@@ -28,12 +31,21 @@ func (s *Suite) GlobalSetup() error {
 	var err error
 	// set global infraProxy
 	infraProxy, err = newInfraProxyServer()
-
-	//Adds data bag items records
-	addDataBagItems(dataBagName, 10)
 	if err != nil {
 		return err
 	}
+
+	// Add role records
+	addRoles(totalRecords)
+
+	// Add data bag records
+	addDatabagsWithItems(totalRecords)
+
+	// Add environment records
+	addEnvironments(totalRecords)
+
+	// Add client records
+	addClients(totalRecords)
 
 	return nil
 }

--- a/components/infra-proxy-service/integration_test/suite_test.go
+++ b/components/infra-proxy-service/integration_test/suite_test.go
@@ -29,6 +29,8 @@ func (s *Suite) GlobalSetup() error {
 	// set global infraProxy
 	infraProxy, err = newInfraProxyServer()
 
+	//Adds data bag items records
+	addDataBagItems(dataBagName, 10)
 	if err != nil {
 		return err
 	}

--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -124,6 +124,11 @@ configure_retention() {
   }'
 }
 
+populate_integration_data_data() {
+  hab pkg install core/go -b
+  TOTAL_RECORDS=100 INFRA_SERVER_ID="auto-deployed-chef-server" INFRA_SERVER_ORG_ID="auto-deployed-chef-org" A2_SVC_NAME="infra-proxy-service" A2_SVC_PATH="/hab/svc/infra-proxy-service" go test "github.com/chef/automate/components/infra-proxy-service/integration_test"
+}
+
 configure_automate_infra_views() {
   if chef-automate dev grpcurl automate-gateway list | grep "chef.automate.api.infra_proxy.InfraProxy" &> /dev/null; then
       chef_server_admin_key="$(</hab/chef-server-admin-key.txt tr '\n' ':' | sed 's/:/\\n/g')"
@@ -151,6 +156,8 @@ EOM
           }
 EOM
       fi
+      # put the integration test data into auto deployed Chef Infra Server
+      populate_integration_data_data
   fi
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
- Cover more integration tests.
- Add `infra_service_load_test_data  -N records -S SERVER_ID -O ORG_ID` to put data into provided chef-server.  

### :chains: Related Resources
Fixes: https://github.com/chef/automate/issues/4775

### :+1: Definition of Done
- Added the `infra_service_load_test_data` command to load the data into provided chef infra server detail.

### :athletic_shoe: How to Build and Test the Change
- `source .studio/infra-proxy-service`
- Add existing chef-server detail To add data using 3rd internal steps https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views

   OR
 
   run `infra_service_load_chef_repo` to spinup and setup the local chef-server.(it also load some data using knife upload)
- Load data using  `infra_service_load_test_data  -N records -S SERVER_ID -O ORG_ID`


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>