### PR TITLE
Added delete option in policy files

### DIFF
--- a/components/automate-ui/src/app/entities/policy-files/policy-file.action.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.action.ts
@@ -5,7 +5,10 @@ import { PolicyFile } from './policy-file.model';
 export enum PolicyFileActionTypes {
   GET_ALL = 'POLICYFILES::GET_ALL',
   GET_ALL_SUCCESS = 'POLICYFILES::GET_ALL::SUCCESS',
-  GET_ALL_FAILURE = 'POLICYFILES::GET_ALL::FAILURE'
+  GET_ALL_FAILURE = 'POLICYFILES::GET_ALL::FAILURE',
+  DELETE          = 'POLICYFILES::DELETE',
+  DELETE_SUCCESS  = 'POLICYFILES::DELETE::SUCCESS',
+  DELETE_FAILURE  = 'POLICYFILES::DELETE::FAILURE'
 }
 
 export interface PolicyFilesSuccessPayload {
@@ -27,7 +30,25 @@ export class GetPolicyFilesFailure implements Action {
   constructor(public payload: HttpErrorResponse) { }
 }
 
+export class DeletePolicyFile implements Action {
+  readonly type = PolicyFileActionTypes.DELETE;
+  constructor(public payload: { server_id: string, org_id: string, name: string }) { }
+}
+
+export class DeletePolicyFileSuccess implements Action {
+  readonly type = PolicyFileActionTypes.DELETE_SUCCESS;
+  constructor(public payload: { name: string }) { }
+}
+
+export class DeletePolicyFileFailure implements Action {
+  readonly type = PolicyFileActionTypes.DELETE_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
 export type PolicyFileActions =
   | GetPolicyFiles
   | GetPolicyFilesSuccess
-  | GetPolicyFilesFailure;
+  | GetPolicyFilesFailure
+  | DeletePolicyFile
+  | DeletePolicyFileSuccess
+  | DeletePolicyFileFailure;

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
@@ -11,7 +11,10 @@ import {
   GetPolicyFilesSuccess,
   PolicyFilesSuccessPayload,
   GetPolicyFilesFailure,
-  PolicyFileActionTypes
+  PolicyFileActionTypes,
+  DeletePolicyFile,
+  DeletePolicyFileSuccess,
+  DeletePolicyFileFailure
 } from './policy-file.action';
 
 import { PolicyFileRequests } from './policy-file.requests';
@@ -43,4 +46,33 @@ export class PolicyFileEffects {
         });
       })));
 
+  deletePolicyFile$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PolicyFileActionTypes.DELETE),
+      mergeMap(({ payload: { server_id, org_id, name } }: DeletePolicyFile) =>
+        this.requests.deletePolicyFiles(server_id, org_id, name).pipe(
+          map(() => new DeletePolicyFileSuccess({ name })),
+          catchError((error: HttpErrorResponse) =>
+            observableOf(new DeletePolicyFileFailure(error)))))));
+
+  deletePolicyFileSuccess$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PolicyFileActionTypes.DELETE_SUCCESS),
+      map(({ payload: { name } }: DeletePolicyFileSuccess) => {
+        return new CreateNotification({
+          type: Type.info,
+          message: `Successfully deleted policy files - ${name}.`
+        });
+    })));
+
+  deletePolicyFileFailure$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(PolicyFileActionTypes.DELETE_FAILURE),
+      map(({ payload: { error } }: DeletePolicyFileFailure) => {
+        const msg = error.error;
+        return new CreateNotification({
+          type: Type.error,
+          message: `Could not delete policy files: ${msg || error}`
+        });
+    })));
 }

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.effects.ts
@@ -61,7 +61,7 @@ export class PolicyFileEffects {
       map(({ payload: { name } }: DeletePolicyFileSuccess) => {
         return new CreateNotification({
           type: Type.info,
-          message: `Successfully deleted policy files - ${name}.`
+          message: `Successfully deleted policy file: ${name}.`
         });
     })));
 
