### PR TITLE
Cleanup recent buf exceptions

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -424,7 +424,3 @@ breaking:
     # it's the best/least bad option, you can add it here and remove it in a
     # later PR:
     # - external/oops/oops.proto
-    - config/esgateway/config_request.proto
-    - external/infra_proxy/request/nodes.proto
-    - external/infra_proxy/response/nodes.proto
-    - external/infra_proxy/infra_proxy.proto

--- a/buf.yaml
+++ b/buf.yaml
@@ -415,8 +415,7 @@ lint:
     - external/habitat/event.proto # this file is owned by habitat and copied here
 breaking:
   use:
-    # TODO: TEMPORARY CHANGE JUST FOR THIS PR!
-    - FILE
+    - PACKAGE
   ignore:
     # Changes to interservice APIs are okay until (if ever) we support clusters
     # of interconnected internal services that would not upgrade in unison


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In order to get breaking protobuf changes through Buildkite, we need to make an exception in the buf.yaml config file. But then we need to take those exceptions out again in a follow-up PR. This is that follow-up PR.

### :chains: Related Resources

### :+1: Definition of Done
Buildkite passes now with those protobuf changes locked in.

### :athletic_shoe: How to Build and Test the Change
Observe Buildkite

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
