### PR TITLE
Remove feature flag for the data bag + some minor UI changes

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.scss
@@ -45,17 +45,8 @@ chef-loading-spinner {
   height: 100%;
 }
 
-.empty-section {
-  margin-top: 130px;
-  text-align: center;
-}
-
 .clients-list-paging {
   margin: 0 0 35px;
-}
-
-img {
-  width: 70px;
 }
 
 .three-dot-column {
@@ -93,4 +84,14 @@ chef-button button {
 chef-toolbar chef-button:first-child {
   margin: 18px 0px 0px 0px;
   float: right;
+}
+
+.empty-section {
+  text-align: center;
+}
+
+img {
+  margin-top: 130px;
+  margin-left: 44PX;
+  width: 70px;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
@@ -42,6 +42,6 @@
   </ng-container>
   <div class="empty-section" *ngIf="!dataBagsListLoading && (dataBags.length === 0)">
     <img alt="No preview" src="/assets/img/no_preview.gif"/>
-    <p>No databags available</p>
+    <p>No databags available.</p>
   </div>
 </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
@@ -41,7 +41,7 @@
     </chef-table>
   </ng-container>
   <div class="empty-section" *ngIf="!dataBagsListLoading && (dataBags.length === 0)">
-    <img alt="No preview" src="/assets/img/no_preview.gif" [ngClass]="chefInfraViewsFeatureFlagOn ? '' : 'no-margin-img'"/>
+    <img alt="No preview" src="/assets/img/no_preview.gif"/>
     <p>No databags available</p>
   </div>
 </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.html
@@ -16,7 +16,7 @@
   </app-create-data-bag-modal>
   <app-empty-state *ngIf="authFailure" moduleTitle="data bags" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
   <ng-container  *ngIf="!dataBagsListLoading && !authFailure">
-    <chef-toolbar *ngIf="chefInfraViewsFeatureFlagOn">
+    <chef-toolbar>
       <app-authorized [allOf]="['/api/v0/infra/servers', 'post']">
         <chef-button primary (click)="openCreateModal()">Create Databag</chef-button>
       </app-authorized>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.scss
@@ -25,7 +25,3 @@ chef-toolbar chef-button:first-child {
   margin: 10px 0px 0px 0px;
   float: right;
 }
-
-.no-margin-img {
-  margin-left: 0px;
-}

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-list/data-bags-list.component.ts
@@ -8,7 +8,6 @@ import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { EntityStatus } from 'app/entities/entities';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { GetDataBags, DeleteDataBag } from 'app/entities/data-bags/data-bags.actions';
-import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { DataBag } from 'app/entities/data-bags/data-bags.model';
 import {
   allDataBags,
@@ -28,7 +27,6 @@ export class DataBagsListComponent implements OnInit, OnDestroy {
   @Output() resetKeyRedirection = new EventEmitter<boolean>();
 
   public authFailure = false;
-  public chefInfraViewsFeatureFlagOn: boolean;
   public dataBags: DataBag[];
   public dataBagsListLoading = true;
   public dataBagToDelete: DataBag;
@@ -38,13 +36,8 @@ export class DataBagsListComponent implements OnInit, OnDestroy {
 
   constructor(
     private store: Store<NgrxStateAtom>,
-    private layoutFacade: LayoutFacadeService,
-    private featureFlagsService: FeatureFlagsService
-  ) {
-    // feature flag enable and disable the create button
-    this.chefInfraViewsFeatureFlagOn =
-    this.featureFlagsService.getFeatureStatus('chefInfraTabsViews');
-  }
+    private layoutFacade: LayoutFacadeService
+  ) { }
 
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Infrastructure);

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -95,12 +95,8 @@
           </div>
           <hr class="divider-constraints" />
           <div class="json-container">
-            <div *ngIf="hasDefaultJson" class="scroll">
+            <div class="scroll">
               <app-json-tree-table class="json-tree-container" #tre [json]="selectedAttrs?.default_attributes"></app-json-tree-table>
-            </div>
-            <div *ngIf="!hasDefaultJson" class="img-section">
-              <img alt="No preview" src="/assets/img/no_preview.gif" />
-              <p>There are no items for Display.</p>
             </div>
           </div>
         </div>
@@ -123,12 +119,8 @@
           </div>
           <hr class="divider-constraints" />
           <div class="json-container">
-            <div *ngIf="hasOverrideJson" class="scroll">
+            <div class="scroll">
               <app-json-tree-table class="json-tree-container" #tree [json]="selectedAttrs?.override_attributes"></app-json-tree-table>
-            </div>
-            <div *ngIf="!hasOverrideJson" class="img-section">
-              <img alt="No preview" src="/assets/img/no_preview.gif" />
-              <p>There are no items for Display.</p>
             </div>
           </div>
         </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -83,10 +83,10 @@
         </label>
         <div class="attr">
           <div class="expand-collapse">
-            <chef-button class="add-circle" primary (click)="tree.expand()">
+            <chef-button class="add-circle" primary (click)="tre.expand()">
               <img alt="Edit" src="/assets/img/expand_all.png" />
             </chef-button>
-            <chef-button class="collapse-circle" primary (click)="tree.collapse()">
+            <chef-button class="collapse-circle" primary (click)="tre.collapse()">
               <img alt="Collapse" src="/assets/img/collapse_tree.png" />
             </chef-button>
             <chef-button class="action" primary (click)="openEditAttributeModal(environment?.default_attributes, 'Default')">

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -83,10 +83,10 @@
         </label>
         <div class="attr">
           <div class="expand-collapse">
-            <chef-button class="add-circle" primary (click)="tre.expand()">
+            <chef-button class="add-circle" primary (click)="tree.expand()">
               <img alt="Edit" src="/assets/img/expand_all.png" />
             </chef-button>
-            <chef-button class="collapse-circle" primary (click)="tre.collapse()">
+            <chef-button class="collapse-circle" primary (click)="tree.collapse()">
               <img alt="Collapse" src="/assets/img/collapse_tree.png" />
             </chef-button>
             <chef-button class="action" primary (click)="openEditAttributeModal(environment?.default_attributes, 'Default')">

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -86,7 +86,6 @@
             <chef-button class="add-circle" primary (click)="tre.expand()">
               <img alt="Edit" src="/assets/img/expand_all.png" />
             </chef-button>
-
             <chef-button class="collapse-circle" primary (click)="tre.collapse()">
               <img alt="Collapse" src="/assets/img/collapse_tree.png" />
             </chef-button>
@@ -118,7 +117,6 @@
             <chef-button class="action" primary (click)="openEditAttributeModal(environment?.override_attributes, 'Override')">
               <img alt="Edit" src="/assets/img/content and icon.png" />
             </chef-button>
-
           </div>
           <hr class="divider-constraints" />
           <div class="json-container">

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -95,12 +95,15 @@
           </div>
           <hr class="divider-constraints" />
           <div class="json-container">
-            <div class="scroll">
+            <div *ngIf="hasDefaultJson" class="scroll">
               <app-json-tree-table class="json-tree-container" #tre [json]="selectedAttrs?.default_attributes"></app-json-tree-table>
+            </div>
+            <div *ngIf="!hasDefaultJson" class="img-section">
+              <img alt="No preview" src="/assets/img/no_preview.gif" />
+              <p>There are no items for Display.</p>
             </div>
           </div>
         </div>
-
         <label>
           <span class="label override">Override Attributes</span>
         </label>
@@ -120,8 +123,12 @@
           </div>
           <hr class="divider-constraints" />
           <div class="json-container">
-            <div class="scroll">
+            <div *ngIf="hasOverrideJson" class="scroll">
               <app-json-tree-table class="json-tree-container" #tree [json]="selectedAttrs?.override_attributes"></app-json-tree-table>
+            </div>
+            <div *ngIf="!hasOverrideJson" class="img-section">
+              <img alt="No preview" src="/assets/img/no_preview.gif" />
+              <p>There are no items for Display.</p>
             </div>
           </div>
         </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
@@ -296,7 +296,3 @@ chef-button {
     border: none;
   }
 }
-
-.img-section {
-  text-align: center;
-}

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
@@ -199,7 +199,7 @@ img {
 }
 
 .attr {
-  width: 1218px;
+  width: 98%;
   height: 242px;
   left: 189px;
   top: 274px;

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.scss
@@ -143,7 +143,6 @@ img {
     width: 103px;
     height: 20px;
   }
-
 }
 
 .collapse-circle {
@@ -167,7 +166,6 @@ img {
   font-weight: bold;
   font-size: 12px;
   line-height: 20px;
-  /* identical to box height, or 167% */
   letter-spacing: 0.5px;
   color: #000000;
 }
@@ -212,8 +210,6 @@ img {
   border-radius: 2px;
 }
 
-
-
 .action {
   float: right;
   margin-right: 32px;
@@ -226,21 +222,13 @@ img {
   }
 }
 
-
 .json-container {
-
-  //width: 380px;
   height: 169px;
-
   font-size: 12px;
   line-height: 20px;
-  /* or 167% */
-
   letter-spacing: 0.5px;
   text-transform: capitalize;
-
   color: #000000;
-
 }
 
 .scroll {
@@ -265,27 +253,21 @@ img {
   margin-left: 16px;
   font-size: 12px;
   line-height: 20px;
-  /* or 167% */
-
   letter-spacing: 0.5px;
   text-transform: capitalize;
-
   color: #000000;
 }
-
 
 .divider {
   margin-left: 16px;
   margin-top: 11px;
   margin-right: 18px;
-
 }
 
 .divider-constraint {
   margin-left: 16px;
   margin-top: 42px;
   margin-right: 18px;
-
 }
 
 .divider-constraints {
@@ -313,4 +295,8 @@ chef-button {
     outline: none;
     border: none;
   }
+}
+
+.img-section {
+  text-align: center;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -49,8 +49,6 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
     default_attributes: '',
     override_attributes: ''
   });
-  public hasOverrideJson = true;
-  public hasDefaultJson = true;
   public cookbookConstraints: Array<CookbookConstraintGrid> = [];
   public name_id = '';
   public openEdit = false;
@@ -66,7 +64,6 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
 
   @ViewChild(JsonTreeTable, { static: true })
   tree: JsonTreeTable;
-  tre: JsonTreeTable;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -123,10 +120,6 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
       if (Object.keys(environment.cookbook_versions).length > 0) {
         this.hasCookbookConstraints = true;
       }
-      this.hasDefaultJson =
-        Object.keys(JSON.parse(this.environment.default_attributes)).length > 0 ? true : false;
-      this.hasOverrideJson =
-        Object.keys(JSON.parse(this.environment.override_attributes)).length > 0 ? true : false;
       this.attributes = new EnvironmentAttributes(this.environment);
 
       setTimeout(() => this.filter(this.selected_level), 10);

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -41,7 +41,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
   public show = false;
   public hasCookbookConstraints = false;
   private isDestroyed = new Subject<boolean>();
-  environmentDetailsLoading = true;
+  public environmentDetailsLoading = true;
   public editAttrModalVisible = false;
   public editAttributeForm: FormGroup;
   public label: string;
@@ -49,15 +49,13 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
     default_attributes: '',
     override_attributes: ''
   });
-
+  public hasOverrideJson = true;
+  public hasDefaultJson = true;
   public cookbookConstraints: Array<CookbookConstraintGrid> = [];
   public name_id = '';
-
   public openEdit = false;
-
   public selectedAttrs: any;
   public selected_level = 'all';
-
   public jsonText: any;
   public openEnvironmentModal = new EventEmitter<boolean>();
 
@@ -124,6 +122,10 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
       if (Object.keys(environment.cookbook_versions).length > 0) {
         this.hasCookbookConstraints = true;
       }
+      this.hasDefaultJson =
+        Object.keys(JSON.parse(this.environment.default_attributes)).length > 0 ? true : false;
+      this.hasOverrideJson =
+        Object.keys(JSON.parse(this.environment.override_attributes)).length > 0 ? true : false;
       this.attributes = new EnvironmentAttributes(this.environment);
 
       setTimeout(() => this.filter(this.selected_level), 10);

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -66,6 +66,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
 
   @ViewChild(JsonTreeTable, { static: true })
   tree: JsonTreeTable;
+  tre: JsonTreeTable;
 
   constructor(
     private store: Store<NgrxStateAtom>,

--- a/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.html
@@ -16,7 +16,7 @@
     [orgId]="orgId"
     [currentPage]="current_page">    
   </app-create-environment-modal>
-  <ng-container *ngIf="!environmentsListLoading && !authFailure">
+  <ng-container *ngIf="!environmentsListLoading && !authFailure" class="env">
     <div class="search-items">
       <app-infra-search-bar (searchButtonClick)="searchEnvironment($event)" placeHolder="environments"></app-infra-search-bar>
       <chef-toolbar>

--- a/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.html
@@ -16,7 +16,7 @@
     [orgId]="orgId"
     [currentPage]="current_page">    
   </app-create-environment-modal>
-  <ng-container *ngIf="!environmentsListLoading && !authFailure" class="env">
+  <ng-container *ngIf="!environmentsListLoading && !authFailure">
     <div class="search-items">
       <app-infra-search-bar (searchButtonClick)="searchEnvironment($event)" placeHolder="environments"></app-infra-search-bar>
       <chef-toolbar>

--- a/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.scss
@@ -79,7 +79,14 @@ img {
   ::ng-deep {
     .search-items app-infra-search-bar .search-wrapper {
       float: left;
+      margin-top: 10px;
       width: calc(100% - 187px);
+      margin-right: 32px;
     }
+  }
+
+  chef-toolbar chef-button:first-child {
+    margin: 18px 0px 0px 0px;
+    float: right;
   }
 }


### PR DESCRIPTION
… UI changes

Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
We need to remove the feature flag for the data bag and add some minor UI changes.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/4870
### :+1: Definition of Done
I have added changes to remove the feature flag for the data bag and added some minor changes for the UI.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab

navigate to `https://a2-dev.test/infrastructure/client-runs`
add some sample data and then test the changes using tab change
```
To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
```

Go to the `infrastructure tab` from the top navigation bar then you can see the `Chef Server`
If you have data then you can see the list of servers --> then click to any of the server --> see the list of orgs 
--> click to any of org ---> you can see the multiple tabs
--> click to `databags` tab
--> see the list of databags ---> where you can see the create data bag button without enable/disable the feature flag
```
### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
