### PR TITLE
Increase RAM in quickstart demo

### DIFF
--- a/components/docs-chef-io/content/automate/_index.md
+++ b/components/docs-chef-io/content/automate/_index.md
@@ -90,7 +90,7 @@ TERMS
   config.vm.provider "virtualbox" do |v|
     v.name       = 'chef-automate'
     v.memory     = 8192
-    v.cpus       = 2
+    v.cpus       = 4
     v.customize ['modifyvm', :id, '--audio', 'none']
   end
 

--- a/components/docs-chef-io/content/automate/_index.md
+++ b/components/docs-chef-io/content/automate/_index.md
@@ -140,8 +140,8 @@ Retrieving a trial license through Chef Automate requires the Vagrant instance t
 You can install Chef Automate on any x86_64 Linux instance running CentOS 7.5,
 RHEL 7.5, or Ubuntu 16.04 with the following minimum system resources:
 
-* 8 GB RAM
+* 4 CPU
+* 16 GB RAM
 * 5 GB free disk space
-* 2 CPUs
 
 Follow the [Installation Guide]({{< relref "install.md" >}}) to install Chef Automate on your own resources.


### PR DESCRIPTION
Signed-off-by: Kimberly Garmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

Users should be able to start Automate in the quickstart.
You really can't start Automate with 4GB. Changes the doc to 8.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
