### PR TITLE
Notifications Rewrite: Rules CRUD w/ validations

### DIFF
--- a/components/notifications-service2/pkg/server/rules.go
+++ b/components/notifications-service2/pkg/server/rules.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	notifications "github.com/chef/automate/api/interservice/notifications/service"
+	"github.com/chef/automate/components/notifications-service2/pkg/storage"
+)
+
+func (s *Server) AddRule(ctx context.Context, req *notifications.Rule) (*notifications.RuleAddResponse, error) {
+	newRuleQuery, err := storage.NewRuleFromReq(req)
+	if err != nil {
+		return &notifications.RuleAddResponse{}, errors.Wrap(err, "unable to format AddRule request data into database request")
+	}
+	if messages, ok := newRuleQuery.ValidateForInsert(); !ok {
+		return &notifications.RuleAddResponse{
+			Messages: messages,
+			Code:     notifications.RuleAddResponse_VALIDATION_ERROR,
+		}, nil
+	}
+	newRuleWithId, err := s.db.AddRule(newRuleQuery)
+	if err != nil && storage.IsUniqueConstraintViolation(err) {
+		return &notifications.RuleAddResponse{
+			Code:     notifications.RuleAddResponse_DUPLICATE_NAME,
+			Messages: []string{"A rule with this name already exists"},
+		}, nil
+	}
+	if err != nil {
+		return &notifications.RuleAddResponse{}, errors.Wrap(err, "failed to insert rule into the database")
+	}
+
+	ruleRet := newRuleWithId.Proto()
+	ruleRet.Id = ""
+	return &notifications.RuleAddResponse{
+		Id:   newRuleWithId.Id,
+		Rule: ruleRet,
+	}, nil
+}
+func (s *Server) DeleteRule(ctx context.Context, req *notifications.RuleIdentifier) (*notifications.RuleDeleteResponse, error) {
+	err := s.db.DeleteRule(&storage.DeleteRuleQuery{Id: req.Id})
+	return &notifications.RuleDeleteResponse{}, err
+}
+func (s *Server) UpdateRule(context.Context, *notifications.Rule) (*notifications.RuleUpdateResponse, error) {
+	return &notifications.RuleUpdateResponse{}, nil
+}
+func (s *Server) GetRule(ctx context.Context, req *notifications.RuleIdentifier) (*notifications.RuleGetResponse, error) {
+	query := &storage.GetRuleQuery{Id: req.Id}
+	rule, err := s.db.GetRule(query)
+	if err != nil {
+		return &notifications.RuleGetResponse{}, errors.Wrap(err, "failed to get rule from the database")
+	}
+	return &notifications.RuleGetResponse{
+		Rule: rule.Proto(),
+	}, nil
+}
+func (s *Server) ListRules(context.Context, *notifications.Empty) (*notifications.RuleListResponse, error) {
+	rules, err := s.db.ListRules()
+	if err != nil {
+		return &notifications.RuleListResponse{}, errors.Wrap(err, "failed to list rules from the database")
+	}
+
+	ret := &notifications.RuleListResponse{Rules: []*notifications.Rule{}}
+
+	for _, r := range rules {
+		ret.Rules = append(ret.Rules, r.Proto())
+	}
+
+	return ret, nil
+}

