### PR TITLE
Moving the chef repo dependencies of workflow server from master to main

### DIFF
--- a/components/automate-workflow-server/rebar.config
+++ b/components/automate-workflow-server/rebar.config
@@ -32,7 +32,7 @@
          {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
 
         {sqerl, ".*",
-         {git, "https://github.com/chef/sqerl.git", {branch, "master"}}},
+         {git, "https://github.com/chef/sqerl.git", {branch, "main"}}},
 
         {erlpass, ".*",
          {git, "https://github.com/ferd/erlpass.git", {tag, "1.0.3"}}},
@@ -61,10 +61,10 @@
 
         %% chef_req uses SSH url for chef_authn
         {chef_authn, ".*",
-         {git, "https://github.com/chef/chef_authn.git", {branch, "master"}}},
+         {git, "https://github.com/chef/chef_authn.git", {branch, "main"}}},
 
         {chef_req, ".*",
-         {git, "https://github.com/chef/chef_req.git", {branch, "master"}}},
+         {git, "https://github.com/chef/chef_req.git", {branch, "main"}}},
 
         {erlware_commons, ".*",
          {git, "https://github.com/erlware/erlware_commons.git",


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Buildkite is failing to build the workflow server package since some of the dependencies maintained by chef have moved from master to main

### :chains: Related Resources

### :+1: Definition of Done
- Tried  running the build on buildkite for the branch and it build successfully. 
https://buildkite.com/chef/chef-automate-main-habitat-build/builds?branch=kallol%2Ffix_git_dependency_workflow

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
