### PR TITLE
Capitalize clients to match other breadcrumbs

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
@@ -4,7 +4,7 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Orgs</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">clients</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Clients</chef-breadcrumb>
          {{client?.name}}
       </chef-breadcrumbs>
       <chef-page-header>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The breadcrumbs are all capitalized except for clients, which is kinda
weird.

Before: 
<img width="466" alt="Screen Shot 2021-08-09 at 11 02 40 PM" src="https://user-images.githubusercontent.com/1015200/128816572-73caee25-0384-4cfa-a711-e4ceb673d0cc.png">


### :chains: Related Resources

### :+1: Definition of Done

It's consistent

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