@@ -72,7 +72,7 @@ export class PolicyFileEffects {
         const msg = error.error;
         return new CreateNotification({
           type: Type.error,
-          message: `Could not delete policy files: ${msg || error}`
+          message: `Could not delete policy file: ${msg || error}`
         });
     })));
 }

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
@@ -6,13 +6,20 @@ import { PolicyFile } from './policy-file.model';
 
 export interface PolicyFileEntityState extends EntityState<PolicyFile> {
   getAllStatus: EntityStatus;
+  deleteStatus: EntityStatus;
+  // policyFileList: {
+  //   items: PolicyFile[]
+  // }
 }
 
 const GET_ALL_STATUS = 'getAllStatus';
+const DELETE_STATUS = 'deleteStatus';
 
 export const policyFileEntityAdapter: EntityAdapter<PolicyFile> =
   createEntityAdapter<PolicyFile>({
   selectId: (policyFile: PolicyFile) => policyFile.revision_id
+  // ,
+  // deleteStatus: EntityStatus.notLoaded
 });
 
 export const PolicyFileEntityInitialState: PolicyFileEntityState =
@@ -24,18 +31,36 @@ export function policyFileEntityReducer(
   state: PolicyFileEntityState = PolicyFileEntityInitialState,
   action: PolicyFileActions): PolicyFileEntityState {
 
-  switch (action.type) {
+    switch (action.type) {
     case PolicyFileActionTypes.GET_ALL:
       return set(GET_ALL_STATUS, EntityStatus.loading, policyFileEntityAdapter.removeAll(state));
 
     case PolicyFileActionTypes.GET_ALL_SUCCESS:
       return pipe(
-        set(GET_ALL_STATUS, EntityStatus.loadingSuccess))
+        set(GET_ALL_STATUS, EntityStatus.loadingSuccess)
+        // ,
+        // set('policyFileList.items', action.payload.policies || [])
+        )
         (policyFileEntityAdapter.setAll(action.payload.policies, state)) as
         PolicyFileEntityState;
 
     case PolicyFileActionTypes.GET_ALL_FAILURE:
       return set(GET_ALL_STATUS, EntityStatus.loadingFailure, state);
+
+    case PolicyFileActionTypes.DELETE:
+      return set(DELETE_STATUS, EntityStatus.loading, state);
+
+    case PolicyFileActionTypes.DELETE_SUCCESS:
+      // const policyFiles =
+      //   state.policyFileList.items.filter(policyFile => policyFi.name !== action.payload.name);
+      return pipe(
+        set(DELETE_STATUS, EntityStatus.loadingSuccess)
+        // ,
+        // set('policyFileList.items', policyFiles || []),
+      )(state) as PolicyFileEntityState;
+
+    case PolicyFileActionTypes.DELETE_FAILURE:
+      return set(DELETE_STATUS, EntityStatus.loadingFailure, state);
 
     default:
       return state;

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.reducer.ts
@@ -7,9 +7,6 @@ import { PolicyFile } from './policy-file.model';
 export interface PolicyFileEntityState extends EntityState<PolicyFile> {
   getAllStatus: EntityStatus;
   deleteStatus: EntityStatus;
-  // policyFileList: {
-  //   items: PolicyFile[]
-  // }
 }
 
 const GET_ALL_STATUS = 'getAllStatus';
@@ -18,13 +15,12 @@ const DELETE_STATUS = 'deleteStatus';
 export const policyFileEntityAdapter: EntityAdapter<PolicyFile> =
   createEntityAdapter<PolicyFile>({
   selectId: (policyFile: PolicyFile) => policyFile.revision_id
-  // ,
-  // deleteStatus: EntityStatus.notLoaded
 });
 
 export const PolicyFileEntityInitialState: PolicyFileEntityState =
   policyFileEntityAdapter.getInitialState(<PolicyFileEntityState>{
-  getAllStatus: EntityStatus.notLoaded
+  getAllStatus: EntityStatus.notLoaded,
+  deleteStatus: EntityStatus.notLoaded
 });
 
 export function policyFileEntityReducer(
@@ -38,8 +34,6 @@ export function policyFileEntityReducer(
     case PolicyFileActionTypes.GET_ALL_SUCCESS:
       return pipe(
         set(GET_ALL_STATUS, EntityStatus.loadingSuccess)
-        // ,
-        // set('policyFileList.items', action.payload.policies || [])
         )
         (policyFileEntityAdapter.setAll(action.payload.policies, state)) as
         PolicyFileEntityState;
@@ -51,12 +45,8 @@ export function policyFileEntityReducer(
       return set(DELETE_STATUS, EntityStatus.loading, state);
 
     case PolicyFileActionTypes.DELETE_SUCCESS:
-      // const policyFiles =
-      //   state.policyFileList.items.filter(policyFile => policyFi.name !== action.payload.name);
       return pipe(
         set(DELETE_STATUS, EntityStatus.loadingSuccess)
-        // ,
-        // set('policyFileList.items', policyFiles || []),
       )(state) as PolicyFileEntityState;
 
     case PolicyFileActionTypes.DELETE_FAILURE:

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.requests.ts
@@ -17,4 +17,9 @@ export class PolicyFileRequests {
     return this.http.get<PolicyFilesSuccessPayload>(
       `${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/policyfiles`, {headers});
   }
+
+  public deletePolicyFiles(server_id: string, org_id: string, name: string): Observable<{}> {
+    return this.http.delete(`${env.infra_proxy_url}/servers/${server_id}/orgs/${org_id}/policyfiles/${name}`,
+    {headers});
+  }
 }

--- a/components/automate-ui/src/app/entities/policy-files/policy-file.selectors.ts
+++ b/components/automate-ui/src/app/entities/policy-files/policy-file.selectors.ts
@@ -19,3 +19,8 @@ export const infraPolicyFileFromRoute = createSelector(
   routeParams,
   (state, { revision_id }) => find({ revision_id }, state)
 );
+
+export const deleteStatus = createSelector(
+  policyFileState,
+  (state) => state.deleteStatus
+);

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.html
@@ -1,5 +1,13 @@
 <section class="policy-files">
   <chef-loading-spinner *ngIf="policyFilesListLoading" size="50"></chef-loading-spinner>
+  <app-delete-infra-object-modal
+    [visible]="deleteModalVisible"
+    objectNoun="policyFile"
+    [objectName]="policyfileToDelete?.name"
+    (close)="closeDeleteModal()"
+    (deleteClicked)="deletePolicyfile()"
+    objectAction="Delete">
+  </app-delete-infra-object-modal>
   <app-empty-state *ngIf="authFailure" moduleTitle="policyfiles" (resetKeyRedirection)="resetKeyTabRedirection($event)"></app-empty-state>
   <ng-container *ngIf="!policyFilesListLoading && !authFailure">
     <div class="search-create-container">
@@ -11,6 +19,7 @@
       <p *ngIf="searchValue !== ''">No results found for "{{searchValue}}".</p>
       <p *ngIf="searchValue === ''">No policy files available</p>
     </div>
+    <chef-loading-spinner class="full-screen-spinner" *ngIf="deleting" size="50" fixed></chef-loading-spinner>
     <div id="policy-file-table-container" *ngIf="policyFiles.length" data-cy="policy-file-table-container">
       <chef-table>
         <chef-thead *ngIf="!searchFlag || searchArr.length">
@@ -26,7 +35,17 @@
             <chef-td>{{ policyFile.name }}</chef-td>
             <chef-td>{{ policyFile.revision_id }}</chef-td>
             <chef-td></chef-td>
-            <chef-td class="three-dot-column"></chef-td>
+            <chef-td class="three-dot-column">
+              <mat-select panelClass="chef-control-menu">
+                <mat-option 
+                  data-cy="delete"
+                  class="secondary"
+                  (onSelectionChange)="startpolicyFilesDelete(policyFile)">
+                  Delete
+                  <chef-icon aria-hidden="true" class="primary">remove</chef-icon>
+                </mat-option>
+              </mat-select>
+            </chef-td>
           </chef-tr>
         </chef-tbody>
       </chef-table>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
@@ -63,4 +63,23 @@ chef-loading-spinner {
     height: 36px;
     margin-top: 4px;
   }
+  
+  ::ng-deep .mat-select-panel .mat-option {
+
+    &.secondary {
+      height: 2.3em;
+      background: $chef-white;
+      color: $chef-critical;
+    }
+
+    &:hover {
+      background: $chef-primary-bright;
+      color: $chef-white;
+
+      chef-icon.primary {
+        color: $chef-white;
+      }
+
+    }
+  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.scss
@@ -63,23 +63,30 @@ chef-loading-spinner {
     height: 36px;
     margin-top: 4px;
   }
-  
-  ::ng-deep .mat-select-panel .mat-option {
 
-    &.secondary {
-      height: 2.3em;
-      background: $chef-white;
-      color: $chef-critical;
-    }
+}
 
-    &:hover {
-      background: $chef-primary-bright;
+::ng-deep .mat-select-panel .mat-option {
+
+  &.secondary {
+    width: 150px;
+    height: 2.3em;
+    background: $chef-white;
+    color: $chef-critical;
+  }
+
+  chef-icon.primary {
+    float: right;
+    margin-top: 15px;
+  }
+
+  &:hover {
+    background: $chef-primary-bright;
+    color: $chef-white;
+
+    chef-icon.primary {
       color: $chef-white;
-
-      chef-icon.primary {
-        color: $chef-white;
-      }
-
     }
+
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.spec.ts
@@ -41,6 +41,11 @@ describe('PolicyFilesComponent', () => {
         MockComponent({ selector: 'chef-td' }),
         MockComponent({ selector: 'a', inputs: ['routerLink'] }),
         MockComponent({ selector: 'input', inputs: ['resetOrigin'] }),
+        MockComponent({
+          selector: 'app-delete-infra-object-modal',
+          inputs: ['default', 'visible', 'objectNoun', 'objectName'],
+          outputs: ['close', 'deletePolicyFile']
+        }),
         PolicyFilesComponent
       ],
       providers: [

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -36,6 +36,10 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
   public searchArr: PolicyFile[];
   pageOfItems: Array<any>;
 
+  public policyfileToDelete: PolicyFile;
+  public deleteModalVisible = false;
+  public deleting = false;
+
   constructor(
     private store: Store<NgrxStateAtom>,
     private layoutFacade: LayoutFacadeService
@@ -55,6 +59,26 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, allPolicyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(allPolicyFilesState)) {
         this.policyFiles = allPolicyFilesState;
+        this.policyFiles.push({
+          name: 'test3',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test4',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test5',
+          revision_id: '0',
+          policy_group: 'e'
+        });
+        this.policyFiles.push({
+          name: 'test6',
+          revision_id: '0',
+          policy_group: 'e'
+        });
         this.policyFilesListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyFilesListLoading = false;
@@ -92,4 +116,20 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
     }
     this.searching = false;
   }
+
+  public startpolicyFilesDelete(policyFile: PolicyFile): void {
+    this.policyfileToDelete = policyFile;
+    this.deleteModalVisible = true;
+  }
+
+  public deletePolicyfile(): void {
+    this.deleting = true;
+    this.closeDeleteModal();
+  }
+
+  public closeDeleteModal(): void {
+    this.deleteModalVisible = false;
+    this.deleting = false;
+  }
+
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-files/policy-files.component.ts
@@ -7,7 +7,7 @@ import { isNil } from 'lodash/fp';
 import { NgrxStateAtom } from 'app/ngrx.reducers';
 import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
 import { EntityStatus } from 'app/entities/entities';
-import { GetPolicyFiles } from 'app/entities/policy-files/policy-file.action';
+import { GetPolicyFiles, DeletePolicyFile } from 'app/entities/policy-files/policy-file.action';
 import { PolicyFile } from 'app/entities/policy-files/policy-file.model';
 import {
   allPolicyFiles,
@@ -125,6 +125,9 @@ export class PolicyFilesComponent implements OnInit, OnDestroy {
   public deletePolicyfile(): void {
     this.deleting = true;
     this.closeDeleteModal();
+    this.store.dispatch(new DeletePolicyFile({
+      server_id: this.serverId, org_id: this.orgId, name: this.policyfileToDelete.name
+    }));
   }
 
   public closeDeleteModal(): void {

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -11,7 +11,7 @@ describe('infra policy file', () => {
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
   const policyFileName = `${cypressPrefix}-policyFile-${now}-1`;
-
+  
   before(() => {
     cy.adminLogin('/').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));
@@ -171,15 +171,8 @@ describe('infra policy file', () => {
               contains(`Successfully deleted policy file - ${policyFileName}.`);
             cy.get('app-notification.info chef-icon').click();
 
-            getPolicyFile().then((response) => {
-              checkResponse(response);
-            });
-
             cy.get('[data-cy=search-filter]').clear();
             cy.get('[data-cy=search-entity]').click();
-            getPolicyFile().then((response) => {
-              checkResponse(response);
-            });
           }
         });
     });

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -11,7 +11,7 @@ describe('infra policy file', () => {
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
   const policyFileName = `${cypressPrefix}-policyFile-${now}-1`;
-  
+
   before(() => {
     cy.adminLogin('/').then(() => {
       const admin = JSON.parse(<string>localStorage.getItem('chef-automate-user'));

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -10,7 +10,7 @@ describe('infra policy file', () => {
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
-  const policyFileName = `${cypressPrefix}-policy-${now}-1`;
+  const policyFileName = `${cypressPrefix}-policyFie-${now}-1`;
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -152,5 +152,36 @@ describe('infra policy file', () => {
     });
   });
 
+    it('can delete policy file', () => {
+      getPolicyFile().then((response) => {
+        if (checkResponse(response)) {
+          cy.get('[data-cy=search-filter]').type(`${cypressPrefix}-policyFile-${now}`);
+          cy.get('[data-cy=search-entity]').click();
+            cy.get('[data-cy=policy-file-table-container]').contains(policyFileName)
+              .should('exist');
+            cy.get('app-policy-files [data-cy=policy-file-table-container] chef-td a')
+              .contains(policyFileName).parent().parent().find('.mat-select-trigger').click();
+
+            cy.get('[data-cy=delete]').should('be.visible')
+              .click();
+            // accept dialog
+            cy.get('app-policy-files chef-button').contains('Delete').click();
+            // verify success notification and then dismiss it
+            cy.get('app-notification.info').
+              contains(`Successfully deleted policy file - ${policyFileName}.`);
+            cy.get('app-notification.info chef-icon').click();
+          
+            getPolicyFile().then((response) => {
+              checkResponse(response);
+            });
+
+            cy.get('[data-cy=search-filter]').clear();
+            cy.get('[data-cy=search-entity]').click();
+            getPolicyFile().then((response) => {
+              checkResponse(response);
+            });
+          }
+        });
+    });
   });
 });

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-list.spec.ts
@@ -10,7 +10,7 @@ describe('infra policy file', () => {
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
-  const policyFileName = `${cypressPrefix}-policyFie-${now}-1`;
+  const policyFileName = `${cypressPrefix}-policyFile-${now}-1`;
 
   before(() => {
     cy.adminLogin('/').then(() => {
@@ -170,7 +170,7 @@ describe('infra policy file', () => {
             cy.get('app-notification.info').
               contains(`Successfully deleted policy file - ${policyFileName}.`);
             cy.get('app-notification.info chef-icon').click();
-          
+
             getPolicyFile().then((response) => {
               checkResponse(response);
             });


### PR DESCRIPTION
Signed-off-by: Chaitali Mane cmane@progress.com

### :nut_and_bolt: Description: What code changed, and why?
User can delete individual policy file from policy files list. 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5241

### :+1: Definition of Done
Added delete option to each policy file.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
Steps for Policyfiles tab:
Go To Infrastructure -> Chef Servers -> click server name-> click on org name -> Policyfiles.

For cypress Build
https://github.com/chef/automate/tree/master/e2e

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Delete option available :
![policy-delete](https://user-images.githubusercontent.com/71449322/124765823-fde73600-df53-11eb-809d-b72e342c077b.png)

Delete modal for Policy file:
![delete-policy1](https://user-images.githubusercontent.com/71449322/124766119-40107780-df54-11eb-8e51-07dcc02ad15f.png)
