### PR TITLE
fix unittest for esIndex generator, case for 31st of month handled

### DIFF
--- a/components/compliance-service/reporting/relaxting/util_test.go
+++ b/components/compliance-service/reporting/relaxting/util_test.go
@@ -1,23 +1,30 @@
 package relaxting
 
 import (
-	"github.com/chef/automate/components/compliance-service/ingest/ingestic/mappings"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/chef/automate/components/compliance-service/ingest/ingestic/mappings"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetEsIndexNoTimeLast24h(t *testing.T) {
 	sum := mappings.IndexNameSum
 	filters := make(map[string][]string)
 
+	todayTime := time.Now().UTC()
+
 	index, err := GetEsIndex(filters, true)
-
-	today := time.Now().UTC().Format("2006.01.02")
-	yesterday := time.Now().Add(-24 * time.Hour).UTC().Format("2006.01.02")
-
-	assert.Equal(t, sum+"-"+yesterday+"*,"+sum+"-"+today+"*", index)
 	assert.NoError(t, err)
+
+	today := todayTime.Format("2006.01.02")
+	if today[len(today)-2:] == "31" {
+		//if it's the 31st, shave off the 1 and make it 3*, which will be the 30th and 31st
+		assert.Equal(t, sum+"-"+today[:len(today)-1]+"*", index)
+	} else {
+		yesterday := todayTime.Add(-24 * time.Hour).Format("2006.01.02")
+		assert.Equal(t, sum+"-"+yesterday+"*,"+sum+"-"+today+"*", index)
+	}
 }
 
 func TestGetEsIndexWithOnlyEndTimeFilter(t *testing.T) {

--- a/components/compliance-service/reporting/relaxting/util_test.go
+++ b/components/compliance-service/reporting/relaxting/util_test.go
@@ -18,9 +18,9 @@ func TestGetEsIndexNoTimeLast24h(t *testing.T) {
 	assert.NoError(t, err)
 
 	today := todayTime.Format("2006.01.02")
-	if today[len(today)-2:] == "31" {
+	if todayTime.Day() == 31 {
 		//if it's the 31st, shave off the 1 and make it 3*, which will be the 30th and 31st
-		assert.Equal(t, sum+"-"+today[:len(today)-1]+"*", index)
+		assert.Equal(t, sum+"-"+"3*", index)
 	} else {
 		yesterday := todayTime.Add(-24 * time.Hour).Format("2006.01.02")
 		assert.Equal(t, sum+"-"+yesterday+"*,"+sum+"-"+today+"*", index)

--- a/components/compliance-service/reporting/relaxting/util_test.go
+++ b/components/compliance-service/reporting/relaxting/util_test.go
@@ -20,7 +20,7 @@ func TestGetEsIndexNoTimeLast24h(t *testing.T) {
 	today := todayTime.Format("2006.01.02")
 	if todayTime.Day() == 31 {
 		//if it's the 31st, shave off the 1 and make it 3*, which will be the 30th and 31st
-		assert.Equal(t, sum+"-"+"3*", index)
+		assert.Equal(t, sum+"-3*", index)
 	} else {
 		yesterday := todayTime.Add(-24 * time.Hour).Format("2006.01.02")
 		assert.Equal(t, sum+"-"+yesterday+"*,"+sum+"-"+today+"*", index)


### PR DESCRIPTION
Signed-off-by: Vivek Yadav <vivek.yadav@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Bug fix in the unit test for Index generation for ES.
The test used to fail for the 31st of any month.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Unit Test : TestGetEsIndexNoTimeLast24h should pass on 31st of any Month.

### :athletic_shoe: How to Build and Test the Change
Outside Hab studio.
Go to Automate Repo directory
```bash
cd components/compliance-service/
make lint test-unit
```
All test should pass.
Then change your local system date to 2021-03-31.
Now, again run the tests, this will confirm the test works.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes) **no doc change needed as only unit test was changed**

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
