### PR TITLE
Documentation for windows machine configuration

### DIFF
--- a/components/docs-chef-io/content/automate/node_credentials.md
+++ b/components/docs-chef-io/content/automate/node_credentials.md
@@ -45,9 +45,9 @@ Select _Add Credential_ and a dialog box appears as shown below. Select the _Cre
 **WinRM** requires a credential name, a user name, and a WinRM password.
 
 Windows machines **must have** the following configurations:
+
 * Ports 3389(RDP), 80(HTTP), 443(HTTPS), 5985(WinRM) and 5986(WinRM) must be open.
 * Use the below script to configure WinRM:
-
   ```powershell
   winrm quickconfig -q
   winrm create winrm/config/Listener?Address=*+Transport=HTTP

--- a/components/docs-chef-io/content/automate/node_credentials.md
+++ b/components/docs-chef-io/content/automate/node_credentials.md
@@ -46,7 +46,7 @@ Select _Add Credential_ and a dialog box appears as shown below. Select the _Cre
 
 Windows machines **must have** the following configurations:
 
-* Ports 3389(RDP), 80(HTTP), 443(HTTPS), 5985(WinRM) and 5986(WinRM) must be open.
+* Ports 3389(RDP), 80(HTTP), 443(HTTPS), 5985(WinRM) and 5986(WinRM) must be open and reachable from Chef Automate.
 * Use the below script to configure WinRM:
   ```powershell
   winrm quickconfig -q

--- a/components/docs-chef-io/content/automate/node_credentials.md
+++ b/components/docs-chef-io/content/automate/node_credentials.md
@@ -44,6 +44,27 @@ Select _Add Credential_ and a dialog box appears as shown below. Select the _Cre
 
 **WinRM** requires a credential name, a user name, and a WinRM password.
 
+Windows machines **must have** the following configurations:
+* Ports 3389(RDP), 80(HTTP), 443(HTTPS), 5985(WinRM) and 5986(WinRM) must be open.
+* Use the below script to configure WinRM:
+
+  ```powershell
+  winrm quickconfig -q
+  winrm create winrm/config/Listener?Address=*+Transport=HTTP
+  winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
+  winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+  winrm set winrm/config/winrs '@{MaxShellsPerUser="50"'
+  winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
+  winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+  winrm set winrm/config/service/auth '@{Basic="true"}'
+  netsh advfirewall firewall add rule name="WinRM 5985" protocol=TCP dir=in localport=5985 action=allow
+  netsh advfirewall firewall add rule name="WinRM 5986" protocol=TCP dir=in localport=5986 action=allow
+  NetSh Advfirewall set allprofiles state off
+  net stop winrm
+  sc.exe config winrm start=auto
+  net start winrm
+  ```
+
 ### Add a Sudo Credential
 
 ![Sudo Credential Form](/images/automate/credentials-sudo.png)


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Documentation for setting up windows node. Earlier windows node configuration documentation was not clear and we faced issues setting up windows node for initiating scans from automate.

### :chains: Related Resources

### :+1: Definition of Done
Windows node setup prerequisites like ports, firewall and WinRM settings must be clear.

### :athletic_shoe: How to Build and Test the Change
Check the docs netlify link

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)- not required
- [x] Docs added/updated? (all customer-facing changes)
