### PR TITLE
add some more verbage to describe requirements for deep filtering

### DIFF
--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -94,6 +94,28 @@ Deep filtering supports filtering for:
 - one profile
 - one profile and one of its associated controls
 
+In order to narrow the data to only one profile, we must use profile_id. The reason that profile_name doesn't suffice here is that we may have different versions of profile_name. Filtering by profile_id guarantees that we are querying with exactly one profile. We require this singularity of profile because we don't do the various stats aggregations at a granular level when computing stats, as doing so would be very slow, due to the number of reports in the system.
+
+Similarly, for control level narrowing of stats, we require that exactly one control be included in the filter and that control must be a child of one single profile (again, included as profile_id and not profile_name)
+
+in summary deep filtering works as follows:
+
+Rules for profile depth:
+
+    exactly one profile in the filter, specified as profile_id
+    no controls allowed in the filter
+    any of the other supported reporting filters may also be included without any constraints on their respective quantities
+
+Rules for control depth:
+
+    exactly one profile in the filter, specified as profile_id
+    exactly one control in the filter that must be a child of the specified profile in rule 1
+    any of the other supported reporting filters may also be included without any constraints on their respective quantities
+
+*N.B. profile and control depth rules differ only by the second rule
+
+Anything not conforming to the rules above will yield report depth
+
 ### Waivers
 
 A node's waived status appears if applicable in displays where a node's status appears in Chef Automate.

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -107,7 +107,7 @@ To create a report at the profile level:
 
 #### Control Deep Filtering
 
-Deep filtering for a control scopes the report to a single control within a versioned profile.
+Deep filtering for a control scopes a compliance report to a single control within a versioned profile.
 
 To create a report at the control level:
 

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -86,7 +86,7 @@ Role
 
 ### Deep Filtering
 
-Deep filtering provides reports on compliance profiles and controls. Apply deep filtering to see the compliance reporting for an entire profile or an individual control within a profile.
+Deep filtering provides reports on compliance profiles and controls. Apply deep filtering to see the compliance reporting for a profile version or one of its controls.
 
 Chef Automate saves computational time and storage space by computing compliance reporting statistics at the aggregate level. Deep filtering uses the `profile_id` attribute to drill down to the granular level of your compliance status. In contrast, filtering with the `profile_name` attribute instead of `profile_id` creates a report for every version of `profile_name` in your infrastructure.
 
@@ -115,7 +115,8 @@ To create a report at the control level:
     1. Add a control
     1. Apply additional reporting filters
 
-If the results returned by your filtering is incorrectly scoped, review the `profile_id` and control field contents.
+If the results returned by your deep filter are incorrectly scoped, review the `profile_id` and control field contents.
+
 ### Waivers
 
 A node's waived status appears if applicable in displays where a node's status appears in Chef Automate.

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -97,7 +97,7 @@ Deep filtering supports reports for:
 
 #### Profile Deep Filtering
 
-Deep Filtering with `profile_id` queries a specific profile and creates a compliance report for that version of the profile in your infrastructure.
+Deep Filtering with `profile_id` scopes a compliance report to a versioned profile.
 
 To create a report at the profile level:
 
@@ -107,7 +107,7 @@ To create a report at the profile level:
 
 #### Control Deep Filtering
 
-Deep filtering for a control scopes the report to level of a single control within a versioned profile.
+Deep filtering for a control scopes the report to a single control within a versioned profile.
 
 To create a report at the control level:
 

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -86,36 +86,36 @@ Role
 
 ### Deep Filtering
 
-Deep filtering shifts the perspective of the results from the node to the profile and its associated control.
-Use deep filtering to see the compliance reporting for an entire profile or an individual control within a profile.
+Deep filtering provides reports on compliance profiles and controls. Apply deep filtering to see the compliance reporting for an entire profile or an individual control within a profile.
 
-Deep filtering supports filtering for:
+Chef Automate saves computational time and storage space by computing compliance reporting statistics at the aggregate level. Deep filtering uses the `profile_id` attribute to drill down to the granular level of your compliance status. In contrast, filtering with the `profile_name` attribute instead of `profile_id` creates a report for every version of `profile_name` in your infrastructure.
+
+Deep filtering supports reports for:
 
 - one profile
 - one profile and one of its associated controls
 
-In order to narrow the data to only one profile, we must use profile_id. The reason that profile_name doesn't suffice here is that we may have different versions of profile_name. Filtering by profile_id guarantees that we are querying with exactly one profile. We require this singularity of profile because we don't do the various stats aggregations at a granular level when computing stats, as doing so would be very slow, due to the number of reports in the system.
+#### Profile Deep Filtering
 
-Similarly, for control level narrowing of stats, we require that exactly one control be included in the filter and that control must be a child of one single profile (again, included as profile_id and not profile_name)
+Deep Filtering with `profile_id` queries a specific profile and creates a compliance report for that version of the profile in your infrastructure.
 
-in summary deep filtering works as follows:
+To create a report at the profile level:
 
-Rules for profile depth:
+    1. Specify the profile in the filter using `profile_id`
+    1. Leave the control filter empty
+    1. Apply additional reporting filters
 
-    exactly one profile in the filter, specified as profile_id
-    no controls allowed in the filter
-    any of the other supported reporting filters may also be included without any constraints on their respective quantities
+#### Control Deep Filtering
 
-Rules for control depth:
+Deep filtering for a control scopes the report to level of a single control within a versioned profile.
 
-    exactly one profile in the filter, specified as profile_id
-    exactly one control in the filter that must be a child of the specified profile in rule 1
-    any of the other supported reporting filters may also be included without any constraints on their respective quantities
+To create a report at the control level:
 
-*N.B. profile and control depth rules differ only by the second rule
+    1. Enter the `profile_id` in the filter
+    1. Add a control
+    1. Apply additional reporting filters
 
-Anything not conforming to the rules above will yield report depth
-
+If the results returned by your filtering is incorrectly scoped, review the `profile_id` and control field contents.
 ### Waivers
 
 A node's waived status appears if applicable in displays where a node's status appears in Chef Automate.

--- a/components/docs-chef-io/content/automate/reports.md
+++ b/components/docs-chef-io/content/automate/reports.md
@@ -88,7 +88,7 @@ Role
 
 Deep filtering provides reports on compliance profiles and controls. Apply deep filtering to see the compliance reporting for a profile version or one of its controls.
 
-Chef Automate saves computational time and storage space by computing compliance reporting statistics at the aggregate level. Deep filtering uses the `profile_id` attribute to drill down to the granular level of your compliance status. In contrast, filtering with the `profile_name` attribute instead of `profile_id` creates a report for every version of `profile_name` in your infrastructure.
+Chef Automate saves computational time and storage space by calculating compliance reporting statistics at the aggregate level. Deep filtering uses the `profile_id` attribute to drill down to the granular level of your compliance status. In contrast, filtering with the `profile_name` attribute instead of `profile_id` creates a report for every version of `profile_name` in your infrastructure.
 
 Deep filtering supports reports for:
 


### PR DESCRIPTION
Signed-off-by: Rick Marry <rick.marry@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
Just added a little verbiage to describe why we require one profile_id and/or one control of said profile id for deep filtering
addresses ambiguities pointed out in issue: #5090

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

All PRs **from Progress employees** should tick these if appropriate:

- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
