### PR TITLE
Remove chef-client management from pipeline instances

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/main.tf
+++ b/terraform/test-environments/modules/chef_automate_install/main.tf
@@ -43,18 +43,6 @@ data "template_file" "install_chef_automate_cli" {
   }
 }
 
-module "chef_baseline" {
-  source = "github.com/chef/es-terraform//modules/cd_base"
-
-  instance_id   = "${var.instance_id}"
-  instance_fqdn = "${var.instance_fqdn}"
-  ssh_username  = "${var.ssh_username}"
-
-  enable_email      = "${var.enable_email}"
-  enable_monitoring = "${var.enable_monitoring}"
-  chef_environment  = "${var.chef_environment}"
-}
-
 locals {
   saml_config = <<SAML
 [dex.v1.sys.connectors.saml]


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?

We are removing the chef-client module from our dev/acceptance pipelines. 

* Our cookbooks are pinned to an older (unsupported) version of Chef Infra Client
* These cookbooks are no longer required (or functional) now that we are under Progress

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
