### PR TITLE
Soft fail security pipeline

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -800,6 +800,7 @@ steps:
     command:
       - integration/run_test integration/tests/security.sh
     timeout_in_minutes: 20
+    soft_fail: true
     expeditor:
       executor:
         linux:


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

We are finding consistent failures of the security taskin verify_private pipeline with the error:
```
  Local problem: ./bin/openssl.Linux.x86_64 doesn't support "s_client -tls1_3"
```
This seems to be because of there is a breaking change merged to an upstream repository:
https://github.com/drwetter/testssl.sh

By the time, we get a proper commit and fix this, I am keeping this behind soft_fail


### :chains: Related Resources

### :+1: Definition of Done

Buildkite pipeline should be green.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [x] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
