### PR TITLE
Added search bar in policy files

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
@@ -2,7 +2,11 @@
   <chef-loading-spinner *ngIf="policyFilesListLoading" size="50"></chef-loading-spinner>
   <app-empty-state *ngIf="authFailure" moduleTitle="policyfiles" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
   <ng-container *ngIf="!policyFilesListLoading && !authFailure">
-    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length">
+    <div class="search-create-container">
+      <app-infra-search-bar (searchButtonClick)="searchPolicyFiles($event)" placeHolder="Policy">
+      </app-infra-search-bar>
+    </div>
+    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (serachArr.length === 0) ">
       <img alt="No preview" src="/assets/img/no_preview.gif" />
       <p>No policy files available</p>
     </div>
@@ -16,8 +20,16 @@
             <chef-th class="no_border_th three-dot-column"></chef-th>
           </chef-tr>
         </chef-thead>
-        <chef-tbody>
+        <chef-tbody *ngIf="!searchFlag">
           <chef-tr *ngFor="let policyFile of pageOfItems">
+            <chef-td>{{ policyFile.name }}</chef-td>
+            <chef-td>{{ policyFile.revision_id }}</chef-td>
+            <chef-td></chef-td>
+            <chef-td class="three-dot-column"></chef-td>
+          </chef-tr>
+        </chef-tbody>
+        <chef-tbody *ngIf="searchFlag">
+          <chef-tr *ngFor="let policyFile of serachArr">
             <chef-td>{{ policyFile.name }}</chef-td>
             <chef-td>{{ policyFile.revision_id }}</chef-td>
             <chef-td></chef-td>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
@@ -3,7 +3,7 @@
   <app-empty-state *ngIf="authFailure" moduleTitle="policyfiles" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
   <ng-container *ngIf="!policyFilesListLoading && !authFailure">
     <div class="search-create-container">
-      <app-infra-search-bar (searchButtonClick)="searchPolicyFiles($event)" placeHolder="Policy">
+      <app-infra-search-bar (searchButtonClick)="searchPolicyFiles($event)" placeHolder="Policy files">
       </app-infra-search-bar>
     </div>
     <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0) ">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
@@ -6,13 +6,14 @@
       <app-infra-search-bar (searchButtonClick)="searchPolicyFiles($event)" placeHolder="Policy">
       </app-infra-search-bar>
     </div>
-    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (serachArr.length === 0) ">
+    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0) ">
       <img alt="No preview" src="/assets/img/no_preview.gif" />
-      <p>No policy files available</p>
+      <p *ngIf="searchValue !== ''">No results found for "{{searchValue}}".</p>
+      <p *ngIf="searchValue === ''">No policy files available</p>
     </div>
     <div id="policy-file-table-container" *ngIf="policyFiles.length" data-cy="policy-file-table-container">
       <chef-table>
-        <chef-thead>
+        <chef-thead *ngIf="!searchFlag || searchArr.length">
           <chef-tr class="no_border_tr">
             <chef-th class="no_border_th">Name</chef-th>
             <chef-th class="no_border_th">Revision ID</chef-th>
@@ -20,16 +21,8 @@
             <chef-th class="no_border_th three-dot-column"></chef-th>
           </chef-tr>
         </chef-thead>
-        <chef-tbody *ngIf="!searchFlag">
+        <chef-tbody>
           <chef-tr *ngFor="let policyFile of pageOfItems">
-            <chef-td>{{ policyFile.name }}</chef-td>
-            <chef-td>{{ policyFile.revision_id }}</chef-td>
-            <chef-td></chef-td>
-            <chef-td class="three-dot-column"></chef-td>
-          </chef-tr>
-        </chef-tbody>
-        <chef-tbody *ngIf="searchFlag">
-          <chef-tr *ngFor="let policyFile of serachArr">
             <chef-td>{{ policyFile.name }}</chef-td>
             <chef-td>{{ policyFile.revision_id }}</chef-td>
             <chef-td></chef-td>
@@ -38,8 +31,14 @@
         </chef-tbody>
       </chef-table>
     </div>
-    <app-pagination
+    <app-pagination *ngIf="!searchFlag"
       [items]="policyFiles"
