### PR TITLE
5503 a2ha command mapping

### DIFF
--- a/components/automate-cli/cmd/chef-automate/secrets-ha-template.go
+++ b/components/automate-cli/cmd/chef-automate/secrets-ha-template.go
@@ -1,0 +1,27 @@
+package main
+
+var secretsHelpDocs = `
+Usage:
+    chef-automate secrets SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                       subcommand
+    [ARG] ...                        subcommand arguments
+
+Subcommands:
+    init                             Generate a new secrets key used to encrypt the secret store.
+    set                              Add a new secrets: for more info use 'secrets set --help'
+    show                             Show existing secrets: for more info use 'secrets show --help'
+    delete                           Delete existing secrets: for more info use 'secrets delete --help'
+
+Args:
+	automate_admin_password			Set automate admin password
+	sudo_password					Set sudo password to login in machines
+	fe_sudo_password				Set different sudo password for frontend machines
+	be_sudo_password				Set different sudo password for bacend machines
+
+Options:
+    -h, --help                       print help
+    -v, --verbose                    Enable verbose output
+    -c, --config-file CONFIG_FILE    Load settings from config file (default: "a2ha.rb")
+`

--- a/components/automate-cli/cmd/chef-automate/secrets-ha.go
+++ b/components/automate-cli/cmd/chef-automate/secrets-ha.go
@@ -50,7 +50,7 @@ func executeSecretCommand(args []string) error {
 		writer.Printf(stderr.String())
 		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+secretsHelpDocs)
 	}
-	writer.Print(string(out.String()))
+	writer.Print(out.String())
 	writer.Printf("A2HA new secret set. %d, exiting\n", c.Process.Pid)
 	return err
 }

--- a/components/automate-cli/cmd/chef-automate/secrets-ha.go
+++ b/components/automate-cli/cmd/chef-automate/secrets-ha.go
@@ -1,0 +1,52 @@
+// Copyright © 2017 Chef Software
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	secretsCmd.SetUsageTemplate(secretsHelpDocs)
+	RootCmd.AddCommand(secretsCmd)
+}
+
+var secretsCmd = &cobra.Command{
+	Use:   "secrets",
+	Short: "set secrets to automate HA",
+	Long:  "set secrets for automate sudo password and admin password in HA mode.",
+	Annotations: map[string]string{
+		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
+	},
+	Args: cobra.RangeArgs(0, 2),
+	RunE: runSecretsConfigCmd,
+}
+
+func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
+	return executeSecretCommand(args)
+}
+
+func executeSecretCommand(args []string) error {
+	writer.Printf("setting A2HA secrets \n")
+	args = append([]string{"secrets"}, args...)
+	c := exec.Command("automate-cluster-ctl", args...)
+	c.Dir = "/hab/a2_deploy_workspace"
+	c.Stdin = os.Stdin
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		writer.Printf(err.Error())
+		return status.Wrap(err, status.CommandExecutionError, stderr.String())
+	}
+	writer.Print(string(out.String()))
+	writer.Printf("A2HA new secret set. %d, exiting\n", c.Process.Pid)
+	return err
+}

