### PR TITLE
Reinstate sidebar tests to have a safety net

### DIFF
--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
@@ -1,20 +1,21 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { StoreModule, Store } from '@ngrx/store';
-import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
 
-import { SidebarComponent } from './sidebar.component';
+import { NgrxStateAtom, ngrxReducers, defaultInitialState, runtimeChecks } from 'app/ngrx.reducers';
+import { using } from 'app/testing/spec-helpers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { SettingsLandingComponent } from 'app/pages/settings-landing/settings-landing.component';
-import { using } from 'app/testing/spec-helpers';
 import { ComplianceLandingComponent } from 'app/pages/compliance-landing/compliance-landing.component';
+import { SidebarEntryComponent } from 'app/components/sidebar-entry/sidebar-entry.component';
+import { SidebarComponent } from './sidebar.component';
 
 describe('SidebarComponent', () => {
   let store: Store<NgrxStateAtom>;
   let component: SidebarComponent;
   let fixture: ComponentFixture<SidebarComponent>;
-  // let element: HTMLElement;
+  let element: HTMLElement;
   let layoutFacade: LayoutFacadeService;
   let featureFlags: FeatureFlagsService;
 
@@ -39,48 +40,49 @@ describe('SidebarComponent', () => {
     spyOn(store, 'dispatch').and.callThrough();
   }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SidebarComponent);
-    component = fixture.componentInstance;
-    // element = fixture.debugElement.nativeElement;
+  describe('component is created', () => {
 
-    // enable all feature flags, if any, for testing
-    featureFlags.setFeature('servicenow_cmdb', true);
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SidebarComponent);
+      component = fixture.componentInstance;
+    });
 
-    fixture.detectChanges();
+    it('should be created', () => {
+      expect(component).toBeTruthy();
+    });
   });
 
-  it('should be created', () => {
-    expect(component).toBeTruthy();
-  });
-
+  // Only need to check components that copy the route structure defined by LayoutSidebarService.
+  // The unit tests here are a meta-check to ensure that if you make a change in one place,
+  // you must also make the same change in the copy.
   using([
-    [new SettingsLandingComponent(), Sidebar.Settings, 'Settings Landing Component'],
-    [new ComplianceLandingComponent(), Sidebar.Compliance, 'Compliance Landing Component']
+    [new SettingsLandingComponent(), Sidebar.Settings, 'servicenow_cmdb', 'Settings Landing Component'],
+    [new ComplianceLandingComponent(), Sidebar.Compliance, '', 'Compliance Landing Component']
 
-  ], function (_landingComponent: any, sidebar: Sidebar,  description: string) {
+  ], function (landingComponent: any, sidebar: Sidebar,  featureFlag: string, description: string) {
     describe(`${description} route list`, () => {
 
       beforeEach(() => {
+        if (featureFlag) {
+          featureFlags.setFeature(featureFlag, true);
+        }
+
+        fixture = TestBed.createComponent(SidebarComponent);
+        element = fixture.debugElement.nativeElement;
+
         layoutFacade.showSidebar(sidebar);
         fixture.detectChanges();
       });
 
-      // FIXME(tc): Sometimes missing elements. Needs investigation.
-      // it('has length consistent with sidebar', () => {
-      //   const links = element.querySelectorAll('div.nav-items chef-sidebar-entry');
-      //   expect(links.length).toBe(landingComponent.routeList.length);
-      // });
-
-      // FIXME(sr): This test randomly fails, insofar as the elements are all there,
-      //            but in the wrong order.
-      // it('has route order consistent with sidebar', () => {
-      //   const links = element.querySelectorAll('div.nav-items chef-sidebar-entry');
-      //   for (let i = 0; i < links.length; i++) {
-      //     const link: any = links[i];
-      //     expect(link.route).toBe(landingComponent.routeList[i].route);
-      //   }
-      // });
+      it('has route order consistent with sidebar', () => {
+        const links = element.querySelectorAll('div.nav-items chef-sidebar-entry');
+        expect(links.length).toBe(landingComponent.routeList.length);
+        for (let i = 0; i < links.length; i++) {
+          // link is both an Element and a SidebarEntryComponent, but we only care about the latter
+          const link = links[i] as unknown as SidebarEntryComponent;
+          expect(link.route).toBe(landingComponent.routeList[i].route);
+        }
+      });
     });
   });
 });

