### PR TITLE
Fix monitoring token testing documentation

### DIFF
--- a/components/docs-chef-io/content/automate/monitoring.md
+++ b/components/docs-chef-io/content/automate/monitoring.md
@@ -60,7 +60,7 @@ To use `/status`, set up an authentication token for use with your monitoring sy
 3. Test that your token and policy give you access to the `/status` endpoint by running the following command:
 
     ```bash
-    curl -k -H "api-token: <token-id>" https://automate.example.com/api/v0/status?pretty
+    curl -k -H "api-token: <monitoring-token>" https://automate.example.com/api/v0/status?pretty
     ```
 
    The output appears in the following JSON format:


### PR DESCRIPTION
This step of the doc should reflect passing your _actual_ monitoring token as the `api-token` and _not_ the monitoring token's `token-id`.

### :nut_and_bolt: Description: What code changed, and why?

Currently the documentation for monitoring Chef Automate is imprecise insofar that it states one should pass in the monitoring token's `<token-id>` as the `api-token` value for authenticating against the API. This is incorrect and should really say `<monitoring-token>` (as to stick with the convention used by `<admin-token>` on L57 of the same doc.

### :chains: Related Resources

N/A.

### :+1: Definition of Done

🤷‍♂️ 

### :athletic_shoe: How to Build and Test the Change

It is documentation so not really applicable.

### :white_check_mark: Checklist



**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

📸  