--- a/components/notifications-service2/pkg/server/server.go
+++ b/components/notifications-service2/pkg/server/server.go
@@ -57,21 +57,6 @@ func (s *Server) Health() *health.Service {
 func (s *Server) Notify(context.Context, *notifications.Event) (*notifications.Response, error) {
 	return &notifications.Response{}, nil
 }
-func (s *Server) AddRule(context.Context, *notifications.Rule) (*notifications.RuleAddResponse, error) {
-	return &notifications.RuleAddResponse{}, nil
-}
-func (s *Server) DeleteRule(context.Context, *notifications.RuleIdentifier) (*notifications.RuleDeleteResponse, error) {
-	return &notifications.RuleDeleteResponse{}, nil
-}
-func (s *Server) UpdateRule(context.Context, *notifications.Rule) (*notifications.RuleUpdateResponse, error) {
-	return &notifications.RuleUpdateResponse{}, nil
-}
-func (s *Server) GetRule(context.Context, *notifications.RuleIdentifier) (*notifications.RuleGetResponse, error) {
-	return &notifications.RuleGetResponse{}, nil
-}
-func (s *Server) ListRules(context.Context, *notifications.Empty) (*notifications.RuleListResponse, error) {
-	return &notifications.RuleListResponse{}, nil
-}
 func (s *Server) ValidateWebhook(context.Context, *notifications.URLValidationRequest) (*notifications.URLValidationResponse, error) {
 	return &notifications.URLValidationResponse{}, nil
 }

--- a/components/notifications-service2/pkg/storage/client.go
+++ b/components/notifications-service2/pkg/storage/client.go
@@ -1,5 +1,27 @@
 package storage
 
+import (
+	"net/url"
+
+	notifications "github.com/chef/automate/api/interservice/notifications/service"
+)
+
+// Constants ActionType... map to values of the `rule_action` enum in the schema.
+const (
+	ActionTypeSlackAlert      = "SlackAlert"
+	ActionTypeWebhookAlert    = "WebhookAlert"
+	ActionTypeServiceNowAlert = "ServiceNowAlert"
+)
+
+// Constants EventType... map to values of the `rule_event` enum in the schema.
+const (
+	EventTypeCCRSuccess        = "CCRSuccess"
+	EventTypeCCRFailure        = "CCRFailure"
+	EventTypeComplianceSuccess = "ComplianceSuccess"
+	EventTypeComplianceFailure = "ComplianceFailure"
+	EventTypeAssets            = "Assets"
+)
+
 // Client is the interface for storage operations used by `server.Server`.
 // In production, it's a `postgres.Postgres` object. We use an interface here
 // for two reasons:
@@ -7,4 +29,184 @@ package storage
 // 2. Expose only a subset of the functionality of the Postgres object's
 // methods: we wish to hide low-level and testing-only methods from the
 // application code in the Server.
-type Client interface{}
+type Client interface {
+	AddRule(*Rule) (*Rule, error)
+	GetRule(*GetRuleQuery) (*Rule, error)
+	ListRules() ([]*Rule, error)
+	DeleteRule(*DeleteRuleQuery) error
+}
+
+type Rule struct {
+	Id                   string `db:"id"`
+	Name                 string `db:"name"`
+	Event                string `db:"event"`
+	Action               string `db:"action"`
+	URL                  string `db:"url"`
+	SecretId             string `db:"secret_id"`
+	CriticalControlsOnly bool   `db:"critical_controls_only"`
+}
+
+func (r *Rule) Proto() *notifications.Rule {
+	p := &notifications.Rule{
+		Id:   r.Id,
+		Name: r.Name,
+	}
+	switch r.Action {
+	case ActionTypeSlackAlert:
+		p.Action = &notifications.Rule_SlackAlert{
+			SlackAlert: &notifications.SlackAlert{
+				Url: r.URL,
+			},
+		}
+	case ActionTypeWebhookAlert:
+		p.Action = &notifications.Rule_WebhookAlert{
+			WebhookAlert: &notifications.WebhookAlert{
+				Url: r.URL,
+			},
+		}
+	case ActionTypeServiceNowAlert:
+		p.Action = &notifications.Rule_ServiceNowAlert{
+			ServiceNowAlert: &notifications.ServiceNowAlert{
+				Url:                  r.URL,
+				SecretId:             r.SecretId,
+				CriticalControlsOnly: r.CriticalControlsOnly,
+			},
+		}
+	}
+
+	return p
+}
+
+type GetRuleQuery struct {
+	Id string
+}
+
+type DeleteRuleQuery struct {
+	Id string
+}
+
+func IsUniqueConstraintViolation(err error) bool {
+	_, ok := err.(*uniqueConstraintViolation)
+	return ok
+}
+
+func NewUniqueConstraintViolation(err error) error {
+	return &uniqueConstraintViolation{Err: err}
+}
+
+type uniqueConstraintViolation struct {
+	Err error
+}
+
+func (u *uniqueConstraintViolation) Error() string {
+	return u.Err.Error()
+}
+
+type action struct {
+	// ActionType is what kind of alert it is. The value should match exactly one
+	// of the allowed values of the `rule_action` type defined in the database
+	// schema. These are defined above as the constants named `ActionType...`
+	ActionType string
+	// URL of the webhook receiver service.
+	URL string
+	// SecretId references a secret stored in the secrets service. Not all types
+	// of action have this.
+	SecretId string
+	// Some alert types allow the user to specify whether they only want alerts
+	// on critical control failures.
+	CriticalControlsOnly bool
+}
+
+func NewRuleFromReq(req *notifications.Rule) (*Rule, error) {
+	action, err := actionFromReq(req)
+	if err != nil {
+		return nil, err
+	}
+	event, err := eventFromReq(req.Event)
+	if err != nil {
+		return nil, err
+	}
+	return &Rule{
+		Id:                   req.Id,
+		Name:                 req.Name,
+		Event:                event,
+		Action:               action.ActionType,
+		URL:                  action.URL,
+		SecretId:             action.SecretId,
+		CriticalControlsOnly: action.CriticalControlsOnly,
+	}, nil
+}
+
+func actionFromReq(req *notifications.Rule) (*action, error) {
+	if a := req.GetSlackAlert(); a != nil {
+		return &action{ActionType: ActionTypeSlackAlert, URL: a.Url}, nil
+	}
+	if a := req.GetWebhookAlert(); a != nil {
+		return &action{ActionType: ActionTypeWebhookAlert, URL: a.Url}, nil
+	}
+	if a := req.GetServiceNowAlert(); a != nil {
+		return &action{ActionType: ActionTypeServiceNowAlert, URL: a.Url}, nil
+	}
+	return &action{}, nil
+}
+
+func eventFromReq(eventReq notifications.Rule_Event) (string, error) {
+	switch eventReq {
+	case notifications.Rule_CCRFailure:
+		return EventTypeCCRFailure, nil
+	case notifications.Rule_CCRSuccess:
+		return EventTypeCCRSuccess, nil
+	case notifications.Rule_ComplianceFailure:
+		return EventTypeComplianceFailure, nil
+	case notifications.Rule_ComplianceSuccess:
+		return EventTypeComplianceSuccess, nil
+	default:
+		return "", nil
+	}
+}
+
+func (r *Rule) ValidateForInsert() ([]string, bool) {
+	messages := []string{}
+	if r.Id != "" {
+		messages = append(messages, "Rule ID may not be included in an add-rule request")
+	}
+	if r.Name == "" {
+		messages = append(messages, "Rule name must be supplied.")
+	}
+	if r.Event == "" {
+		messages = append(messages, "FIXME")
+	}
+
+	actionErrors := r.validateAction()
+	messages = append(messages, actionErrors...)
+
+	ok := (len(messages) == 0)
+
+	return messages, ok
+}
+
+func (r *Rule) validateAction() []string {
+	messages := []string{}
+	if r.Action == "" {
+		messages = append(messages, "Action must be set.")
+		return messages
+	}
+	if r.URL == "" {
+		messages = append(messages, "A valid action URL must be supplied")
+		return messages
+	}
+	actionURL, err := url.Parse(r.URL)
+	if err != nil {
+		messages = append(messages, "A valid action URL must be supplied")
+		return messages
+	}
+
+	if actionURL.Scheme != "http" && actionURL.Scheme != "https" {
+		messages = append(messages, "A valid action URL must be supplied")
+	}
+	if actionURL.Host == "" {
+		messages = append(messages, "A valid action URL must be supplied")
+	}
+
+	return messages
+}

--- a/components/notifications-service2/pkg/storage/postgres/db.go
+++ b/components/notifications-service2/pkg/storage/postgres/db.go
@@ -34,10 +34,6 @@ func Start(c *config.Notifications) (*Postgres, error) {
 		return nil, err
 	}
 
-	if err := p.InitDbMap(); err != nil {
-		return nil, err
-	}
-
 	if err := p.Migrate(); err != nil {
 		return nil, err
 	}
@@ -56,6 +52,10 @@ func (db *Postgres) Connect() error {
 	}
 	if db.MaxOpenConns > 0 {
 		dbConn.SetMaxOpenConns(db.MaxOpenConns)
+	}
+
+	if err := db.InitDbMap(); err != nil {
+		return err
 	}
 
 	// Verify database

--- a/components/notifications-service2/pkg/storage/postgres/rules.go
+++ b/components/notifications-service2/pkg/storage/postgres/rules.go
@@ -1,0 +1,64 @@
+package postgres
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/chef/automate/components/notifications-service2/pkg/storage"
+	uuid "github.com/chef/automate/lib/uuid4"
+)
+
+const (
+	selectRuleQuery  = `SELECT id, name, event, action, url, secret_id, critical_controls_only FROM rules WHERE id = $1`
+	selectRulesQuery = `SELECT id, name, event, action, url, secret_id, critical_controls_only FROM rules ORDER BY id`
+	deleteRuleQuery  = `DELETE FROM rules WHERE id = $1`
+)
+
+const (
+	errUniqueViolation = `duplicate key value violates unique constraint`
+)
+
+func (db *Postgres) AddRule(newRule *storage.Rule) (*storage.Rule, error) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate ID for new rule insert")
+	}
+
+	newRule.Id = id.String()
+
+	err = db.DbMap.Insert(newRule)
+	if (err != nil) && strings.Contains(err.Error(), errUniqueViolation) {
+		return nil, storage.NewUniqueConstraintViolation(errors.Wrapf(err, "insert failed due to duplicate name value %q", newRule.Name))
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to insert rule data %+v", newRule)
+	}
+
+	return newRule, nil
+}
+
+func (db *Postgres) GetRule(q *storage.GetRuleQuery) (*storage.Rule, error) {
+	rule := &storage.Rule{}
+	err := db.DbMap.SelectOne(rule, selectRuleQuery, q.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to select rule with query data %+v", q)
+	}
+
+	return rule, nil
+}
+
+func (db *Postgres) ListRules() ([]*storage.Rule, error) {
+	rules := []*storage.Rule{}
+	_, err := db.DbMap.Select(&rules, selectRulesQuery)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to select rules")
+	}
+
+	return rules, nil
+}
+
+func (db *Postgres) DeleteRule(q *storage.DeleteRuleQuery) error {
+	_, err := db.DbMap.Exec(deleteRuleQuery, q.Id)
+	return err
+}

