### PR TITLE
Correct previous bad merge

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -64,37 +64,6 @@ steps:
             - HAB_STUDIO_SUP=false
             - HAB_NONINTERACTIVE=true
 
-  # - label: ":semgrep: Custom"
-  #   expeditor:
-  #     executor:
-  #       docker:
-  #         image: returntocorp/semgrep:latest
-  #         entrypoint: semgrep
-  #         command: [
-  #           "--error",
-  #           "--exclude", "*.spec.ts",
-  #           "--config", "/go/src/github.com/chef/automate/semgrep",
-  #           "/go/src/github.com/chef/automate"
-  #         ]
-
-  - label: ":semgrep: Published"
-    expeditor:
-      executor:
-        docker:
-          image: returntocorp/semgrep:latest
-          entrypoint: semgrep
-          command: [
-            "--error",
-            "--exclude", "third_party",
-            "--exclude", "*_test.go",
-            "--exclude", "*.pb.go",
-            "--exclude", "*.bindata.go",
-            "--exclude", "*.spec.ts",
-            "--timeout", "120",
-            "--config", "https://semgrep.dev/p/r2c-ci",
-            "/go/src/github.com/chef/automate"
-          ]
-
   #
   # Static & Unit tests
   #


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The merge of PR https://github.com/chef/automate/pull/4425 (commit 21371a8e)
re-materialized code that was deleted in the prior commit (84333a19).
This deletes that code... again.
(FYI: It has migrated over to verify_private.pipeline.yml).

### :chains: Related Resources
Noted above. 

### :+1: Definition of Done
Semgrep no longer appears on https://buildkite.com/chef-oss/chef-automate-master-verify

### :athletic_shoe: How to Build and Test the Change
Just check the buildkite page above.

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA