### PR TITLE
Fix hardened  image to allow chef-ci to login

### DIFF
--- a/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
+++ b/terraform/test-environments/modules/chef_automate_install/templates/install_chef_automate_cli.sh.tpl
@@ -301,3 +301,10 @@ chef-ci ALL=(ALL) NOPASSWD:ALL
 EOH
 sudo mv /tmp/chef-ci-sudoer /etc/sudoers.d/10-chef-ci
 sudo chmod 0440 /etc/sudoers.d/10-chef-ci
+
+# Add chef-ci to sshd_config in hardened image
+if [[ "${hardened_security}" == "true" ]]; then
+    sudo sed  -i -r "s/^AllowUsers (.*)/AllowUsers \\1 chef-ci/" /etc/ssh/sshd_config
+    sudo chmod 0644  /etc/ssh/sshd_config
+    sudo systemctl restart sshd.service
+fi


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Post Merge is failing because chef-ci cannot log into the VM  due to ssh being configured with AllowUsers and not included chef-ci user.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
