### PR TITLE
Added server, org, reset admin key update button css changes.

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -43,7 +43,7 @@
         (deleteClicked)="deleteOrg()"
         objectAction="Delete">
       </app-delete-infra-object-modal>
-      <section class="page-body" *ngIf="tabValue === 'details'">
+      <section class="page-body details-tab" *ngIf="tabValue === 'details'">
         <form [formGroup]="updateServerForm">
           <chef-form-field>
             <label>
@@ -110,8 +110,8 @@
               (click)="saveServer()">
               <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
               <span *ngIf="saveInProgress">Saving...</span>
-              <span *ngIf="!saveInProgress">Save</span></chef-button>
-            <span id="saved-note" *ngIf="saveSuccessful && !updateServerForm.dirty">All changes saved.</span>
+              <span *ngIf="!saveInProgress">Save</span>
+            </chef-button>
           </div>
         </form>
       </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -1,6 +1,8 @@
 <div class="content-container">
   <div class="container">
-    <chef-loading-spinner *ngIf="orgsListLoading" size="50" fixed></chef-loading-spinner>
+    <div class="spinner">
+      <chef-loading-spinner *ngIf="orgsListLoading" size="50" fixed></chef-loading-spinner>
+    </div>
     <main>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
@@ -106,7 +108,7 @@
               primary
               inline
               data-cy="save-button"
-              [disabled]="isLoading || !updateServerForm.valid || !updateServerForm.dirty"
+              [disabled]="isLoading || !updateServerForm.valid || !updateServerForm.dirty || saveInProgress"
               (click)="saveServer()">
               <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
               <span *ngIf="saveInProgress">Saving...</span>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -78,11 +78,13 @@ chef-table {
   }
 }
 
-chef-loading-spinner {
-  width: auto;
-  z-index: 199;
-  background-color: $chef-white;
-  opacity: 0.7;
+.spinner {
+  chef-loading-spinner {
+    width: auto;
+    z-index: 199;
+    background-color: $chef-white;
+    opacity: 0.7;
+  }
 }
 
 .empty-section {

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -30,49 +30,6 @@ chef-toolbar {
   }
 }
 
-form {
-
-  chef-form-field {
-    width: 300px;
-    margin-bottom: 15px;
-  }
-
-  input {
-    font-size: 1em;
-  }
-
-  input[type="text"]:disabled {
-    opacity: 0.5;
-    background-color: $chef-grey;
-    border: none;
-  }
-
-  #changes-not-allowed {
-    font-size: 12px;
-  }
-
-  #button-bar {
-    margin-top: 15px;
-
-    span#saved-note {
-      display: inline-block;
-      margin-top: 5px;
-      font-size: 12px;
-    }
-
-    chef-button {
-      margin-top: 0;
-      margin-left: 0;
-
-      chef-loading-spinner {
-        position: relative;
-        top: 2px;
-        margin-right: 5px;
-      }
-    }
-  }
-}
-
 thead {
   font-size: 14px;
   letter-spacing: 0.2px;

--- a/components/automate-ui/src/app/modules/infra-proxy/infra_shared/shared.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra_shared/shared.scss
@@ -26,3 +26,45 @@ chef-tab-selector {
     background: $chef-azureish-gray;
   }
 }
