### PR TITLE
Added search functionality in policy group

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
@@ -1,5 +1,5 @@
 <chef-table>
-  <chef-thead>
+  <chef-thead *ngIf="!searchFlag">
     <chef-tr class="no_border_tr">
       <chef-th class="no_border_th">Policy Group</chef-th>
       <chef-th class="no_border_th">Number of Policyfiles</chef-th>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
@@ -1,5 +1,5 @@
 <chef-table>
-  <chef-thead *ngIf="!searchFlag">
+  <chef-thead *ngIf="policyGroups.length">
     <chef-tr class="no_border_tr">
       <chef-th class="no_border_th">Policy Group</chef-th>
       <chef-th class="no_border_th">Number of Policyfiles</chef-th>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.ts
@@ -1,12 +1,14 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'app-policy-groups-list',
   templateUrl: './policy-groups-list.component.html'
 })
-export class PolicyGroupsListComponent implements OnInit {
+export class PolicyGroupsListComponent implements OnInit, OnChanges {
   @Input() policyFiles: [];
+  @Input() searchFlag: boolean;
   public policyGroups = [];
+  public list = [];
 
   constructor() { }
 
@@ -14,26 +16,39 @@ export class PolicyGroupsListComponent implements OnInit {
     this.filterDataGroupWise();
   }
 
+    ngOnChanges(changes: SimpleChanges) {
+    // update list if items array has changed
+    if (changes.policyFiles.currentValue !== changes.policyFiles.previousValue) {
+      this.list = this.policyFiles;
+      this.filterDataGroupWise();
+    }
+  }
+
   filterDataGroupWise() {
     const key = 'policy_group';
-    this.policyFiles.forEach((x) => {
-      // Checking if there is any object in this.policyGroupsList
-      // which contains the key value
-      if (this.policyGroups.some((val) => val[key] === x[key])) {
-        // If yes! then increase the occurrence by 1
-        this.policyGroups.forEach((k) => {
-          if (k[key] === x[key]) {
-            k['occurrence']++;
-          }
-        });
-      } else {
-        // If not! Then create a new object initialize
-        // it with the present iteration key's value and set the occurrence to 1
-        const a = {};
-        a[key] = x[key];
-        a['occurrence'] = 1;
-        this.policyGroups.push(a);
-      }
-    });
+    this.policyGroups = [];
+    if (this.list.length > 0) {
+      this.list.forEach((x) => {
+        // Checking if there is any object in this.policyGroupsList
+        // which contains the key value
+        if (this.policyGroups.some((val) => val[key] === x[key])) {
+          // If yes! then increase the occurrence by 1
+          this.policyGroups.forEach((k) => {
+            if (k[key] === x[key]) {
+              k['occurrence']++;
+            }
+          });
+        } else {
+          // If not! Then create a new object initialize
+          // it with the present iteration key's value and set the occurrence to 1
+          const a = {};
+          a[key] = x[key];
+          a['occurrence'] = 1;
+          this.policyGroups.push(a);
+        }
+      });
+    } else {
+      this.policyGroups = [];
+    }
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
@@ -4,7 +4,9 @@
   </app-empty-state>
   <ng-container *ngIf="!policyGroupsListLoading && !authFailure">
     <div class="search-create-container">
-      <app-infra-search-bar (searchButtonClick)="searchPolicyGroups($event)" placeHolder="Policyfiles group by name...">
+      <app-infra-search-bar 
+      (input)="onSearchChange($event.target.value)"
+       placeHolder="Policyfiles group by name...">
       </app-infra-search-bar>
     </div>
     <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0)">
@@ -15,7 +17,14 @@
 
     <div id="policy-group-table-container" *ngIf="policyFiles.length" data-cy="policy-group-table-container">
       <app-policy-groups-list
-        [policyFiles]= "policyFiles">
+      *ngIf="!searchFlag"
+        [policyFiles]= "policyFiles"
+        [searchFlag]= "searchFlag">
+      </app-policy-groups-list>
+      <app-policy-groups-list
+        *ngIf="searchFlag"
+        [policyFiles]= "list"
+        [searchFlag]="searchFlag">
       </app-policy-groups-list>
     </div>
   </ng-container>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
@@ -3,10 +3,14 @@
   <app-empty-state *ngIf="authFailure" moduleTitle="policyGroups" (resetKeyRedirection)="resetKeyTabRedirection($event)">
   </app-empty-state>
   <ng-container *ngIf="!policyGroupsListLoading && !authFailure">
-    
-    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length">
-      <img alt="No preview" src="/assets/img/no_preview.gif" />      
-      <p>No policy groups available</p>
+    <div class="search-create-container">
+      <app-infra-search-bar (searchButtonClick)="searchPolicyGroups($event)" placeHolder="Policyfiles group by name...">
+      </app-infra-search-bar>
+    </div>
+    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0)">
+      <img alt="No preview" src="/assets/img/no_preview.gif" />  
+      <p *ngIf="searchValue !== ''">No results found for "{{searchValue}}".</p>    
+      <p *ngIf="searchValue === ''">No policy groups available</p>
     </div>
 
     <div id="policy-group-table-container" *ngIf="policyFiles.length" data-cy="policy-group-table-container">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
@@ -18,7 +18,7 @@
     <chef-loading-spinner class="full-screen-spinner" *ngIf="searching" size="50" fixed></chef-loading-spinner>
     <div id="policy-group-table-container" *ngIf="policyFiles.length" data-cy="policy-group-table-container">
       <app-policy-groups-list
-        [policyFiles]= "list"
+        [policyFiles]= "groupList"
         [searchFlag]="searchFlag">
       </app-policy-groups-list>
     </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
@@ -9,7 +9,7 @@
         placeHolder="Policy group by name...">
       </app-infra-search-bar>
     </div>
-    <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0)">
+    <div data-cy="empty-list" class="empty-section" *ngIf="!groupList.length">
       <img alt="No preview" src="/assets/img/no_preview.gif" />  
       <p *ngIf="searchValue !== ''">No results found for "{{searchValue}}".</p>    
       <p *ngIf="searchValue === ''">No policy groups available</p>
