### PR TITLE
Removed bintray dependencies from deployment

### DIFF
--- a/components/automate-deployment/a1-migration/install.rb
+++ b/components/automate-deployment/a1-migration/install.rb
@@ -62,7 +62,7 @@ end
 # Install us some habitat so that we can build a1-migration-data artifacts
 
 hab_zip_path = ::File.join(Chef::Config[:file_cache_path], 'hab.tgz')
-hab_source = 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux'
+hab_source = 'https://packages.chef.io/files/current/habitat/latest/hab-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux'
 
 remote_file hab_zip_path do
   source hab_source

--- a/components/automate-deployment/basic-a1/install.rb
+++ b/components/automate-deployment/basic-a1/install.rb
@@ -56,7 +56,7 @@ end
 # Install habitat so that we can build data artifacts
 
 hab_zip_path = ::File.join(Chef::Config[:file_cache_path], 'hab.tgz')
-hab_source = 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux'
+hab_source = 'https://packages.chef.io/files/current/habitat/latest/hab-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux'
 
 remote_file hab_zip_path do
   source hab_source

--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -51,12 +51,11 @@ const (
 	pcioBaseURLFmt = "https://packages.chef.io/files/habitat/%s/hab-x86_64-linux.tar.gz"
 )
 
-// netHabDownloader downloads the habitat binary from either
-// habitat.bintray.com or packages.chef.io.
+// netHabDownloader downloads the habitat binary from either packages.chef.io.
 type netHabDownloader struct{}
 
 // NewNetHabDownloader returns a new HabBinaryDownloader that pulls
