### PR TITLE
Updates Environment the response attributes for Delete, Create and Update API

### DIFF
--- a/components/automate-gateway/handler/infra_proxy/environments.go
+++ b/components/automate-gateway/handler/infra_proxy/environments.go
@@ -73,7 +73,13 @@ func (a *InfraProxyServer) CreateEnvironment(ctx context.Context, r *gwreq.Creat
 	}
 
 	return &gwres.Environment{
-		Name: res.GetName(),
+		Name:               res.GetName(),
+		ChefType:           res.GetChefType(),
+		Description:        res.GetDescription(),
+		CookbookVersions:   res.GetCookbookVersions(),
+		JsonClass:          res.GetJsonClass(),
+		DefaultAttributes:  res.GetDefaultAttributes(),
+		OverrideAttributes: res.GetOverrideAttributes(),
 	}, nil
 }
 
@@ -90,7 +96,13 @@ func (a *InfraProxyServer) DeleteEnvironment(ctx context.Context, r *gwreq.Envir
 	}
 
 	return &gwres.Environment{
-		Name: res.GetName(),
+		Name:               res.GetName(),
+		ChefType:           res.GetChefType(),
+		Description:        res.GetDescription(),
+		CookbookVersions:   res.GetCookbookVersions(),
+		JsonClass:          res.GetJsonClass(),
+		DefaultAttributes:  res.GetDefaultAttributes(),
+		OverrideAttributes: res.GetOverrideAttributes(),
 	}, nil
 }
 
@@ -112,7 +124,13 @@ func (a *InfraProxyServer) UpdateEnvironment(ctx context.Context, r *gwreq.Updat
 	}
 
 	return &gwres.Environment{
-		Name: res.GetName(),
+		Name:               res.GetName(),
+		ChefType:           res.GetChefType(),
+		Description:        res.GetDescription(),
+		CookbookVersions:   res.GetCookbookVersions(),
+		JsonClass:          res.GetJsonClass(),
+		DefaultAttributes:  res.GetDefaultAttributes(),
+		OverrideAttributes: res.GetOverrideAttributes(),
 	}, nil
 }
 

--- a/components/infra-proxy-service/integration_test/databags_test.go
+++ b/components/infra-proxy-service/integration_test/databags_test.go
@@ -71,6 +71,21 @@ func TestGetDatabagItems(t *testing.T) {
 	addDataBagItems(ctx, dataBagName, 10)
 
 	t.Run("items list with a per_page search param", func(t *testing.T) {
+		itemId := fmt.Sprintf("item-%d", time.Now().Nanosecond())
+		createReq := &request.CreateDataBagItem{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     dataBagName,
+			Data: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId}},
+				},
+			},
+		}
+		dbItem, err := infraProxy.CreateDataBagItem(ctx, createReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, dbItem)
+
 		req.SearchQuery = &request.SearchQuery{
 			PerPage: 1,
 		}
@@ -84,6 +99,36 @@ func TestGetDatabagItems(t *testing.T) {
 	})
 
 	t.Run("items list with a page search param", func(t *testing.T) {
+		itemId1 := fmt.Sprintf("item-%d", time.Now().Nanosecond())
+		createReq1 := &request.CreateDataBagItem{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     dataBagName,
+			Data: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId1}},
+				},
+			},
+		}
+		dbItem1, err := infraProxy.CreateDataBagItem(ctx, createReq1)
+		assert.NoError(t, err)
+		assert.NotNil(t, dbItem1)
+
+		itemId2 := fmt.Sprintf("item-%d", time.Now().Nanosecond())
+		createReq2 := &request.CreateDataBagItem{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     dataBagName,
+			Data: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"id": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: itemId2}},
+				},
+			},
+		}
+		dbItem2, err := infraProxy.CreateDataBagItem(ctx, createReq2)
+		assert.NoError(t, err)
+		assert.NotNil(t, dbItem2)
+
 		req.SearchQuery = &request.SearchQuery{
 			PerPage: 1,
 			Page:    1,

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -161,6 +161,11 @@ func TestCreateEnvironment(t *testing.T) {
 					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
 				},
 			},
+			OverrideAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "override"}},
+				},
+			},
 		}
 		res, err := infraProxy.CreateEnvironment(ctx, req)
 		assert.NoError(t, err)