@@ -18,8 +18,7 @@
     <chef-loading-spinner class="full-screen-spinner" *ngIf="searching" size="50" fixed></chef-loading-spinner>
     <div id="policy-group-table-container" *ngIf="policyFiles.length" data-cy="policy-group-table-container">
       <app-policy-groups-list
-        [policyFiles]= "groupList"
-        [searchFlag]="searchFlag">
+        [policyFiles]= "groupList">
       </app-policy-groups-list>
     </div>
   </ng-container>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.html
@@ -4,9 +4,9 @@
   </app-empty-state>
   <ng-container *ngIf="!policyGroupsListLoading && !authFailure">
     <div class="search-create-container">
-      <app-infra-search-bar 
-      (input)="onSearchChange($event.target.value)"
-       placeHolder="Policyfiles group by name...">
+      <app-infra-search-bar
+        (searchButtonClick)="searchPolicyFiles($event)"
+        placeHolder="Policy group by name...">
       </app-infra-search-bar>
     </div>
     <div data-cy="empty-list" class="empty-section" *ngIf="!policyFiles.length || searchFlag && (searchArr.length === 0)">
@@ -15,14 +15,9 @@
       <p *ngIf="searchValue === ''">No policy groups available</p>
     </div>
 
+    <chef-loading-spinner class="full-screen-spinner" *ngIf="searching" size="50" fixed></chef-loading-spinner>
     <div id="policy-group-table-container" *ngIf="policyFiles.length" data-cy="policy-group-table-container">
       <app-policy-groups-list
-      *ngIf="!searchFlag"
-        [policyFiles]= "policyFiles"
-        [searchFlag]= "searchFlag">
-      </app-policy-groups-list>
-      <app-policy-groups-list
-        *ngIf="searchFlag"
         [policyFiles]= "list"
         [searchFlag]="searchFlag">
       </app-policy-groups-list>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.scss
@@ -27,3 +27,20 @@ chef-loading-spinner {
   width: 100px;
   z-index: 199;
 }
