### PR TITLE
change default setting for time format for user settings

### DIFF
--- a/components/user-settings-service/pkg/storage/postgres/schema/sql/02_user_settings.up.sql
+++ b/components/user-settings-service/pkg/storage/postgres/schema/sql/02_user_settings.up.sql
@@ -1,0 +1,17 @@
+UPDATE user_settings
+SET settings = '{
+          "date_format": {
+            "default_value": "ddd, DD MMM YYYY HH:mm:ss [UTC]",
+            "value": "ddd, DD MMM YYYY HH:mm:ss [UTC]",
+            "enabled": true,
+            "valid_values": [
+              "ddd, DD MMM YYYY HH:mm:ss [UTC]",
+              "YYYY-M-D",
+              "ddd, DD MMM YYYY",
+              "DD MMM YYYY",
+              "ddd, DD MMM",
+              "YYYY-MM-DD"
+            ]
+          }
+        }'
+WHERE user_name='_default' AND connector='local';


### PR DESCRIPTION
Signed-off-by: Rick Marry <rick.marry@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
**from hab:**
`rebuild components/user-settings-service`
`chef-automate dev psql postgres`
**then from psql:**
`\c chef_user_settings_service`
`select * from user_settings;`

_default val should be:_
`"default_value": "ddd, DD MMM YYYY HH:mm:ss [UTC]",`
_value should be:_
`"value": "ddd, DD MMM YYYY HH:mm:ss [UTC]",`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