--- a/components/notifications-service2/pkg/storage/postgres/rules.go
+++ b/components/notifications-service2/pkg/storage/postgres/rules.go
@@ -13,10 +13,17 @@ const (
 	selectRuleQuery  = `SELECT id, name, event, action, url, secret_id, critical_controls_only FROM rules WHERE id = $1`
 	selectRulesQuery = `SELECT id, name, event, action, url, secret_id, critical_controls_only FROM rules ORDER BY id`
 	deleteRuleQuery  = `DELETE FROM rules WHERE id = $1`
+	// PG normally returns number of rows updated - so if we find a match but
+	// there is no change to it, it will return 0 rows updated.  To work around
+	// that we declare "RETURNING id" - this makes sure if the record is found,
+	// the ID is returned even if nothing changes.  When the record is not found,
+	// this will not be included in the response.
+	updateRuleQuery = `UPDATE rules SET name = $2, event = $3, action = $4, url = $5, secret_id = $6, critical_controls_only = $7 WHERE id = $1 RETURNING id`
 )
 
 const (
 	errUniqueViolation = `duplicate key value violates unique constraint`
+	errInvalidUUID     = `invalid input syntax for uuid`
 )
 
 func (db *Postgres) AddRule(newRule *storage.Rule) (*storage.Rule, error) {
@@ -41,6 +48,9 @@ func (db *Postgres) AddRule(newRule *storage.Rule) (*storage.Rule, error) {
 func (db *Postgres) GetRule(q *storage.GetRuleQuery) (*storage.Rule, error) {
 	rule := &storage.Rule{}
 	err := db.DbMap.SelectOne(rule, selectRuleQuery, q.Id)
+	if (err != nil) && strings.Contains(err.Error(), errInvalidUUID) {
+		return nil, storage.NewRuleNotFound(err)
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to select rule with query data %+v", q)
 	}
@@ -58,7 +68,28 @@ func (db *Postgres) ListRules() ([]*storage.Rule, error) {
 	return rules, nil
 }
 
+func (db *Postgres) UpdateRule(r *storage.Rule) (*storage.Rule, error) {
+	// updateRuleQuery = `UPDATE rules SET name = $2, event = $3, action = $4, url = $5, secret_id = $6, critical_controls_only = $7 WHERE id = $1 RETURNING id`
+	updatedId, err := db.DbMap.SelectStr(updateRuleQuery, r.Id, r.Name, r.Event, r.Action, r.URL, r.SecretId, r.CriticalControlsOnly)
+	if (err != nil) && (strings.Contains(err.Error(), errUniqueViolation)) {
+		return nil, storage.NewUniqueConstraintViolation(errors.Wrapf(err, "update failed due to duplicate name value %q", r.Name))
+	}
+	if (err != nil) && (strings.Contains(err.Error(), errInvalidUUID)) {
+		return nil, storage.NewRuleNotFound(err)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update rule data %+v", r)
+	}
+	if (updatedId != r.Id) || (updatedId == "") {
+		return nil, storage.NewRuleNotFound(errors.Errorf("could not find rule with id %q for update", r.Id))
+	}
+	return r, nil
+}
+
 func (db *Postgres) DeleteRule(q *storage.DeleteRuleQuery) error {
 	_, err := db.DbMap.Exec(deleteRuleQuery, q.Id)
+	if (err != nil) && strings.Contains(err.Error(), errInvalidUUID) {
+		return storage.NewRuleNotFound(err)
+	}
 	return err
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We are rewriting the notifications service to better align with our org's capabilities.

In this PR, we implement CRUD operations (with validation) for the new notifications service. After this, all integration tests for `RulesCRUD` pass.

### :chains: Related Resources

#4686

### :+1: Definition of Done

Integration tests for `RulesCRUD` pass.

### :athletic_shoe: How to Build and Test the Change

In the hab studio, `start_all_services` and then `build components/notifications-service2`. 

Then `cd /src/components/notifications-service2` and run the tests with `go test -v integration_test/*go -run TestRulesCRUD -count 1`

NOTE: notification dispatch is still unimplemented and thus the full integration test suite has many errors. Running `go test -v integration_test/*go  -count 1` will show this.