+      class="policy-file-list-paging"
+      label="name"
+      (changePage)="onChangePage($event)">
+    </app-pagination>
+    <app-pagination *ngIf="searchFlag"
+      [items]="searchArr"
       class="policy-file-list-paging"
       label="name"
       (changePage)="onChangePage($event)">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
@@ -47,3 +47,20 @@ chef-loading-spinner {
 .policy-file-list-paging {
   margin: 0 0 35px;
 }
+
+.search-create-container {
+  display: flex;
+  margin: 24px 0 18px;
+  flex-direction: row;
+
+  app-infra-search-bar {
+    flex-grow: 2;
+  }
+
+  chef-button {
+    margin: 0;
+    margin-left: 16px;
+    height: 36px;
+    margin-top: 4px;
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
@@ -11,6 +11,7 @@ import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.se
 import { By } from '@angular/platform-browser';
 import { GetPolicyFilesSuccess } from 'app/entities/policy-files/policy-file.action';
 import { PolicyFile } from 'app/entities/policy-files/policy-file.model';
+import { using } from 'app/testing/spec-helpers';
 
 describe('PolicyFilesComponent', () => {
   let component: PolicyFilesComponent;
@@ -92,4 +93,86 @@ describe('PolicyFilesComponent', () => {
       expect(component.policyFiles.length).toBe(0);
     });
   });
+
+  describe('#search', () => {
+    describe('search shows no data', () => {
+      using([
+        ['contains tilde.', 'policy~'],
+        ['contains acute, back quote,', 'policy`'],
+        ['contains exclamation mark', 'policy!'],
+        ['contains ampersat, at', 'policy@'],
+        ['contains dollar sign', 'policy$'],
+        ['contains percent.', 'policy%'],
+        ['contains caret or circumflex.,', 'policy^'],
+        ['contains ampersand', 'policy&'],
+        ['contains asterisk', 'policy*'],
+        ['contains open or left parenthesis.', 'policy('],
+        ['contains close or right parenthesis,', 'policy)'],
+        ['contains plus', 'policy+'],
+        ['contains equal', 'policy='],
+        ['contains open brace', 'policy{'],
+        ['contains close brace', 'policy}'],
+        ['contains open bracket', 'policy['],
+        ['contains closed bracket', 'policy]'],
+        ['contains pipe', 'policy|'],
+        ['contains backslash', 'policy\\'],
+        ['contains forward slash', 'policy/'],
+        ['contains colon', 'policy:'],
+        ['contains semicolon.', 'policy;'],
+        ['contains quote', 'policy"'],
+        ['contains apostrophe', 'policy\'test'],
+        ['contains less than', 'policy<'],
+        ['contains greater than', 'policy>'],
+        ['contains comma', 'policy,'],
+        ['contains period, dot', 'policy.'],
+        ['contains question mark', 'policy?'],
+        ['contains space', 'policy test1'],
+        ['has mixed alphabet, number, special character', 'policy-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+          component.searchPolicyFiles(input);
+          expect(component.policyFiles.length).toBe(0);
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+          component.searchPolicyFiles(input);
+          expect(component.policyFiles.length).toBe(0);
+        });
+      });
+    });
+  });
+
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -30,6 +30,10 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
   public policyFiles: PolicyFile[] = [];
   public policyFilesListLoading = true;
   public authFailure = false;
+  public searching = false;
+  public searchValue = '';
+  public searchFlag = false;
+  public serachArr: PolicyFile[];
   pageOfItems: Array<any>;
 
   constructor(
@@ -51,6 +55,31 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, allPolicyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState)) {
         this.policyFiles = allPolicyFilesState;
+        this.policyFiles.push({
+          name: 'test3',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test4',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test5',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test6',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'new1',
+          revision_id: '0',
+          policy_group: 'e'
+        });
         this.policyFilesListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyFilesListLoading = false;
@@ -71,5 +100,21 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  public searchPolicyFiles(searchText: string): void {
+    this.searching = true;
+    this.searchValue = searchText;
+    if (!this.policyFiles || !searchText) {
+      this.searchFlag = false;
+    } else {
+      this.serachArr = this.policyFiles.filter((key) => {
+        this.searchFlag = true;
+        if (key) {
+          return key.name.includes(searchText);
+        }
+      });
+    }
+    this.searching = false;
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -55,31 +55,6 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, allPolicyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState)) {
         this.policyFiles = allPolicyFilesState;
-        this.policyFiles.push({
-          name: 'test3',
-          revision_id: '0',
-          policy_group: 'e'
-        });
-        this.policyFiles.push({
-          name: 'test4',
-          revision_id: '0',
-          policy_group: 'e'
-        });
-        this.policyFiles.push({
-          name: 'test5',
-          revision_id: '0',
-          policy_group: 'e'
-        });
-        this.policyFiles.push({
-          name: 'test6',
-          revision_id: '0',
-          policy_group: 'e'
-        });
-        this.policyFiles.push({
-          name: 'new1',
-          revision_id: '0',
-          policy_group: 'e'
-        });
         this.policyFilesListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyFilesListLoading = false;

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -33,7 +33,7 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
   public searching = false;
   public searchValue = '';
   public searchFlag = false;
-  public serachArr: PolicyFile[];
+  public searchArr: PolicyFile[];
   pageOfItems: Array<any>;
 
   constructor(
@@ -55,7 +55,7 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, allPolicyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState)) {
         this.policyFiles = allPolicyFilesState;
-        this.policyFilesListLoading = false;
+                this.policyFilesListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyFilesListLoading = false;
         this.authFailure = true;
@@ -83,7 +83,7 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     if (!this.policyFiles || !searchText) {
       this.searchFlag = false;
     } else {
-      this.serachArr = this.policyFiles.filter((key) => {
+      this.searchArr = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
           return key.name.includes(searchText);

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -55,7 +55,7 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, allPolicyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState)) {
         this.policyFiles = allPolicyFilesState;
-                this.policyFilesListLoading = false;
+        this.policyFilesListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyFilesListLoading = false;
         this.authFailure = true;

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -10,6 +10,7 @@ describe('infra policy file', () => {
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
+  const policyFileName = `${cypressPrefix}-policy-${now}-1`;
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -130,5 +131,29 @@ describe('infra policy file', () => {
         });
       });
     });
+
+    context('can search and change page in dataBag', () => {
+      it('can search a DataBag and check if empty or not', () => {
+      getPolicyFile().then((response) => {
+        if (checkResponse(response)) {
+          cy.get('[data-cy=search-filter]').type(policyFileName);
+          cy.get('[data-cy=search-entity]').click();
+          cy.get('[data-cy=policy-file-table-container]').then(body => {
+            if (body.text().includes(policyFileName)) {
+              cy.get('[data-cy=policy-file-table-container]')
+              .contains(policyFileName).should('exist');
+            }
+          });
+
+          cy.get('[data-cy=search-filter]').clear();
+          cy.get('[data-cy=search-entity]').click();
+          // getPolicyFile().then((response) => {
+          //   checkResponse(response);
+          // });
+        }
+      });
+    });
+  });
+
   });
 });

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -147,9 +147,6 @@ describe('infra policy file', () => {
 
           cy.get('[data-cy=search-filter]').clear();
           cy.get('[data-cy=search-entity]').click();
-          // getPolicyFile().then((response) => {
-          //   checkResponse(response);
-          // });
         }
       });
     });


### PR DESCRIPTION
Signed-off-by: Chaitali Mane [cmane@progress.com](cmane@progress.com)

### :nut_and_bolt: Description: What code changed, and why?
We need search functionality in policy files list

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5240

### :+1: Definition of Done
Added search bar functionality for policy files

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
Steps for Policyfiles tab:
Go To Infrastructure -> Chef Servers -> click server name-> click on org name -> Policyfiles.

For cypress Build
https://github.com/chef/automate/tree/master/e2e

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
1. Search bar
![search-policy](https://user-images.githubusercontent.com/71449322/123974825-902e8d80-d9da-11eb-98f5-920ad5fe6d1c.png)

2. No data after search
![search-policy1](https://user-images.githubusercontent.com/71449322/123974970-a76d7b00-d9da-11eb-85a8-63f3aa2e8a38.png)
