### PR TITLE
Adding chef server using FQDN or IP address

### DIFF
--- a/components/infra-proxy-service/server/servers.go
+++ b/components/infra-proxy-service/server/servers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	"github.com/chef/automate/api/interservice/infra_proxy/request"
 	"github.com/chef/automate/api/interservice/infra_proxy/response"
@@ -16,15 +17,22 @@ func (s *Server) CreateServer(ctx context.Context, req *request.CreateServer) (*
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Validate all request fields are required
+	// Validate Name and ID are required.
 	err := validation.New(validation.Options{
-		Target:          "server",
-		Request:         *req,
-		RequiredDefault: true,
+		Target:  "server",
+		Request: *req,
+		Rules: validation.Rules{
+			"Id":   []string{"required"},
+			"Name": []string{"required"},
+		},
 	}).Validate()
 
 	if err != nil {
 		return nil, err
+	}
+
+	if req.Fqdn == "" && req.IpAddress == "" {
+		return nil, errors.New("FQDN or IP required to add the server.")
 	}
 
 	server, err := s.service.Storage.StoreServer(ctx, req.Id, req.Name, req.Fqdn, req.IpAddress)

--- a/components/infra-proxy-service/server/servers.go
+++ b/components/infra-proxy-service/server/servers.go
@@ -119,13 +119,20 @@ func (s *Server) UpdateServer(ctx context.Context, req *request.UpdateServer) (*
 
 	// Validate all request fields are required
 	err := validation.New(validation.Options{
-		Target:          "server",
-		Request:         *req,
-		RequiredDefault: true,
+		Target:  "server",
+		Request: *req,
+		Rules: validation.Rules{
+			"Id":   []string{"required"},
+			"Name": []string{"required"},
+		},
 	}).Validate()
 
 	if err != nil {
 		return nil, err
+	}
+
+	if req.Fqdn == "" && req.IpAddress == "" {
+		return nil, errors.New("FQDN or IP required to update the server.")
 	}
 
 	server, err := s.service.Storage.EditServer(ctx, req.Id, req.Name, req.Fqdn, req.IpAddress)

--- a/components/infra-proxy-service/server/servers_test.go
+++ b/components/infra-proxy-service/server/servers_test.go
@@ -105,27 +105,6 @@ func TestServers(t *testing.T) {
 			grpctest.AssertCode(t, codes.InvalidArgument, err)
 		})
 
-		t.Run("when the server fqdn is missing, raise invalid argument error", func(t *testing.T) {
-			resp, err := cl.CreateServer(ctx, &request.CreateServer{
-				Id:        "chef-infra-server",
-				Name:      "Chef infra server",
-				IpAddress: "0.0.0.0",
-			})
-			assert.Nil(t, resp)
-			assert.Error(t, err, "must supply server fqdn")
-			grpctest.AssertCode(t, codes.InvalidArgument, err)
-		})
-
-		t.Run("when the server IP address is missing, raise invalid argument error", func(t *testing.T) {
-			resp, err := cl.CreateServer(ctx, &request.CreateServer{
-				Id:   "chef-infra-server",
-				Name: "Chef infra server",
-				Fqdn: "domain.com",
-			})
-			assert.Nil(t, resp)
-			assert.Error(t, err, "must supply server IP address")
-			grpctest.AssertCode(t, codes.InvalidArgument, err)
-		})
 	})
 
 	t.Run("GetServers", func(t *testing.T) {
@@ -440,28 +419,6 @@ func TestServers(t *testing.T) {
 			})
 			assert.Nil(t, resp)
 			assert.Error(t, err, "must supply server name")
-			grpctest.AssertCode(t, codes.InvalidArgument, err)
-		})
-
-		t.Run("when the server fqdn for the server to update is missing, raise invalid argument error", func(t *testing.T) {
-			resp, err := cl.UpdateServer(ctx, &request.UpdateServer{
-				Id:        "chef-infra-server",
-				Name:      "Chef infra server",
-				IpAddress: "0.0.0.0",
-			})
-			assert.Nil(t, resp)
-			assert.Error(t, err, "must supply server fqdn")
-			grpctest.AssertCode(t, codes.InvalidArgument, err)
-		})
-
-		t.Run("when the server IP address for the server to update is missing, raise invalid argument error", func(t *testing.T) {
-			resp, err := cl.UpdateServer(ctx, &request.UpdateServer{
-				Id:   "chef-infra-server",
-				Name: "Chef infra server",
-				Fqdn: "domain.com",
-			})
-			assert.Nil(t, resp)
-			assert.Error(t, err, "must supply server IP address")
 			grpctest.AssertCode(t, codes.InvalidArgument, err)
 		})
 


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
User can able to add the server using FQDN or IP address, means one of these fields can be used to add the server with infra chef server API.
### :chains: Related Resources
https://github.com/chef/automate/issues/5585
### :+1: Definition of Done
I have added some changes for the add server API, and allow users to add the server using only the FQDN or IP address.
### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/infra-proxy-service
```
using the postman API tool you can user pass the only FQDN or IP address to add the server.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1363" alt="Screenshot 2021-09-02 at 4 32 39 PM" src="https://user-images.githubusercontent.com/12297653/131832994-476a84a0-c3a5-44f4-8be3-4107a08592dc.png">
<img width="1363" alt="Screenshot 2021-09-02 at 4 33 20 PM" src="https://user-images.githubusercontent.com/12297653/131833010-579cea17-534e-466c-b470-5f04b973c79c.png">
<img width="1363" alt="Screenshot 2021-09-02 at 4 35 39 PM" src="https://user-images.githubusercontent.com/12297653/131833016-0a3df3b2-1aa0-42fe-9b78-1172856bc98a.png">
