### PR TITLE
Fix Chef Server -> Chef Infra Server branding

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/included-policies-details/included-policies-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/included-policies-details/included-policies-details.component.html
@@ -47,11 +47,11 @@
       </table>
       <p class="policy-file-info meta-info" data-cy="policyfile-meta-info">METADATA</p>
       <div class="policy-file">
-        <div>Chef Server</div>
+        <div>Chef Infra Server</div>
         <p class="server-id-info">{{serverId}}</p>
       </div>
       <div class="policy-file">
-        <div> Chef Organization</div>
+        <div>Chef Infra Organization</div>
         <p class="org-id-info">{{orgId}}</p>
       </div>
       <div class="bottom">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -37,7 +37,7 @@
               </tr>
               <tr>
                 <th id="chef-server">
-                  Chef Server
+                  Chef Infra Server
                 </th>
                 <td data-cy="policy-file-server">
                   {{serverId}}
@@ -45,7 +45,7 @@
               </tr>
               <tr>
                 <th id="chef-organization">
-                  Chef Organization
+                  Chef Infra Organization
                 </th>
                 <td data-cy="policy-file-org">
                   {{orgId}}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Make sure we use Chef Infra instead of Chef in some Policyfiles details pages.

Before:

<img width="1007" alt="Screen Shot 2021-08-06 at 8 21 41 AM" src="https://user-images.githubusercontent.com/1015200/128538486-56ac1c68-9178-49f3-895c-5a148a3a09d5.png">

### :chains: Related Resources

### :+1: Definition of Done

Branding for products is correct.

### :athletic_shoe: How to Build and Test the Change

???

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
