### PR TITLE
Change serial number mapping for windows

### DIFF
--- a/components/data-feed-service/service/data-feed-aggregate-task.go
+++ b/components/data-feed-service/service/data-feed-aggregate-task.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"time"
 
@@ -228,6 +229,7 @@ func (d *DataFeedAggregateTask) getNodeData(ctx context.Context, filters []strin
 	nodeDataContent["ipaddress"] = ipaddress
 	nodeDataContent["automate_fqdn"] = d.externalFqdn
 	addDataContent(nodeDataContent, automaticAttrs)
+	fmt.Println(nodeDataContent, ":::::", automaticAttrs)
 	nodeData["node"] = nodeDataContent
 	return nodeData, nil
 }

--- a/components/data-feed-service/service/data-feed-aggregate-task.go
+++ b/components/data-feed-service/service/data-feed-aggregate-task.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"time"
 
@@ -229,7 +228,6 @@ func (d *DataFeedAggregateTask) getNodeData(ctx context.Context, filters []strin
 	nodeDataContent["ipaddress"] = ipaddress
 	nodeDataContent["automate_fqdn"] = d.externalFqdn
 	addDataContent(nodeDataContent, automaticAttrs)
-	fmt.Println(nodeDataContent, ":::::", automaticAttrs)
 	nodeData["node"] = nodeDataContent
 	return nodeData, nil
 }

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -184,20 +184,32 @@ func (client DataClient) sendNotification(notification datafeedNotification) err
 func addDataContent(nodeDataContent map[string]interface{}, attributes map[string]interface{}) {
 	os, _ := attributes["os"].(string)
 	if strings.ToLower(os) == "windows" {
-		kernel, ok := attributes["kernel"].(map[string]interface{})
+		dmi, ok := attributes["dmi"].(map[string]interface{})
 		if !ok {
 			nodeDataContent["serial_number"] = ""
+		}
+		system, ok := dmi["system"].(map[string]interface{})
+		if !ok {
+			nodeDataContent["serial_number"] = ""
+		}
+		serialNumber, ok := system["serial_number"].(string)
+		if !ok {
+			nodeDataContent["serial_number"] = ""
+		}
+
+		nodeDataContent["serial_number"] = serialNumber
+		fmt.Println(nodeDataContent["serial_number"], serialNumber)
+
+		kernel, ok := attributes["kernel"].(map[string]interface{})
+		if !ok {
 			nodeDataContent["os_service_pack"] = ""
-			return
 		}
 
 		osInfo, ok := kernel["os_info"].(map[string]interface{})
 		if !ok {
-			nodeDataContent["serial_number"] = ""
 			nodeDataContent["os_service_pack"] = ""
-			return
 		}
-		nodeDataContent["serial_number"] = osInfo["serial_number"]
+
 		nodeDataContent["os_service_pack"] = ""
 		majorVersion, ok := osInfo["service_pack_major_version"].(float64)
 		if !ok {

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -196,9 +196,7 @@ func addDataContent(nodeDataContent map[string]interface{}, attributes map[strin
 		if !ok {
 			nodeDataContent["serial_number"] = ""
 		}
-
 		nodeDataContent["serial_number"] = serialNumber
-		fmt.Println(nodeDataContent["serial_number"], serialNumber)
 
 		kernel, ok := attributes["kernel"].(map[string]interface{})
 		if !ok {
@@ -209,7 +207,6 @@ func addDataContent(nodeDataContent map[string]interface{}, attributes map[strin
 		if !ok {
 			nodeDataContent["os_service_pack"] = ""
 		}
-
 		nodeDataContent["os_service_pack"] = ""
 		majorVersion, ok := osInfo["service_pack_major_version"].(float64)
 		if !ok {

--- a/components/data-feed-service/service/data-feed-service.go
+++ b/components/data-feed-service/service/data-feed-service.go
@@ -184,30 +184,18 @@ func (client DataClient) sendNotification(notification datafeedNotification) err
 func addDataContent(nodeDataContent map[string]interface{}, attributes map[string]interface{}) {
 	os, _ := attributes["os"].(string)
 	if strings.ToLower(os) == "windows" {
-		dmi, ok := attributes["dmi"].(map[string]interface{})
-		if !ok {
-			nodeDataContent["serial_number"] = ""
-		}
-		system, ok := dmi["system"].(map[string]interface{})
-		if !ok {
-			nodeDataContent["serial_number"] = ""
-		}
-		serialNumber, ok := system["serial_number"].(string)
-		if !ok {
-			nodeDataContent["serial_number"] = ""
+		dmi, _ := attributes["dmi"].(map[string]interface{})
+		system, _ := dmi["system"].(map[string]interface{})
+		serialNumber := system["serial_number"]
+		if serialNumber == nil {
+			serialNumber = ""
 		}
 		nodeDataContent["serial_number"] = serialNumber
 
-		kernel, ok := attributes["kernel"].(map[string]interface{})
-		if !ok {
-			nodeDataContent["os_service_pack"] = ""
-		}
-
-		osInfo, ok := kernel["os_info"].(map[string]interface{})
-		if !ok {
-			nodeDataContent["os_service_pack"] = ""
-		}
+		kernel, _ := attributes["kernel"].(map[string]interface{})
+		osInfo, _ := kernel["os_info"].(map[string]interface{})
 		nodeDataContent["os_service_pack"] = ""
+
 		majorVersion, ok := osInfo["service_pack_major_version"].(float64)
 		if !ok {
 			return

--- a/components/data-feed-service/service/data-feed-service_test.go
+++ b/components/data-feed-service/service/data-feed-service_test.go
@@ -37,7 +37,7 @@ var mockErr = errors.New(mockErrMsg)
 var mockAttrString = "{\"foo\":\"bar\"}"
 var mockAttrs = map[string]string{"foo": "bar"}
 var automaticAttrs = "{\"dmi\":{\"system\":{\"serial_number\":\"serial-number\"}},\"hostname\":\"test.chef.com\",\"hostnamectl\":{\"operating_system\":\"ubuntu\"},\"ipaddress\":\"172.18.2.120\",\"macaddress\":\"00:1C:42:C1:2D:87\",\"os\":\"linux\",\"os_version\":\"4.13.0-45-generic\"}"
-var automaticAttrsWin = "{\"os\":\"windows\",\"kernel\":{\"os_info\":{\"serial_number\":\"serial-number\",\"service_pack_major_version\":2,\"service_pack_minor_version\":1}},\"dmi\":{\"system\":{\"serial_number\":\"\"}},\"hostname\":\"test.chef.com\",\"ipaddress\":\"172.18.2.120\",\"macaddress\":\"00:1C:42:C1:2D:87\"}"
+var automaticAttrsWin = "{\"os\":\"windows\",\"kernel\":{\"os_info\":{\"serial_number\":\"serial-number\",\"service_pack_major_version\":2,\"service_pack_minor_version\":1}},\"dmi\":{\"system\":{\"serial_number\":\"serial-number\"}},\"hostname\":\"test.chef.com\",\"ipaddress\":\"172.18.2.120\",\"macaddress\":\"00:1C:42:C1:2D:87\"}"
 var mockConfig = &config.DataFeedConfig{}
 var acceptedStatusCodes []int32 = []int32{200, 201, 202, 203, 204}
 var mockCredentials = NewBasicAuthCredentials("user", "pass")
@@ -385,15 +385,23 @@ func TestAddDataContentWindows(t *testing.T) {
 	attributes := make(map[string]interface{})
 	attributes["os"] = "windows"
 	kernel := make(map[string]interface{})
+	dmi := make(map[string]interface{})
+
+	system := make(map[string]interface{})
+	system["serial_number"] = serialNumber
+	dmi["system"] = system
+
 	osInfo := make(map[string]interface{})
 	osInfo["serial_number"] = serialNumber
 	osInfo["service_pack_major_version"] = servicePackMajorVersion
 	osInfo["service_pack_minor_version"] = servicePackMinorVersion
 	kernel["os_info"] = osInfo
 	attributes["kernel"] = kernel
+	attributes["dmi"] = dmi
 
 	nodeDataContent := make(map[string]interface{})
 
+	t.Log(attributes)
 	addDataContent(nodeDataContent, attributes)
 	if len(nodeDataContent) != 2 {
 		t.Log("expected nodeDataContent to have length 2")
@@ -418,6 +426,12 @@ func TestAddDataContentWindowsNoSPMajorVer(t *testing.T) {
 	osInfo["service_pack_minor_version"] = servicePackMinorVersion
 	kernel["os_info"] = osInfo
 	attributes["kernel"] = kernel
+
+	dmi := make(map[string]interface{})
+	system := make(map[string]interface{})
+	system["serial_number"] = serialNumber
+	dmi["system"] = system
+	attributes["dmi"] = dmi
 
 	nodeDataContent := make(map[string]interface{})
 
@@ -445,6 +459,12 @@ func TestAddDataContentWindowsNoSPMinorVer(t *testing.T) {
 	osInfo["service_pack_major_version"] = servicePackMajorVersion
 	kernel["os_info"] = osInfo
 	attributes["kernel"] = kernel
+
+	dmi := make(map[string]interface{})
+	system := make(map[string]interface{})
+	system["serial_number"] = serialNumber
+	dmi["system"] = system
+	attributes["dmi"] = dmi
 
 	nodeDataContent := make(map[string]interface{})
 

--- a/components/data-feed-service/service/data-feed-service_test.go
+++ b/components/data-feed-service/service/data-feed-service_test.go
@@ -392,7 +392,6 @@ func TestAddDataContentWindows(t *testing.T) {
 	dmi["system"] = system
 
 	osInfo := make(map[string]interface{})
-	osInfo["serial_number"] = serialNumber
 	osInfo["service_pack_major_version"] = servicePackMajorVersion
 	osInfo["service_pack_minor_version"] = servicePackMinorVersion
 	kernel["os_info"] = osInfo
@@ -455,7 +454,6 @@ func TestAddDataContentWindowsNoSPMinorVer(t *testing.T) {
 	attributes["os"] = "windows"
 	kernel := make(map[string]interface{})
 	osInfo := make(map[string]interface{})
-	osInfo["serial_number"] = serialNumber
 	osInfo["service_pack_major_version"] = servicePackMajorVersion
 	kernel["os_info"] = osInfo
 	attributes["kernel"] = kernel
@@ -483,10 +481,59 @@ func TestAddDataContentWindowsNoSPMinorVer(t *testing.T) {
 	}
 }
 
-func TestAddDataContentWindowsEmptyKernel(t *testing.T) {
+func TestAddDataContentWindowsEmptyKernelAndEmptyDmi(t *testing.T) {
 	attributes := make(map[string]interface{})
 	attributes["os"] = "windows"
 	attributes["kernel"] = make(map[string]interface{})
+	attributes["dmi"] = make(map[string]interface{})
+	nodeDataContent := make(map[string]interface{})
+
+	addDataContent(nodeDataContent, attributes)
+	if len(nodeDataContent) != 2 {
+		t.Log("expected nodeDataContent to have length 2")
+		t.Fail()
+	}
+	if nodeDataContent["serial_number"].(string) != "" {
+		t.Logf("expected serial number %s, got %v", "", nodeDataContent["serial_number"])
+		t.Fail()
+	}
+	if nodeDataContent["os_service_pack"].(string) != "" {
+		t.Logf("expected service pack '', got %v", nodeDataContent["os_service_pack"])
+		t.Fail()
+	}
+}
+
+func TestAddDataContentWindowsEmptyOsinfo(t *testing.T) {
+	attributes := make(map[string]interface{})
+	attributes["os"] = "windows"
+	kernel := make(map[string]interface{})
+	osInfo := make(map[string]interface{})
+	kernel["os_info"] = osInfo
+	attributes["kernel"] = kernel
+	nodeDataContent := make(map[string]interface{})
+
+	addDataContent(nodeDataContent, attributes)
+	if len(nodeDataContent) != 2 {
+		t.Log("expected nodeDataContent to have length 2")
+		t.Fail()
+	}
+	if nodeDataContent["serial_number"].(string) != "" {
+		t.Logf("expected serial number %s, got %v", "", nodeDataContent["serial_number"])
+		t.Fail()
+	}
+	if nodeDataContent["os_service_pack"].(string) != "" {
+		t.Logf("expected service pack '', got %v", nodeDataContent["os_service_pack"])
+		t.Fail()
+	}
+}
+
+func TestAddDataContentWindowsEmptySystem(t *testing.T) {
+	attributes := make(map[string]interface{})
+	attributes["os"] = "windows"
+	dmi := make(map[string]interface{})
+	system := make(map[string]interface{})
+	dmi["system"] = system
+	attributes["dmi"] = dmi
 	nodeDataContent := make(map[string]interface{})
 
 	addDataContent(nodeDataContent, attributes)


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
We get the Serial Number in this json path: 
`attributes` -> `automatic` -> `dmi` -> `system` -> `serial_number`
Which is used by Chef Automate 2 to populate `node` -> `serial_number`
Earlier Chef Automate 2 reads value for Windows Platform from this location : 
`attributes` -> `automatic` -> `kernel` -> `os_info` -> `serial_number` 
which contains windows os installation disk serial number. 
And this is used to populate `node` -> `serial_number`.
For case of Chef Infra Client version 12.x, it doesn't have `attributes` -> `automatic` -> `dmi` data populated, then we should not populate any value for serial number in this location: `node` -> `serial_number` and keep it empty ("").

### :chains: Related Resources
https://github.com/chef/automate/issues/5430

### :+1: Definition of Done

Chef Automate 2 should read value from `attributes` -> `automatic` -> `dmi` -> `system` -> `serial_number`
and populate to `node` -> `serial_number`.
If it is not found then `node` -> `serial_number` should be "".

### :athletic_shoe: How to Build and Test the Change
- `rebuild components/data-feed-service`
- Run Client Run using Chef Infra Client version 16+ on windows platform which sends data to Chef Automate 2.
- Check the data received in Chef Automate 2 for this Client Run.
- Run Client Run using Chef Infra Client version 12+ on windows platform which sends data to Chef Automate 2.
- Check the data received in Chef Automate 2 for this Client Run.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) - not required as it was already present
- [ ] Docs added/updated? (all customer-facing changes) - not required as it was a bug

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
