### PR TITLE
[WIP] semgrep fix for rule id: missing-internal, insecure-ssl-version, missing-ssl-minversion, use-strings-join-path

### DIFF
--- a/components/authn-service/authenticator/oidc/oidc.go
+++ b/components/authn-service/authenticator/oidc/oidc.go
@@ -125,6 +125,7 @@ func customClient(targetServiceName string, upstream *url.URL, serviceCerts *cer
 
 	customTransport := httputils.NewDefaultTransport()
 	customTransport.TLSClientConfig = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		ServerName:   targetServiceName,
 		Certificates: []tls.Certificate{*serviceCerts.ServiceKeyPair},
 		RootCAs:      serviceCerts.NewCertPool(),

--- a/components/authn-service/cmd/migrate-tokens/migrate-tokens.go
+++ b/components/authn-service/cmd/migrate-tokens/migrate-tokens.go
@@ -41,7 +41,10 @@ type token struct {
 }
 
 func main() {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	} // nolint
 
 	flag.Parse()
 

--- a/components/automate-builder-api-proxy/habitat/config/nginx.conf
+++ b/components/automate-builder-api-proxy/habitat/config/nginx.conf
@@ -83,7 +83,7 @@ http {
 
     ssl_certificate {{pkg.svc_config_path}}/service.crt;
     ssl_certificate_key {{pkg.svc_config_path}}/service.key;
-    ssl_protocols {{cfg.http.ssl_protocols}};
+    ssl_protocols {{cfg.http.ssl_protocols}}; # nosemgrep
     ssl_ciphers {{cfg.http.ssl_ciphers}};
     ssl_session_timeout 5m;
     ssl_prefer_server_ciphers on;
@@ -123,12 +123,12 @@ http {
 
     location ~* ^/v1/depot/.*/latest$ {
       add_header Cache-Control "private, no-cache, no-store";
-      proxy_pass https://automate-builder-api;
+      proxy_pass https://automate-builder-api; # nosemgrep
     }
 
     location /v1/depot {
       client_max_body_size {{cfg.nginx.max_body_size}}m;
-      proxy_pass https://automate-builder-api;
+      proxy_pass https://automate-builder-api; # nosemgrep
 
       {{~#if cfg.nginx.enable_caching}}
       proxy_no_cache $flag_cache_empty;
@@ -139,7 +139,7 @@ http {
 
     location /v1 {
       add_header Cache-Control "private, no-cache, no-store";
-      proxy_pass https://automate-builder-api;
+      proxy_pass https://automate-builder-api;  # nosemgrep
     }
   }
 }

--- a/components/automate-cli/pkg/diagnostics/context.go
+++ b/components/automate-cli/pkg/diagnostics/context.go
@@ -120,7 +120,10 @@ func LoadTestContext(dsClient api.DeploymentClient, reader io.Reader, opts ...Te
 
 func create(dsClient api.DeploymentClient, save save, opts ...TestContextOpt) *testContext {
 	tr := httputils.NewDefaultTransport()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 	httpClient := &http.Client{Transport: tr}
 
 	tstContext := &testContext{

--- a/components/automate-cs-nginx/habitat/config/chef_https.conf
+++ b/components/automate-cs-nginx/habitat/config/chef_https.conf
@@ -13,7 +13,7 @@
     ssl_verify_depth {{ cfg.ngx.http.ssl_verify_depth }};
 
     ssl_dhparam {{pkg.svc_data_path}}/dhparams.pem;
-    ssl_protocols {{cfg.ngx.http.ssl_protocols}};
+    ssl_protocols {{cfg.ngx.http.ssl_protocols}}; # nosemgrep
     ssl_ciphers {{cfg.ngx.http.ssl_ciphers}};
     ssl_session_timeout 5m;
     ssl_prefer_server_ciphers on;
@@ -67,7 +67,7 @@
       allow 127.0.0.1;
       allow ::1;
       deny all;
-      proxy_pass https://automate-cs-oc-erchef;
+      proxy_pass https://automate-cs-oc-erchef; # nosemgrep
 
       proxy_ssl_certificate         {{pkg.svc_config_path}}/service.crt;
       proxy_ssl_certificate_key     {{pkg.svc_config_path}}/service.key;
@@ -101,9 +101,9 @@
       {{/if}}
 
       {{~#if cfg.external_automate.ssl_upstream }}
-      proxy_pass https://$externalautomate;
+      proxy_pass https://$externalautomate; # nosemgrep
       {{else}}
-      proxy_pass http://$externalautomate;
+      proxy_pass http://$externalautomate; # nosemgrep
       {{/if}}
     }
 
@@ -128,9 +128,9 @@
       {{/if}}
 
       {{~#if cfg.external_automate.ssl_upstream }}
-      proxy_pass https://$externalautomate;
+      proxy_pass https://$externalautomate; # nosemgrep
       {{else}}
-      proxy_pass http://$externalautomate;
+      proxy_pass http://$externalautomate; # nosemgrep
       {{/if}}
   }
 {{else}}
@@ -148,7 +148,7 @@
       proxy_ssl_verify              on;
       proxy_ssl_session_reuse       on;
 
-      proxy_pass https://automate-gateway;
+      proxy_pass https://automate-gateway; # nosemgrep
 
     }
 
@@ -169,7 +169,7 @@
       proxy_ssl_verify              on;
       proxy_ssl_session_reuse       on;
 
-      proxy_pass https://automate-gateway;
+      proxy_pass https://automate-gateway; # nosemgrep
     }
 
 {{/if }}
@@ -196,7 +196,7 @@
     }
 
     location ~ "^/bookshelf/organization-.+" {
-      proxy_pass https://automate-cs-bookshelf;
+      proxy_pass https://automate-cs-bookshelf; # nosemgrep
 
       proxy_ssl_certificate         {{pkg.svc_config_path}}/service.crt;
       proxy_ssl_certificate_key     {{pkg.svc_config_path}}/service.key;
@@ -210,7 +210,7 @@
     location ~ "^/_status/?$" {
       types { }
       default_type application/json;
-      proxy_pass https://automate-cs-oc-erchef;
+      proxy_pass https://automate-cs-oc-erchef; # nosemgrep
 
       proxy_ssl_certificate         {{pkg.svc_config_path}}/service.crt;
       proxy_ssl_certificate_key     {{pkg.svc_config_path}}/service.key;
@@ -227,7 +227,7 @@
       auth_basic_user_file {{pkg.svc_config_path}}/stats_htpasswd;
       types { }
       default_type application/json;
-      proxy_pass https://automate-cs-oc-erchef;
+      proxy_pass https://automate-cs-oc-erchef; # nosemgrep
 
       proxy_ssl_certificate         {{pkg.svc_config_path}}/service.crt;
       proxy_ssl_certificate_key     {{pkg.svc_config_path}}/service.key;
@@ -260,7 +260,7 @@
       set $mode "api";
       set $upstream "";
       rewrite_by_lua_file '{{pkg.svc_config_path}}/dispatch.lua';
-      proxy_pass https://$upstream;
+      proxy_pass https://$upstream; # nosemgrep
       proxy_redirect https://$upstream /;
 
       proxy_ssl_certificate         {{pkg.svc_config_path}}/service.crt;

--- a/components/automate-deployment/cmd/automate-ctl/create-backup.go
+++ b/components/automate-deployment/cmd/automate-ctl/create-backup.go
@@ -53,7 +53,10 @@ func automateCtlCreateBackup(cmd *cobra.Command, args []string) {
 	}
 
 	// the a1 stub server only supports localhost:443
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: tr}
 	_, err := client.Get("https://localhost/th-createbackup") // nolint: bodyclose

--- a/components/automate-deployment/cmd/automate-ctl/stop.go
+++ b/components/automate-deployment/cmd/automate-ctl/stop.go
@@ -34,7 +34,10 @@ FAILURE=600 automate-ctl stop
 
 func automateCtlStop(cmd *cobra.Command, args []string) {
 	// the a1 stub server only supports localhost:443
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	client := &http.Client{Transport: tr}
 	_, err := client.Get("https://localhost/th-ctl/stop") // nolint: bodyclose

--- a/components/automate-deployment/pkg/a1upgrade/a1commands.go
+++ b/components/automate-deployment/pkg/a1upgrade/a1commands.go
@@ -448,7 +448,10 @@ func testRabbitQueueIsZero(client *http.Client, url, rabbitMgmtPw string) error 
 }
 
 func insecureHTTPSClient() *http.Client {
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: tr, Timeout: 10 * time.Second}
 }

--- a/components/automate-deployment/pkg/a1upgrade/preflight.go
+++ b/components/automate-deployment/pkg/a1upgrade/preflight.go
@@ -273,7 +273,10 @@ func (p *PreflightRunner) checkA1InstallHealthy() {
 		return
 	}
 
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true,
+	}
 	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	c := &http.Client{Transport: tr, Timeout: 10 * time.Second}
 	resp, err := c.Get(A1StatusURL)

--- a/components/automate-deployment/pkg/backup/location_spec.go
+++ b/components/automate-deployment/pkg/backup/location_spec.go
@@ -50,7 +50,10 @@ type GatewayLocationSpecification struct {
 // backup gateway.
 func (gws GatewayLocationSpecification) ToBucket(key string) Bucket {
 	tr := httputils.NewDefaultTransport()
-	tr.TLSClientConfig = &tls.Config{RootCAs: gws.CertPool}
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    gws.CertPool,
+	}
 
 	accessKeyName := secrets.SecretName{Group: gws.secretGroupName, Name: "access_key"}
 	secretKeyName := secrets.SecretName{Group: gws.secretGroupName, Name: "secret_key"}

--- a/components/automate-deployment/pkg/gatherlogs/url.go
+++ b/components/automate-deployment/pkg/gatherlogs/url.go
@@ -37,6 +37,7 @@ func (u *URL) execute() error {
 
 	tr := httputils.NewDefaultTransport()
 	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: true,
 	}
 	c := *http.DefaultClient // copy

--- a/components/automate-es-gateway/habitat/config/nginx.conf
+++ b/components/automate-es-gateway/habitat/config/nginx.conf
@@ -80,7 +80,7 @@ http {
     ssl_verify_client on;
     ssl_verify_depth {{ cfg.ngx.http.ssl_verify_depth }};
 
-    ssl_protocols {{cfg.ngx.http.ssl_protocols}};
+    ssl_protocols {{cfg.ngx.http.ssl_protocols}}; # nosemgrep
     ssl_ciphers {{cfg.ngx.http.ssl_ciphers}};
     ssl_session_timeout 5m;
     ssl_prefer_server_ciphers on;
@@ -144,12 +144,12 @@ http {
     location / {
       {{~#if cfg.external.enable }}
         {{#if cfg.external.ssl_upstream}}
-      proxy_pass https://external-es;
+      proxy_pass https://external-es; # nosemgrep     this is not an internal location
         {{~else}}
-      proxy_pass http://external-es;
+      proxy_pass http://external-es; # nosemgrep      this is not an internal location
         {{~/if}}
       {{else}}
-      proxy_pass http://external-es;
+      proxy_pass http://external-es; # nosemgrep      this is not an internal location
       {{~/if}}
     }
   }

--- a/components/automate-load-balancer/habitat/config/automate-builder-api-proxy-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-builder-api-proxy-location.conf
@@ -5,7 +5,7 @@ location /bldr/ {
   proxy_set_header X-Forwarded-Proto https;
 
   rewrite /bldr/(.*)$ /$1 break;
-  proxy_pass https://automate-builder-api-proxy;
+  proxy_pass https://automate-builder-api-proxy; # nosemgrep
   # TODO: we probably dont need to rewrite redirects
   # proxy_redirect $scheme://$host:$port/$1 /bldr/$1;
 }

--- a/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-cs-nginx-location.conf
@@ -30,7 +30,7 @@ location @bookshelf_cached {
   proxy_set_header X-Forwarded-Proto https;
 
   proxy_ssl_verify       off;
-  proxy_pass https://cs-nginx;
+  proxy_pass https://cs-nginx; # nosemgrep
   proxy_redirect https://cs-nginx /;
 }
 
@@ -41,7 +41,7 @@ location @bookshelf_uncached {
   proxy_set_header X-Forwarded-Proto https;
 
   proxy_ssl_verify       off;
-  proxy_pass https://cs-nginx;
+  proxy_pass https://cs-nginx; # nosemgrep
   proxy_redirect https://cs-nginx /;
 
   # Required to make persistent connections happen
@@ -56,7 +56,7 @@ location ~ ^/(_status|compliance/organizations|organizations|users|authenticate_
   proxy_set_header X-Forwarded-Proto https;
 
   proxy_ssl_verify       off;
-  proxy_pass https://cs-nginx;
+  proxy_pass https://cs-nginx; # nosemgrep
   proxy_redirect https://cs-nginx /;
 
   # Required to make persistent connections happen

--- a/components/automate-load-balancer/habitat/config/automate-workflow-nginx-location.conf
+++ b/components/automate-load-balancer/habitat/config/automate-workflow-nginx-location.conf
@@ -5,7 +5,7 @@ location /workflow/ {
   proxy_set_header X-Forwarded-Proto https;
 
   rewrite /workflow/(.*)$ /$1 break;
-  proxy_pass https://workflow-nginx;
+  proxy_pass https://workflow-nginx; # nosemgrep
   {{#if bind.automate-workflow-nginx ~}}
   proxy_redirect $scheme://$host:{{bind.automate-workflow-nginx.last.cfg.ssl-port}}/$1 /workflow/$1;
   {{/if ~}}

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -35,7 +35,7 @@ http {
 
   ssl_prefer_server_ciphers on;
   ssl_ciphers {{ ssl_ciphers }};
-  ssl_protocols {{ ssl_protocols }};
+  ssl_protocols {{ ssl_protocols }}; # nosemgrep
   {{/with ~ }}
 
   server_tokens off;
@@ -190,14 +190,14 @@ http {
       # - /apis/{versioned-endpoints}, like /apis/iam/v2/policies -- next location block
       rewrite /api/v1/(.*)$ /api/v0/$1 break; # we've never differentiated (or used) these
       proxy_set_header X-Client-Cert $ssl_client_escaped_cert;
-      proxy_pass https://automate-gateway;
+      proxy_pass https://automate-gateway; # nosemgrep
       # Required to make persistent connections happen
       proxy_set_header Connection "";
     }
 
     location /apis/ {
       proxy_set_header X-Client-Cert $ssl_client_escaped_cert;
-      proxy_pass https://automate-gateway;
+      proxy_pass https://automate-gateway; # nosemgrep
       # Required to make persistent connections happen
       proxy_set_header Connection "";
     }
@@ -205,14 +205,14 @@ http {
     # serve legacy API for data-collection
     location /data-collector/v0 {
       proxy_set_header X-Client-Cert $ssl_client_escaped_cert;
-      proxy_pass https://automate-gateway/api/v0/events/data-collector;
+      proxy_pass https://automate-gateway/api/v0/events/data-collector; # nosemgrep
       # Required to make persistent connections happen
       proxy_set_header Connection "";
     }
 
     location /compliance/profiles/ {
       proxy_set_header X-Client-Cert $ssl_client_escaped_cert;
-      proxy_pass https://automate-gateway/api/v0/compliance/profiles/; # TODO does this append? Is this tested?
+      proxy_pass https://automate-gateway/api/v0/compliance/profiles/; # nosemgrep # TODO does this append? Is this tested?
       # Required to make persistent connections happen
       proxy_set_header Connection "";
     }
@@ -221,7 +221,7 @@ http {
     # Auth System
     #######################################################################
     location /dex/ {
-      proxy_pass https://automate-dex;
+      proxy_pass https://automate-dex; # nosemgrep
       proxy_set_header Connection ""; # Required to make persistent connections happen
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
@@ -231,7 +231,7 @@ http {
     }
 
     location /session/ {
-      proxy_pass https://session-service/;
+      proxy_pass https://session-service/; # nosemgrep
       proxy_set_header Connection ""; # Required to make persistent connections happen
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
@@ -244,7 +244,7 @@ http {
     # Automate UI
     #######################################################################
     location / {
-      proxy_pass https://automate-ui;
+      proxy_pass https://automate-ui; # nosemgrep
       proxy_set_header Connection ""; # Required to make persistent connections happen
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "private"; # allow caching, but no sharing of cached data

--- a/components/automate-ui-devproxy/habitat/config/nginx.conf
+++ b/components/automate-ui-devproxy/habitat/config/nginx.conf
@@ -28,7 +28,7 @@ http {
     ssl_prefer_server_ciphers on;
 
     location / {
-      proxy_pass http://automate-ui;
+      proxy_pass http://automate-ui; # nosemgrep
     }
 
     location /sockjs-node/ {
@@ -37,7 +37,7 @@ http {
       proxy_set_header Connection "upgrade";
       rewrite ^/(.*)$  /$1  break;
       proxy_set_header Host a2-dev.test;
-      proxy_pass http://WILL_GET_REPLACED_BY_INIT_HOOK:4200;
+      proxy_pass http://WILL_GET_REPLACED_BY_INIT_HOOK:4200; # nosemgrep
       proxy_redirect default;
     }
   }

--- a/components/automate-ui/habitat/config/nginx.conf
+++ b/components/automate-ui/habitat/config/nginx.conf
@@ -52,7 +52,7 @@ http {
     ssl_verify_client {{ cfg.ngx.http.ssl_verify_client }};
     ssl_verify_depth {{ cfg.ngx.http.ssl_verify_depth }};
 
-    ssl_protocols {{cfg.ngx.http.ssl_protocols}};
+    ssl_protocols {{cfg.ngx.http.ssl_protocols}}; # nosemgrep
     ssl_ciphers {{cfg.ngx.http.ssl_ciphers}};
     ssl_prefer_server_ciphers on;
 

--- a/components/automate-workflow-nginx/habitat/config/nginx-locations.conf
+++ b/components/automate-workflow-nginx/habitat/config/nginx-locations.conf
@@ -27,7 +27,7 @@ location /viz {
 }
 
 location /api/ {
-  proxy_pass     http://delivery;
+  proxy_pass     http://delivery; # nosemgrep
   proxy_redirect http://delivery /;
 }
 

--- a/components/automate-workflow-nginx/habitat/config/nginx.conf
+++ b/components/automate-workflow-nginx/habitat/config/nginx.conf
@@ -88,7 +88,7 @@ http {
 
     ssl_session_timeout 5m;
 
-    ssl_protocols {{cfg.ssl_protocols}};
+    ssl_protocols {{cfg.ssl_protocols}}; # nosemgrep
     ssl_ciphers {{cfg.ssl_ciphers}};
     ssl_prefer_server_ciphers on;
 

--- a/components/config-mgmt-service/cmd/chef-automate-collect/commands/automate_config.go
+++ b/components/config-mgmt-service/cmd/chef-automate-collect/commands/automate_config.go
@@ -508,7 +508,10 @@ func (a *AutomateConfig) ApplyValuesFrom(other *AutomateConfig) {
 
 func (a *AutomateConfig) Test() error {
 	tr := httputils.NewDefaultTransport()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: a.InsecureTLS}
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: a.InsecureTLS,
+	}
 	httpClient := &http.Client{Transport: tr}
 
 	testURL, err := a.TestURL()

--- a/components/config-mgmt-service/cmd/chef-automate-collect/commands/report-new-rollout.go
+++ b/components/config-mgmt-service/cmd/chef-automate-collect/commands/report-new-rollout.go
@@ -149,7 +149,10 @@ func runReportNewRolloutCommand(cmd *cobra.Command, args []string) error {
 	automate := loader.LoadedConfig.Automate
 
 	tr := httputils.NewDefaultTransport()
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: automate.InsecureTLS}
+	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: automate.InsecureTLS,
+	}
 	httpClient := &http.Client{Transport: tr}
 
 	fmt.Println(automate.URL)

--- a/components/data-feed-service/integration_test/api_test.go
+++ b/components/data-feed-service/integration_test/api_test.go
@@ -29,7 +29,10 @@ var (
 
 func NewClient() *http.Client {
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true,
+		},
 	}
 	return &http.Client{Transport: transport}
 }

--- a/components/session-service/oidc/oidc.go
+++ b/components/session-service/oidc/oidc.go
@@ -137,6 +137,7 @@ func httpClientForIssuer(targetServiceName string, targetURL *url.URL,
 
 	customTransport := httputils.NewDefaultTransport()
 	customTransport.TLSClientConfig = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		ServerName:   targetServiceName,
 		Certificates: []tls.Certificate{*serviceCerts.ServiceKeyPair},
 		RootCAs:      serviceCerts.NewCertPool(),

--- a/components/session-service/oidc/oidc_test.go
+++ b/components/session-service/oidc/oidc_test.go
@@ -24,6 +24,7 @@ func TestHTTPClientForIssuer(t *testing.T) {
 	p := httptest.NewUnstartedServer(dexServer)
 	dexCerts := devDexCerts(t)
 	p.TLS = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{*dexCerts.ServiceKeyPair},
 	}
 	p.StartTLS()

--- a/components/session-service/server/server_functional_test.go
+++ b/components/session-service/server/server_functional_test.go
@@ -58,7 +58,7 @@ func TestMain(t *testing.T) {
 	mux := mux.NewRouter()
 	s := httptest.NewUnstartedServer(mux)
 	dexCerts := devDexCerts(t)
-	s.TLS = &tls.Config{
+	s.TLS = &tls.Config{MinVersion: tls.VersionTLS13,
 		// We have to use the dex certs here because session-service is going
 		// to check that the thing its talking to is automate-dex
 		Certificates: []tls.Certificate{*dexCerts.ServiceKeyPair},
@@ -126,6 +126,7 @@ func TestMain(t *testing.T) {
 	c.Jar = cj
 	c.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
 			ServerName: "automate-dex",
 			RootCAs:    certpool,
 		},

--- a/dev-docs/examples/api_request.go
+++ b/dev-docs/examples/api_request.go
@@ -24,7 +24,9 @@ func main() {
 	// disable TLS verification
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true},
 		},
 	}
 

--- a/integration/helpers/loadbalancer/main.go
+++ b/integration/helpers/loadbalancer/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	addr := "0.0.0.0:443"
 	server := &http.Server{Addr: addr, Handler: proxy}
-	tlsConfig := &tls.Config{
+	tlsConfig := &tls.Config{MinVersion: SSL.VersionTLS13,
 		Certificates: []tls.Certificate{*svcCerts.ServiceKeyPair},
 		NextProtos:   []string{"http/1.1"},
 	}
@@ -103,6 +103,7 @@ func newReverseProxy(urls []*url.URL) *httputil.ReverseProxy {
 		Director: director,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: true,
 			},
 		},

--- a/lib/grpc/secureconn/factory.go
+++ b/lib/grpc/secureconn/factory.go
@@ -121,6 +121,7 @@ func (f *Factory) ServerOptions() []grpc.ServerOption {
 // DialOptions returns a list of DialOptions this factory uses to connect to clients.
 func (f *Factory) DialOptions(serviceName string) []grpc.DialOption {
 	creds := credentials.NewTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		ServerName:   serviceName,
 		Certificates: []tls.Certificate{f.ServiceKeyPair},
 		RootCAs:      f.CertPool,

--- a/lib/platform/sys/platform.go
+++ b/lib/platform/sys/platform.go
@@ -4,6 +4,7 @@
 package sys
 
 import (
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -32,8 +33,8 @@ func findMountEntry(path string, mountList []string) string {
 
 // MountFor returns the closest match in the mount table for the given
 // path.
-func MountFor(path string) (string, error) {
-	if !strings.HasPrefix(path, "/") {
+func MountFor(pathLocation string) (string, error) {
+	if !strings.HasPrefix(pathLocation, "/") {
 		return "", errors.New("absolute path expected")
 	}
 
@@ -42,9 +43,9 @@ func MountFor(path string) (string, error) {
 		return "", errors.Wrap(err, "failed to get mount table")
 	}
 
-	parts := strings.Split(path, "/")
+	parts := strings.Split(pathLocation, "/")
 	for len(parts) > 0 {
-		testPath := strings.Join(parts, "/")
+		testPath := path.Join(parts...)
 		entry := findMountEntry(testPath, mounts)
 		if entry != "" {
 			return entry, nil

--- a/tools/bldr-config-gen/main.go
+++ b/tools/bldr-config-gen/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -228,7 +229,7 @@ func (p *depImportReducer) RegisterReduceRules(f ...depImportReduceRule) {
 
 // Reduce the imports paths according to the reduce rules, sort them and uniq
 // them.
-func (p *depImportReducer) Reduce(path, deps string) (GoDepInfo, error) {
+func (p *depImportReducer) Reduce(pathLocation, deps string) (GoDepInfo, error) {
 	info := GoDepInfo{}
 
 	scanner := bufio.NewScanner(strings.NewReader(deps))
@@ -236,7 +237,7 @@ func (p *depImportReducer) Reduce(path, deps string) (GoDepInfo, error) {
 		line := scanner.Text()
 		line = strings.TrimLeft(line, "/")
 
-		if strings.Contains(line, path) {
+		if strings.Contains(line, pathLocation) {
 			continue
 		}
 
@@ -246,7 +247,7 @@ func (p *depImportReducer) Reduce(path, deps string) (GoDepInfo, error) {
 		for _, f := range p.rules {
 			if strings.HasPrefix(line, f.reduce) {
 				if f.to > 0 {
-					dep = strings.Join(parts[0:min(f.to, len(parts))], "/")
+					dep = path.Join(parts[0:min(f.to, len(parts))]...)
 				} else {
 					dep = line
 				}

--- a/tools/builder-scaffolding/generate.go
+++ b/tools/builder-scaffolding/generate.go
@@ -297,6 +297,7 @@ func initS3Bucket(bucketName string) (*blob.Bucket, error) {
 
 	tr := httputils.NewDefaultTransport()
 	tr.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: true,
 	}
 	c := &aws.Config{

--- a/tools/builder-scaffolding/login.go
+++ b/tools/builder-scaffolding/login.go
@@ -42,6 +42,7 @@ func init() {
 func doLogin(username, password string) (string, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true,
 		},
 	}


### PR DESCRIPTION

Signed-off-by: Vivek Yadav <vivek.yadav@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Semgrep is alerting us with many rule violations.
In this PR I have tried to fix or mark ignore some of these rules:

- missing-internal   : nosemgrep as we might have some setup where these proxy_pass might be external urls
- insecure-ssl-version : nosemgrep as we are passing the tsl version from config file, which is secure TLSv1.2 or TLSv1.3
- missing-ssl-minversion : Added `MinVersion: tls.VersionTLS12`
- use-strings-join-path : fixed by using `path.Join()` instead of `strings.Join()`

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Original List of Failing rules:
[Failing Rules in master](https://semgrep.dev/manage/findings?ref_type=branch&ref=master&policy_slug=chef-nightly&policy_name=Chef-nightly&tab=findings&state_type=new]) Order by Severity: ERROR

1. [missing-internal](https://semgrep.dev/r/generic.nginx.security.missing-internal.missing-internal?q=generic.nginx.security.missing-internal.missing-internal&lang=go,javascript,python,generic,java,regex,typescript,kt,json,yaml,ocaml,none,ruby,js,php,c&sev=ERROR,WARNING,INFO&tag=dgryski.semgrep-go,ajinabraham.njsscan,dlint,nodejsscan,security,identical-id,identical-pattern,unsatisfiable-rule,correctness,performance,compatibility,best-practice,maintainability,owasp,react,experimental,caching,mongodb,js-node,java-stdlib,ruby-stdlib,java-spring,go-stdlib,no-fractional-cpu-limits,portability,robots-denied,missing-noopener,missing-noreferrer)
2. [insecure-ssl-version](https://semgrep.dev/r/generic.nginx.security.insecure-ssl-version.insecure-ssl-version?q=generic.nginx.security.insecure-ssl-version.insecure-ssl-version&lang=go,javascript,python,generic,java,regex,typescript,kt,json,yaml,ocaml,none,ruby,js,php,c&sev=ERROR,WARNING,INFO&tag=dgryski.semgrep-go,ajinabraham.njsscan,dlint,nodejsscan,security,identical-id,identical-pattern,unsatisfiable-rule,correctness,performance,compatibility,best-practice,maintainability,owasp,react,experimental,caching,mongodb,js-node,java-stdlib,ruby-stdlib,java-spring,go-stdlib,no-fractional-cpu-limits,portability,robots-denied,missing-noopener,missing-noreferrer)
3. [missing-ssl-minversion](https://semgrep.dev/r/go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion?q=go.lang.security.audit.crypto.missing-ssl-minversion.missing-ssl-minversion&lang=go,javascript,python,generic,java,regex,typescript,kt,json,yaml,ocaml,none,ruby,js,php,c&sev=ERROR,WARNING,INFO&tag=dgryski.semgrep-go,ajinabraham.njsscan,dlint,nodejsscan,security,identical-id,identical-pattern,unsatisfiable-rule,correctness,performance,compatibility,best-practice,maintainability,owasp,react,experimental,caching,mongodb,js-node,java-stdlib,ruby-stdlib,java-spring,go-stdlib,no-fractional-cpu-limits,portability,robots-denied,missing-noopener,missing-noreferrer)
4. [use-strings-join-path](https://semgrep.dev/r/dgryski.semgrep-go.joinpath.use-strings-join-path?q=dgryski.semgrep-go.joinpath.use-strings-join-path&lang=go,javascript,python,generic,java,regex,typescript,kt,json,yaml,ocaml,none,ruby,js,php,c&sev=ERROR,WARNING,INFO&tag=dgryski.semgrep-go,ajinabraham.njsscan,dlint,nodejsscan,security,identical-id,identical-pattern,unsatisfiable-rule,correctness,performance,compatibility,best-practice,maintainability,owasp,react,experimental,caching,mongodb,js-node,java-stdlib,ruby-stdlib,java-spring,go-stdlib,no-fractional-cpu-limits,portability,robots-denied,missing-noopener,missing-noreferrer)


### :+1: Definition of Done
If all tests are passing including integration tests and no impact to any UI or functional features.
And these rule errors are not captured in Semgrep.

### :athletic_shoe: How to Build and Test the Change
Go to automate repo dir, in your local.

`hab studio enter`
`start_all_services`
After all services are up and you can open the [https://a2-dev.test](https://a2-dev.test)
```shell
rebuild components/automate-platform-tools/
rebuild components/authn-service/
rebuild components/authz-service/
rebuild components/event-gateway/
rebuild components/automate-gateway/
rebuild components/automate-load-balancer/
rebuild components/compliance-service/
rebuild components/config-mgmt-service/
rebuild components/automate-cli/
rebuild components/deployment-service/
rebuild components/es-sidecar-service/
rebuild components/automate-es-gateway/
rebuild components/pg-sidecar-service/
rebuild components/event-service/
rebuild components/applications-service/
rebuild components/nodemanager-service/
rebuild components/ingest-service/
rebuild components/license-control-service/
rebuild components/local-user-service/
rebuild components/secrets-service/
rebuild components/session-service/
rebuild components/teams-service/
rebuild components/automate-cs-nginx/
rebuild components/automate-workflow-nginx/
rebuild components/data-feed-service/
rebuild components/event-feed-service/
rebuild components/cereal-service/
rebuild components/infra-proxy-service/
rebuild components/automate-cds/
rebuild components/automate-builder-api-proxy/
rebuild components/sample-data-service/
rebuild components/automate-ui/
rebuild components/backup-gateway/
rebuild components/automate-elasticsearch/
rebuild components/automate-dex/
rebuild components/applications-load-gen/
rebuild components/automate-cs-bookshelf/
rebuild components/automate-cs-oc-bifrost/
rebuild components/automate-cs-oc-erchef/
rebuild components/automate-minio/
rebuild components/automate-builder-api/
rebuild components/automate-workflow-ctl/
rebuild components/automate-workflow-server/
rebuild components/notifications-service/
```
Check again the [https://a2-dev.test](https://a2-dev.test) if everything is running fine.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)* 
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)* 
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