+
+.details-tab {
+
+  chef-loading-spinner {
+    width: auto;
+    z-index: 199;
+    background-color: $chef-white;
+    opacity: 0.7;
+  }
+
+  form {
+    chef-form-field {
+      width: 310px;
+      margin-bottom: 30px;
+    }
+
+    input[type="text"]:disabled {
+      opacity: 0.5;
+      background-color: $chef-grey;
+      border: none;
+    }
+
+    #changes-not-allowed {
+      font-size: 12px;
+    }
+
+    #button-bar {
+      margin-top: 15px;
+
+      chef-button {
+        margin-top: 0;
+        margin-left: 0;
+
+        chef-loading-spinner {
+          position: relative;
+          top: 2px;
+          margin-right: 5px;
+        }
+      }
+    }
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/infra_shared/shared.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra_shared/shared.scss
@@ -29,13 +29,6 @@ chef-tab-selector {
 
 .details-tab {
 
-  chef-loading-spinner {
-    width: auto;
-    z-index: 199;
-    background-color: $chef-white;
-    opacity: 0.7;
-  }
-
   form {
     chef-form-field {
       width: 310px;

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
@@ -1,45 +1,47 @@
-<chef-loading-spinner *ngIf="isLoading" size="50"></chef-loading-spinner>
-<section class="org-edit">
-  <form [formGroup]="updateOrgForm">
-    <chef-form-field>
-      <label>
-      <span class="label">Name <span aria-hidden="true">*</span></span>
-      <input chefInput formControlName="name" type="text" autocomplete="off"
-        data-cy="update-org-name" [resetOrigin]="saveSuccessful">
-      </label>
-      <chef-error
-        *ngIf="(updateOrgForm.get('name').hasError('required') || updateOrgForm.get('name').hasError('pattern')) && updateOrgForm.get('name').dirty">
-        Name is required.
-      </chef-error>
-    </chef-form-field>
-    <chef-form-field id='projects-container'>
-      <app-projects-dropdown
-        [checkedProjectIDs]="org?.projects"
-        (onDropdownClosing)="onProjectDropdownClosing($event)">
-      </app-projects-dropdown>
-    </chef-form-field>
-    <chef-form-field>
-      <label>
-        <span class="label">Admin User <span aria-hidden="true">*</span></span>
-        <input chefInput formControlName="admin_user" type="text" autocomplete="off"
-          data-cy="update-Org-admin-user" [resetOrigin]="saveSuccessful">
-      </label>
-      <chef-error
-        *ngIf="(updateOrgForm.get('admin_user').hasError('required') || updateOrgForm.get('admin_user').hasError('pattern')) && updateOrgForm.get('admin_user').dirty">
-        Admin User is required.
-      </chef-error>
-    </chef-form-field>
-    <chef-form-field>
-      <div id="button-bar">
-        <chef-button [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty" primary
-        inline (click)="saveOrg()">
-          <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
-          <span *ngIf="saveInProgress">Saving...</span>
-          <span *ngIf="!saveInProgress">Save</span>
-        </chef-button>
-        <span id="saved-note" *ngIf="saveSuccessful && !updateOrgForm.dirty">All changes
-        saved.</span>
-      </div>
-    </chef-form-field>
-  </form>
+<section class="org-edit details-tab">
+  <chef-loading-spinner *ngIf="orgDetailsLoading" size="50" fixed></chef-loading-spinner>
+  <ng-container *ngIf="!orgDetailsLoading">
+    <form [formGroup]="updateOrgForm">
+      <chef-form-field>
+        <label>
+        <span class="label">Name <span aria-hidden="true">*</span></span>
+        <input chefInput formControlName="name" type="text" autocomplete="off"
+          data-cy="update-org-name" [resetOrigin]="saveSuccessful">
+        </label>
+        <chef-error
+          *ngIf="(updateOrgForm.get('name').hasError('required') || updateOrgForm.get('name').hasError('pattern')) && updateOrgForm.get('name').dirty">
+          Name is required.
+        </chef-error>
+      </chef-form-field>
+      <chef-form-field id='projects-container'>
+        <app-projects-dropdown
+          [checkedProjectIDs]="org?.projects"
+          (onDropdownClosing)="onProjectDropdownClosing($event)">
+        </app-projects-dropdown>
+      </chef-form-field>
+      <chef-form-field>
+        <label>
+          <span class="label">Admin User <span aria-hidden="true">*</span></span>
+          <input chefInput formControlName="admin_user" type="text" autocomplete="off"
+            data-cy="update-Org-admin-user" [resetOrigin]="saveSuccessful">
+        </label>
+        <chef-error
+          *ngIf="(updateOrgForm.get('admin_user').hasError('required') || updateOrgForm.get('admin_user').hasError('pattern')) && updateOrgForm.get('admin_user').dirty">
+          Admin User is required.
+        </chef-error>
+      </chef-form-field>
+      <chef-form-field>
+        <div id="button-bar">
+          <chef-button
+            [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty"
+            primary
+            inline (click)="saveOrg()">
+            <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
+            <span *ngIf="saveInProgress">Saving...</span>
+            <span *ngIf="!saveInProgress">Save</span>
+          </chef-button>
+        </div>
+      </chef-form-field>
+    </form>
+  </ng-container>
 </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.html
@@ -1,5 +1,7 @@
 <section class="org-edit details-tab">
-  <chef-loading-spinner *ngIf="orgDetailsLoading" size="50" fixed></chef-loading-spinner>
+  <div class="spinner">
+    <chef-loading-spinner *ngIf="orgDetailsLoading" size="50" fixed></chef-loading-spinner>
+  </div>
   <ng-container *ngIf="!orgDetailsLoading">
     <form [formGroup]="updateOrgForm">
       <chef-form-field>
@@ -33,7 +35,7 @@
       <chef-form-field>
         <div id="button-bar">
           <chef-button
-            [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty"
+            [disabled]="isLoading || !updateOrgForm.valid || !updateOrgForm.dirty || saveInProgress"
             primary
             inline (click)="saveOrg()">
             <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
@@ -1,4 +1,5 @@
 @import "~styles/variables";
+@import '../infra_shared/shared';
 
 chef-page-header {
   padding-bottom: 0;
@@ -15,51 +16,4 @@ chef-toolbar {
     position: absolute;
     right: 0;
   }
-}
-
-form {
-  chef-form-field {
-    width: 310px;
-    margin-bottom: 30px;
-  }
-
-  textarea {
-    height: 200px;
-  }
-
-  input[type="text"]:disabled {
-    opacity: 0.5;
-    background-color: $chef-grey;
-    border: none;
-  }
-
-  #changes-not-allowed {
-    font-size: 12px;
-  }
-
-  #button-bar {
-    margin-top: 15px;
-
-    span#saved-note {
-      display: inline-block;
-      margin-top: 5px;
-      font-size: 12px;
-    }
-
-    chef-button {
-      margin-top: 0;
-      margin-left: 0;
-    }
-  }
-}
-
-chef-loading-spinner {
-  z-index: 199;
-}
-
-chef-loading-spinner {
-  display: block;
-  margin: 100px auto;
-  width: 100px;
-  z-index: 199;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.scss
@@ -17,3 +17,14 @@ chef-toolbar {
     right: 0;
   }
 }
+
+.org-edit {
+  .spinner {
+    chef-loading-spinner {
+      width: auto;
+      z-index: 199;
+      background-color: $chef-white;
+      opacity: 0.7;
+    }
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-edit/org-edit.component.ts
@@ -24,6 +24,7 @@ export class OrgEditComponent implements OnInit, OnDestroy {
   @Input() orgId: string;
 
   public org: Org;
+  public orgDetailsLoading = true;
   public saveSuccessful = false;
   public saveInProgress = false;
   public isLoading = true;
@@ -70,6 +71,7 @@ export class OrgEditComponent implements OnInit, OnDestroy {
       this.updateOrgForm.controls['name'].setValue(this.org.name);
       this.updateOrgForm.controls['admin_user'].setValue(this.org.admin_user);
       this.updateOrgForm.controls.projects.setValue(this.org.projects);
+      this.orgDetailsLoading = false;
     });
 
     this.store.select(updateStatus).pipe(

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
@@ -1,5 +1,8 @@
+
 <section class="reset-admin-key details-tab">
-  <chef-loading-spinner *ngIf="resetKeyLoading" size="50" fixed></chef-loading-spinner>
+  <div class="spinner">
+    <chef-loading-spinner *ngIf="resetKeyLoading" size="50" fixed></chef-loading-spinner>
+  </div>
   <ng-container  *ngIf="!resetKeyLoading">
       <form [formGroup]="resetKeyForm">
         <chef-form-field>
@@ -22,8 +25,10 @@
         </chef-form-field>
         <chef-form-field>
           <div id="button-bar">
-            <chef-button [disabled]="isLoading || !resetKeyForm.valid" primary
-            inline (click)="saveNewKey()">
+            <chef-button
+              [disabled]="isLoading || !resetKeyForm.valid || saveInProgress"
+              primary
+              inline (click)="saveNewKey()">
               <chef-loading-spinner *ngIf="saveInProgress"></chef-loading-spinner>
               <span *ngIf="saveInProgress">Saving...</span>
               <span *ngIf="!saveInProgress">Reset Admin Key</span>

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.html
@@ -1,6 +1,6 @@
-<chef-loading-spinner *ngIf="isLoading" size="50"></chef-loading-spinner>
-<section class="reset-admin-key">
-  <ng-container>
+<section class="reset-admin-key details-tab">
+  <chef-loading-spinner *ngIf="resetKeyLoading" size="50" fixed></chef-loading-spinner>
+  <ng-container  *ngIf="!resetKeyLoading">
       <form [formGroup]="resetKeyForm">
         <chef-form-field>
           <label>

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
@@ -1,4 +1,5 @@
 @import "~styles/variables";
+@import '../infra_shared/shared';
 
 chef-page-header {
   padding-bottom: 0;
@@ -17,39 +18,13 @@ chef-toolbar {
   }
 }
 
-form {
-  chef-form-field {
-    width: 300px;
-    margin-bottom: 15px;
-  }
+.reset-admin-key {
 
   textarea {
     height: 200px;
   }
 
-  input[type="text"]:disabled {
-    opacity: 0.5;
-    background-color: $chef-grey;
-    border: none;
-  }
-
   .chef-error {
     margin-top: -6px;
   }
-
-  #button-bar {
-    margin-top: 15px;
-
-    chef-button {
-      margin-top: 0;
-      margin-left: 0;
-    }
-  }
-}
-
-chef-loading-spinner {
-  display: block;
-  margin: 100px auto;
-  width: 100px;
-  z-index: 199;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.scss
@@ -28,3 +28,14 @@ chef-toolbar {
     margin-top: -6px;
   }
 }
+
+.reset-admin-key {
+  .spinner {
+    chef-loading-spinner {
+      width: auto;
+      z-index: 199;
+      background-color: $chef-white;
+      opacity: 0.7;
+    }
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-admin-key/reset-admin-key.component.ts
@@ -26,6 +26,7 @@ export class ResetAdminKeyComponent implements OnInit, OnDestroy {
   public saveSuccessful = false;
   public saveInProgress = false;
   public isLoading = true;
+  public resetKeyLoading = true;
   public resetKeyForm: FormGroup;
   private isDestroyed = new Subject<boolean>();
 
@@ -41,7 +42,7 @@ export class ResetAdminKeyComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.layoutFacade.showSidebar(Sidebar.Infrastructure);
-
+    this.resetKeyLoading = false;
     this.store.select(updateStatus).pipe(
       takeUntil(this.isDestroyed)
     ).subscribe(([status]) => {


### PR DESCRIPTION
Signed-off-by: Himanshi Chhabra <hchhabra@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Add changes for chef server save button which is expanding when a chef server is renamed.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#4935 
### :+1: Definition of Done
Added the common CSS for the save button in the infra shared folder which we are also using in reset admin key and org details.
Also removed the  ```All changes saved``` because of this we are getting button label as ```SaveSaving..```(for this refer to screenshot).

In chef server details page removed the ```All changes saved``` and added 
### :athletic_shoe: How to Build and Test the Change
**PFA for video**
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views

Steps for server detail: 
1. Go To  Infrastructure -> Chef Servers -> click server name-> click on Details Tab.
2. Renamed the server -> click save.

Steps for org detail: 
1. Go To  Infrastructure -> Chef Servers -> click server name-> click org name -> Type ```feat```-> refresh the page.
2. Click on Details tab -> Renamed the org -> click save.

Steps for reset admin key: 
1. Go To  Infrastructure -> Chef Servers -> click server name-> click org name -> Type ```feat```-> refresh the page.
2. Click on Reset Admin key tab -> update the key-> click Reset admin key.
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Screenshot for button label : SaveSaving visible  earlier in button: 

![saveSaving](https://user-images.githubusercontent.com/61003053/115869990-436b8b00-a45c-11eb-9f01-9ef8bc1f4839.png)

Video:

https://user-images.githubusercontent.com/61003053/115869537-a577c080-a45b-11eb-9440-2023320f1e26.mp4


