### PR TITLE
Added validation on create pop-up, search bar inside org details

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -12,6 +12,13 @@ export class Regex {
     // NB: neither \S nor ^\s work inside the brackets in this regex language.
     NON_BLANK: '.*[^ ].*',
 
+    // Only allows words or numbers or hyphen or underscore also combined
+    // Will Not allow wildcard alone also not combination also not space
+    // Legal Values: _, -, chef, _state, -chef, 19test, tes-1-9-A_test etc.
+    // Illegal Values: abc*, *chef, c*h*e*f, **, * chef
+    // Allows no special characters except hyphen and underscore.
+    NO_WILDCARD_ALLOW_HYPHEN: /^[0-9a-zA-Z-_]+$/,
+
     // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.spec.ts
@@ -11,7 +11,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { By } from '@angular/platform-browser';
 import { GetClientsSuccess } from 'app/entities/clients/client.action';
 import { Client } from 'app/entities/clients/client.model';
-
+import { using } from 'app/testing/spec-helpers';
 
 describe('ClientsComponent', () => {
   let component: ClientsComponent;
@@ -70,6 +70,108 @@ describe('ClientsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('#search', () => {
+    describe('search shows no data', () => {
+
+      using([
+        ['contains tilde.', 'client~'],
+        ['contains acute, back quote,', 'client`'],
+        ['contains exclamation mark', 'client!'],
+        ['contains ampersat, at', 'client@'],
+        ['contains dollar sign', 'client$'],
+        ['contains percent.', 'client%'],
+        ['contains caret or circumflex.,', 'client^'],
+        ['contains ampersand', 'client&'],
+        ['contains asterisk', 'client*'],
+        ['contains open or left parenthesis.', 'client('],
+        ['contains close or right parenthesis,', 'client)'],
+        ['contains plus', 'client+'],
+        ['contains equal', 'client='],
+        ['contains open brace', 'client{'],
+        ['contains close brace', 'client}'],
+        ['contains open bracket', 'client['],
+        ['contains closed bracket', 'client]'],
+        ['contains pipe', 'client|'],
+        ['contains backslash', 'client\\'],
+        ['contains forward slash', 'client/'],
+        ['contains colon', 'client:'],
+        ['contains semicolon.', 'client;'],
+        ['contains quote', 'client"'],
+        ['contains apostrophe', 'client\'test'],
+        ['contains less than', 'client<'],
+        ['contains greater than', 'client>'],
+        ['contains comma', 'client,'],
+        ['contains period, dot', 'client.'],
+        ['contains question mark', 'client?'],
+        ['contains space', 'client test1'],
+        ['has mixed alphabet, number, special character', 'client-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+          component.searchClients(input);
+          expect(component.clients.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+          component.searchClients(input);
+          expect(component.clients.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+    });
+
+    describe('the form should be valid', () => {
+
+      using([
+        ['contains numbers range 0-9.', 'client123'],
+        ['contains alphabets a-z', 'client-test'],
+        ['contains underscore.', 'client_test'],
+        ['contains hyphen, minus, or dash.', 'client_test-1'],
+        ['has mixed characters', 'client-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+
+          component.searchClients(input);
+          expect(component.clients.length).not.toBeNull();
+          expect(element.query(By.css('.empty-section'))).toBeNull();
+        });
+      });
+    });
   });
 
   describe('client list', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
@@ -10,6 +10,7 @@ import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade'
 import { GetClients, DeleteClient } from 'app/entities/clients/client.action';
 import { Client } from 'app/entities/clients/client.model';
 import { getAllStatus, clientList, deleteStatus } from 'app/entities/clients/client.selectors';
+import { Regex } from 'app/helpers/auth/regex';
 
 @Component({
   selector: 'app-clients',
@@ -81,7 +82,13 @@ export class ClientsComponent implements OnInit, OnDestroy {
     this.current_page = 1;
     this.searching = true;
     this.searchValue = currentText;
-    this.getClientsData();
+    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+      this.searching = false;
+      this.clients.length = 0;
+      this.total = 0;
+    } else {
+      this.getClientsData();
+    }
   }
 
   onPageChange(event: number): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
@@ -6,9 +6,13 @@
         <chef-form-field>
           <label *ngIf="!created">
             <span class="label">Client Name</span>
-            <input chefInput firstFocus formControlName="name" type="text" (keyup)="handleNameInput($event)" autocomplete="off" />
+            <input chefInput firstFocus formControlName="name" type="text" (keyup)="handleInput($event)" autocomplete="off" />
           </label>
           <chef-error *ngIf="error">{{error}}</chef-error>
+          <chef-error
+            *ngIf="createForm.get('name').hasError('pattern') && createForm.get('name').dirty">
+            name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+          </chef-error>
         </chef-form-field>
         <chef-form-field>
           <chef-checkbox *ngIf="!created" (change)="updateValidatorCheckbox($event.detail)"

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.html
@@ -11,7 +11,7 @@
           <chef-error *ngIf="error">{{error}}</chef-error>
           <chef-error
             *ngIf="createForm.get('name').hasError('pattern') && createForm.get('name').dirty">
-            name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+            Name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
           </chef-error>
         </chef-form-field>
         <chef-form-field>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.spec.ts
@@ -1,15 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import { ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { CreateClientModalComponent } from './create-client-modal.component';
 import { ClientKey } from 'app/entities/clients/client.model';
 import { EventEmitter } from '@angular/core';
+import { Regex } from 'app/helpers/auth/regex';
+import { using } from 'app/testing/spec-helpers';
 
 describe('CreateClientModalComponent', () => {
   let component: CreateClientModalComponent;
   let fixture: ComponentFixture<CreateClientModalComponent>;
+
+  let createForm: FormGroup;
+  let errors = {};
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -33,12 +38,144 @@ describe('CreateClientModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateClientModalComponent);
     component = fixture.componentInstance;
+    component.createForm = new FormBuilder().group({
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
+      validator: ['']
+    });
     component.openEvent = new EventEmitter();
+    createForm = component.createForm;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('form validity', () => {
+    describe('the form should be invalid', () => {
+      it('when all inputs are empty', () => {
+        expect(createForm.valid).toBeFalsy();
+      });
+
+      it('when name is missing', () => {
+
+        errors = createForm.controls['name'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      using([
+        ['contains tilde.', 'client~'],
+        ['contains acute, back quote,', 'client`'],
+        ['contains exclamation mark', 'client!'],
+        ['contains ampersat, at', 'client@'],
+        ['contains dollar sign', 'client$'],
+        ['contains percent.', 'client%'],
+        ['contains caret or circumflex.,', 'client^'],
+        ['contains ampersand', 'client&'],
+        ['contains asterisk', 'client*'],
+        ['contains open or left parenthesis.', 'client('],
+        ['contains close or right parenthesis,', 'client)'],
+        ['contains plus', 'client+'],
+        ['contains equal', 'client='],
+        ['contains open brace', 'client{'],
+        ['contains close brace', 'client}'],
+        ['contains open bracket', 'client['],
+        ['contains closed bracket', 'client]'],
+        ['contains pipe', 'client|'],
+        ['contains backslash', 'client\\'],
+        ['contains forward slash', 'client/'],
+        ['contains colon', 'client:'],
+        ['contains semicolon.', 'client;'],
+        ['contains quote', 'client"'],
+        ['contains apostrophe', 'client\'test'],
+        ['contains less than', 'client<'],
+        ['contains greater than', 'client>'],
+        ['contains comma', 'client,'],
+        ['contains period, dot', 'client.'],
+        ['contains question mark', 'client?'],
+        ['contains space', 'client test1'],
+        ['has mixed alphabet, number, special character', 'client-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+    });
+
+    describe('the form should be valid', () => {
+      it('when all inputs are filled and valid', () => {
+        expect(createForm.valid).toBeFalsy();
+        createForm.controls['name'].setValue('client');
+        expect(createForm.valid).toBeTruthy();
+      });
+
+      using([
+        ['contains numbers range 0-9.', 'client123'],
+        ['contains alphabets a-z', 'client-test'],
+        ['contains underscore.', 'client_test'],
+        ['contains hyphen, minus, or dash.', 'client_test-1'],
+        ['has mixed characters', 'client-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeTruthy();
+          expect(errors['pattern']).toBeFalsy();
+        });
+      });
+    });
   });
 
   describe('#createClientForm', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
@@ -46,7 +46,8 @@ export class CreateClientModalComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>
   ) {
     this.createForm = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       validator: ['']
     });
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.ts
@@ -46,7 +46,7 @@ export class CreateClientModalComponent implements OnInit, OnDestroy {
     private store: Store<NgrxStateAtom>
   ) {
     this.createForm = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+      name: ['', [Validators.required,
         Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       validator: ['']
     });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
@@ -9,11 +9,15 @@
             <input chefInput firstFocus formControlName="name" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
           </label>
           <chef-error
-          *ngIf="(createForm.get('name').hasError('required') || createForm.get('name').hasError('pattern')) && createForm.get('name').dirty">
+          *ngIf="createForm.get('name').hasError('required') && createForm.get('name').dirty">
           Name is required.
         </chef-error>
         <chef-error *ngIf="conflictError">
           Name "{{createForm.get('name').value}}" already exists.
+        </chef-error>
+        <chef-error
+          *ngIf="createForm.get('name').hasError('pattern') && createForm.get('name').dirty">
+          name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
         </chef-error>
         </chef-form-field>
       </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.html
@@ -17,7 +17,7 @@
         </chef-error>
         <chef-error
           *ngIf="createForm.get('name').hasError('pattern') && createForm.get('name').dirty">
-          name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+          Name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
         </chef-error>
         </chef-form-field>
       </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.spec.ts
@@ -1,6 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MockComponent } from 'ng2-mock-component';
@@ -17,11 +17,16 @@ import {
 import {
   DataBag
 } from 'app/entities/data-bags/data-bags.model';
+import { Regex } from 'app/helpers/auth/regex';
+import { using } from 'app/testing/spec-helpers';
 
 
 describe('CreateDataBagModalComponent', () => {
   let component: CreateDataBagModalComponent;
   let fixture: ComponentFixture<CreateDataBagModalComponent>;
+
+  let createForm: FormGroup;
+  let errors = {};
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -54,12 +59,143 @@ describe('CreateDataBagModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateDataBagModalComponent);
     component = fixture.componentInstance;
+    component.createForm = new FormBuilder().group({
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]]
+    });
     component.openEvent = new EventEmitter();
+    createForm = component.createForm;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('form validity', () => {
+    describe('the form should be invalid', () => {
+      it('when all inputs are empty', () => {
+        expect(createForm.valid).toBeFalsy();
+      });
+
+      it('when name is missing', () => {
+
+        errors = createForm.controls['name'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      using([
+        ['contains tilde.', 'databag~'],
+        ['contains acute, back quote,', 'databag`'],
+        ['contains exclamation mark', 'databag!'],
+        ['contains ampersat, at', 'databag@'],
+        ['contains dollar sign', 'databag$'],
+        ['contains percent.', 'databag%'],
+        ['contains caret or circumflex.,', 'databag^'],
+        ['contains ampersand', 'databag&'],
+        ['contains asterisk', 'databag*'],
+        ['contains open or left parenthesis.', 'databag('],
+        ['contains close or right parenthesis,', 'databag)'],
+        ['contains plus', 'databag+'],
+        ['contains equal', 'databag='],
+        ['contains open brace', 'databag{'],
+        ['contains close brace', 'databag}'],
+        ['contains open bracket', 'databag['],
+        ['contains closed bracket', 'databag]'],
+        ['contains pipe', 'databag|'],
+        ['contains backslash', 'databag\\'],
+        ['contains forward slash', 'databag/'],
+        ['contains colon', 'databag:'],
+        ['contains semicolon.', 'databag;'],
+        ['contains quote', 'databag"'],
+        ['contains apostrophe', 'databag\'test'],
+        ['contains less than', 'databag<'],
+        ['contains greater than', 'databag>'],
+        ['contains comma', 'databag,'],
+        ['contains period, dot', 'databag.'],
+        ['contains question mark', 'databag?'],
+        ['contains space', 'databag test1'],
+        ['has mixed alphabet, number, special character', 'databag-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+    });
+
+    describe('the form should be valid', () => {
+      it('when all inputs are filled and valid', () => {
+        expect(createForm.valid).toBeFalsy();
+        createForm.controls['name'].setValue('databag');
+        expect(createForm.valid).toBeTruthy();
+      });
+
+      using([
+        ['contains numbers range 0-9.', 'databag123'],
+        ['contains alphabets a-z', 'databag-test'],
+        ['contains underscore.', 'databag_test'],
+        ['contains hyphen, minus, or dash.', 'databag_test-1'],
+        ['has mixed characters', 'databag-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+
+          createForm.controls['name'].setValue(input);
+          errors = createForm.controls['name'].errors || {};
+
+          expect(createForm.valid).toBeTruthy();
+          expect(errors['pattern']).toBeFalsy();
+        });
+      });
+    });
   });
 
   describe('#createDataBagForm', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
@@ -49,7 +49,8 @@ export class CreateDataBagModalComponent implements OnInit, OnDestroy {
   ) {
     this.createForm = this.fb.group({
       // Must stay in sync with error checks in create-notification-modal.component.html
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+              Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]]
     });
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-data-bag-modal/create-data-bag-modal.component.ts
@@ -49,7 +49,7 @@ export class CreateDataBagModalComponent implements OnInit, OnDestroy {
   ) {
     this.createForm = this.fb.group({
       // Must stay in sync with error checks in create-notification-modal.component.html
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+      name: ['', [Validators.required,
               Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]]
     });
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.html
@@ -9,12 +9,16 @@
               <input chefInput formControlName="itemId" type="text" id="name-input" (keyup)="handleInput($event)" autocomplete="off"/>
             </label>
             <chef-error
-            *ngIf="(createForm.get('itemId').hasError('required') || createForm.get('itemId').hasError('pattern')) && createForm.get('itemId').dirty">
-            Data Bag Item ID is required.
-          </chef-error>
-          <chef-error *ngIf="conflictError">
-            ID "{{createForm.get('itemId').value}}" already exists.
-          </chef-error>
+              *ngIf="createForm.get('itemId').hasError('required') && createForm.get('itemId').dirty">
+              Data Bag Item ID is required.
+            </chef-error>
+            <chef-error *ngIf="conflictError">
+              ID "{{createForm.get('itemId').value}}" already exists.
+            </chef-error>
+            <chef-error
+              *ngIf="createForm.get('itemId').hasError('pattern') && createForm.get('itemId').dirty">
+              ID can only contain 'a-z', '0-9', '_', '-'.
+            </chef-error>
           </chef-form-field>
         </div>
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { StoreModule, Store } from '@ngrx/store';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MockComponent } from 'ng2-mock-component';
@@ -16,10 +16,15 @@ import {
 import {
   DataBagItem
 } from 'app/entities/data-bags/data-bags.model';
+import { Regex } from 'app/helpers/auth/regex';
+import { using } from 'app/testing/spec-helpers';
 
 describe('CreateDatabagItemModalComponent', () => {
   let component: CreateDatabagItemModalComponent;
   let fixture: ComponentFixture<CreateDatabagItemModalComponent>;
+
+  let createForm: FormGroup;
+  let errors = {};
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -47,12 +52,144 @@ describe('CreateDatabagItemModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CreateDatabagItemModalComponent);
     component = fixture.componentInstance;
+    component.createForm = new FormBuilder().group({
+      itemId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
+      itemAttr: ['{}']
+    });
     component.openEvent = new EventEmitter();
+    createForm = component.createForm;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('form validity', () => {
+    describe('the form should be invalid', () => {
+      it('when all inputs are empty', () => {
+        expect(createForm.valid).toBeFalsy();
+      });
+
+      it('when name is missing', () => {
+
+        errors = createForm.controls['itemId'].errors || {};
+
+        expect(createForm.valid).toBeFalsy();
+        expect(errors['required']).toBeTruthy();
+      });
+
+      using([
+        ['contains tilde.', 'item~'],
+        ['contains acute, back quote,', 'item`'],
+        ['contains exclamation mark', 'item!'],
+        ['contains ampersat, at', 'item@'],
+        ['contains dollar sign', 'item$'],
+        ['contains percent.', 'item%'],
+        ['contains caret or circumflex.,', 'item^'],
+        ['contains ampersand', 'item&'],
+        ['contains asterisk', 'item*'],
+        ['contains open or left parenthesis.', 'item('],
+        ['contains close or right parenthesis,', 'item)'],
+        ['contains plus', 'item+'],
+        ['contains equal', 'item='],
+        ['contains open brace', 'item{'],
+        ['contains close brace', 'item}'],
+        ['contains open bracket', 'item['],
+        ['contains closed bracket', 'item]'],
+        ['contains pipe', 'item|'],
+        ['contains backslash', 'item\\'],
+        ['contains forward slash', 'item/'],
+        ['contains colon', 'item:'],
+        ['contains semicolon.', 'item;'],
+        ['contains quote', 'item"'],
+        ['contains apostrophe', 'item\'test'],
+        ['contains less than', 'item<'],
+        ['contains greater than', 'item>'],
+        ['contains comma', 'item,'],
+        ['contains period, dot', 'item.'],
+        ['contains question mark', 'item?'],
+        ['contains space', 'item test1'],
+        ['has mixed alphabet, number, special character', 'item-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the item id ' + description), () => {
+
+          createForm.controls['itemId'].setValue(input);
+          errors = createForm.controls['itemId'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the item id only' + description), () => {
+
+          createForm.controls['itemId'].setValue(input);
+          errors = createForm.controls['itemId'].errors || {};
+
+          expect(createForm.valid).toBeFalsy();
+          expect(errors['pattern']).toBeTruthy();
+        });
+      });
+    });
+
+    describe('the form should be valid', () => {
+      it('when all inputs are filled and valid', () => {
+        expect(createForm.valid).toBeFalsy();
+        createForm.controls['itemId'].setValue('item');
+        expect(createForm.valid).toBeTruthy();
+      });
+
+      using([
+        ['contains numbers range 0-9.', 'item123'],
+        ['contains alphabets a-z', 'item-test'],
+        ['contains underscore.', 'item_test'],
+        ['contains hyphen, minus, or dash.', 'item_test-1'],
+        ['has mixed characters', 'item-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+
+          createForm.controls['itemId'].setValue(input);
+          errors = createForm.controls['itemId'].errors || {};
+
+          expect(createForm.valid).toBeTruthy();
+          expect(errors['pattern']).toBeFalsy();
+        });
+      });
+    });
   });
 
   describe('#createDataBagItemForm', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
@@ -58,7 +58,8 @@ export class CreateDatabagItemModalComponent implements OnInit, OnDestroy {
     private fb: FormBuilder
   ) {
     this.createForm = this.fb.group({
-      itemId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      itemId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       itemAttr: ['{}']
     });
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-databag-item-modal/create-databag-item-modal.component.ts
@@ -58,7 +58,7 @@ export class CreateDatabagItemModalComponent implements OnInit, OnDestroy {
     private fb: FormBuilder
   ) {
     this.createForm = this.fb.group({
-      itemId: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+      itemId: ['', [Validators.required,
         Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       itemAttr: ['{}']
     });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
@@ -21,11 +21,15 @@
                     autocomplete="off"/>
                 </label>
                 <chef-error
-                  *ngIf="(detailsFormGroup.get('name').hasError('required') || detailsFormGroup.get('name').hasError('pattern')) && detailsFormGroup.get('name').dirty">
+                  *ngIf="detailsFormGroup.get('name').hasError('required') && detailsFormGroup.get('name').dirty">
                   Name is required.
                 </chef-error>
                 <chef-error *ngIf="conflictError">
                   Environment "{{detailsFormGroup.get('name').value}}" already exists.
+                </chef-error>
+                <chef-error
+                  *ngIf="detailsFormGroup.get('name').hasError('pattern') && detailsFormGroup.get('name').dirty">
+                  name can only contain 'a-z', '0-9', 'A-Z', '_', '-'.
                 </chef-error>
               </chef-form-field>
             </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.html
@@ -29,7 +29,7 @@
                 </chef-error>
                 <chef-error
                   *ngIf="detailsFormGroup.get('name').hasError('pattern') && detailsFormGroup.get('name').dirty">
-                  name can only contain 'a-z', '0-9', 'A-Z', '_', '-'.
+                  Name can only contain 'a-z', '0-9', 'A-Z', '_', '-'.
                 </chef-error>
               </chef-form-field>
             </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.ts
@@ -97,7 +97,8 @@ export class CreateEnvironmentModalComponent implements OnInit, OnDestroy {
     });
 
     this.detailsFormGroup = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+           Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-environment-modal/create-environment-modal.component.ts
@@ -97,7 +97,7 @@ export class CreateEnvironmentModalComponent implements OnInit, OnDestroy {
     });
 
     this.detailsFormGroup = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+      name: ['', [Validators.required,
            Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });

--- a/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
@@ -22,11 +22,15 @@
                     autocomplete="off"/>
                 </label>
                 <chef-error
-                  *ngIf="(detailsFormGroup.get('name').hasError('required') || detailsFormGroup.get('name').hasError('pattern')) && detailsFormGroup.get('name').dirty">
+                  *ngIf="detailsFormGroup.get('name').hasError('required') && detailsFormGroup.get('name').dirty">
                   Name is required.
                 </chef-error>
                 <chef-error *ngIf="conflictError">
                   Role "{{detailsFormGroup.get('name').value}}" already exists.
+                </chef-error>
+                <chef-error
+                  *ngIf="detailsFormGroup.get('name').hasError('pattern') && detailsFormGroup.get('name').dirty">
+                  name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
                 </chef-error>
               </chef-form-field>
             </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.html
@@ -30,7 +30,7 @@
                 </chef-error>
                 <chef-error
                   *ngIf="detailsFormGroup.get('name').hasError('pattern') && detailsFormGroup.get('name').dirty">
-                  name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+                  Name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.
                 </chef-error>
               </chef-form-field>
             </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.ts
@@ -75,7 +75,8 @@ export class CreateInfraRoleModalComponent implements OnInit, OnDestroy {
     private telemetryService: TelemetryService
   ) {
     this.detailsFormGroup = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+        Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
     this.defaultAttrFormGroup = this.fb.group({

--- a/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-infra-role-modal/create-infra-role-modal.component.ts
@@ -75,7 +75,7 @@ export class CreateInfraRoleModalComponent implements OnInit, OnDestroy {
     private telemetryService: TelemetryService
   ) {
     this.detailsFormGroup = this.fb.group({
-      name: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK),
+      name: ['', [Validators.required,
         Validators.pattern(Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN)]],
       description: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -16,6 +16,7 @@ import { DataBagItems, DataBagsItemDetails } from 'app/entities/data-bags/data-b
 import { getAllStatus, dataBagItemList, deleteStatus } from 'app/entities/data-bags/data-bag-details.selector';
 import { GetDataBagItemDetails } from 'app/entities/data-bags/data-bag-item-details.actions';
 import { dataBagItemDetailsFromRoute, getStatus  } from 'app/entities/data-bags/data-bag-item-details.selector';
+import { Regex } from 'app/helpers/auth/regex';
 
 export type DataBagsDetailsTab = 'details';
 
@@ -159,7 +160,13 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
     this.searching = true;
     this.current_page = 1;
     this.searchValue = currentText;
-    this.getDataBagItemsData();
+    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+      this.searching = false;
+      this.dataBagItems.length = 0;
+      this.total = 0;
+    } else {
+      this.getDataBagItemsData();
+    }
   }
 
   onPageChange(event: number): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.spec.ts
@@ -11,6 +11,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { By } from '@angular/platform-browser';
 import { GetEnvironmentsSuccess } from 'app/entities/environments/environment.action';
 import { Environment } from 'app/entities/environments/environment.model';
+import { using } from 'app/testing/spec-helpers';
 
 describe('EnvironmentsComponent', () => {
   let component: EnvironmentsComponent;
@@ -70,6 +71,105 @@ describe('EnvironmentsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('#search', () => {
+    describe('search shows no data', () => {
+      using([
+        ['contains tilde.', 'environment~'],
+        ['contains acute, back quote,', 'environment`'],
+        ['contains exclamation mark', 'environment!'],
+        ['contains ampersat, at', 'environment@'],
+        ['contains dollar sign', 'environment$'],
+        ['contains percent.', 'environment%'],
+        ['contains caret or circumflex.,', 'environment^'],
+        ['contains ampersand', 'environment&'],
+        ['contains asterisk', 'environment*'],
+        ['contains open or left parenthesis.', 'environment('],
+        ['contains close or right parenthesis,', 'environment)'],
+        ['contains plus', 'environment+'],
+        ['contains equal', 'environment='],
+        ['contains open brace', 'environment{'],
+        ['contains close brace', 'environment}'],
+        ['contains open bracket', 'environment['],
+        ['contains closed bracket', 'environment]'],
+        ['contains pipe', 'environment|'],
+        ['contains backslash', 'environment\\'],
+        ['contains forward slash', 'environment/'],
+        ['contains colon', 'environment:'],
+        ['contains semicolon.', 'environment;'],
+        ['contains quote', 'environment"'],
+        ['contains apostrophe', 'environment\'test'],
+        ['contains less than', 'environment<'],
+        ['contains greater than', 'environment>'],
+        ['contains comma', 'environment,'],
+        ['contains period, dot', 'environment.'],
+        ['contains question mark', 'environment?'],
+        ['contains space', 'environment test1'],
+        ['has mixed alphabet, number, special character', 'environment-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+          component.searchEnvironment(input);
+          expect(component.environments.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+          component.searchEnvironment(input);
+          expect(component.environments.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+    });
+
+    describe('the form should be valid', () => {
+      using([
+        ['contains numbers range 0-9.', 'environment123'],
+        ['contains alphabets a-z', 'environment-test'],
+        ['contains underscore.', 'environment_test'],
+        ['contains hyphen, minus, or dash.', 'environment_test-1'],
+        ['has mixed characters', 'environment-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+          component.searchEnvironment(input);
+          expect(component.environments.length).not.toBeNull();
+          expect(element.query(By.css('.empty-section'))).toBeNull();
+        });
+      });
+    });
   });
 
   describe('environment list', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environments/environments.component.ts
@@ -9,6 +9,7 @@ import { GetEnvironments, DeleteEnvironment } from 'app/entities/environments/en
 import { Environment } from 'app/entities/environments/environment.model';
 import { getAllStatus, deleteStatus, environmentList } from 'app/entities/environments/environment.selectors';
 import { EntityStatus } from 'app/entities/entities';
+import { Regex } from 'app/helpers/auth/regex';
 
 @Component({
   selector: 'app-environments',
@@ -86,7 +87,13 @@ export class EnvironmentsComponent implements OnInit, OnDestroy {
     this.current_page = 1;
     this.searching = true;
     this.searchValue = currentText;
-    this.getEnvironmentData();
+    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+      this.searching = false;
+      this.environments.length = 0;
+      this.total = 0;
+    } else {
+      this.getEnvironmentData();
+    }
   }
 
   onPageChange(event: number): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.spec.ts
@@ -10,6 +10,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { By } from '@angular/platform-browser';
 import { GetRolesSuccess } from 'app/entities/infra-roles/infra-role.action';
 import { InfraRole } from 'app/entities/infra-roles/infra-role.model';
+import { using } from 'app/testing/spec-helpers';
 
 describe('InfraRolesComponent', () => {
   let component: InfraRolesComponent;
@@ -65,6 +66,105 @@ describe('InfraRolesComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('#search', () => {
+    describe('search shows no data', () => {
+      using([
+        ['contains tilde.', 'role~'],
+        ['contains acute, back quote,', 'role`'],
+        ['contains exclamation mark', 'role!'],
+        ['contains ampersat, at', 'role@'],
+        ['contains dollar sign', 'role$'],
+        ['contains percent.', 'role%'],
+        ['contains caret or circumflex.,', 'role^'],
+        ['contains ampersand', 'role&'],
+        ['contains asterisk', 'role*'],
+        ['contains open or left parenthesis.', 'role('],
+        ['contains close or right parenthesis,', 'role)'],
+        ['contains plus', 'role+'],
+        ['contains equal', 'role='],
+        ['contains open brace', 'role{'],
+        ['contains close brace', 'role}'],
+        ['contains open bracket', 'role['],
+        ['contains closed bracket', 'role]'],
+        ['contains pipe', 'role|'],
+        ['contains backslash', 'role\\'],
+        ['contains forward slash', 'role/'],
+        ['contains colon', 'role:'],
+        ['contains semicolon.', 'role;'],
+        ['contains quote', 'role"'],
+        ['contains apostrophe', 'role\'test'],
+        ['contains less than', 'role<'],
+        ['contains greater than', 'role>'],
+        ['contains comma', 'role,'],
+        ['contains period, dot', 'role.'],
+        ['contains question mark', 'role?'],
+        ['contains space', 'role test1'],
+        ['has mixed alphabet, number, special character', 'role-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the role' + description), () => {
+          component.searchRoles(input);
+          expect(component.roles.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the role only' + description), () => {
+          component.searchRoles(input);
+          expect(component.roles.length).toBe(0);
+          expect(component.total).toBe(0);
+        });
+      });
+    });
+
+    describe('search shows the role list if available', () => {
+      using([
+        ['contains numbers range 0-9.', 'role123'],
+        ['contains alphabets a-z', 'role-test'],
+        ['contains underscore.', 'role_test'],
+        ['contains hyphen, minus, or dash.', 'role_test-1'],
+        ['has mixed characters', 'role-Test_10']
+      ], function (description: string, input: string) {
+        it(('when the role ' + description), () => {
+          component.searchRoles(input);
+          expect(component.roles.length).not.toBeNull();
+          expect(element.query(By.css('.empty-section'))).toBeNull();
+        });
+      });
+    });
   });
 
   describe('infra role list', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-roles/infra-roles.component.ts
@@ -25,6 +25,7 @@ import {
   getAllStatus as getAllRecipesForOrgStatus
 } from 'app/entities/recipes/recipe.selectors';
 import { EntityStatus } from 'app/entities/entities';
+import { Regex } from 'app/helpers/auth/regex';
 
 export interface AvailableType {
   name: string;
@@ -100,7 +101,13 @@ export class InfraRolesComponent implements OnInit, OnDestroy {
     this.currentPage = 1;
     this.searching = true;
     this.searchValue = currentText;
-    this.getRolesData();
+    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+      this.searching = false;
+      this.roles.length = 0;
+      this.total = 0;
+    } else {
+      this.getRolesData();
+    }
   }
 
   onPageChange(event: number): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.html
@@ -13,18 +13,14 @@
     placeholder="Search {{ placeHolder }}"
     aria-label="Search"
     autocomplete="off"
-    data-cy="search-filter"
-    (keyup)="handleEditVersion($event)">
+    data-cy="search-filter">
   <button
     type="submit"
     class="primary"
     primary
-    [disabled]="disabled"
     data-cy="search-entity">
     <span aria-hidden="true" class="hidden">Submit Search</span>
     <chef-icon>search</chef-icon>
   </button>
 </form>
-<chef-error *ngIf="error">
-  Only contain 'a-z', 'A-Z', '0-9', '_', '-'.
-</chef-error>
+

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.html
@@ -13,13 +13,18 @@
     placeholder="Search {{ placeHolder }}"
     aria-label="Search"
     autocomplete="off"
-    data-cy="search-filter">
+    data-cy="search-filter"
+    (keyup)="handleEditVersion($event)">
   <button
     type="submit"
     class="primary"
     primary
+    [disabled]="disabled"
     data-cy="search-entity">
     <span aria-hidden="true" class="hidden">Submit Search</span>
     <chef-icon>search</chef-icon>
   </button>
 </form>
+<chef-error *ngIf="error">
+  Only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+</chef-error>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.scss
@@ -40,8 +40,18 @@ button {
     outline: none;
     border: 1px solid $chef-primary-bright;
   }
+
+  &[disabled] {
+    cursor: auto;
+  }
 }
 
 chef-icon {
   margin-top: 6px;
+}
+
+chef-error {
+  background-color: $chef-critical;
+  color: $chef-white;
+  border-radius: 0 0 4px 4px;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
@@ -4,6 +4,7 @@ import {
   Output,
   Input
 } from '@angular/core';
+import { Regex } from 'app/helpers/auth/regex';
 
 @Component({
   selector: 'app-infra-search-bar',
@@ -14,6 +15,8 @@ import {
 export class InfraSearchBarComponent {
   inputText = '';
   formActive = false;
+  error = false;
+  disabled = false;
 
   @Input() placeHolder: string;
   @Output() searchButtonClick = new EventEmitter<string>();
@@ -26,4 +29,14 @@ export class InfraSearchBarComponent {
     this.formActive = !this.formActive;
   }
 
+  handleEditVersion(event: { target: { value: string}}) {
+    const search = event.target.value;
+    if ( search !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(search)) {
+      this.error = true;
+      this.disabled = true;
+    } else {
+      this.error = false;
+      this.disabled = false;
+    }
+  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
@@ -4,7 +4,7 @@ import {
   Output,
   Input
 } from '@angular/core';
-import { Regex } from 'app/helpers/auth/regex';
+// import { Regex } from 'app/helpers/auth/regex';
 
 @Component({
   selector: 'app-infra-search-bar',
@@ -16,7 +16,6 @@ export class InfraSearchBarComponent {
   inputText = '';
   formActive = false;
   error = false;
-  disabled = false;
 
   @Input() placeHolder: string;
   @Output() searchButtonClick = new EventEmitter<string>();
@@ -29,14 +28,12 @@ export class InfraSearchBarComponent {
     this.formActive = !this.formActive;
   }
 
-  handleEditVersion(event: { target: { value: string}}) {
-    const search = event.target.value;
-    if ( search !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(search)) {
-      this.error = true;
-      this.disabled = true;
-    } else {
-      this.error = false;
-      this.disabled = false;
-    }
-  }
+  // handleEditVersion(event: { target: { value: string}}) {
+  //   const search = event.target.value;
+  //   if ( search !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(search)) {
+  //     this.error = true;
+  //   } else {
+  //     this.error = false;
+  //   }
+  // }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-search-bar/infra-search-bar.component.ts
@@ -27,13 +27,4 @@ export class InfraSearchBarComponent {
   toggleFocus(): void {
     this.formActive = !this.formActive;
   }
-
-  // handleEditVersion(event: { target: { value: string}}) {
-  //   const search = event.target.value;
-  //   if ( search !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(search)) {
-  //     this.error = true;
-  //   } else {
-  //     this.error = false;
-  //   }
-  // }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.html
@@ -40,6 +40,9 @@
                 placeholder="Search.."
                 (keyup)="handleInput(keyInput.value)"
                 data-cy="search-roles-and-recipes"/>
+              <chef-error *ngIf="error">
+                Only contain 'a-z', 'A-Z', '0-9', '_', '-'.
+              </chef-error>
             </div>
             <cdk-virtual-scroll-viewport
               #scroller

--- a/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.html
@@ -40,9 +40,6 @@
                 placeholder="Search.."
                 (keyup)="handleInput(keyInput.value)"
                 data-cy="search-roles-and-recipes"/>
-              <chef-error *ngIf="error">
-                Only contain 'a-z', 'A-Z', '0-9', '_', '-'.
-              </chef-error>
             </div>
             <cdk-virtual-scroll-viewport
               #scroller

--- a/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.scss
@@ -364,6 +364,13 @@
   color: $chef-black;
 }
 
+chef-error {
+  background-color: $chef-critical;
+  color: $chef-white;
+  border-radius: 0 0 4px 4px;
+  margin-top: -15px;
+}
+
 ::ng-deep mat-select {
   width: 277px;
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/select-box/src/lib/select-box.component.ts
@@ -359,6 +359,7 @@ export class SelectBoxComponent implements OnInit, OnChanges, OnDestroy, AfterVi
         if (this.searchValue !== '' && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(
           this.searchValue)) {
           this.error = true;
+          this.originalItems = [];
         } else {
           this.error = false;
           this.getRecipes(this.searchValue);


### PR DESCRIPTION
Signed-off-by: Himanshi Chhabra <hchhabra@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
- Add validation on name field for the create pop-up of Role/ Data bag / Data bag item/ Client/ Environment Tabs.
- Add validation on search box for  Role/ Data bag item/ Client/ Environment Tabs.
- Add unit testcase for Validate of Role/ Data bag item/ Client/ Environment Tabs.
- Add validation on Run list search bar
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#4960 
### :+1: Definition of Done
 **VALDATION:-**   Added validation that name can only contain ```alphabets``` **a-z, A-Z**, ```numbers``` **0-9**, ```Underscore```  **_**, ```Hyphen```  **-**.
- Added this above validation on  name/id field for the create pop-up of Role/ Data bag / Data bag item/ Client/ Environment Tabs.
- Added this above validation on search box for  Role/ Data bag item/ Client/ Environment Tabs.
- Added unit testcase for above validation that form is valid or invalid of Role/ Data bag item/ Client/ Environment Tabs.
- Added the above validation on the Run list search bar.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
Steps to reproduce:
   - Go To  Infrastructure -> Chef Servers -> click server name-> click on org name ->
  -  **Steps for Validate Create Role:** 
           1. Click Roles -> Create Role -> add name with ```test role``` -> show error -> ```name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.``` and create button is ```disabled```.
           2. add name with ```test_role-1:::::``` -> show error -> ```name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.``` and create button is ```disabled```.
           3. add name with ```test_role-1``` -> no error.
           4. Same for others tab.
  -  **Steps for Validate Search Role:** 
         1. Click Roles -> add text on search bar with ```test@role``` -> show error -> ```name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.``` and search button is ```disabled```.
         2. add name with ```test[role]-1:::::``` -> ```no roles available with this name.```
         3. add name with ```test_role-1``` -> no error.
         4. Same for others tab. 
   -  **Steps for Validate Run list search bar:** 
         1. Click Roles -> click Create Role -> add name and description -> click runlist
         2.  add text on search bar with ```role(role-1``` -> show error -> ```name can only contain 'a-z', 'A-Z', '0-9', '_', '-'.```
         3. add name with ```test[role]-1``` -> show ```Not available```.
         4. add name with ```test_role-1``` -> no error.


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


https://user-images.githubusercontent.com/61003053/117340823-f73e3300-aebe-11eb-8289-5561d51a5332.mp4


- For run list search:
![Chef-Automate (20)](https://user-images.githubusercontent.com/61003053/117340767-e5f52680-aebe-11eb-99d3-21c630cba855.png)



