### PR TITLE
Remove custom staging area unlock logic

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -18,9 +18,6 @@ schedules:
   - name: cleanup_abandoned_a2_instances
     description: Cleanup abandoned a2instances
     cronline: "0 1 * * *" # every day at 1am
-  - name: unlock_staging_area_in_case_of_stall
-    description: Unlock staging area in case of stall
-    cronline: "0 2 * * *" # every day at 2am
 
 # These are our Buildkite pipelines where deploys take place
 pipelines:
@@ -168,8 +165,3 @@ subscriptions:
   - workload: schedule_triggered:{{agent_id}}:cleanup_abandoned_a2_instances:*
     actions:
       - bash:.expeditor/cleanup-abandoned-a2-instances.sh
-  - workload: schedule_triggered:{{agent_id}}:unlock_staging_area_in_case_of_stall:*
-    actions:
-      - unlock_staging_area:post_merge:
-          post_commit: true
-          always_run: true


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Removed some custom logic that would force the staging area to unlock every day at 2am. This was actually dangerous because it could prematurely unlock the staging area. To avoid this, Expeditor will now automatically unlock staging areas after 24hrs. 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