-// from bintray or packages.chef.io based on the version being
+// from packages.chef.io based on the version being
 // requested.
 func NewNetHabDownloader() HabBinaryDownloader {
 	return &netHabDownloader{}

--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -48,11 +48,7 @@ type HabBinaryDownloader interface {
 }
 
 const (
-	// Last version for which hab tars lived on bintray
-	lastBintrayVersion = "0.89.0"
-
 	pcioBaseURLFmt    = "https://packages.chef.io/files/habitat/%s/hab-x86_64-linux.tar.gz"
-	bintrayBaseURLFmt = "https://habitat.bintray.com/stable/linux/x86_64/hab-%s-%s-x86_64-linux.tar.gz"
 )
 
 // netHabDownloader downloads the habitat binary from either
@@ -67,21 +63,7 @@ func NewNetHabDownloader() HabBinaryDownloader {
 }
 
 func urlForVersion(version string, release string) (string, error) {
-	targetVersion, err := habpkg.ParseSemverishVersion(version)
-	if err != nil {
-		return "", err
-	}
-
-	switchoverVersion, err := habpkg.ParseSemverishVersion(lastBintrayVersion)
-	if err != nil {
-		return "", err
-	}
-
-	if habpkg.CompareSemverish(targetVersion, switchoverVersion) == habpkg.SemverishGreater {
-		return fmt.Sprintf(pcioBaseURLFmt, version), nil
-	} else {
-		return fmt.Sprintf(bintrayBaseURLFmt, version, release), nil
-	}
+	return fmt.Sprintf(pcioBaseURLFmt, version), nil
 }
 
 func (dl *netHabDownloader) DownloadHabBinary(version string, release string, w io.Writer) error {

--- a/components/automate-deployment/pkg/airgap/bundle_creator.go
+++ b/components/automate-deployment/pkg/airgap/bundle_creator.go
@@ -48,7 +48,7 @@ type HabBinaryDownloader interface {
 }
 
 const (
-	pcioBaseURLFmt    = "https://packages.chef.io/files/habitat/%s/hab-x86_64-linux.tar.gz"
+	pcioBaseURLFmt = "https://packages.chef.io/files/habitat/%s/hab-x86_64-linux.tar.gz"
 )
 
 // netHabDownloader downloads the habitat binary from either

--- a/components/automate-deployment/pkg/target/local_target.go
+++ b/components/automate-deployment/pkg/target/local_target.go
@@ -1357,22 +1357,7 @@ func (t *LocalTarget) installHabViaInstallScript(ctx context.Context, requiredVe
 		return err
 	}
 
-	// TODO(ssd) 2019-12-03: HACK until we remove the use of install.sh
-	lastBintrayVersion := "0.89.0"
-	targetVersion, err := habpkg.ParseSemverishVersion(requiredVersion.Version())
-	if err != nil {
-		return err
-	}
-
-	switchoverVersion, err := habpkg.ParseSemverishVersion(lastBintrayVersion)
-	if err != nil {
-		return err
-	}
-
 	version := requiredVersion.Version()
-	if habpkg.CompareSemverish(targetVersion, switchoverVersion) != habpkg.SemverishGreater {
-		version = habpkg.VersionString(requiredVersion)
-	}
 
 	output, execErr := t.Executor.CombinedOutput(
 		"bash",

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -322,6 +322,7 @@ func TestInstallHabitat(t *testing.T) {
 	manifest := mockManifest(habResponseFixture("manifest"))
 	hasHabCmd := expectCommand("bash", "-c", "command -v hab")
 	habHabInstall := expectHabCommand("hab", "pkg", "install", "core/hab/0.54.0/20180221022026")
+	habBinlink := expectHabCommand("hab", "pkg", "binlink", "--force", "core/hab/0.54.0/20180221022026", "hab")
 
 	mockScriptInstall := func(t *testing.T, mockExec *command.MockExecutor, tempDir string, installError error) {
 		filename, err := testTempFileProvider.NextFileName()
@@ -342,13 +343,14 @@ func TestInstallHabitat(t *testing.T) {
 			func(t *testing.T, mockExec *command.MockExecutor, tempDir string) {
 				mockExec.Expect("CombinedOutput", hasHabCmd).Return("", errors.New("")).Once()
 				mockScriptInstall(t, mockExec, tempDir, nil)
-				mockExec.Expect("CombinedOutput", habHabInstall).Return("", nil).Once()
+				mockExec.Expect("CombinedOutput", habBinlink).Return("", nil).Once()
 			},
 		},
 		{"installs hab via the hab if hab is found", false,
 			func(t *testing.T, mockExec *command.MockExecutor, tempDir string) {
 				mockExec.Expect("CombinedOutput", hasHabCmd).Return("/bin/hab", nil).Once()
 				mockExec.Expect("CombinedOutput", habHabInstall).Return("", nil).Once()
+				mockExec.Expect("CombinedOutput", habBinlink).Return("", nil).Once()
 			},
 		},
 		{"returns error when hab script install fails", true,

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -322,7 +322,6 @@ func TestInstallHabitat(t *testing.T) {
 	manifest := mockManifest(habResponseFixture("manifest"))
 	hasHabCmd := expectCommand("bash", "-c", "command -v hab")
 	habHabInstall := expectHabCommand("hab", "pkg", "install", "core/hab/0.54.0/20180221022026")
-	habBinlink := expectHabCommand("hab", "pkg", "binlink", "--force", "core/hab/0.54.0/20180221022026", "hab")
 
 	mockScriptInstall := func(t *testing.T, mockExec *command.MockExecutor, tempDir string, installError error) {
 		filename, err := testTempFileProvider.NextFileName()
@@ -343,14 +342,13 @@ func TestInstallHabitat(t *testing.T) {
 			func(t *testing.T, mockExec *command.MockExecutor, tempDir string) {
 				mockExec.Expect("CombinedOutput", hasHabCmd).Return("", errors.New("")).Once()
 				mockScriptInstall(t, mockExec, tempDir, nil)
-				mockExec.Expect("CombinedOutput", habBinlink).Return("", nil).Once()
+				mockExec.Expect("CombinedOutput", habHabInstall).Return("", nil).Once()
 			},
 		},
 		{"installs hab via the hab if hab is found", false,
 			func(t *testing.T, mockExec *command.MockExecutor, tempDir string) {
 				mockExec.Expect("CombinedOutput", hasHabCmd).Return("/bin/hab", nil).Once()
 				mockExec.Expect("CombinedOutput", habHabInstall).Return("", nil).Once()
-				mockExec.Expect("CombinedOutput", habBinlink).Return("", nil).Once()
 			},
 		},
 		{"returns error when hab script install fails", true,

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -329,7 +329,7 @@ func TestInstallHabitat(t *testing.T) {
 		mockExec.Expect("CombinedOutput", command.ExpectedCommand{
 			Env:  []string{fmt.Sprintf("TMPDIR=%s/tmp", tempDir)},
 			Cmd:  "bash",
-			Args: []string{filename, "-v", "0.54.0/20180221022026"},
+			Args: []string{filename, "-v", "0.54.0"},
 		}).Return("", installError).Once()
 	}
 


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

`Bintray` has been deprecated. As communicated in https://github.com/chef/release-engineering/issues/1498.
The older versions are moved to `packages.chef.io` as part of https://github.com/habitat-sh/habitat/issues/7312.

### :chains: Related Resources

https://github.com/chef/release-engineering/issues/1498

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
- `hab studio enter` 
- `rebuild components/automate-deployment`
- `rebuild components/automate-cli`
- cd to the automate-cli folder like `cd /hab/pkgs/chef/automate-cli/0.1.0/20210618075758/bin/` 
- `./chef-automate airgap bundle create --version VERSION` use version `20180326145220`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
