### PR TITLE
Modifying some pipeline scripts to account for new "main" branch

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,11 +5,11 @@ set -eu
 docker ps || true
 free -m
 
-# We've now seen cases where origin/master on the build hosts can get
+# We've now seen cases where origin/main on the build hosts can get
 # out of date. This causes us to build components unnecessarily.
 # Fetching it here hopefully will prevent this situation.
-echo "Fetching origin/master"
-git fetch origin master
+echo "Fetching origin/main"
+git fetch origin main
 
 # DEBUGGING FOR RELENG
 # Fetch the git tags to see if that addresses the weird smart build behavior for Habitat

--- a/.expeditor/buildkite/semgrep.sh
+++ b/.expeditor/buildkite/semgrep.sh
@@ -12,12 +12,12 @@ export SEMGREP_JOB_URL=$BUILDKITE_BUILD_URL
 export SEMGREP_REPO_URL=https://github.com/chef/automate
 
 BASELINE=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-MERGE_BASE=$(git merge-base "${BASELINE:-master}" HEAD)
-if [ "$SEMGREP_BRANCH" == "master" ] ; then
-  echo "build on master; using 'master~1' as base branch" && BASELINE=master~1
-elif [ "$SEMGREP_BRANCH" != "master" ] && [ -n "$BASELINE" ] ; then
+MERGE_BASE=$(git merge-base "${BASELINE:-main}" HEAD)
+if [ "$SEMGREP_BRANCH" == "main" ] ; then
+  echo "build on main; using 'main~1' as base branch" && BASELINE=main~1
+elif [ "$SEMGREP_BRANCH" != "main" ] && [ -n "$BASELINE" ] ; then
   echo "PR build on '$SEMGREP_BRANCH' branch; base is $MERGE_BASE (merge-base of '$BASELINE')" && BASELINE=$MERGE_BASE
-elif [ "$SEMGREP_BRANCH" != "master" ] && [ -z "$BASELINE" ] ; then
-  echo "manual build on '$SEMGREP_BRANCH' branch; using merge-base of master as base ($MERGE_BASE)" && BASELINE=$MERGE_BASE
+elif [ "$SEMGREP_BRANCH" != "main" ] && [ -z "$BASELINE" ] ; then
+  echo "manual build on '$SEMGREP_BRANCH' branch; using merge-base of main as base ($MERGE_BASE)" && BASELINE=$MERGE_BASE
 fi
 python -m semgrep_agent --publish-token "$SEMGREP_TOKEN" --publish-deployment "$SEMGREP_ID" --baseline-ref "$BASELINE"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Modifying some pipeline scripts to account for new "main" branch

master branch was renamed to main today