--- a/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/components/automate-ui/src/app/components/sidebar/sidebar.component.spec.ts
@@ -35,7 +35,6 @@ describe('SidebarComponent', () => {
       ]
     }).compileComponents();
     store = TestBed.inject(Store);
-    layoutFacade = TestBed.inject(LayoutFacadeService);
     featureFlags = TestBed.inject(FeatureFlagsService);
     spyOn(store, 'dispatch').and.callThrough();
   }));
@@ -66,6 +65,8 @@ describe('SidebarComponent', () => {
         if (featureFlag) {
           featureFlags.setFeature(featureFlag, true);
         }
+        // must be after feature flag setting!
+        layoutFacade = TestBed.inject(LayoutFacadeService);
 
         fixture = TestBed.createComponent(SidebarComponent);
         element = fixture.debugElement.nativeElement;

--- a/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
+++ b/components/automate-ui/src/app/pages/settings-landing/settings-landing.component.ts
@@ -12,8 +12,7 @@ export class SettingsLandingComponent {
   public routeList: RoutePerms[] = [
     { anyOfCheck: [['/api/v0/notifications/rules', 'get']], route: '/settings/notifications' },
     { anyOfCheck: [['/api/v0/datafeed/destinations', 'post']], route: '/settings/data-feeds' },
-    { anyOfCheck: [['/api/v0/retention/nodes/status', 'get']],
-      route: '/settings/data-lifecycle' },
+    { anyOfCheck: [['/api/v0/retention/nodes/status', 'get']], route: '/settings/data-lifecycle' },
     { anyOfCheck: [['/api/v0/nodemanagers/search', 'post']], route: '/settings/node-integrations' },
     { anyOfCheck: [['/api/v0/secrets/search', 'post']], route: '/settings/node-credentials' },
     { allOfCheck: [['/apis/iam/v2/users', 'get']], route: '/settings/users' },


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Sometimes when we write code, it either reflects some data from elsewhere in the code base or requires certain structure or annotation that other parts of the system depend on. A canonical example of this is protobuf source files. Each such file is, in essence, reflected in a revised format in one or more *.pb.go files in our system. We have a number of meta-tests that ensure the generated files are consistent with the source files as well as checking for required annotations unique to Automate -- see [How Automate Ensures Integrity of Protobuf Files](https://github.com/chef/automate/blob/master/components/automate-gateway/docs/proto-integrity.md).

Similarly in the UI, there are some meta-tests that ensure appropriate consistency and constraints; this PR deals with one such set of tests. The code for these tests had been deactivated some time back because they were failing and the cause was not determined. I took another look and was able to discover that a sequencing error was causing this failure (truncated for brevity):
```
Chrome 88.0.4324.192 (Mac OS 11.2.2) SidebarComponent Settings Landing Component route list has route order consistent with sidebar FAILED
	Error: Expected 10 to be 11.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/components/sidebar/sidebar.component.spec.ts:80:30)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
	    at ProxyZoneSpec.push.tWgn.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/proxy.js:117:1)
	Error: Expected '/settings/data-lifecycle' to be '/settings/data-feeds'.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/components/sidebar/sidebar.component.spec.ts:84:30)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
	    at ProxyZoneSpec.push.tWgn.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/proxy.js:117:1)
	Error: Expected '/settings/node-integrations' to be '/settings/data-lifecycle'.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/components/sidebar/sidebar.component.spec.ts:84:30)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
	    at ProxyZoneSpec.push.tWgn.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/proxy.js:117:1)
    . . .
```

The reason had been known--it was due to one item that was conditionally masked by a feature flag -- hence the discrepancy between 10 and 11 in the output above. The rest of the errors were just because in comparing two arrays, one item was missing in the second position, so everything after that was a mismatch.

As to the root cause, though, that is what I just discovered: we were setting the necessary feature flag appropriately but that setting had been ignored because it was only checked when LayoutFacadeService is instantiated, and that was too late.

Just to be absolutely sure that there was no intermittent component of the problem, I reran the buildkite test 6 times and there were no failures.

### :chains: Related Resources
NA

### :+1: Definition of Done
Newly reinstated tests pass.

### :athletic_shoe: How to Build and Test the Change
1. cd automate-ui
2. make unit

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
NA