### PR TITLE
Declare buf version

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,3 +1,4 @@
+version: v1beta1
 ################################################################################
 # Protocol Buffers Linter Configuration
 ################################################################################
@@ -6,7 +7,7 @@
 # use `lint_all_protobuf_components` in the habitat studio.
 #
 # ## References:
-# 
+#
 # - Style Guide: https://buf.build/docs/style-guide/
 # - Docs for individual checkers: https://buf.build/docs/lint-checkers
 # - Config docs: https://buf.build/docs/lint-configuration
@@ -57,12 +58,12 @@ lint:
   use:
     - DEFAULT
   except:
-    # This linter requires your proto package names to end with .v1 or similar. 
+    # This linter requires your proto package names to end with .v1 or similar.
     # Adopting this for existing code would break anyone using our protos
-    - PACKAGE_VERSION_SUFFIX 
+    - PACKAGE_VERSION_SUFFIX
     # buf wants you to use a file hierarchy that matches your proto package
     # names, but this is difficult and probably breaking to adopt now
-    - PACKAGE_SAME_DIRECTORY 
+    - PACKAGE_SAME_DIRECTORY
     - PACKAGE_DIRECTORY_MATCH
   ignore_only:
     SERVICE_SUFFIX:


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

The buf linter **really** wants this to exist on line 1 in the repo. [Buf FAQ](https://docs.buf.build/faq)

The irony will be if having this line breaks buf.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
