### PR TITLE
Added disable edit button functionality in Infra-Role

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
@@ -81,7 +81,8 @@
               <chef-button
                 tertiary
                 class="float-right action"
-                (click)="openEditModal(role?.default_attributes, 'Run List')">
+                (click)="openEditModal(role?.default_attributes, 'Run List')"
+                [disabled]="editDisabled">
                 <span class="material-icons edit-item">mode_edit</span>
                 <span class="edit-text">Edit</span>
               </chef-button>
@@ -108,7 +109,8 @@
                   tertiary
                   class="float-right action"
                   (click)="openEditModal(role?.default_attributes, 'Run List')"
-                  data-cy="edit-runlist">
+                  data-cy="edit-runlist"
+                  [disabled]="editDisabled">
                   <span class="material-icons edit-item">mode_edit</span>
                   <span class="edit-text">Edit</span>
                 </chef-button>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -60,6 +60,7 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
   public roleAttributeLoading = true;
   public runListLoading = true;
   public openEdit = false;
+  public editDisabled = false;
   public treeOptions: Options<ExpandedChildList> = {
     capitalizedHeader: true
   };
@@ -174,6 +175,7 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
 
   selectChangeHandler(id: string): void {
     this.env_id = id;
+    this.editDisabled = (this.env_id === '_default') ? false : true;
     this.runListLoading = true;
     this.hasRun_List = false;
     this.arrayOfNodesTree = [];


### PR DESCRIPTION
Signed-off-by: chaitali-mane <cmane@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Add edit button must be disabled if the environment is not _default.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
[5022](https://github.com/chef/automate/issues/5022)

### :+1: Definition of Done
Added disabled edit button if the environment is not _default.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
To add data
https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views

Steps for Role tab:
- Go To Infrastructure -> Chef Servers -> click server name-> click org name -> Go to Role tab
- click role name -> select different environment if we have then edit button must be disabled.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Edit button disabled 
![Role-edit-disabl](https://user-images.githubusercontent.com/71449322/121017829-58f20580-c7bb-11eb-91c6-d1c2c93c0774.png)
