### PR TITLE
Fix unittest for 31st day of month of ES index

### DIFF
--- a/components/compliance-service/reporting/relaxting/util_test.go
+++ b/components/compliance-service/reporting/relaxting/util_test.go
@@ -19,8 +19,9 @@ func TestGetEsIndexNoTimeLast24h(t *testing.T) {
 
 	today := todayTime.Format("2006.01.02")
 	if todayTime.Day() == 31 {
+		today = todayTime.Format("2006.01.")
 		//if it's the 31st, shave off the 1 and make it 3*, which will be the 30th and 31st
-		assert.Equal(t, sum+"-3*", index)
+		assert.Equal(t, sum+"-"+today+"3*", index)
 	} else {
 		yesterday := todayTime.Add(-24 * time.Hour).Format("2006.01.02")
 		assert.Equal(t, sum+"-"+yesterday+"*,"+sum+"-"+today+"*", index)


### PR DESCRIPTION
Signed-off-by: Vivek Yadav <vivek.yadav@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Unit Test again failed due to 31st day of the month issue.
No change in the index name creation, just the unit test is modified to consider comp-7-s-2021.05.3*

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
