### PR TITLE
Separate health check and health check status config options for erchef

### DIFF
--- a/components/automate-cs-oc-erchef/habitat/config/sys.config
+++ b/components/automate-cs-oc-erchef/habitat/config/sys.config
@@ -102,7 +102,7 @@
         {server_version, ""},
         {health_ping_timeout, 400},
         {health_ping_modules, [
-{{#if cfg.data_collector.enabled }}
+{{#if cfg.data_collector_health_check.enabled }}
             data_collector,
 {{/if }}
             oc_chef_authz,

--- a/components/automate-cs-oc-erchef/habitat/config/sys.config
+++ b/components/automate-cs-oc-erchef/habitat/config/sys.config
@@ -102,7 +102,7 @@
         {server_version, ""},
         {health_ping_timeout, 400},
         {health_ping_modules, [
-{{#if cfg.data_collector_health_check.enabled }}
+{{#if cfg.data_collector.health_check_enabled }}
             data_collector,
 {{/if }}
             oc_chef_authz,

--- a/components/automate-cs-oc-erchef/habitat/default.toml
+++ b/components/automate-cs-oc-erchef/habitat/default.toml
@@ -60,6 +60,7 @@ timeout = 5000
 pool_init_size = 25
 pool_max_size = 100
 enabled=true
+health_check_enabled=true
 
 [depsolver]
 pool_max_size=5


### PR DESCRIPTION
WIP: Do not merge yet.

I want separate data collector enabled and data collector health check status enabled config options for Erchef. In the case where a chef server is connected to an unstable Automate server, I want a customer to be able to disable their Chef server from failing a health check based on unavailability of the data collector.

Signed-off-by: Andrew Dufour <adufour@chef.io>

### :nut_and_bolt: Description:  Added a health_check_enabled config option separate from the enabled config option in the hab plan and sys.config template.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests) - not new functionality, test needed?
- [] Docs added/updated? (all customer-facing changes) - Docs need to be updated.

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
