### PR TITLE
Increases report export deadlines to 5 minutes from 1 minute

### DIFF
--- a/components/config-mgmt-service/grpcserver/node_export.go
+++ b/components/config-mgmt-service/grpcserver/node_export.go
@@ -81,7 +81,7 @@ func (s *CfgMgmtServer) NodeExport(request *pRequest.NodeExport, stream service.
 	streamCtx := stream.Context()
 	deadline, ok := streamCtx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(time.Minute)
+		deadline = time.Now().Add(5 * time.Minute)
 	}
 	ctx, cancel := context.WithDeadline(streamCtx, deadline)
 	defer cancel()

--- a/components/config-mgmt-service/grpcserver/report_export.go
+++ b/components/config-mgmt-service/grpcserver/report_export.go
@@ -78,7 +78,7 @@ func (s *CfgMgmtServer) ReportExport(request *pRequest.ReportExport, stream serv
 	streamCtx := stream.Context()
 	deadline, ok := streamCtx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(time.Minute)
+		deadline = time.Now().Add(5 * time.Minute)
 	}
 	ctx, cancel := context.WithDeadline(streamCtx, deadline)
 	defer cancel()

--- a/components/event-feed-service/pkg/server/event_export.go
+++ b/components/event-feed-service/pkg/server/event_export.go
@@ -59,7 +59,7 @@ func (eventFeedServer *EventFeedServer) EventExport(request *event_feed.EventExp
 	streamCtx := stream.Context()
 	deadline, ok := streamCtx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(time.Minute)
+		deadline = time.Now().Add(5 * time.Minute)
 	}
 	ctx, cancel := context.WithDeadline(streamCtx, deadline)
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Increases the deadline for export functions on nodes, reports and events to 5 minutes from current 1 minute to allow for larger data-sets or less-performant environments.

This is to address #4944 

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
