### PR TITLE
Fixing ha_chef_server failure

### DIFF
--- a/integration/tests/chef_server_backup.sh
+++ b/integration/tests/chef_server_backup.sh
@@ -27,7 +27,9 @@ do_deploy() {
 }
 
 do_test_deploy() {
-    PATH="/hab/bin:/bin" chef-server-ctl test
+    ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
+    ## adding smoke tag or else all the test will be considered skipping only the status test
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
     test_chef_server_ctl
     do_test_deploy_default
 }

--- a/integration/tests/chef_server_upgrade.sh
+++ b/integration/tests/chef_server_upgrade.sh
@@ -22,14 +22,18 @@ do_deploy() {
 }
 
 do_test_deploy() {
-    PATH="/hab/bin:/bin" chef-server-ctl test
+    ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
+    ## adding smoke tag or else all the test will be considered skipping only the status test
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
     test_chef_server_ctl
     test_knife
     do_test_deploy_default
 }
 
 do_test_upgrade() {
-    PATH="/hab/bin:/bin" chef-server-ctl test
+    ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
+    ## adding smoke tag or else all the test will be considered skipping only the status test
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
     test_chef_server_ctl
     test_knife
     do_test_upgrade_default

--- a/integration/tests/ha_chef_server.sh
+++ b/integration/tests/ha_chef_server.sh
@@ -172,7 +172,9 @@ EOH
 }
 
 do_test_deploy() {
-    hab pkg exec chef/automate-cs-nginx chef-server-ctl test
+    ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
+    ## adding smoke tag or else all the test will be considered skipping only the status test
+    hab pkg exec chef/automate-cs-nginx chef-server-ctl test --smoke --skip-status
 }
 
 do_cleanup() {


### PR DESCRIPTION
The `ha_chef_server` scenario fails in the pipeline because of the status test.

The status test requires a file which is not available in the automate environment. The status test is part of the smoke test tag in the pedant. It needs to be skipped everywhere we run `chef-server-ctl test`.

Changes - Skipping the status test while running `chef-server-ctl test`. 

Signed-off-by: Vinay Satish <vinay.satish@progress.com>

