### PR TITLE
Changes to the document to include web UI time out configuration

### DIFF
--- a/api/config/dex/config_request.go
+++ b/api/config/dex/config_request.go
@@ -46,6 +46,8 @@ func DefaultConfigRequest() *ConfigRequest {
 
 	c.V1.Sys.Log.Level = w.String("info")
 
+	c.V1.Sys.Expiry.IdTokens = w.String("1h")
+
 	return c
 }
 

--- a/components/docs-chef-io/content/automate/configuration.md
+++ b/components/docs-chef-io/content/automate/configuration.md
@@ -452,6 +452,20 @@ Configuration to sign out users from Chef Automate when they close the browser.
   persistent = false
 ```
 
+
+#### Setting up Web UI Session Timeout
+
+Default timeout for Local Users is 24 hour.
+Check [SAML]({{< relref "saml.md#saml-default-session-timeout" >}}) and [LDAP]({{< relref "ldap.md#ldap-default-session-timeout" >}}) Configuration for other connectors.
+Web UI Session timeout can be set by patching the following configuration:
+
+```toml
+[dex.v1.sys.expiry]
+  # This can set the expiry time of id_token
+  # Valid time units are "s"(second), "m"(minute), "h"(hour)
+  id_tokens = "1h"
+```
+
 ### Troubleshooting
 
 Common syntax errors may cause issues in configuration files:

--- a/components/docs-chef-io/content/automate/ldap.md
+++ b/components/docs-chef-io/content/automate/ldap.md
@@ -274,6 +274,10 @@ Once the user has provided a username and password at the sign in screen, Chef A
 
 Chef Automate supports defining permissions for LDAP users and their groups. See [IAM members and policies]({{< ref "iam_v2_overview.md#members-and-policies" >}}).
 
+#### Default Session Timout {#ldap-default-session-timeout}
+
+The default session timeout for LDAP connection is 3minutes
+
 #### Connect
 
 Chef Automate first needs to establish a TCP connection to your LDAP service, secured by TLS.

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -189,3 +189,7 @@ These values are accepted for `name_id_policy_format`:
  - `urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos`
  - `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`
  - `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`
+
+#### Default Session Timeout {#saml-default-session-timeout}
+
+The default session timeout for LDAP connection is 24hours.


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Web UI session timer is set by default  as "3m" if SAML is not configured as connector.
In case SAML is configured as connector the session timer is "24h"

This configuration can be set from the config.toml too but it is not documented anywhere in the docs nor in the output of:
```
chef-automate 
```

### :chains: Related Resources

### :+1: Definition of Done

The document
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
