### PR TITLE
Rm/fix vagrant undefined hasmap except

### DIFF
--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -4,6 +4,17 @@ require 'vagrant-aws'
 require 'resolv'
 require 'mkmf'
 
+class Hash
+  def slice(*keep_keys)
+    h = {}
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
+    h
+  end unless Hash.method_defined?(:slice)
+  def except(*less_keys)
+    slice(*keys - less_keys)
+  end unless Hash.method_defined?(:except)
+end
+
 home_dir="/home/ubuntu"
 current_branch=`git rev-parse --abbrev-ref HEAD`
 latest_head_commit=`git rev-parse HEAD`

--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -4,6 +4,8 @@ require 'vagrant-aws'
 require 'resolv'
 require 'mkmf'
 
+#Undefined HashMap method except with Vagrant 2.2.7
+# work around was found here: https://github.com/mitchellh/vagrant-aws/issues/566#issuecomment-580812210
 class Hash
   def slice(*keep_keys)
     h = {}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
This change fixes the issue the "undefined hashmap method except with Vagrant 2.2.7" issue, which was keeping our ./ec2/Vagrantfile from working properly to provision an ec2 instance.

This change simply applies the workaround initially documented here: https://github.com/mitchellh/vagrant-aws/issues/566#issuecomment-580812210


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
The Hasmap method except issue listed about should no longer prevent us from provisioning an ec2 insance using `vagrant up`

### :athletic_shoe: How to Build and Test the Change
Following the directions in ./ec2/README.md, we should once again be able to provision and use an ec2 instance

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
