### PR TITLE
Jamie/4828 modal first focus flexible

### DIFF
--- a/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
+++ b/components/automate-ui/src/app/components/create-object-modal/create-object-modal.component.ts
@@ -13,6 +13,7 @@ import { Project, ProjectConstants } from 'app/entities/projects/project.model';
 import { GetPolicies } from 'app/entities/policies/policy.actions';
 import { allPolicies } from 'app/entities/policies/policy.selectors';
 import { ResourceCheckedSection } from 'app/components/resource-dropdown/resource-dropdown.component';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 const INGEST_POLICY_ID = 'ingest-access';
 
@@ -113,7 +114,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyID && !this.isNavigationKey(event)) {
+    if (!this.modifyID && !Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.createForm.controls.id.setValue(
         IdMapper.transform(this.createForm.controls.name.value.trim()));
@@ -121,7 +122,7 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
   }
 
   handleIDInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -136,7 +137,4 @@ export class CreateObjectModalComponent implements OnInit, OnDestroy, OnChanges 
     this.createClicked.emit();
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/helpers/utilities/utilities.spec.ts
+++ b/components/automate-ui/src/app/helpers/utilities/utilities.spec.ts
@@ -1,0 +1,45 @@
+import { Utilities } from './utilities';
+import { using } from 'app/testing/spec-helpers';
+
+describe('Utilities', () => {
+
+  describe('isNavigationKey', () => {
+
+    using([
+      ['Shift'],
+      ['Tab'],
+      ['Enter']
+    ],
+      function(key: string) {
+        it('returns true if key pressed is ' + key, () => {
+          const event = new KeyboardEvent('keypress', {
+            'key': key
+          });
+          expect(Utilities.isNavigationKey(event)).toBe(true);
+        });
+      });
+
+    using([
+      ['A'],
+      ['D'],
+      ['Z'],
+      ['c'],
+      ['l'],
+      ['y'],
+      ['3'],
+      ['!'],
+      ['8'],
+      ['_'],
+      ['?']
+    ],
+      function (key: string) {
+        it('returns true if key pressed is ' + key, () => {
+          const event = new KeyboardEvent('keypress', {
+            'key': key
+          });
+          expect(Utilities.isNavigationKey(event)).toBe(false);
+        });
+      });
+
+  });
+});

--- a/components/automate-ui/src/app/helpers/utilities/utilities.ts
+++ b/components/automate-ui/src/app/helpers/utilities/utilities.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class Utilities {
+
+  static isNavigationKey(event: KeyboardEvent): boolean {
+    return event.key === 'Shift' || event.key === 'Tab' || event.key === 'Enter';
+  }
+
+}
+

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.html
@@ -8,6 +8,7 @@
             <span class="label">Name <span aria-hidden="true">*</span></span>
             <input
               chefInput
+              firstFocus
               formControlName="name"
               data-cy="add-name"
               type="text"

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { FormGroup } from '@angular/forms';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 @Component({
   selector: 'app-create-chef-server-modal',
@@ -28,7 +29,7 @@ export class CreateChefServerModalComponent implements OnInit {
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyID && !this.isNavigationKey(event)) {
+    if (!this.modifyID && !Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.createForm.controls.id.setValue(
         IdMapper.transform(this.createForm.controls.name.value.trim()));
@@ -36,7 +37,7 @@ export class CreateChefServerModalComponent implements OnInit {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -51,7 +52,4 @@ export class CreateChefServerModalComponent implements OnInit {
     this.createClicked.emit();
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
@@ -6,7 +6,7 @@
         <chef-form-field>
           <label *ngIf="!created">
             <span class="label">Client Name</span>
-            <input chefInput formControlName="name" type="text" (keyup)="handleNameInput($event)" autocomplete="off" />
+            <input chefInput firstFocus formControlName="name" type="text" (keyup)="handleNameInput($event)" autocomplete="off" />
           </label>
           <chef-error *ngIf="error">{{error}}</chef-error>
         </chef-form-field>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
@@ -10,6 +10,7 @@ import { CreateClient, GetClients } from 'app/entities/clients/client.action';
 import { saveError, createClient } from 'app/entities/clients/client.selectors';
 import { isNil } from 'lodash/fp';
 import { saveAs } from 'file-saver';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 @Component({
   selector: 'app-create-client-modal',
@@ -89,7 +90,7 @@ export class CreateClientModalComponent implements OnInit, OnDestroy {
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.isNavigationKey(event)) {
+    if (!Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.error = '';
       this.createForm.controls.name.setValue(
@@ -98,7 +99,7 @@ export class CreateClientModalComponent implements OnInit, OnDestroy {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -155,7 +156,4 @@ export class CreateClientModalComponent implements OnInit, OnDestroy {
     saveAs(blob, this.createdClient + '.pem');
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
@@ -5,8 +5,8 @@
       <div class="margin">
         <chef-form-field>
           <label>
-            <span class="label">Name <span aria-hidden="true">*</span></span>
-            <input chefInput formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
+            <span class="label">Name</span>
+            <input chefInput firstFocus formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
           </label>
           <chef-error
           *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
@@ -22,6 +22,7 @@ import { DataBag } from 'app/entities/data-bags/data-bags.model';
 import {
   CreateDataBag
 } from 'app/entities/data-bags/data-bags.actions';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 @Component({
   selector: 'app-create-data-bag-modal',
@@ -93,7 +94,7 @@ export class CreateDataBagModalComponent implements OnInit, OnDestroy {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -122,7 +123,4 @@ export class CreateDataBagModalComponent implements OnInit, OnDestroy {
     this.conflictError = false;
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
@@ -15,6 +15,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, pending } from 'app/entities/entities';
 import { HttpStatus } from 'app/types/types';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import {
   saveStatus,
   saveError
@@ -103,7 +104,7 @@ export class CreateDatabagItemModalComponent implements OnInit, OnDestroy {
   }
 
   handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -160,7 +161,4 @@ export class CreateDatabagItemModalComponent implements OnInit, OnDestroy {
     this.itemAttrParseError = false;
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
@@ -11,7 +11,7 @@
               <chef-form-field>
                 <label>
                   <span class="label">Name <span aria-hidden="true">*</span></span>
-                  <input chefInput formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
+                  <input chefInput firstFocus formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
                 </label>
                 <chef-error
                   *ngIf="(detailsFormGroup.get('name').hasError('required') || detailsFormGroup.get('name').hasError('pattern')) && detailsFormGroup.get('name').dirty">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
@@ -11,7 +11,7 @@
                             <chef-form-field>
                                 <label>
                                     <span class="label">Name <span aria-hidden="true">*</span></span>
-                                    <input chefInput formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
+                                    <input chefInput firstFocus formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
                                 </label>
                                 <chef-error
                                     *ngIf="(detailsFormGroup.get('name').hasError('required') || detailsFormGroup.get('name').hasError('pattern')) && detailsFormGroup.get('name').dirty">

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.html
@@ -8,6 +8,7 @@
             <span class="label">Name <span aria-hidden="true">*</span></span>
             <input
               chefInput
+              firstFocus
               name="name"
               formControlName="name"
               type="text"

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
@@ -75,6 +75,6 @@ export class CreateOrgModalComponent implements OnInit, OnChanges {
   }
 
   private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
+    return event.key === 'Shift' || event.key === 'Tab' || event.key === 'Enter';
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-org-modal/create-org-modal.component.ts
@@ -9,6 +9,7 @@ import { Component,
 import { FormGroup } from '@angular/forms';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { ProjectConstants } from 'app/entities/projects/project.model';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 @Component({
   selector: 'app-create-org-modal',
@@ -49,7 +50,7 @@ export class CreateOrgModalComponent implements OnInit, OnChanges {
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyID && !this.isNavigationKey(event)) {
+    if (!this.modifyID && !Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.createForm.controls.id.setValue(
         IdMapper.transform(this.createForm.controls.name.value.trim()));
@@ -57,7 +58,7 @@ export class CreateOrgModalComponent implements OnInit, OnChanges {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -74,7 +75,4 @@ export class CreateOrgModalComponent implements OnInit, OnChanges {
     this.checkedProjectIDs = [];
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab' || event.key === 'Enter';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/edit-data-bag-item-modal/edit-data-bag-item-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/edit-data-bag-item-modal/edit-data-bag-item-modal.component.ts
@@ -15,6 +15,7 @@ import { pending, EntityStatus } from 'app/entities/entities';
 import { Subject } from 'rxjs';
 import { UpdateDataBagItem } from 'app/entities/data-bags/data-bag-details.actions';
 import { updateStatus } from 'app/entities/data-bags/data-bag-details.selector';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 @Component({
   selector: 'app-edit-data-bag-item-modal',
@@ -77,7 +78,7 @@ export class EditDataBagItemModalComponent implements OnChanges, OnInit, OnDestr
   }
 
   handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -116,7 +117,4 @@ export class EditDataBagItemModalComponent implements OnChanges, OnInit, OnDestr
     }
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/edit-environment-attribute-modal/edit-environment-attribute-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/edit-environment-attribute-modal/edit-environment-attribute-modal.component.ts
@@ -19,6 +19,7 @@ import {
 import { isNil } from 'ngx-cookie';
 import { Cookbook } from 'app/entities/cookbooks/cookbook.model';
 import { Regex } from 'app/helpers/auth/regex';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 export class CookbookConstraintGrid {
   id: number;
@@ -160,7 +161,7 @@ export class EditEnvironmentAttributeModalComponent implements OnChanges, OnInit
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.isNavigationKey(event)) {
+    if (!Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.defaultAttributeForm.controls.default.setValue(
         IdMapper.transform(this.defaultAttributeForm.controls.default.value.trim()));
@@ -294,10 +295,6 @@ export class EditEnvironmentAttributeModalComponent implements OnChanges, OnInit
     this.store.dispatch(
       new UpdateEnvironment(environment)
     );
-  }
-
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
   }
 
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-environment-constraint/infra-environment-constraint.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-environment-constraint/infra-environment-constraint.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 
 import { FormGroup } from '@angular/forms';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 import { CookbookConstraintGrid } from '../create-environment-modal/create-environment-modal.component';
 
@@ -76,7 +77,7 @@ export class InfraEnvironmentConstraintComponent implements OnInit {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -138,10 +139,6 @@ export class InfraEnvironmentConstraintComponent implements OnInit {
       }
     });
     return previousName;
-  }
-
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
   }
 
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.ts
@@ -8,6 +8,7 @@ import { getStatus,
   resetKeyClient,
   saveError } from 'app/entities/clients/client-details.selectors';
 import { EntityStatus } from 'app/entities/entities';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import { isNil } from 'lodash/fp';
 import { saveAs } from 'file-saver';
 import { ResetKey } from 'app/entities/clients/client.model';
@@ -77,7 +78,7 @@ export class ResetClientKeyComponent implements OnInit, OnDestroy {
   }
 
   handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
   }
@@ -115,7 +116,4 @@ export class ResetClientKeyComponent implements OnInit, OnDestroy {
     saveAs(blob, this.name + '.pem');
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
+++ b/components/automate-ui/src/app/page-components/create-user-modal/create-user-modal.component.ts
@@ -11,6 +11,7 @@ import { Regex } from 'app/helpers/auth/regex';
 import { UsernameMapper } from 'app/helpers/auth/username-mapper';
 import { ChefValidators } from 'app/helpers/auth/validator';
 import { EntityStatus } from 'app/entities/entities';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import { CreateUserPayload, CreateUser } from 'app/entities/users/user.actions';
 import { createStatus, createError } from 'app/entities/users/user.selectors';
 
@@ -112,14 +113,14 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
   }
 
   handleUsernameInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyUsername && !this.isNavigationKey(event)) {
+    if (!this.modifyUsername && !Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.createUserForm.controls.username.setValue(
         UsernameMapper.transform(this.createUserForm.controls.displayName.value.trim()));
@@ -132,7 +133,7 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
     // Since the match validator is only activated by changes to confirmPassword,
     // we have to manually revalidate confirmPassword here
     this.createUserForm.get('confirmPassword').updateValueAndValidity();
-    if (!this.isNavigationKey(event)) {
+    if (!Utilities.isNavigationKey(event)) {
       this.passwordError = false;
     }
   }
@@ -151,7 +152,4 @@ export class CreateUserModalComponent implements OnInit, OnDestroy {
       (this.createUserForm.get(field).touched || this.createUserForm.get(field).dirty));
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/create-node-credential-modal/create-node-credential-modal.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/create-node-credential-modal/create-node-credential-modal.component.ts
@@ -10,6 +10,7 @@ import { takeUntil, filter } from 'rxjs/operators';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { EntityStatus } from 'app/entities/entities';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import {
   saveError,
   saveStatus
@@ -124,7 +125,7 @@ export class CreateNodeCredentialModalComponent implements OnInit, OnDestroy {
   }
 
   handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyID && !this.isNavigationKey(event)) {
+    if (!this.modifyID && !Utilities.isNavigationKey(event)) {
       this.conflictError = false;
       this.createNodeCredForm.controls.id.setValue(
         IdMapper.transform(this.createNodeCredForm.controls.name.value.trim()));
@@ -136,7 +137,7 @@ export class CreateNodeCredentialModalComponent implements OnInit, OnDestroy {
   }
 
   handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -145,10 +146,6 @@ export class CreateNodeCredentialModalComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
-  }
-
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
   }
 
 }

--- a/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.ts
+++ b/components/automate-ui/src/app/pages/create-data-feed-modal/create-data-feed-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { Utilities } from 'app/helpers/utilities/utilities';
 
 enum UrlTestState {
   Inactive,
@@ -34,7 +35,7 @@ export class CreateDataFeedModalComponent implements OnInit {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -56,8 +57,5 @@ export class CreateDataFeedModalComponent implements OnInit {
     return this.createForm.controls.url.value !== '' ? true : false;
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }
 

--- a/components/automate-ui/src/app/pages/create-notification-modal/create-notification-modal.component.ts
+++ b/components/automate-ui/src/app/pages/create-notification-modal/create-notification-modal.component.ts
@@ -14,6 +14,7 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { Regex } from 'app/helpers/auth/regex';
 import { EntityStatus, pending } from 'app/entities/entities';
 import { HttpStatus } from 'app/types/types';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import {
   saveStatus,
   saveError
@@ -123,7 +124,7 @@ export class CreateNotificationModalComponent implements OnInit, OnDestroy {
   }
 
   public handleInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
@@ -221,8 +222,5 @@ export class CreateNotificationModalComponent implements OnInit, OnDestroy {
     this.notificationRule.ruleType === 'ComplianceFailure';
   }
 
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
-  }
 }
 

--- a/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
+++ b/components/automate-ui/src/app/pages/project/rules/project-rules.component.ts
@@ -13,6 +13,7 @@ import { IdMapper } from 'app/helpers/auth/id-mapper';
 import { Regex } from 'app/helpers/auth/regex';
 import { AuthorizedChecker } from 'app/helpers/auth/authorized';
 import { EntityStatus } from 'app/entities/entities';
+import { Utilities } from 'app/helpers/utilities/utilities';
 import {
   Rule, RuleTypeMappedObject, Condition, ConditionOperator, isConditionOperator, KVPair
 } from 'app/entities/rules/rule.model';
@@ -301,7 +302,7 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   public handleNameInput(event: KeyboardEvent): void {
-    if (!this.modifyID && !this.isNavigationKey(event) && !this.editingRule) {
+    if (!this.modifyID && !Utilities.isNavigationKey(event) && !this.editingRule) {
       this.conflictError = false;
       this.ruleForm.controls.id.setValue(
         IdMapper.transform(this.ruleForm.controls.name.value.trim()));
@@ -309,14 +310,10 @@ export class ProjectRulesComponent implements OnInit, OnDestroy {
   }
 
   handleIDInput(event: KeyboardEvent): void {
-    if (this.isNavigationKey(event)) {
+    if (Utilities.isNavigationKey(event)) {
       return;
     }
     this.conflictError = false;
-  }
-
-  private isNavigationKey(event: KeyboardEvent): boolean {
-    return event.key === 'Shift' || event.key === 'Tab';
   }
 
   get conditionControls(): { [key: string]: AbstractControl } {

--- a/components/chef-ui-library/package-lock.json
+++ b/components/chef-ui-library/package-lock.json
@@ -2063,7 +2063,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {

--- a/components/chef-ui-library/package-lock.json
+++ b/components/chef-ui-library/package-lock.json
@@ -2063,7 +2063,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {

--- a/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
+++ b/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
@@ -413,6 +413,8 @@ export class ChefButton {
    */
   @Prop({ reflectToAttr: true }) target: string;
 
+  @Prop({ reflectToAttr: true }) firstFocus = false;
+
   render() {
     const link = (
       <a href={this.url} target={this.target}>

--- a/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
+++ b/components/chef-ui-library/src/atoms/chef-button/chef-button.tsx
@@ -413,8 +413,6 @@ export class ChefButton {
    */
   @Prop({ reflectToAttr: true }) target: string;
 
-  @Prop({ reflectToAttr: true }) firstFocus = false;
-
   render() {
     const link = (
       <a href={this.url} target={this.target}>

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -49,7 +49,7 @@ import {
  * <chef-modal label="unique-id">
  *    <h2 id="unique-id"> TITLE OF MODAL </h2>
  * ```
- * 
+ *
  * Using custom autofocus
  * By default, autofocus will apply to the modal itself on locked modals
  * and to the close button on unlocked modals.  We can customize where
@@ -71,7 +71,7 @@ import {
  * <p> Switch to the `Console` pane and type `$0.visible = true`. </p>
  * <p> Type `$0.visible = false` to turn off the modal again.</p>
  * </chef-modal>
- * 
+ *
  * @example
  * <chef-modal label="with-custom-focus" label="example-id">
  *    <h2 slot="title" id="example-id"> Using custom autofocus </h2>
@@ -130,7 +130,7 @@ export class ChefModal {
       this.prevFocusedElement = document.activeElement as HTMLElement;
 
       const focusElement = this.getFocusElement(this.locked);
- 
+
       const focusElementInterval = setInterval(() => {
         focusElement.focus();
         if (focusElement === document.activeElement) {
@@ -184,14 +184,14 @@ export class ChefModal {
   private getFocusElement(lockStatus: boolean): HTMLElement {
     const modal = this.el.getElementsByClassName('modal').item(0) as HTMLElement;
     const closeFocus = this.el.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
-    let firstFocus = this.el.querySelector('[firstFocus]') as HTMLElement;
+    const firstFocus = this.el.querySelector('[firstFocus]') as HTMLElement;
 
     if (lockStatus) {
-      return modal
+      return modal;
     } else if (firstFocus) {
       return firstFocus.tagName === 'CHEF-BUTTON'
         ? firstFocus.firstElementChild as HTMLElement
-        : firstFocus
+        : firstFocus;
     }
 
     return closeFocus;

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -118,9 +118,27 @@ export class ChefModal {
       // when Angular detects the modal is open
       // sets the focus on the close button for unlocked modals,
       // or the div for locked modals
-      const focusElement =
-        (this.locked ? this.el.getElementsByClassName('modal').item(0) :
-        this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement;
+
+      // const focusElement =
+      //   (this.locked 
+      //     ? this.el.getElementsByClassName('modal').item(0)
+      //     : this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement;
+      
+      const focusElement = getFirstFocus(this.locked, this.el);
+      
+      function getFirstFocus(lockStatus: boolean, modal: HTMLElement) {
+        const thisModal = modal.getElementsByClassName('modal').item(0) as HTMLElement;
+        const firstFocus = modal.querySelector('[firstFocus]') as HTMLElement;
+        const closeFocus = modal.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
+
+        if(lockStatus) {
+          return thisModal
+        } else if (firstFocus) {
+          return firstFocus;
+        }
+
+        return closeFocus;
+      }
 
       const focusElementInterval = setInterval(() => {
         focusElement.focus();

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -49,6 +49,13 @@ import {
  * <chef-modal label="unique-id">
  *    <h2 id="unique-id"> TITLE OF MODAL </h2>
  * ```
+ * 
+ * Using custom autofocus
+ * By default, autofocus will apply to the modal itself on locked modals
+ * and to the close button on unlocked modals.  We can customize where
+ * the autofocus goes first, by adding the attribute "firstFocus" to the
+ * desired element.  Currently this works with all standard HTML input elements as
+ * well as our custom chef-button element.
  *
  * @example
  * <chef-modal locked="false" label="unique-id">
@@ -63,6 +70,13 @@ import {
  * </p>
  * <p> Switch to the `Console` pane and type `$0.visible = true`. </p>
  * <p> Type `$0.visible = false` to turn off the modal again.</p>
+ * </chef-modal>
+ * 
+ * @example
+ * <chef-modal label="with-custom-focus" label="example-id">
+ *    <h2 slot="title" id="example-id"> Using custom autofocus </h2>
+ *    <label>this input will be focused upon opening</label>
+ *    <input type="text" firstFocus/>
  * </chef-modal>
  */
 @Component({

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -129,29 +129,8 @@ export class ChefModal {
     if (visible) {
       this.prevFocusedElement = document.activeElement as HTMLElement;
 
-      // when Angular detects the modal is open
-      // sets the focus by default on the close button for unlocked modals,
-      // or the div for locked modals
-      // User can specify element to focus first using firstFocus attribute
-      
-      const focusElement = getFirstFocus(this.locked, this.el);
-      
-      function getFirstFocus(lockStatus: boolean, thisEl: HTMLElement) {
-        const modal = thisEl.getElementsByClassName('modal').item(0) as HTMLElement;
-        const closeFocus = thisEl.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
-        let firstFocus = thisEl.querySelector('[firstFocus]') as HTMLElement;
-
-        if(lockStatus) {
-          return modal
-        } else if (firstFocus) {
-          return firstFocus.tagName === 'CHEF-BUTTON' 
-            ? firstFocus.firstElementChild as HTMLElement 
-            : firstFocus
-        }
-
-        return closeFocus;
-      }
-
+      const focusElement = this.getFocusElement(this.locked);
+ 
       const focusElementInterval = setInterval(() => {
         focusElement.focus();
         if (focusElement === document.activeElement) {
@@ -196,6 +175,26 @@ export class ChefModal {
     }
 
     return '';
+  }
+
+  // when Angular detects the modal is open
+  // it sets the focus by default on the close button for unlocked modals,
+  // or the modal div for locked modals
+  // Developer can specify element to focus first using firstFocus attribute
+  private getFocusElement(lockStatus: boolean): HTMLElement {
+    const modal = this.el.getElementsByClassName('modal').item(0) as HTMLElement;
+    const closeFocus = this.el.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
+    let firstFocus = this.el.querySelector('[firstFocus]') as HTMLElement;
+
+    if (lockStatus) {
+      return modal
+    } else if (firstFocus) {
+      return firstFocus.tagName === 'CHEF-BUTTON'
+        ? firstFocus.firstElementChild as HTMLElement
+        : firstFocus
+    }
+
+    return closeFocus;
   }
 
   private handleClose() {

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -116,25 +116,23 @@ export class ChefModal {
       this.prevFocusedElement = document.activeElement as HTMLElement;
 
       // when Angular detects the modal is open
-      // sets the focus on the close button for unlocked modals,
+      // sets the focus by default on the close button for unlocked modals,
       // or the div for locked modals
-
-      // const focusElement =
-      //   (this.locked 
-      //     ? this.el.getElementsByClassName('modal').item(0)
-      //     : this.el.getElementsByClassName('close').item(0).firstElementChild) as HTMLElement;
+      // User can specify element to focus first using firstFocus attribute
       
       const focusElement = getFirstFocus(this.locked, this.el);
       
       function getFirstFocus(lockStatus: boolean, modal: HTMLElement) {
         const thisModal = modal.getElementsByClassName('modal').item(0) as HTMLElement;
-        const firstFocus = modal.querySelector('[firstFocus]') as HTMLElement;
         const closeFocus = modal.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
+        let firstFocus = modal.querySelector('[firstFocus]') as HTMLElement;
 
         if(lockStatus) {
           return thisModal
         } else if (firstFocus) {
-          return firstFocus;
+          return firstFocus.tagName === 'CHEF-BUTTON' 
+            ? firstFocus.firstElementChild as HTMLElement 
+            : firstFocus
         }
 
         return closeFocus;

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -136,13 +136,13 @@ export class ChefModal {
       
       const focusElement = getFirstFocus(this.locked, this.el);
       
-      function getFirstFocus(lockStatus: boolean, modal: HTMLElement) {
-        const thisModal = modal.getElementsByClassName('modal').item(0) as HTMLElement;
-        const closeFocus = modal.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
-        let firstFocus = modal.querySelector('[firstFocus]') as HTMLElement;
+      function getFirstFocus(lockStatus: boolean, thisEl: HTMLElement) {
+        const modal = thisEl.getElementsByClassName('modal').item(0) as HTMLElement;
+        const closeFocus = thisEl.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;
+        let firstFocus = thisEl.querySelector('[firstFocus]') as HTMLElement;
 
         if(lockStatus) {
-          return thisModal
+          return modal
         } else if (firstFocus) {
           return firstFocus.tagName === 'CHEF-BUTTON' 
             ? firstFocus.firstElementChild as HTMLElement 

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -180,7 +180,8 @@ export class ChefModal {
   // when Angular detects the modal is open
   // it sets the focus by default on the close button for unlocked modals,
   // or the modal div for locked modals
-  // Developer can specify element to focus first using firstFocus attribute
+  // Developer can specify element to focus first by using firstFocus attribute 
+  // on an unlocked modal
   private getFocusElement(lockStatus: boolean): HTMLElement {
     const modal = this.el.getElementsByClassName('modal').item(0) as HTMLElement;
     const closeFocus = this.el.getElementsByClassName('close').item(0).firstElementChild as HTMLElement;

--- a/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
+++ b/components/chef-ui-library/src/molecules/chef-modal/chef-modal.tsx
@@ -180,7 +180,7 @@ export class ChefModal {
   // when Angular detects the modal is open
   // it sets the focus by default on the close button for unlocked modals,
   // or the modal div for locked modals
-  // Developer can specify element to focus first by using firstFocus attribute 
+  // Developer can specify element to focus first by using firstFocus attribute
   // on an unlocked modal
   private getFocusElement(lockStatus: boolean): HTMLElement {
     const modal = this.el.getElementsByClassName('modal').item(0) as HTMLElement;

--- a/e2e/cypress/integration/ui/infra-proxy/chef-servers.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-servers.spec.ts
@@ -27,6 +27,7 @@ describe('chef server', () => {
     it('can add a server', () => {
       cy.get('[data-cy=add-server-button]').contains('Add Chef Server').click();
       cy.get('app-chef-servers-list chef-modal').should('exist');
+      cy.get('[data-cy=add-name]').should('have.focus');
       cy.get('[data-cy=add-name]').type(serverName);
       cy.get('[data-cy=id-label]').contains(generatedServerID);
       cy.get('[data-cy=add-fqdn]').type(serverFQDN);

--- a/e2e/cypress/integration/ui/infra-proxy/chef-servers.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-servers.spec.ts
@@ -27,7 +27,9 @@ describe('chef server', () => {
     it('can add a server', () => {
       cy.get('[data-cy=add-server-button]').contains('Add Chef Server').click();
       cy.get('app-chef-servers-list chef-modal').should('exist');
-      cy.get('[data-cy=add-name]').should('have.focus');
+      cy.get('[data-cy=add-name]')
+        .should('have.focus')
+        .should('have.attr', 'firstFocus');
       cy.get('[data-cy=add-name]').type(serverName);
       cy.get('[data-cy=id-label]').contains(generatedServerID);
       cy.get('[data-cy=add-fqdn]').type(serverFQDN);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Looking for a more flexible way to decide where the first focus on a modal should be so that we can provide a better UX experience to our customers.  This update will allow developers to more easily decide what gets focused first without hacky javascript overwriting.

### :chains: Related Resources
addresses https://github.com/chef/automate/issues/4828

### :+1: Definition of Done
A developer is able to place `firstFocus` on an element that they would like to have focused first when opening a modal.

### :athletic_shoe: How to Build and Test the Change
Terminal 1
in Automate Folder 
`hab studio enter`
`build components/automate-ui-devproxy && start_all_services`
If you do not currently have servers in your sample data you may need: `infra_service_load_sample_data`

Terminal 2
in Automate/components/automate-ui
`make update-ui-lib`
`make serve`

navigate to https://a2-dev.test/infrastructure/chef-servers
click on a server in your list
click on 'Add Chef Organization' button
when the modal opens, you should notice the first text input is automatically focused

This has now been activated in each of the "Add" modals within infrastructure


### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] Tests added/updated?
- [x] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
Example After:
![first focus example](https://user-images.githubusercontent.com/16737484/111397617-f4714f80-867e-11eb-8e2a-0fe3d03e56d6.gif)