+
+.search-create-container {
+  display: flex;
+  margin: 24px 0 18px;
+  flex-direction: row;
+
+  app-infra-search-bar {
+    flex-grow: 2;
+  }
+
+  chef-button {
+    margin: 0;
+    margin-left: 16px;
+    height: 36px;
+    margin-top: 4px;
+  }
+}

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.spec.ts
@@ -7,6 +7,7 @@ import { Store, StoreModule } from '@ngrx/store';
 import { NgrxStateAtom, ngrxReducers, runtimeChecks } from 'app/ngrx.reducers';
 import { FeatureFlagsService } from 'app/services/feature-flags/feature-flags.service';
 import { By } from '@angular/platform-browser';
+import { using } from 'app/testing/spec-helpers';
 import { PolicyGroupsComponent } from './policy-groups.component';
 import { PolicyFile } from 'app/entities/policy-files/policy-file.model';
 import { GetPolicyGroupsSuccess } from 'app/entities/policy-files/policy-file.action';
@@ -73,6 +74,87 @@ describe('PolicyGroupsComponent', () => {
     it('show no preview image', () => {
       store.dispatch(new GetPolicyGroupsSuccess({policies: emptyPolicyGroup}));
       expect(component.policyFiles.length).toBe(0);
+    });
+  });
+
+  describe('#search', () => {
+    describe('search shows no data', () => {
+      using([
+        ['contains tilde.', 'policy~'],
+        ['contains acute, back quote,', 'policy`'],
+        ['contains exclamation mark', 'policy!'],
+        ['contains ampersat, at', 'policy@'],
+        ['contains dollar sign', 'policy$'],
+        ['contains percent.', 'policy%'],
+        ['contains caret or circumflex.,', 'policy^'],
+        ['contains ampersand', 'policy&'],
+        ['contains asterisk', 'policy*'],
+        ['contains open or left parenthesis.', 'policy('],
+        ['contains close or right parenthesis,', 'policy)'],
+        ['contains plus', 'policy+'],
+        ['contains equal', 'policy='],
+        ['contains open brace', 'policy{'],
+        ['contains close brace', 'policy}'],
+        ['contains open bracket', 'policy['],
+        ['contains closed bracket', 'policy]'],
+        ['contains pipe', 'policy|'],
+        ['contains backslash', 'policy\\'],
+        ['contains forward slash', 'policy/'],
+        ['contains colon', 'policy:'],
+        ['contains semicolon.', 'policy;'],
+        ['contains quote', 'policy"'],
+        ['contains apostrophe', 'policy\'test'],
+        ['contains less than', 'policy<'],
+        ['contains greater than', 'policy>'],
+        ['contains comma', 'policy,'],
+        ['contains period, dot', 'policy.'],
+        ['contains question mark', 'policy?'],
+        ['contains space', 'policy test1'],
+        ['has mixed alphabet, number, special character', 'policy-test!+ test1']
+      ], function (description: string, input: string) {
+        it(('when the name ' + description), () => {
+          component.onSearchChange(input);
+          expect(component.policyFiles.length).toBe(0);
+        });
+      });
+
+      using([
+        ['contains tilde.', '~'],
+        ['contains acute, back quote,', '`'],
+        ['contains exclamation mark', '!'],
+        ['contains ampersat, at', '@'],
+        ['contains dollar sign', '$'],
+        ['contains percent.', '%'],
+        ['contains caret or circumflex.,', '^'],
+        ['contains ampersand', '&'],
+        ['contains asterisk', '*'],
+        ['contains open or left parenthesis.', '('],
+        ['contains close or right parenthesis,', ')'],
+        ['contains plus', '+'],
+        ['contains equal', '='],
+        ['contains open brace', '{'],
+        ['contains close brace', '}'],
+        ['contains open bracket', '['],
+        ['contains closed bracket', ']'],
+        ['contains pipe', '|'],
+        ['contains backslash', '\\'],
+        ['contains forward slash', '/'],
+        ['contains colon', ':'],
+        ['contains semicolon.', ';'],
+        ['contains quote', '"'],
+        ['contains apostrophe', '\'test'],
+        ['contains less than', '<'],
+        ['contains greater than', '>'],
+        ['contains comma', ','],
+        ['contains period, dot', '.'],
+        ['contains question mark', '?'],
+        ['contains space', '    test1']
+      ], function (description: string, input: string) {
+        it(('when the name only' + description), () => {
+          component.onSearchChange(input);
+          expect(component.policyFiles.length).toBe(0);
+        });
+      });
     });
   });
 });

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.spec.ts
@@ -113,7 +113,7 @@ describe('PolicyGroupsComponent', () => {
         ['has mixed alphabet, number, special character', 'policy-test!+ test1']
       ], function (description: string, input: string) {
         it(('when the name ' + description), () => {
-          component.onSearchChange(input);
+          component.searchPolicyFiles(input);
           expect(component.policyFiles.length).toBe(0);
         });
       });
