### PR TITLE
Bump FQDN regex to allow for 25 characters

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -23,6 +23,7 @@ export class Regex {
     NO_MIXED_WILDCARD_ALLOW_SPECIAL: '^(\\*|[^:*]+)$',
 
     // Allows valid FQDN only
+    // Top level domain is limited to a maximum number of 25 characters
     VALID_FQDN: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,25}(:[0-9]{1,5})?(\/.*)?$/,
     // Allows valid IP Address only (ipv4)
     VALID_IP_ADDRESS: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$',

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -23,7 +23,7 @@ export class Regex {
     NO_MIXED_WILDCARD_ALLOW_SPECIAL: '^(\\*|[^:*]+)$',
 
     // Allows valid FQDN only
-    VALID_FQDN: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
+    VALID_FQDN: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,25}(:[0-9]{1,5})?(\/.*)?$/,
     // Allows valid IP Address only (ipv4)
     VALID_IP_ADDRESS: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$',
 

--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -24,7 +24,8 @@ export class Regex {
 
     // Allows valid FQDN only
     // Top level domain is limited to a maximum number of 25 characters
-    VALID_FQDN: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,25}(:[0-9]{1,5})?(\/.*)?$/,
+    VALID_FQDN: /^(https?:\/\/)?[a-zA-Z0-9_]+([\-\.]{1}[a-zA-Z0-9]+)*\.[a-zA-Z]{2,25}(:[0-9]{1,5})?(\/.*)?$/,
+
     // Allows valid IP Address only (ipv4)
     VALID_IP_ADDRESS: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$',
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -135,7 +135,12 @@ describe('CreateChefServerModalComponent', () => {
         ['has numbers in the TLD', 'chef.017'],
         ['has a port number that is too high', 'https://chef.io:987274892'],
         ['has a colon but no port number', 'https://chef.io:'],
-        ['has a letter in the port', 'https://chef.io:123a']
+        ['has a letter in the port', 'https://chef.io:123a'],
+        ['has no domain', 'http://'],
+        ['has no secure domain', 'https://'],
+        ['domain is dots', 'https://..'],
+        ['domain is hash', 'http://#'],
+        ['domain has a space', 'http:// shouldfail.net']
       ], function (description: string, input: string) {
         it(('when the fqdn ' + description), () => {
           createForm.controls['name'].setValue('test');

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -125,15 +125,17 @@ describe('CreateChefServerModalComponent', () => {
         expect(errors['pattern']).toBeTruthy();
       });
 
-            using([
-        ['has a TLD that is longer than 25 characters', 'chef.thisisareallylongtldandwontwork'],
+      using([
+        ['is using something other than http or https', 'httpld://www.chef.io'],
         ['contains two periods', 'chef..internal'],
+        ['there is no TLD suffix', 'http://foo.com.'],
+        ['contains hypens in the TLD', 'chef.this-will-not'],
+        ['has a TLD that is longer than 25 characters', 'chef.thisisareallylongtldandwontwork'],
         ['has a TLD that is shorter than 2 characters', 'chef.i'],
         ['has numbers in the TLD', 'chef.017'],
-        ['there is no TLD suffix', 'http://foo.com.'],
         ['has a port number that is too high', 'https://chef.io:987274892'],
         ['has a colon but no port number', 'https://chef.io:'],
-        ['is using something other than http or https', 'httpld://www.chef.io']
+        ['has a letter in the port', 'https://chef.io:123a']
       ], function (description: string, input: string) {
         it(('when the fqdn ' + description), () => {
           createForm.controls['name'].setValue('test');
@@ -160,6 +162,30 @@ describe('CreateChefServerModalComponent', () => {
         createForm.controls['ip_address'].setValue('1.2.3.4');
         expect(createForm.valid).toBeTruthy();
       });
+
+      using([
+        ['has a TLD that is longer than 2 and less than 25 characters', 'chef.internal'],
+        ['uses https', 'https://chef.io'],
+        ['uses http', 'http://chef.io'],
+        ['omits http or https', 'chef.thisworks'],
+        ['has a port number', 'https://chef.io:123'],
+        ['contains hyphens in the domain', 'new-company-who-dis.nice'],
+        ['contains underscores in the domain', 'new_company_who_dis.chef'],
+        ['contains digits in the domain', '8675309.jenny']
+      ], function (description: string, input: string) {
+        it(('when the fqdn ' + description), () => {
+          createForm.controls['name'].setValue('test');
+          createForm.controls['id'].setValue('test');
+          createForm.controls['ip_address'].setValue('1.2.3.4');
+
+          createForm.controls['fqdn'].setValue(input);
+          errors = createForm.controls['fqdn'].errors || {};
+
+          expect(createForm.valid).toBeTruthy();
+          expect(errors['pattern']).toBeFalsy();
+        });
+      });
+
     });
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from '@angular/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
 import { Regex } from 'app/helpers/auth/regex';
@@ -10,6 +10,9 @@ import { CreateChefServerModalComponent } from './create-chef-server-modal.compo
 describe('CreateChefServerModalComponent', () => {
   let component: CreateChefServerModalComponent;
   let fixture: ComponentFixture<CreateChefServerModalComponent>;
+
+  let createForm: FormGroup;
+  let errors = {};
 
   beforeEach( waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -51,6 +54,7 @@ describe('CreateChefServerModalComponent', () => {
       ]]
     });
     component.conflictErrorEvent = new EventEmitter();
+    createForm = component.createForm;
     fixture.detectChanges();
   });
 
@@ -61,52 +65,65 @@ describe('CreateChefServerModalComponent', () => {
   describe('form validity', () => {
     describe('the form should be invalid', () => {
       it('when all inputs are empty', () => {
-        expect(component.createForm.valid).toBeFalsy();
+        expect(createForm.valid).toBeFalsy();
       });
 
       it('when only 3 of the 4 inputs are complete', () => {
-        component.createForm.controls['name'].setValue('test');
-        component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['fqdn'].setValue('test.net');
-        expect(component.createForm.valid).toBeFalsy();
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['fqdn'].setValue('test.net');
+
+        errors = createForm.controls['ip_address'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
       });
 
       it('when the ip_address in invalid', () => {
-        component.createForm.controls['name'].setValue('test');
-        component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['fqdn'].setValue('chef.internal');
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['fqdn'].setValue('chef.internal');
 
-        component.createForm.controls['ip_address'].setValue('1.2234.3.4');
-        expect(component.createForm.valid).toBeFalsy();
+        createForm.controls['ip_address'].setValue('1.2234.3.4');
+        errors = createForm.controls['ip_address'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['pattern']).toBeTruthy();
       });
 
       it('when the fqdn Top Level Domain is less than 2 characters', () => {
-        component.createForm.controls['name'].setValue('test');
-        component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['ip_address'].setValue('1.2.3.4');
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
 
-        component.createForm.controls['fqdn'].setValue('chef.i');
-        expect(component.createForm.valid).toBeFalsy();
+        createForm.controls['fqdn'].setValue('chef.i');
+        errors = createForm.controls['fqdn'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['pattern']).toBeTruthy();
       });
 
       it('when the fqdn Top Level Domain is longer than 25 characters', () => {
-        component.createForm.controls['name'].setValue('test');
-        component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['ip_address'].setValue('1.2.3.4');
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
 
-        component.createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
-        expect(component.createForm.valid).toBeFalsy();
+        createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
+        errors = createForm.controls['fqdn'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['pattern']).toBeTruthy();
       });
     });
 
     describe('the form should be valid', () => {
       it('when all 4 inputs are filled and valid', () => {
-        expect(component.createForm.valid).toBeFalsy();
-        component.createForm.controls['name'].setValue('test');
-        component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['fqdn'].setValue('chef.internal');
-        component.createForm.controls['ip_address'].setValue('1.2.3.4');
-        expect(component.createForm.valid).toBeTruthy();
+        expect(createForm.valid).toBeFalsy();
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['fqdn'].setValue('chef.internal');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
+        expect(createForm.valid).toBeTruthy();
       });
     });
   });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from '@angular/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, FormsModule, Validators } from '@angular/forms';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
+import { Regex } from 'app/helpers/auth/regex';
 
 import { CreateChefServerModalComponent } from './create-chef-server-modal.component';
 
@@ -25,7 +26,7 @@ describe('CreateChefServerModalComponent', () => {
         CreateChefServerModalComponent
       ],
       imports: [
-        ReactiveFormsModule
+        [ReactiveFormsModule, FormsModule]
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
@@ -35,12 +36,19 @@ describe('CreateChefServerModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateChefServerModalComponent);
     component = fixture.componentInstance;
+    // This form must mimic the createForm including Validators
     component.createForm = new FormBuilder().group({
-      id: ['', null],
-      name: ['', null],
-      description: ['', null],
-      fqdn: ['', null],
-      ip_address: ['', null]
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      id: ['',
+        [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]],
+      fqdn: ['', [Validators.required,
+      Validators.pattern(Regex.patterns.NON_BLANK),
+      Validators.pattern(Regex.patterns.VALID_FQDN)
+      ]],
+      ip_address: ['', [Validators.required,
+      Validators.pattern(Regex.patterns.NON_BLANK),
+      Validators.pattern(Regex.patterns.VALID_IP_ADDRESS)
+      ]]
     });
     component.conflictErrorEvent = new EventEmitter();
     fixture.detectChanges();
@@ -48,5 +56,57 @@ describe('CreateChefServerModalComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('form validity', () => {
+    describe('the form should be invalid', () => {
+      it('when all inputs are empty', () => {
+        expect(component.createForm.valid).toBeFalsy();
+      });
+
+      it('when only 3 of the 4 inputs are complete', () => {
+        component.createForm.controls['name'].setValue('test');
+        component.createForm.controls['id'].setValue('test');
+        component.createForm.controls['fqdn'].setValue('test.net');
+        expect(component.createForm.valid).toBeFalsy();
+      });
+
+      it('when the ip_address in invalid', () => {
+        component.createForm.controls['name'].setValue('test');
+        component.createForm.controls['id'].setValue('test');
+        component.createForm.controls['fqdn'].setValue('chef.internal');
+
+        component.createForm.controls['ip_address'].setValue('1.2234.3.4');
+        expect(component.createForm.valid).toBeFalsy();
+      });
+
+      it('when the fqdn Top Level Domain is less than 2 characters', () => {
+        component.createForm.controls['name'].setValue('test');
+        component.createForm.controls['id'].setValue('test');
+        component.createForm.controls['ip_address'].setValue('1.2.3.4');
+
+        component.createForm.controls['fqdn'].setValue('chef.i');
+        expect(component.createForm.valid).toBeFalsy();
+      });
+
+      it('when the fqdn Top Level Domain is longer than 25 characters', () => {
+        component.createForm.controls['name'].setValue('test');
+        component.createForm.controls['id'].setValue('test');
+        component.createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
+        component.createForm.controls['ip_address'].setValue('1.2.3.4');
+        expect(component.createForm.valid).toBeFalsy();
+      });
+    });
+
+    describe('the form should be valid', () => {
+      it('when all 4 inputs are filled and valid', () => {
+        expect(component.createForm.valid).toBeFalsy();
+        component.createForm.controls['name'].setValue('test');
+        component.createForm.controls['id'].setValue('test');
+        component.createForm.controls['fqdn'].setValue('chef.internal');
+        component.createForm.controls['ip_address'].setValue('1.2.3.4');
+        expect(component.createForm.valid).toBeTruthy();
+      });
+    });
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -92,8 +92,9 @@ describe('CreateChefServerModalComponent', () => {
       it('when the fqdn Top Level Domain is longer than 25 characters', () => {
         component.createForm.controls['name'].setValue('test');
         component.createForm.controls['id'].setValue('test');
-        component.createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
         component.createForm.controls['ip_address'].setValue('1.2.3.4');
+
+        component.createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
         expect(component.createForm.valid).toBeFalsy();
       });
     });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -125,6 +125,8 @@ describe('CreateChefServerModalComponent', () => {
         expect(errors['pattern']).toBeTruthy();
       });
 
+      // Many testing ideas attributed to https://mathiasbynens.be/demo/url-regex
+
       using([
         ['is using something other than http or https', 'httpld://www.chef.io'],
         ['contains two periods', 'chef..internal'],
@@ -140,7 +142,8 @@ describe('CreateChefServerModalComponent', () => {
         ['has no secure domain', 'https://'],
         ['domain is dots', 'https://..'],
         ['domain is hash', 'http://#'],
-        ['domain has a space', 'http:// shouldfail.net']
+        ['domain has a space', 'http:// shouldfail.net'],
+        ['contains all numbers', 'http://10.1.1.0']
       ], function (description: string, input: string) {
         it(('when the fqdn ' + description), () => {
           createForm.controls['name'].setValue('test');
@@ -176,7 +179,11 @@ describe('CreateChefServerModalComponent', () => {
         ['has a port number', 'https://chef.io:123'],
         ['contains hyphens in the domain', 'new-company-who-dis.nice'],
         ['contains underscores in the domain', 'new_company_who_dis.chef'],
-        ['contains digits in the domain', '8675309.jenny']
+        ['contains digits in the domain', '8675309.jenny'],
+        ['contains all numbers in the domain', 'http://223.453.739.net'],
+        ['contains a query', 'http://www.chef.io/events/#&product=automate'],
+        ['contains unicode', 'http://foo.com/unicode_(✪)_in_parens'],
+        ['is a citation url', 'http://foo.com/blah_(wikipedia)_blah#cite-1']
       ], function (description: string, input: string) {
         it(('when the fqdn ' + description), () => {
           createForm.controls['name'].setValue('test');

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -69,14 +69,6 @@ describe('CreateChefServerModalComponent', () => {
         expect(createForm.valid).toBeFalsy();
       });
 
-      // using([
-      //   []
-      // ], function (input: string, expected: boolean) {
-      //   it(('when ' + input + ' is missing'), () => {
-
-      //   });
-      // });
-
       it('when name is missing', () => {
         createForm.controls['id'].setValue('test');
         createForm.controls['fqdn'].setValue('test.net');
@@ -133,30 +125,31 @@ describe('CreateChefServerModalComponent', () => {
         expect(errors['pattern']).toBeTruthy();
       });
 
-      it('when the fqdn Top Level Domain is less than 2 characters', () => {
-        createForm.controls['name'].setValue('test');
-        createForm.controls['id'].setValue('test');
-        createForm.controls['ip_address'].setValue('1.2.3.4');
+            using([
+        ['has a TLD that is longer than 25 characters', 'chef.thisisareallylongtldandwontwork'],
+        ['contains two periods', 'chef..internal'],
+        ['has a TLD that is shorter than 2 characters', 'chef.i'],
+        ['has numbers in the TLD', 'chef.017'],
+        ['there is no TLD suffix', 'http://foo.com.'],
+        ['has a port number that is too high', 'https://chef.io:987274892'],
+        ['has a colon but no port number', 'https://chef.io:'],
+        ['is using something other than http or https', 'httpld://www.chef.io']
+      ], function (description: string, input: string) {
+        it(('when the fqdn ' + description), () => {
+          createForm.controls['name'].setValue('test');
+          createForm.controls['id'].setValue('test');
+          createForm.controls['ip_address'].setValue('1.2.3.4');
 
-        createForm.controls['fqdn'].setValue('chef.i');
-        errors = createForm.controls['fqdn'].errors || {};
+          createForm.controls['fqdn'].setValue(input);
+          errors = createForm.controls['fqdn'].errors || {};
 
-        expect(createForm.valid).toBeFalsy();
-        expect(errors['pattern']).toBeTruthy();
-      });
-
-      it('when the fqdn Top Level Domain is longer than 25 characters', () => {
-        createForm.controls['name'].setValue('test');
-        createForm.controls['id'].setValue('test');
-        createForm.controls['ip_address'].setValue('1.2.3.4');
-
-        createForm.controls['fqdn'].setValue('chef.thistldisgoingtobetoolongwow');
-        errors = createForm.controls['fqdn'].errors || {};
-
-        expect(createForm.valid).toBeFalsy();
-        expect(errors['pattern']).toBeTruthy();
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
       });
     });
+
+
 
     describe('the form should be valid', () => {
       it('when all 4 inputs are filled and valid', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from '@angular/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ReactiveFormsModule, FormBuilder, FormsModule, Validators } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
 import { Regex } from 'app/helpers/auth/regex';
@@ -26,7 +26,7 @@ describe('CreateChefServerModalComponent', () => {
         CreateChefServerModalComponent
       ],
       imports: [
-        [ReactiveFormsModule, FormsModule]
+        ReactiveFormsModule
       ],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angula
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
 import { Regex } from 'app/helpers/auth/regex';
+import { using } from 'app/testing/spec-helpers';
 
 import { CreateChefServerModalComponent } from './create-chef-server-modal.component';
 
@@ -68,7 +69,48 @@ describe('CreateChefServerModalComponent', () => {
         expect(createForm.valid).toBeFalsy();
       });
 
-      it('when only 3 of the 4 inputs are complete', () => {
+      // using([
+      //   []
+      // ], function (input: string, expected: boolean) {
+      //   it(('when ' + input + ' is missing'), () => {
+
+      //   });
+      // });
+
+      it('when name is missing', () => {
+        createForm.controls['id'].setValue('test');
+        createForm.controls['fqdn'].setValue('test.net');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
+
+        errors = createForm.controls['name'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      it('when id is missing', () => {
+        createForm.controls['name'].setValue('test');
+        createForm.controls['fqdn'].setValue('test.net');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
+
+        errors = createForm.controls['id'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      it('when fqdn is missing', () => {
+        createForm.controls['name'].setValue('test');
+        createForm.controls['id'].setValue('test');
+        createForm.controls['ip_address'].setValue('1.2.3.4');
+
+        errors = createForm.controls['fqdn'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      it('when ip_address is missing', () => {
         createForm.controls['name'].setValue('test');
         createForm.controls['id'].setValue('test');
         createForm.controls['fqdn'].setValue('test.net');

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-modal/create-chef-server-modal.component.spec.ts
@@ -131,7 +131,7 @@ describe('CreateChefServerModalComponent', () => {
         ['is using something other than http or https', 'httpld://www.chef.io'],
         ['contains two periods', 'chef..internal'],
         ['there is no TLD suffix', 'http://foo.com.'],
-        ['contains hypens in the TLD', 'chef.this-will-not'],
+        ['contains hyphens in the TLD', 'chef.this-will-not'],
         ['has a TLD that is longer than 25 characters', 'chef.thisisareallylongtldandwontwork'],
         ['has a TLD that is shorter than 2 characters', 'chef.i'],
         ['has numbers in the TLD', 'chef.017'],


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently, our FQDN validation caps a the top level domain to 5 characters max.  This was an arbitrary decision from when the validation was originally made that should not prevent us from updating.  This particular branch updates that arbitrary number to 25 characters.

### :chains: Related Resources
#4891 

### :+1: Definition of Done
When entering an FQDN, a user may now use a word longer than 5 letters

### :athletic_shoe: How to Build and Test the Change

Navigate to https://a2-dev.test/infrastructure/chef-servers
Click "Add Chef Server"
in Name field: Enter a name of you choice
in FQDN field: enter `chef-internal`
in IP field, enter any valid IP i.e. `1.2.3.4`
Submit the form by clicking on "Add Chef Server"
Observe a blue successful creation of server ribbon.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
AFTER:
![fqdn update](https://user-images.githubusercontent.com/16737484/113096425-fd4b4080-91a9-11eb-908a-4c1e7d350fdd.gif)