### PR TITLE
Policyfiles is a single word

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -74,7 +74,7 @@
                   </div>
                   <chef-icon class="arrows">keyboard_arrow_down</chef-icon>
                 </div>
-                <div class="submenu" [ngClass]="showIncludedPolicies ? activeIncludedPolicies : ''"> 
+                <div class="submenu" [ngClass]="showIncludedPolicies ? activeIncludedPolicies : ''">
                   <div class="item-details">
                     <div data-cy="empty-list" class="empty-section" *ngIf="!included_policy_locks.length">
                       <img alt="No preview" src="/assets/img/no_preview.gif" />
@@ -84,7 +84,7 @@
                       <chef-table>
                         <chef-thead>
                           <chef-tr class="no_border_tr">
-                            <chef-th class="no_border_th">Policy Files</chef-th>
+                            <chef-th class="no_border_th">Policyfiles</chef-th>
                             <chef-th class="no_border_th">Revision ID</chef-th>
                             <chef-th class="no_border_th"></chef-th>
                             <chef-th class="no_border_th three-dot-column"></chef-th>
@@ -102,7 +102,7 @@
                         </chef-tbody>
                       </chef-table>
                     </div>
-                  </div>  
+                  </div>
                 </div>
               </li>
             </ul>
@@ -114,7 +114,7 @@
                   </div>
                   <chef-icon class="arrows">keyboard_arrow_down</chef-icon>
                 </div>
-                <div class="submenu" [ngClass]="showRunList ? activeRunlist : ''"> 
+                <div class="submenu" [ngClass]="showRunList ? activeRunlist : ''">
                   <div class="item-details">
                     <div data-cy="empty-list" class="empty-section" *ngIf="!cookbook_locks.length">
                       <img alt="No preview" src="/assets/img/no_preview.gif" />
@@ -142,7 +142,7 @@
                         </chef-tbody>
                       </chef-table>
                     </div>
-                  </div>  
+                  </div>
                 </div>
               </li>
             </ul>
@@ -165,7 +165,7 @@
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button tertiary class="action" 
+              <chef-button tertiary class="action"
                 [disabled]= !hasDefaultattributes
                 (click)="tree.collapse()"
                 data-cy="collapse-default-attribute">
@@ -177,7 +177,7 @@
             <div class="json-container">
               <div class="scroll">
                 <app-json-tree-table
-                  class="json-tree-container" 
+                  class="json-tree-container"
                   [hidden]="hasDefaultattributes? false : true"
                   #tree
                   [json]="defaultAttributes">
@@ -228,7 +228,7 @@
                 </div>
               </div>
             </div>
-          </div>    
+          </div>
         </div>
       </section>
       <app-revision-id

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-details.spec.ts
@@ -120,7 +120,7 @@ describe('infra policy details', () => {
     if (response.body.included_policy_locks.length === 0) {
       cy.get('[data-cy=empty-list]').should('be.visible');
     } else {
-      cy.get('[data-cy=included-policy-table-container] chef-th').contains('Policy Files');
+      cy.get('[data-cy=included-policy-table-container] chef-th').contains('Policyfiles');
       cy.get('[data-cy=included-policy-table-container] chef-th').contains('Revision ID');
       return true;
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Policyfiles is Chef Infra term. They are not files containing policies.
They are a very specific feature that we need to get the name right for.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

See that Policyfiles shows up as a single word when you browse them in the UI.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