@@ -168,6 +173,8 @@ func TestCreateEnvironment(t *testing.T) {
 		assert.Equal(t, name, res.GetName())
 		assert.Equal(t, "auto generate chef environment", res.GetDescription())
 		assert.Equal(t, req.CookbookVersions, res.CookbookVersions)
+		assert.Equal(t, "{\"attribute1\":\"value\"}", res.DefaultAttributes)
+		assert.Equal(t, "{\"attribute1\":\"override\"}", res.OverrideAttributes)
 	})
 
 	t.Run("when the environment exists, raise the error environment already exists", func(t *testing.T) {

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -183,6 +183,7 @@ func TestCreateEnvironment(t *testing.T) {
 
 		nextRes, err := infraProxy.CreateEnvironment(ctx, req)
 		assert.Nil(t, nextRes)
+		assert.Error(t, err, "Environment already exists")
 		grpctest.AssertCode(t, codes.AlreadyExists, err)
 	})
 
@@ -193,7 +194,6 @@ func TestCreateEnvironment(t *testing.T) {
 		}
 		res, err := infraProxy.CreateEnvironment(ctx, req)
 		assert.Nil(t, res)
-		grpctest.AssertCode(t, codes.AlreadyExists, err)
 		assert.Error(t, err, "must supply environment name")
 		grpctest.AssertCode(t, codes.InvalidArgument, err)
 	})

--- a/components/infra-proxy-service/integration_test/environments_test.go
+++ b/components/infra-proxy-service/integration_test/environments_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chef/automate/api/interservice/infra_proxy/request"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestGetEnvironments(t *testing.T) {
@@ -99,6 +100,160 @@ func TestGetEnvironments(t *testing.T) {
 		assert.Equal(t, "_default", res.Environments[0].GetName())
 	})
 
+}
+
+func TestGetEnvironment(t *testing.T) {
+	// rpc GetEnvironment (request.Environment) returns (response.Environment)
+	ctx := context.Background()
+	t.Run("when the environment exists, return the environment successfully", func(t *testing.T) {
+		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
+		creReq := &request.CreateEnvironment{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "auto generate chef environment",
+			CookbookVersions: map[string]string{
+				"audit":       ">= 9.5.0",
+				"chef-client": "= 12.3.3",
+			},
+			DefaultAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
+				},
+			},
+		}
+		envRes, err := infraProxy.CreateEnvironment(ctx, creReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, envRes)
+
+		req := &request.Environment{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     name,
+		}
+		res, err := infraProxy.GetEnvironment(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, name, res.GetName())
+		assert.Equal(t, "auto generate chef environment", res.GetDescription())
+		assert.Equal(t, creReq.CookbookVersions, res.CookbookVersions)
+	})
+}
+
+func TestCreateEnvironment(t *testing.T) {
+	// rpc GetEnvironment (request.Environment) returns (response.Environment)
+	ctx := context.Background()
+	t.Run("when the valid request submit, creates the environment successfully", func(t *testing.T) {
+		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
+		req := &request.CreateEnvironment{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "auto generate chef environment",
+			CookbookVersions: map[string]string{
+				"audit":       ">= 9.5.0",
+				"chef-client": "= 12.3.3",
+			},
+			DefaultAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
+				},
+			},
+		}
+		res, err := infraProxy.CreateEnvironment(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, name, res.GetName())
+		assert.Equal(t, "auto generate chef environment", res.GetDescription())
+		assert.Equal(t, req.CookbookVersions, res.CookbookVersions)
+	})
+}
+
+func TestUpdateEnvironment(t *testing.T) {
+	// rpc UpdateEnvironment (request.UpdateEnvironment) returns (response.Environment)
+	ctx := context.Background()
+	t.Run("when the valid request submit, updates the environment successfully", func(t *testing.T) {
+		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
+		req := &request.CreateEnvironment{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "auto generate chef environment",
+			CookbookVersions: map[string]string{
+				"audit":       ">= 9.5.0",
+				"chef-client": "= 12.3.3",
+			},
+			DefaultAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
+				},
+			},
+		}
+		res, err := infraProxy.CreateEnvironment(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Equal(t, name, res.GetName())
+		assert.Equal(t, "auto generate chef environment", res.GetDescription())
+		assert.Equal(t, req.CookbookVersions, res.CookbookVersions)
+
+		updateReq := &request.UpdateEnvironment{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "updated chef environment",
+			CookbookVersions: map[string]string{
+				"audit":       ">= 9.5.0",
+				"chef-client": "= 12.3.3",
+				"aix":         "> 1.3.3",
+			},
+			DefaultAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
+				},
+			},
+		}
+
+		updateEnv, err := infraProxy.UpdateEnvironment(ctx, updateReq)
+		assert.NoError(t, err)
+		assert.NotNil(t, updateEnv)
+		assert.Equal(t, name, updateEnv.GetName())
+		assert.Equal(t, updateReq.Description, updateEnv.GetDescription())
+		assert.Equal(t, updateReq.CookbookVersions, updateEnv.CookbookVersions)
+	})
+}
+
+func TestDeleteEnvironment(t *testing.T) {
+	// rpc DeleteEnvironment (request.Environment) returns (response.Environment)
+	ctx := context.Background()
+	t.Run("when the valid request submit, deletes the environment successfully", func(t *testing.T) {
+		name := fmt.Sprintf("chef-environment-%d", time.Now().Nanosecond())
+		req := &request.CreateEnvironment{
+			ServerId:    autoDeployedChefServerID,
+			OrgId:       autoDeployedChefOrganizationID,
+			Name:        name,
+			Description: "auto generate chef environment",
+			CookbookVersions: map[string]string{
+				"audit":       ">= 9.5.0",
+				"chef-client": "= 12.3.3",
+			},
+			DefaultAttributes: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"attribute1": &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: "value"}},
+				},
+			},
+		}
+		res, err := infraProxy.CreateEnvironment(ctx, req)
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		// Deletes the created environment
+		delRes, err := infraProxy.DeleteEnvironment(ctx, &request.Environment{
+			ServerId: autoDeployedChefServerID,
+			OrgId:    autoDeployedChefOrganizationID,
+			Name:     name,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, delRes)
+	})
 }
 
 // Adds environments records


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
- For UPDATE, DELETE and CREATE API response only contains the environment name irespective of environment contains the attributes or not.

