### PR TITLE
[Infra-proxy] Cypress specs for the Chef organization details page

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -1,6 +1,6 @@
 <section class="cookbooks">
   <chef-loading-spinner *ngIf="cookbooksListLoading" size="50"></chef-loading-spinner>
-  <app-empty-state *ngIf="authFailure" moduleTitle="cookbooks" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
+  <app-empty-state data-cy="empty-state-wrapper" *ngIf="authFailure" moduleTitle="cookbooks" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
   <ng-container  *ngIf="!cookbooksListLoading && !authFailure">
     <div class="empty-section" *ngIf="!cookbooks.length">
       <img alt="No preview" src="/assets/img/no_preview.gif" />

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbooks/cookbooks.component.html
@@ -6,27 +6,29 @@
       <img alt="No preview" src="/assets/img/no_preview.gif" />
       <p>No cookbooks available</p>
     </div>
-    <chef-table *ngIf="cookbooks.length">
-      <chef-thead>
-        <chef-tr class="no_border_tr">
-          <chef-th class="no_border_th">Name</chef-th>
-          <chef-th class="no_border_th">Cookbook Version</chef-th>
-          <chef-th class="no_border_th"></chef-th>
-          <chef-th class="no_border_th"></chef-th>
-          <chef-th class="no_border_th"></chef-th>
-        </chef-tr>
-      </chef-thead>
-      <chef-tbody>
-        <chef-tr *ngFor="let cookbook of cookbooks">
-          <chef-td>
-            <a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
-          </chef-td>
-          <chef-td>{{ cookbook.version }}</chef-td>
-          <chef-td></chef-td>
-          <chef-td></chef-td>
-          <chef-td></chef-td>
-        </chef-tr>
-      </chef-tbody>
-    </chef-table>
+    <div id="cookbooks-table-container" *ngIf="cookbooks.length" data-cy="cookbooks-table-container">
+      <chef-table>
+        <chef-thead>
+          <chef-tr class="no_border_tr">
+            <chef-th class="no_border_th">Name</chef-th>
+            <chef-th class="no_border_th">Cookbook Version</chef-th>
+            <chef-th class="no_border_th"></chef-th>
+            <chef-th class="no_border_th"></chef-th>
+            <chef-th class="no_border_th"></chef-th>
+          </chef-tr>
+        </chef-thead>
+        <chef-tbody>
+          <chef-tr *ngFor="let cookbook of cookbooks">
+            <chef-td>
+              <a [routerLink]="['/infrastructure','chef-servers', serverId, 'organizations', orgId, 'cookbooks', cookbook.name]">{{ cookbook.name }}</a>
+            </chef-td>
+            <chef-td>{{ cookbook.version }}</chef-td>
+            <chef-td></chef-td>
+            <chef-td></chef-td>
+            <chef-td></chef-td>
+          </chef-tr>
+        </chef-tbody>
+      </chef-table>
+    </div>
   </ng-container>
 </section>

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -1,19 +1,7 @@
 describe('chef server', () => {
-  // let adminIdToken = '';
-  // const now = Cypress.moment().format('MMDDYYhhmmss');
-  // const cypressPrefix = 'infra';
-  // const serverName = `${cypressPrefix} server ${now}`;
-  // const serverID = serverName.split(' ').join('-');
-  
-  // const serverFQDN = 'chef-server-1617089723092818000.com';
-  // const serverIP = '176.119.50.159';
-  // const orgName =  `${cypressPrefix} org ${now}`;  
-  // const orgID = orgName.split(' ').join('-');
-  // const adminUser = 'test_admin_user';
-
+  let adminIdToken = '';
   const now = Cypress.moment().format('MMDDYYhhmmss');
   const cypressPrefix = 'infra';
-  let adminIdToken = '';
   const serverID = 'chef-server-dev-test';
   const serverName = 'chef server dev';
   const orgID = 'chef-org-dev';
@@ -23,8 +11,7 @@ describe('chef server', () => {
   const adminUser = 'chefadmin';
   const adminKey = 'Dummy--admin--key';
 
- 
-  const tabNames = ['Roles','Environments','Data Bags','Clients']
+  const tabNames = ['Roles','Environments','Data Bags','Clients','Cookbooks']
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -109,6 +96,12 @@ describe('chef server', () => {
       cy.get('.nav-tab').contains('Cookbooks').should('have.class', 'active');
     });
 
+    tabNames.forEach((val) => {
+      it(`can switch to ${val} tab`, () => {      
+          cy.get('.nav-tab').contains(val).click();
+      });      
+    });
+
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
         if($cookbook.hasClass('empty-section')) {
@@ -122,11 +115,11 @@ describe('chef server', () => {
       })     
     });
 
-    tabNames.forEach((val) => {
-    it(`can switch to ${val} tab`, () => {      
-        cy.get('.nav-tab').contains(val).click();
-      });      
-    });   
+    it('can select cookbook and load data', () => {
+      cy.get('chef-tbody chef-tr chef-td').contains('a')
+      .should('exist');
+      cy.get('chef-tbody chef-tr chef-td').contains('a').click();
+    });
 
   });
 });

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -1,0 +1,132 @@
+describe('chef server', () => {
+  // let adminIdToken = '';
+  // const now = Cypress.moment().format('MMDDYYhhmmss');
+  // const cypressPrefix = 'infra';
+  // const serverName = `${cypressPrefix} server ${now}`;
+  // const serverID = serverName.split(' ').join('-');
+  
+  // const serverFQDN = 'chef-server-1617089723092818000.com';
+  // const serverIP = '176.119.50.159';
+  // const orgName =  `${cypressPrefix} org ${now}`;  
+  // const orgID = orgName.split(' ').join('-');
+  // const adminUser = 'test_admin_user';
+
+  const now = Cypress.moment().format('MMDDYYhhmmss');
+  const cypressPrefix = 'infra';
+  let adminIdToken = '';
+  const serverID = 'chef-server-dev-test';
+  const serverName = 'chef server dev';
+  const orgID = 'chef-org-dev';
+  const orgName = '4thcoffee';
+  const serverFQDN = 'ec2-34-219-25-251.us-west-2.compute.amazonaws.com';
+  const serverIP = '34.219.25.251';
+  const adminUser = 'chefadmin';
+  const adminKey = 'Dummy--admin--key';
+
+ 
+  const tabNames = ['Roles','Environments','Data Bags','Clients']
+
+  before(() => {
+    cy.adminLogin('/').then(() => {
+      const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
+      adminIdToken = admin.id_token;
+
+      cy.request({
+        auth: { bearer: adminIdToken },
+        failOnStatusCode: false,
+        method: 'POST',
+        url: '/api/v0/infra/servers',
+        body: {
+          id: serverID,
+          name: serverName,
+          fqdn: serverFQDN,
+          ip_address: serverIP
+        }
+      }).then((resp) => {
+        if (resp.status === 200 && resp.body.ok === true) {
+          return;
+        } else {
+          cy.request({
+            auth: { bearer: adminIdToken },
+            method: 'GET',
+            url: `/api/v0/infra/servers/${serverID}`,
+            body: {
+              id: serverID
+            }
+          });
+        }
+      });
+
+      cy.request({
+        auth: { bearer: adminIdToken },
+        failOnStatusCode: false,
+        method: 'POST',
+        url: `/api/v0/infra/servers/${serverID}/orgs`,
+        body: {
+          id: orgID,
+          server_id: serverID,
+          name: orgName,
+          admin_user: adminUser,
+          admin_key: adminKey
+        }
+      }).then((response) => {
+        if (response.status === 200 && response.body.ok === true) {
+          return;
+        } else {
+          cy.request({
+            auth: { bearer: adminIdToken },
+            method: 'GET',
+            url: `/api/v0/infra/servers/${serverID}/orgs/${orgID}`,
+            body: {
+              id: orgID,
+              server_id: serverID
+            }
+          });
+        }
+      });
+
+      cy.visit(`/infrastructure/chef-servers/${serverID}/organizations/${orgID}`);
+      cy.get('app-welcome-modal').invoke('hide');
+    });
+
+    cy.restoreStorage();
+  });
+
+  beforeEach(() => {
+    cy.restoreStorage();
+  });
+
+  afterEach(() => {
+    cy.saveStorage();
+  });
+
+  describe('chef organizations details page', () => {
+    it('displays org details', () => {
+      cy.get('.page-title').contains(orgName);
+    });
+
+    it('on page load Cookbook is in active state',() => {
+      cy.get('.nav-tab').contains('Cookbooks').should('have.class', 'active');
+    });
+
+    it('lists of Cookbook', () => {
+      cy.get('.cookbooks').then(($cookbook) => {
+        if($cookbook.hasClass('empty-section')) {
+          cy.get('chef-table chef-th').should('not.be.visible');
+            cy.get('.empty-section').should('be.visible');
+            cy.get('.empty-section p').contains('No cookbooks available');
+        } else {
+          cy.get('chef-table chef-th').contains('Name');
+          cy.get('chef-table chef-th').contains('Cookbook Version');
+        }
+      })     
+    });
+
+    tabNames.forEach((val) => {
+    it(`can switch to ${val} tab`, () => {      
+        cy.get('.nav-tab').contains(val).click();
+      });      
+    });   
+
+  });
+});

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -11,7 +11,7 @@ describe('chef server', () => {
   const adminUser = 'chefadmin';
   const adminKey = 'Dummy--admin--key';
 
-  const tabNames = ['Roles','Environments','Data Bags','Clients','Cookbooks']
+  const tabNames = ['Roles', 'Environments', 'Data Bags', 'Clients', 'Cookbooks'];
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -92,19 +92,19 @@ describe('chef server', () => {
       cy.get('.page-title').contains(orgName);
     });
 
-    it('on page load Cookbook is in active state',() => {
+    it('on page load Cookbook is in active state', () => {
       cy.get('.nav-tab').contains('Cookbooks').should('have.class', 'active');
     });
 
     tabNames.forEach((val) => {
-      it(`can switch to ${val} tab`, () => {      
+      it(`can switch to ${val} tab`, () => {
           cy.get('.nav-tab').contains(val).click();
-      });      
+      });
     });
 
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
-        if($cookbook.hasClass('empty-section')) {
+        if ($cookbook.hasClass('empty-section')) {
           cy.get('chef-table chef-th').should('not.be.visible');
             cy.get('.empty-section').should('be.visible');
             cy.get('.empty-section p').contains('No cookbooks available');
@@ -112,7 +112,7 @@ describe('chef server', () => {
           cy.get('chef-table chef-th').contains('Name');
           cy.get('chef-table chef-th').contains('Cookbook Version');
         }
-      })     
+      });
     });
 
     it('can select cookbook and load data', () => {

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -9,7 +9,7 @@ describe('chef server', () => {
   const serverFQDN = 'ec2-34-219-25-251.us-west-2.compute.amazonaws.com';
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
-  const adminKey = 'Dummy--admin--key';
+  const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
 
   const tabNames = ['Roles', 'Environments', 'Data Bags', 'Clients', 'Cookbooks'];
 
@@ -105,21 +105,15 @@ describe('chef server', () => {
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
         if ($cookbook.hasClass('empty-section')) {
-          cy.get('chef-table chef-th').should('not.be.visible');
+          cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');
             cy.get('.empty-section').should('be.visible');
             cy.get('.empty-section p').contains('No cookbooks available');
         } else {
-          cy.get('chef-table chef-th').contains('Name');
-          cy.get('chef-table chef-th').contains('Cookbook Version');
+          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Name');
+          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Cookbook Version');
         }
       });
     });
-
-    it('can select cookbook and load data', () => {
-      cy.get('chef-tbody chef-tr chef-td').contains('a')
-      .should('exist');
-      cy.get('chef-tbody chef-tr chef-td').contains('a').click();
-    });
-
+   
   });
 });

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -103,7 +103,7 @@ describe('chef server', () => {
 
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
-        if (cy.get('[data-cy=empty-state]')) {
+        if (cy.get('[data-cy=empty-state-wrapper]')) {
           cy.get('[data-cy=empty-state] p')
           .contains('Unable to show cookbooks because admin key is invalid.');
         } else {

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -9,8 +9,8 @@ describe('chef server', () => {
   const serverFQDN = 'ec2-34-219-25-251.us-west-2.compute.amazonaws.com';
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
-  const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
-
+  // const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
+  const adminKey = 'Dummy--admin--key';
   const tabNames = ['Roles', 'Environments', 'Data Bags', 'Clients', 'Cookbooks'];
 
   before(() => {
@@ -114,6 +114,6 @@ describe('chef server', () => {
         }
       });
     });
-   
+
   });
 });

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -103,8 +103,9 @@ describe('chef server', () => {
 
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
-        if(cy.get('[data-cy=empty-state]')) {
-          cy.get('[data-cy=empty-state] p').contains('Unable to show cookbooks because admin key is invalid.')
+        if (cy.get('[data-cy=empty-state]')) {
+          cy.get('[data-cy=empty-state] p')
+          .contains('Unable to show cookbooks because admin key is invalid.');
         } else {
           if ($cookbook.hasClass('empty-section')) {
             cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -9,8 +9,7 @@ describe('chef server', () => {
   const serverFQDN = 'ec2-34-219-25-251.us-west-2.compute.amazonaws.com';
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
-  // const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
-  const adminKey = 'Dummy--admin--key';
+  const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
   const tabNames = ['Roles', 'Environments', 'Data Bags', 'Clients', 'Cookbooks'];
 
   before(() => {
@@ -104,13 +103,17 @@ describe('chef server', () => {
 
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
-        if ($cookbook.hasClass('empty-section')) {
-          cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');
-            cy.get('.empty-section').should('be.visible');
-            cy.get('.empty-section p').contains('No cookbooks available');
+        if(cy.get('[data-cy=empty-state]')) {
+          cy.get('[data-cy=empty-state] p').contains('Unable to show cookbooks because admin key is invalid.')
         } else {
-          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Name');
-          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Cookbook Version');
+          if ($cookbook.hasClass('empty-section')) {
+            cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');
+              cy.get('.empty-section').should('be.visible');
+              cy.get('.empty-section p').contains('No cookbooks available');
+          } else {
+            cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Name');
+            cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Cookbook Version');
+          }
         }
       });
     });

--- a/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/chef-organization-details.spec.ts
@@ -103,18 +103,13 @@ describe('chef server', () => {
 
     it('lists of Cookbook', () => {
       cy.get('.cookbooks').then(($cookbook) => {
-        if (cy.get('[data-cy=empty-state-wrapper]')) {
-          cy.get('[data-cy=empty-state] p')
-          .contains('Unable to show cookbooks because admin key is invalid.');
+        if ($cookbook.hasClass('empty-section')) {
+          cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');
+            cy.get('.empty-section').should('be.visible');
+            cy.get('.empty-section p').contains('No cookbooks available');
         } else {
-          if ($cookbook.hasClass('empty-section')) {
-            cy.get('[data-cy=cookbooks-table-container]').should('not.be.visible');
-              cy.get('.empty-section').should('be.visible');
-              cy.get('.empty-section p').contains('No cookbooks available');
-          } else {
-            cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Name');
-            cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Cookbook Version');
-          }
+          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Name');
+          cy.get('[data-cy=cookbooks-table-container] chef-th').contains('Cookbook Version');
         }
       });
     });


### PR DESCRIPTION
Signed-off-by:  Chaitali Mane cmane@progress.com

### :nut_and_bolt: Description: What code changed, and why?
we need to add the cypress specs for the infra proxy, I have covered the Chef organization details page in this PR.
I have added specs for the organization details page and all tab[Cookbooks, Roles, Environments, Data Bags, Clients]
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
[4906](https://github.com/chef/automate/issues/4906)

### :+1: Definition of Done
I have added specs for the organization details page and all tab with different scenarios.

### :athletic_shoe: How to Build and Test the Change
Please follow this link to run on your local environment.

https://github.com/chef/automate/tree/master/e2e

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

