### PR TITLE
Fix another place where Policyfile needs to be a single word

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/included-policies-details/included-policies-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/included-policies-details/included-policies-details.component.html
@@ -36,7 +36,7 @@
       </div>
     </div>
     <div class="sidenav-body" *ngIf="!error">
-      <p class="policy-file-info" data-cy="policyfile-info">POLICY FILE INFORMATION</p>
+      <p class="policy-file-info" data-cy="policyfile-info">POLICYFILE INFORMATION</p>
       <table summary="Policy file information">
         <tr>
           <th id="revision-id" class="revision-id">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -19,7 +19,7 @@
             <table summary="Policy file information">
               <tr>
                 <th id="information" colspan="2">
-                  <p class="meta-head">POLICY FILE INFORMATION</p>
+                  <p class="meta-head">POLICYFILE INFORMATION</p>
                 </th>
               </tr>
               <tr>

--- a/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-details.spec.ts
+++ b/e2e/cypress/integration/ui/infra-proxy/infra-policy-file-details.spec.ts
@@ -136,7 +136,7 @@ describe('infra policy details', () => {
       cy.get('[data-cy=close-policy-button]').click();
     } else {
       cy.get('[data-cy=policyfile-heading]').contains(includedPolicyFileName);
-      cy.get('[data-cy=policyfile-info]').contains('POLICY FILE INFORMATION');
+      cy.get('[data-cy=policyfile-info]').contains('POLICYFILE INFORMATION');
       cy.get('[data-cy=policyfile-meta-info]').contains('METADATA');
       return true;
     }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The Policyfiles detail page incorrectly has POLICY FILE. This fixes it to POLICYFILE

Before:

<img width="1007" alt="Screen Shot 2021-08-06 at 8 21 41 AM" src="https://user-images.githubusercontent.com/1015200/128533834-f254e2fd-581e-4294-94cd-82277f8da098.png">

### :chains: Related Resources

### :+1: Definition of Done

Correct branding in the UI

### :athletic_shoe: How to Build and Test the Change

Great question

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