```
{
  "name": "chef-environment-887549700",
  "chef_type": "",
  "description": "",
  "json_class": "",
  "cookbook_versions": {
  },
  "default_attributes": "{}",
  "override_attributes": "{}"
}
```

### :chains: Related Resources
Changes requested for PR: https://github.com/chef/automate/issues/4545

### :+1: Definition of Done
- Make uniform environment response object, earlier it was returning environment name for DELETE, CREATE and UPDATE APIs.
- it will return the attributes if exists.

### :athletic_shoe: How to Build and Test the Change
- `rebuild components/infra-proxy-service`
- `rebuild components/automate-gateway`

- Create Environment API

```
curl -sSkH "api-token: $(get_admin_token)" -X POST https://a2-dev.test/api/v0/infra/servers/chef-server-dev-test/orgs/chef-org-dev/environments?pretty -d '{"name": "new-env-test", "description": "test"}'
{
  "name": "new-env-test",
  "chef_type": "environment",
  "description": "test",
  "json_class": "Chef::Environment",
  "cookbook_versions": {
  },
  "default_attributes": "{}",
  "override_attributes": "{}"
}
```

- Update environment API

```
curl -sSkH "api-token: $(get_admin_token)" -X PUT https://a2-dev.test/api/v0/infra/servers/chef-server-dev-test/orgs/chef-org-dev/environments/chef-environment-621641300?pretty -d '{"description": "test"}'
{
  "name": "chef-environment-621641300",
  "chef_type": "environment",
  "description": "test",
  "json_class": "Chef::Environment",
  "cookbook_versions": {
  },
  "default_attributes": "{}",
  "override_attributes": "{}"
}
```

- Delete Environment API

```
curl -sSkH "api-token: $(get_admin_token)" -X DELETE https://a2-dev.test/api/v0/infra/servers/chef-server-dev-test/orgs/chef-org-dev/environments/chef-environment-88754970?pretty
{
  "name": "chef-environment-887549700",
  "chef_type": "environment",
  "description": "",
  "json_class": "Chef::Environment",
  "cookbook_versions": {
  },
  "default_attributes": "{}",
  "override_attributes": "{}"
}
```


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Signed-off-by: Vivek Singh <vivek.singh@msystechnologies.com>