### PR TITLE
Jamie/4936 bug update chef server

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -73,8 +73,12 @@
                 data-cy="update-server-fqdn">
             </label>
             <chef-error
-              *ngIf="(updateServerForm.get('fqdn').hasError('required') || updateServerForm.get('fqdn').hasError('pattern')) && updateServerForm.get('fqdn').dirty">
+              *ngIf="updateServerForm.get('fqdn').hasError('required') && updateServerForm.get('fqdn').dirty">
               FQDN is required.
+            </chef-error>
+            <chef-error
+              *ngIf="updateServerForm.get('fqdn').hasError('pattern') && updateServerForm.get('fqdn').dirty">
+              FQDN is invalid.
             </chef-error>
           </chef-form-field>
           <chef-form-field>
@@ -89,8 +93,12 @@
                 data-cy="update-server-ip-address">
             </label>
             <chef-error
-              *ngIf="(updateServerForm.get('ip_address').hasError('required') || updateServerForm.get('ip_address').hasError('pattern')) && updateServerForm.get('ip_address').dirty">
+              *ngIf="updateServerForm.get('ip_address').hasError('required') && updateServerForm.get('ip_address').dirty">
               IP Address is required.
+            </chef-error>
+            <chef-error
+              *ngIf="updateServerForm.get('ip_address').hasError('pattern') && updateServerForm.get('ip_address').dirty">
+              IP Address is invalid.
             </chef-error>
           </chef-form-field>
           <div id="button-bar">

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -90,8 +90,14 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
 
     this.updateServerForm = this.fb.group({
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      fqdn: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      ip_address: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+      fqdn: ['', [Validators.required,
+        Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.VALID_FQDN)
+      ]],
+      ip_address: ['', [Validators.required,
+        Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.VALID_IP_ADDRESS)
+      ]]
     });
 
     this.store.select(routeParams).pipe(

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -47,6 +47,7 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
 
     this.createChefServerForm = this.fb.group({
       // Must stay in sync with error checks in create-chef-server-modal.component.html
+      // and updateServerForm in chef-server-details.component.ts
       id: ['',
         [Validators.required, Validators.pattern(Regex.patterns.ID), Validators.maxLength(64)]],
       name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We are currently failing to provide any meaningful validation when updating the details of a Chef-Server.  This branch adds _front-end_ validation and related testing to updating server details.

### :chains: Related Resources
fixes: https://github.com/chef/automate/issues/4936

### :+1: Definition of Done
A user can no longer update server with invalid fqdn or ip address details.  They are shown an appropriate error message when details are invalid.

### :athletic_shoe: How to Build and Test the Change
in hab studio
`build components/automate-ui-devproxy && start_all_services`

in Automate/components/automate-ui
`make serve`

navigate to https://a2-dev.test/infrastructure/chef-servers
If you already have servers in your list, click into a server
if you do not have a server in your list create one by clicking the blue button labeled "Add Chef Server"
On the server details page, click on the "Details" tab
adjust the fqdn and/or ip address
watch the error message change based on input
if present Error message will state the input is invalid or is required (see attached video)

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![Update Server Validation](https://user-images.githubusercontent.com/16737484/114082829-15cef100-9863-11eb-9c65-0512ee63a07e.gif)