@@ -151,7 +151,7 @@ describe('PolicyGroupsComponent', () => {
         ['contains space', '    test1']
       ], function (description: string, input: string) {
         it(('when the name only' + description), () => {
-          component.onSearchChange(input);
+          component.searchPolicyFiles(input);
           expect(component.policyFiles.length).toBe(0);
         });
       });

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -33,6 +33,10 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
   public policyFiles: PolicyFile[] = [];
   public policyGroupsListLoading = true;
   public authFailure = false;
+  public searching = false;
+  public searchValue = '';
+  public searchFlag = false;
+  public searchArr;
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -74,5 +78,22 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
       org_id: this.orgId
     };
     this.store.dispatch(new GetPolicyGroups(payload));
+  }
+
+  searchPolicyGroups(searchText: string): void {
+    this.searching = true;
+    this.searchValue = searchText;
+    if (!this.policyFiles || !searchText) {
+      this.searchFlag = false;
+    } else {
+      this.searchArr = this.policyFiles.filter((key) => {
+        this.searchFlag = true;
+        if (key) {
+          return key.policy_group.includes(searchText);
+        }
+      });
+    }
+    this.searching = false;
+    // console.log("this.searchArr -->", this.searchArr);
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -37,6 +37,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
   public searchValue = '';
   public searchFlag = false;
   public searchArr;
+  public list = [];
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -55,6 +56,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, policyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(policyFilesState)) {
         this.policyFiles = policyFilesState;
+        this.list = this.policyFiles;
         this.policyGroupsListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyGroupsListLoading = false;
@@ -80,20 +82,21 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     this.store.dispatch(new GetPolicyGroups(payload));
   }
 
-  searchPolicyGroups(searchText: string): void {
+  onSearchChange(searchText: string): void {
     this.searching = true;
     this.searchValue = searchText;
     if (!this.policyFiles || !searchText) {
       this.searchFlag = false;
     } else {
-      this.searchArr = this.policyFiles.filter((key) => {
+      this.list = [];
+      this.list = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
-          return key.policy_group.includes(searchText);
+          return key.policy_group.includes(this.searchValue);
         }
       });
     }
+    this.searchArr = this.list;
     this.searching = false;
-    // console.log("this.searchArr -->", this.searchArr);
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -89,13 +89,14 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
       this.searchFlag = false;
       this.groupList = this.policyFiles;
     } else {
-      this.groupList = [];
-      this.groupList = this.policyFiles.filter((key) => {
+      let list = [];
+      list = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
           return key.policy_group.includes(this.searchValue);
         }
       });
