### PR TITLE
Adding arbitrary host header check for Http connection

### DIFF
--- a/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
+++ b/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
@@ -1,0 +1,7 @@
+map $http_host $istrusted {
+    default false;
+    "localhost" true;
+    "127.0.0.1" true;
+    {{ cfg.service.external_fqdn }} true;
+}
+

--- a/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
+++ b/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
@@ -1,9 +1,5 @@
 map $http_host $istrusted {
- 
     default false;
 
-    localhost true;
-    127.0.0.1 true;
     {{ cfg.service.external_fqdn }} true;
-
 }

--- a/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
+++ b/components/automate-load-balancer/habitat/config/automate-host-header-validation.conf
@@ -1,7 +1,9 @@
 map $http_host $istrusted {
+ 
     default false;
-    "localhost" true;
-    "127.0.0.1" true;
-    {{ cfg.service.external_fqdn }} true;
-}
 
+    localhost true;
+    127.0.0.1 true;
+    {{ cfg.service.external_fqdn }} true;
+
+}

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -92,6 +92,7 @@ http {
   }
 
   include {{pkg.svc_config_path}}/*upstream.conf;
+  include {{pkg.svc_config_path}}/automate-host-header-validation.conf;
 
   server {
     {{#if cfg.ngx.http.ipv6_supported ~}}
@@ -100,6 +101,11 @@ http {
     listen {{ cfg.service.http_port }};
     {{/if ~}}
     server_name {{ cfg.service.external_fqdn }} default;
+
+    if ($istrusted = false){
+       return 403;
+    }
+
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header x-xss-protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -158,6 +164,10 @@ http {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options DENY;
+
+    if ($istrusted = false){
+       return 403;
+    }
 
     {{#if ../cfg.service.maintenance_mode ~}}
     error_page 503 /maintenance.html;

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -101,11 +101,9 @@ http {
     listen {{ cfg.service.http_port }};
     {{/if ~}}
     server_name {{ cfg.service.external_fqdn }} default;
-
     if ($istrusted = false){
        return 403;
     }
-
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header x-xss-protection "1; mode=block" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -123,6 +121,9 @@ http {
     listen {{ ../cfg.service.https_port }} http2 ssl;
     {{/if ~}}
     server_name {{tls.server_name}};
+    if ($istrusted = false){
+       return 403;
+    }
 
     ssl_certificate {{../pkg.svc_data_path}}/{{tls.server_name}}.cert;
     ssl_certificate_key {{../pkg.svc_data_path}}/{{tls.server_name}}.key;
@@ -164,10 +165,6 @@ http {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options DENY;
-
-    if ($istrusted = false){
-       return 403;
-    }
 
     {{#if ../cfg.service.maintenance_mode ~}}
     error_page 503 /maintenance.html;

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -121,9 +121,6 @@ http {
     listen {{ ../cfg.service.https_port }} http2 ssl;
     {{/if ~}}
     server_name {{tls.server_name}};
-    if ($istrusted = false){
-       return 403;
-    }
 
     ssl_certificate {{../pkg.svc_data_path}}/{{tls.server_name}}.cert;
     ssl_certificate_key {{../pkg.svc_data_path}}/{{tls.server_name}}.key;

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -121,6 +121,9 @@ http {
     listen {{ ../cfg.service.https_port }} http2 ssl;
     {{/if ~}}
     server_name {{tls.server_name}};
+    if ($istrusted = false){
+       return 403;
+    }
 
     ssl_certificate {{../pkg.svc_data_path}}/{{tls.server_name}}.cert;
     ssl_certificate_key {{../pkg.svc_data_path}}/{{tls.server_name}}.key;

--- a/components/automate-ui/src/app/entities/destinations/destination.actions.ts
+++ b/components/automate-ui/src/app/entities/destinations/destination.actions.ts
@@ -166,21 +166,6 @@ export class EnableDisableDestinationFailure implements Action {
 
 
 
-export class EnableDisableDestination implements Action {
-  readonly type = DestinationActionTypes.ENABLE_DISABLE;
-  constructor(public payload: { enableDisable: EnableDestination }) { }
-}
-
-export class EnableDisableDestinationSuccess implements Action {
-  readonly type = DestinationActionTypes.ENABLE_DISABLE_SUCCESS;
-  constructor(public payload) { }
-}
-export class EnableDisableDestinationFailure implements Action {
-  readonly type = DestinationActionTypes.ENABLE_DISABLE_FAILURE;
-  constructor(public payload: HttpErrorResponse) { }
-}
-
-
 export type DestinationActions =
   | GetDestinations
   | GetDestinationsSuccess

--- a/components/automate-ui/src/app/entities/destinations/destination.actions.ts
+++ b/components/automate-ui/src/app/entities/destinations/destination.actions.ts
@@ -166,6 +166,21 @@ export class EnableDisableDestinationFailure implements Action {
 
 
 
+export class EnableDisableDestination implements Action {
+  readonly type = DestinationActionTypes.ENABLE_DISABLE;
+  constructor(public payload: { enableDisable: EnableDestination }) { }
+}
+
+export class EnableDisableDestinationSuccess implements Action {
+  readonly type = DestinationActionTypes.ENABLE_DISABLE_SUCCESS;
+  constructor(public payload) { }
+}
+export class EnableDisableDestinationFailure implements Action {
+  readonly type = DestinationActionTypes.ENABLE_DISABLE_FAILURE;
+  constructor(public payload: HttpErrorResponse) { }
+}
+
+
 export type DestinationActions =
   | GetDestinations
   | GetDestinationsSuccess


### PR DESCRIPTION
Signed-off-by: Mansoor <mchengat@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?

Attackers can use DNS Rebinding to bypass any IP or firewall based access restrictions that may be in place, by proxying through their target's browser. 

### :chains: Related Resources
https://github.com/chef/automate/issues/4850

### :+1: Definition of Done
Added validation of  Host HTTP header for  the incoming requests. 

### :athletic_shoe: How to Build and Test the Change
* Clone the PR changes
* Enter hab studio using hab studio enter
* rebuild components/automate-load-balancer
* Add multiple hostnames to /etc/hosts file and try sending a request to 80/443.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