--- a/components/automate-cli/cmd/chef-automate/secrets-ha.go
+++ b/components/automate-cli/cmd/chef-automate/secrets-ha.go
@@ -32,6 +32,10 @@ func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
 }
 
 func executeSecretCommand(args []string) error {
+	if len(args) == 0 {
+		writer.Print("please refer \n" + secretsHelpDocs)
+		return nil
+	}
 	writer.Printf("setting A2HA secrets \n")
 	args = append([]string{"secrets"}, args...)
 	c := exec.Command("automate-cluster-ctl", args...)
@@ -43,8 +47,8 @@ func executeSecretCommand(args []string) error {
 	c.Stderr = &stderr
 	err := c.Run()
 	if err != nil {
-		writer.Printf(err.Error())
-		return status.Wrap(err, status.CommandExecutionError, stderr.String())
+		writer.Printf(stderr.String())
+		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+secretsHelpDocs)
 	}
 	writer.Print(string(out.String()))
 	writer.Printf("A2HA new secret set. %d, exiting\n", c.Process.Pid)

--- a/components/automate-cli/cmd/chef-automate/workspace-ha-template.go
+++ b/components/automate-cli/cmd/chef-automate/workspace-ha-template.go
@@ -1,0 +1,20 @@
+package main
+
+var workspaceCommandHelpDocs = `
+Usage:
+    chef-automate [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                       subcommand
+    [ARG] ...                        subcommand arguments
+
+Subcommands:
+    setup                            Setup a new workspace
+    update                           Update existing workspace
+    export                           Export workspace bundle for use in other environments
+
+Options:
+    -h, --help                       print help
+    -v, --verbose                    Enable verbose output
+    -c, --config-file CONFIG_FILE    Load settings from config file (default: "a2ha.rb")
+`

--- a/components/automate-cli/cmd/chef-automate/workspace-ha.go
+++ b/components/automate-cli/cmd/chef-automate/workspace-ha.go
@@ -1,0 +1,56 @@
+// Copyright © 2017 Chef Software
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	workspaceCmd.SetUsageTemplate(workspaceCommandHelpDocs)
+	RootCmd.AddCommand(workspaceCmd)
+}
+
+var workspaceCmd = &cobra.Command{
+	Use:   "workspace",
+	Short: "set workspace env for automate HA.",
+	Long:  "set up automate ha cluster workspace.",
+	Annotations: map[string]string{
+		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
+	},
+	Args: cobra.RangeArgs(0, 2),
+	RunE: runWorkspaceCmd,
+}
+
+func runWorkspaceCmd(cmd *cobra.Command, args []string) error {
+	return executeWorkspaceCommand(args)
+}
+
+func executeWorkspaceCommand(args []string) error {
+	if len(args) == 0 {
+		writer.Print("please refer \n" + workspaceCommandHelpDocs)
+		return nil
+	}
+	writer.Printf("setting automate HA cluster workspace \n")
+	args = append([]string{"workspace"}, args...)
+	c := exec.Command("automate-cluster-ctl", args...)
+	c.Dir = "/hab/a2_deploy_workspace"
+	c.Stdin = os.Stdin
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		writer.Printf(stderr.String())
+		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+workspaceCommandHelpDocs)
+	}
+	writer.Print(string(out.String()))
+	writer.Printf("workspace cluster setup done. %d, exiting\n", c.Process.Pid)
+	return err
+}

--- a/components/automate-cli/cmd/chef-automate/workspace-ha.go
+++ b/components/automate-cli/cmd/chef-automate/workspace-ha.go
@@ -50,7 +50,7 @@ func executeWorkspaceCommand(args []string) error {
 		writer.Printf(stderr.String())
 		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+workspaceCommandHelpDocs)
 	}
-	writer.Print(string(out.String()))
+	writer.Print(out.String())
 	writer.Printf("workspace cluster setup done. %d, exiting\n", c.Process.Pid)
 	return err
 }

--- a/components/compliance-service/habitat/plan.sh
+++ b/components/compliance-service/habitat/plan.sh
@@ -46,7 +46,7 @@ else
   # WARNING: chef/automate-compliance-profiles is managed by Expeditor
   # See .expeditor/update-compliance-profiles.sh for details
   pkg_deps+=(
-      chef/automate-compliance-profiles/1.0.0/20210823105624
+      chef/automate-compliance-profiles/1.0.0/20210826044912
   )
 fi
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Mapping of Workspace, secrets, help command in automate from A2HA

Usage:
    chef-automate secrets SUBCOMMAND [ARG] ...
Parameters:
    SUBCOMMAND                       subcommand
    [ARG] ...                        subcommand arguments
Subcommands:
    init                             Generate a new secrets key used to encrypt the secret store.
    set                              Add a new secrets: for more info use 'secrets set --help'
    show                             Show existing secrets: for more info use 'secrets show --help'
    delete                           Delete existing secrets: for more info use 'secrets delete --help'
Args:
	automate_admin_password			Set automate admin password
	sudo_password					Set sudo password to login in machines
	fe_sudo_password				Set different sudo password for frontend machines
	be_sudo_password				Set different sudo password for bacend machines
Options:
    -h, --help                       print help
    -v, --verbose                    Enable verbose output
    -c, --config-file CONFIG_FILE    Load settings from config file (default: "a2ha.rb")





Usage:
    chef-automate [OPTIONS] SUBCOMMAND [ARG] ...
Parameters:
    SUBCOMMAND                       subcommand
    [ARG] ...                        subcommand arguments
Subcommands:
    setup                            Setup a new workspace
    update                           Update existing workspace
    export                           Export workspace bundle for use in other environments
Options:
    -h, --help                       print help
    -v, --verbose                    Enable verbose output
    -c, --config-file CONFIG_FILE    Load settings from config file (default: "a2ha.rb")





<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/5503

### :+1: Definition of Done

written codes, done developer testing of commands

### :athletic_shoe: How to Build and Test the Change

rebuild components/automate-cli/

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
