### PR TITLE
Fix for search nodes api in azure

### DIFF
--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -507,20 +507,7 @@ func reFilterNameAndRegion(filters []*common.Filter, vmList []*manager.ManagerNo
 		}
 	}
 
-	vmList = UniqueListByID(vmList)
 	return vmList
-}
-
-func UniqueListByID(a []*manager.ManagerNode) []*manager.ManagerNode {
-	seen := map[string]bool{}
-	var b []*manager.ManagerNode
-	for _, v := range a {
-		if _, ok := seen[v.Id]; !ok {
-			seen[v.Id] = true
-			b = append(b, v)
-		}
-	}
-	return b
 }
 
 func filterNames(ss []*manager.ManagerNode, test func(string, []string, bool) bool, includeArr []string, exclude bool) (ret []*manager.ManagerNode) {

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -445,8 +445,10 @@ func (creds *Creds) getVMPoolTasks(ctx context.Context, subs []*manager.ManagerN
 					}
 				}
 			}
-
-			vtr.Nodes = reFilterNameAndRegion(filters, vmList)
+			if len(filters) > 0 {
+				vmList = reFilterNameAndRegion(filters, vmList)
+			}
+			vtr.Nodes = vmList
 			return pool.TaskResult(vtr), nil
 		}
 		tasks = append(tasks, pool.NewTask(f))

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -34,7 +34,6 @@ type Creds struct {
 }
 
 type filtersAzure struct {
-	name   []*common.Filter
 	region []*common.Filter
 	others map[string][]*common.Filter
 }

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -544,15 +544,14 @@ func isNameMaching(s string, arr []string, exclude bool) bool {
 			initBool = initBool && s != val
 		}
 	} else {
-		if len(arr) == 0 {
-			return true
-		}
-		initBool = false
-		for _, val := range arr {
-			initBool = initBool || strings.Contains(
-				strings.ToLower(s),
-				strings.ToLower(val),
-			)
+		if len(arr) > 0 {
+			initBool = false
+			for _, val := range arr {
+				initBool = initBool || strings.Contains(
+					strings.ToLower(s),
+					strings.ToLower(val),
+				)
+			}
 		}
 	}
 	return initBool
@@ -566,12 +565,11 @@ func isRegionMaching(s string, arr []string, exclude bool) bool {
 			initBool = initBool && s != val
 		}
 	} else {
-		if len(arr) == 0 {
-			return true
-		}
-		initBool = false
-		for _, val := range arr {
-			initBool = initBool || s == val
+		if len(arr) > 0 {
+			initBool = false
+			for _, val := range arr {
+				initBool = initBool || s == val
+			}
 		}
 	}
 	return initBool
@@ -589,14 +587,13 @@ func isTagMatching(s []*common.Kv, arr []string, exclude bool, key string) bool 
 			}
 		}
 	} else {
-		if len(arr) == 0 {
-			return true
-		}
-		initBool = false
-		for _, val := range arr {
-			for _, v := range s {
-				if v.Key == key {
-					initBool = initBool || v.Value == val
+		if len(arr) > 0 {
+			initBool = false
+			for _, val := range arr {
+				for _, v := range s {
+					if v.Key == key {
+						initBool = initBool || v.Value == val
+					}
 				}
 			}
 		}

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -739,7 +739,6 @@ func (creds *Creds) QueryVMs(ctx context.Context, filters []*common.Filter) (map
 	} else {
 		logrus.Errorf("We had errors retrieving nodes from azure: %+v", poolOfTasks.GetErrors())
 	}
-
 	return vmList, nil
 }
 

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -33,6 +33,12 @@ type Creds struct {
 	SubscriptionID string
 }
 
+type filtersAzure struct {
+	name   []*common.Filter
+	region []*common.Filter
+	others []*common.Filter
+}
+
 // New returns a Creds struct of ServicePrincipalToken and TenantID given azure creds
 func New(clientID string, clientSecret string, tenantID string, subscriptionID string) (Creds, error) {
 	if len(clientID) == 0 && len(clientSecret) == 0 && len(tenantID) == 0 {
@@ -394,12 +400,6 @@ func handleStateResponse(statuses *[]compute.InstanceViewStatus) string {
 		}
 	}
 	return ""
-}
-
-type filtersAzure struct {
-	name   []*common.Filter
-	region []*common.Filter
-	others []*common.Filter
 }
 
 func (creds *Creds) getVMPoolTasks(ctx context.Context, subs []*manager.ManagerNode, filters []*common.Filter) []*pool.Task {

--- a/components/nodemanager-service/managers/azure/azure.go
+++ b/components/nodemanager-service/managers/azure/azure.go
@@ -544,6 +544,9 @@ func isNameMaching(s string, arr []string, exclude bool) bool {
 			initBool = initBool && s != val
 		}
 	} else {
+		if len(arr) == 0 {
+			return true
+		}
 		initBool = false
 		for _, val := range arr {
 			initBool = initBool || strings.Contains(
@@ -563,6 +566,9 @@ func isRegionMaching(s string, arr []string, exclude bool) bool {
 			initBool = initBool && s != val
 		}
 	} else {
+		if len(arr) == 0 {
+			return true
+		}
 		initBool = false
 		for _, val := range arr {
 			initBool = initBool || s == val
@@ -583,6 +589,9 @@ func isTagMatching(s []*common.Kv, arr []string, exclude bool, key string) bool 
 			}
 		}
 	} else {
+		if len(arr) == 0 {
+			return true
+		}
 		initBool = false
 		for _, val := range arr {
 			for _, v := range s {

--- a/components/nodemanager-service/managers/azure/azure_test.go
+++ b/components/nodemanager-service/managers/azure/azure_test.go
@@ -188,3 +188,58 @@ func TestHandleStateResponse(t *testing.T) {
 	state := handleStateResponse(&statuses)
 	assert.Equal(t, "RUNNING", state)
 }
+
+func TestHandleReFilterNameAndRegion(t *testing.T) {
+
+	vmList := []*manager.ManagerNode{
+		{Name: "test-1A", Region: "eastus", Id: "1234"},
+		{Name: "test-2B", Region: "eastus1", Id: "3234"},
+		{Name: "test-3C", Region: "eastus2", Id: "1434"},
+		{Name: "test-4D", Region: "eastus", Id: "12234"},
+	}
+
+	filters := []*common.Filter{
+		{Key: "name", Values: []string{"test-1"}},
+	}
+	filteredResources := reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 1, len(filteredResources))
+	assert.Equal(t, "test-1A", filteredResources[0].Name)
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 2, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "name", Values: []string{"test-4"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "name", Values: []string{"test"}},
+		{Key: "name", Values: []string{"test-1A"}, Exclude: true},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	t.Log("filteredResources...", filteredResources)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 3, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "name", Values: []string{"test"}},
+		{Key: "name", Values: []string{"test-1A"}, Exclude: true},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 2, len(filteredResources))
+}

--- a/components/nodemanager-service/managers/azure/azure_test.go
+++ b/components/nodemanager-service/managers/azure/azure_test.go
@@ -308,6 +308,14 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 		{Key: "Team", Values: []string{"ga"}},
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
-	t.Log(filteredResources)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "Team", Values: []string{"dev", "ga"}},
+		{Key: "Team", Values: []string{"dev"}, Exclude: true},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 1, len(filteredResources))
 }

--- a/components/nodemanager-service/managers/azure/azure_test.go
+++ b/components/nodemanager-service/managers/azure/azure_test.go
@@ -199,9 +199,21 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 	}
 
 	filters := []*common.Filter{
-		{Key: "name", Values: []string{"test-1"}},
+		{Key: "name", Values: []string{"xyz"}, Exclude: true},
 	}
 	filteredResources := reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 4, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "name", Values: []string{"xyz"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 0, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "name", Values: []string{"test-1"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 1, len(filteredResources))
 	assert.Equal(t, "test-1A", filteredResources[0].Name)
 
@@ -210,6 +222,18 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 2, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"xyz"}, Exclude: true},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 4, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"xyz"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 0, len(filteredResources))
 
 	filters = []*common.Filter{
 		{Key: "region", Values: []string{"eastus"}},
@@ -309,6 +333,18 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "Team", Values: []string{"vga"}, Exclude: true},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 6, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "Team", Values: []string{"vga"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 0, len(filteredResources))
 
 	filters = []*common.Filter{
 		{Key: "region", Values: []string{"eastus"}},

--- a/components/nodemanager-service/managers/azure/azure_test.go
+++ b/components/nodemanager-service/managers/azure/azure_test.go
@@ -224,7 +224,6 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 		{Key: "name", Values: []string{"test-1A"}, Exclude: true},
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
-	t.Log("filteredResources...", filteredResources)
 	assert.Equal(t, 1, len(filteredResources))
 
 	filters = []*common.Filter{
@@ -242,4 +241,20 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 2, len(filteredResources))
+
+	vmList = []*manager.ManagerNode{
+		{Name: "ljkp-ubuntu", Region: "eastus", Id: "xxxxxx-373e-48e5-8e0f-xxxxxxxx"},
+		{Name: "ljkp-win", Region: "eastus", Id: "xxxxxxx-37a4-48f7-9314-xxxxxxxx"},
+		{Name: "vj-win-2000", Region: "eastus", Id: "xxxxxxxx-36a5-4514-b864-xxxxxxxx"},
+		{Name: "ljkp-ubuntu20", Region: "eastus", Id: "xxxxxx-83a4-4b02-a43e-xxxxxxxx"},
+		{Name: "ljkp-ubuntu2", Region: "eastus", Id: "xxxxxxxx-a269-4001-ad60-xxxxxxxx"},
+		{Name: "vault-testing", Region: "eastus", Id: "xxxxxxx-1e14-4efe-8221-xxxxxxxxx"},
+	}
+	filters = []*common.Filter{
+		{Key: "name", Values: []string{"ljkp"}, Exclude: false},
+		{Key: "name", Values: []string{"ljkp-win"}, Exclude: true},
+		{Key: "region", Values: []string{"eastus"}, Exclude: false},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 3, len(filteredResources))
 }

