### PR TITLE
Add the comment in docs to notify non support of AWS ES

### DIFF
--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -168,6 +168,7 @@ Add the following to your config.toml:
 
 Because externally-deployed Elasticsearch nodes will not have access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
 
+__Please note that Chef Automate does not support Elastic Search services. Automate is not tested against Elasticsearch services provide by cloud provides like AWS Elasticsearch Service.__
 ##### Adding Resolvers for Elasticsearch
 
 In case you want to resolve the Elasticsearch node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -139,7 +139,7 @@ The directions provided below are intended for use only during initial deploymen
 #### Configuring External Elasticsearch
 
 {{< note >}}
-Chef Automate supports the official Elasticsearch Service by Elastic. Chef Automate does not test or support alternative services, such as AWS Elasticsearch Service (Amazon ES).
+Chef Automate supports the official Elasticsearch Service by Elastic. Chef Automate does not test or support alternative services, such as Amazon Elasticsearch Service (Amazon ES).
 {{< /note >}}
 
 Add the following to your config.toml:

--- a/components/docs-chef-io/content/automate/install.md
+++ b/components/docs-chef-io/content/automate/install.md
@@ -138,6 +138,10 @@ The directions provided below are intended for use only during initial deploymen
 
 #### Configuring External Elasticsearch
 
+{{< note >}}
+Chef Automate supports the official Elasticsearch Service by Elastic. Chef Automate does not test or support alternative services, such as AWS Elasticsearch Service (Amazon ES).
+{{< /note >}}
+
 Add the following to your config.toml:
 
 ```toml
@@ -168,7 +172,6 @@ Add the following to your config.toml:
 
 Because externally-deployed Elasticsearch nodes will not have access to Chef Automate's built-in backup storage services, you must configure Elasticsearch backup settings separately from Chef Automate's primary backup settings. You can configure backups to use either the local filesystem or S3.
 
-__Please note that Chef Automate does not support Elastic Search services. Automate is not tested against Elasticsearch services provide by cloud provides like AWS Elasticsearch Service.__
 ##### Adding Resolvers for Elasticsearch
 
 In case you want to resolve the Elasticsearch node IPs dynamically using DNS servers, you can add resolvers/nameservers to the configuration.


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

We have seen off late customer trying to use cloud provided ElasticSearch services like AWS ES which tends to fail.
Such deployments are not tested and documented anywhere so we need to call it out in the documentation to make sure it is known to the user beforehand.

### :chains: Related Resources

### :+1: Definition of Done
The Automate document should show up the text 
"Please note that Chef Automate does not support Elastic Search services. Automate is not tested against Elasticsearch services provide by cloud provides like AWS Elasticsearch Service."

### :athletic_shoe: How to Build and Test the Change
```
make serve
```
Open up http://localhost:1313 and check the "Install Guide" section in Automate doc under the sub section "Configuring External Elasticsearch" 
 
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