+      this.groupList = list;
     }
     this.searchArr = this.groupList;
     this.searching = false;

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -89,7 +89,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
       this.searchFlag = false;
       this.groupList = this.policyFiles;
     } else {
-      let list = this.policyFiles.filter((key) => {
+      const list = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
           return key.policy_group.includes(this.searchValue);

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -89,8 +89,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
       this.searchFlag = false;
       this.groupList = this.policyFiles;
     } else {
-      let list = [];
-      list = this.policyFiles.filter((key) => {
+      let list = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
           return key.policy_group.includes(this.searchValue);

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -82,11 +82,12 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     this.store.dispatch(new GetPolicyGroups(payload));
   }
 
-  onSearchChange(searchText: string): void {
+  searchPolicyFiles(searchText: string): void {
     this.searching = true;
     this.searchValue = searchText;
     if (!this.policyFiles || !searchText) {
       this.searchFlag = false;
+      this.list = this.policyFiles;
     } else {
       this.list = [];
       this.list = this.policyFiles.filter((key) => {

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -37,7 +37,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
   public searchValue = '';
   public searchFlag = false;
   public searchArr;
-  public list = [];
+  public groupList = [];
 
   constructor(
     private store: Store<NgrxStateAtom>,
@@ -56,7 +56,7 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     .subscribe(([ getPolicyFilesSt, policyFilesState]) => {
       if (getPolicyFilesSt === EntityStatus.loadingSuccess && !isNil(policyFilesState)) {
         this.policyFiles = policyFilesState;
-        this.list = this.policyFiles;
+        this.groupList = this.policyFiles;
         this.policyGroupsListLoading = false;
       } else if (getPolicyFilesSt === EntityStatus.loadingFailure) {
         this.policyGroupsListLoading = false;
@@ -87,17 +87,17 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     this.searchValue = searchText;
     if (!this.policyFiles || !searchText) {
       this.searchFlag = false;
-      this.list = this.policyFiles;
+      this.groupList = this.policyFiles;
     } else {
-      this.list = [];
-      this.list = this.policyFiles.filter((key) => {
+      this.groupList = [];
+      this.groupList = this.policyFiles.filter((key) => {
         this.searchFlag = true;
         if (key) {
           return key.policy_group.includes(this.searchValue);
         }
       });
     }
-    this.searchArr = this.list;
+    this.searchArr = this.groupList;
     this.searching = false;
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups/policy-groups.component.ts
@@ -35,7 +35,6 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
   public authFailure = false;
   public searching = false;
   public searchValue = '';
-  public searchFlag = false;
   public searchArr;
   public groupList = [];
 
@@ -86,11 +85,9 @@ export class PolicyGroupsComponent implements OnInit, OnDestroy {
     this.searching = true;
     this.searchValue = searchText;
     if (!this.policyFiles || !searchText) {
-      this.searchFlag = false;
       this.groupList = this.policyFiles;
     } else {
       const list = this.policyFiles.filter((key) => {
-        this.searchFlag = true;
         if (key) {
           return key.policy_group.includes(this.searchValue);
         }

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-groups-list.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-groups-list.spec.ts
@@ -10,6 +10,7 @@ describe('infra policy groups', () => {
   const serverIP = '34.219.25.251';
   const adminUser = 'chefadmin';
   const adminKey = Cypress.env('AUTOMATE_INFRA_ADMIN_KEY').replace(/\\n/g, '\n');
+  const policyGroupName = `${cypressPrefix}-policyGroup-${now}-1`;
   let policies: any;
 
   before(() => {
@@ -117,6 +118,26 @@ describe('infra policy groups', () => {
     it('can check if policy group has list or not', () => {
       getPolicyGroups().then((response) => {
         checkResponse(response);
+      });
+    });
+
+    context('can search and change page in policyfile', () => {
+      it('can search a Policyfile and check if empty or not', () => {
+        getPolicyGroups().then((response) => {
+          if (checkResponse(response)) {
+            cy.get('[data-cy=search-filter]').type(policyGroupName);
+            cy.get('[data-cy=search-entity]').click();
+            cy.get('[data-cy=policy-group-table-container]').then(body => {
+              if (body.text().includes(policyGroupName)) {
+                cy.get('[data-cy=policy-group-table-container]')
+                .contains(policyGroupName).should('exist');
+              }
+            });
+
+            cy.get('[data-cy=search-filter]').clear();
+            cy.get('[data-cy=search-entity]').click();
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
Signed-off-by: chaitali-mane cmane@progress.com

### :nut_and_bolt: Description: What code changed, and why?
We need to add search functionality for Policy groups.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5389

### :+1: Definition of Done
Added search bar UI and search functionality for Policy groups.

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
Steps for Policy Groups tab:
Go To Infrastructure -> Chef Servers -> click server name-> click on org name -> Policy Groups tab
Where you can see the search bar UI for a list of groups.

For cypress Build
https://github.com/chef/automate/tree/master/e2e

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![serch_policy_group](https://user-images.githubusercontent.com/71449322/128329765-d63f5e11-d36b-4328-95fe-9d6f38854514.png)

https://user-images.githubusercontent.com/71449322/128356844-7490484a-c2e3-4434-9ff7-54b7dc52efa1.mp4