--- a/components/nodemanager-service/managers/azure/azure_test.go
+++ b/components/nodemanager-service/managers/azure/azure_test.go
@@ -247,8 +247,14 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 		{Name: "ljkp-win", Region: "eastus", Id: "xxxxxxx-37a4-48f7-9314-xxxxxxxx"},
 		{Name: "vj-win-2000", Region: "eastus", Id: "xxxxxxxx-36a5-4514-b864-xxxxxxxx"},
 		{Name: "ljkp-ubuntu20", Region: "eastus", Id: "xxxxxx-83a4-4b02-a43e-xxxxxxxx"},
-		{Name: "ljkp-ubuntu2", Region: "eastus", Id: "xxxxxxxx-a269-4001-ad60-xxxxxxxx"},
-		{Name: "vault-testing", Region: "eastus", Id: "xxxxxxx-1e14-4efe-8221-xxxxxxxxx"},
+		{Name: "ljkp-ubuntu2", Region: "eastus", Id: "xxxxxxxx-a269-4001-ad60-xxxxxxxx", Tags: []*common.Kv{
+			{Key: "Team", Value: "ga"},
+		}},
+		{Name: "vault-testing", Region: "eastus", Id: "xxxxxxx-1e14-4efe-8221-xxxxxxxxx", Tags: []*common.Kv{
+			{Key: "Environment", Value: "uat"},
+			{Key: "Environment", Value: "uat1"},
+			{Key: "Team", Value: "dev"},
+		}},
 	}
 	filters = []*common.Filter{
 		{Key: "name", Values: []string{"ljkp"}, Exclude: false},
@@ -257,4 +263,51 @@ func TestHandleReFilterNameAndRegion(t *testing.T) {
 	}
 	filteredResources = reFilterNameAndRegion(filters, vmList)
 	assert.Equal(t, 3, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "name", Values: []string{"vault-testing"}},
+		{Key: "name", Values: []string{"test-1A"}, Exclude: true},
+		{Key: "Environment", Values: []string{"uat", "uat1"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "Environment", Values: []string{"uat", "uat1"}},
+		{Key: "name", Values: []string{"vault-testing"}},
+		{Key: "Environment", Values: []string{"uat"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "Environment", Values: []string{"uat", "uat1"}},
+		{Key: "name", Values: []string{"ljkp-ubuntu2"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 0, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "Environment", Values: []string{"uat", "uat1"}},
+		{Key: "Team", Values: []string{"dev"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	assert.Equal(t, 1, len(filteredResources))
+
+	filters = []*common.Filter{
+		{Key: "region", Values: []string{"eastus"}},
+		{Key: "region", Values: []string{"eastus2"}},
+		{Key: "Team", Values: []string{"ga"}},
+	}
+	filteredResources = reFilterNameAndRegion(filters, vmList)
+	t.Log(filteredResources)
+	assert.Equal(t, 1, len(filteredResources))
 }


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
While filtering nodes in Search Nodes API. Name and region was not getting filtered properly. 

- When we searched for a resource by name it used to return everything in the resource group for that particular resource.

- When we filtered by region it used to return resources in other region as well

The code changes apply a filter just before returning the data from the Search Nodes API. This helps us to get only the desired result. Due to the limitation in azure API where we cannot search for Virtual Machines, we had to introduce this filtering at our end.

### :chains: Related Resources
https://github.com/chef/automate/issues/5315

### :+1: Definition of Done

- Searching for name should return only that node which matches its name
- Filtering by region should return resources belonging to that region only

### :athletic_shoe: How to Build and Test the Change
`rebuild components/nodemanager-service`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

