### PR TITLE
Remove useless role data from the API

### DIFF
--- a/api/external/infra_proxy/response/roles.pb.go
+++ b/api/external/infra_proxy/response/roles.pb.go
@@ -98,7 +98,7 @@ type RoleListItem struct {
 
 	// Name of the role.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Desscription of the role.
+	// Description of the role.
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
 	// Environment for the role.
 	Environments []string `protobuf:"bytes,3,rep,name=environments,proto3" json:"environments,omitempty"`
@@ -164,16 +164,12 @@ type Role struct {
 
 	// Name of the role.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// Type of the chef object.
-	ChefType string `protobuf:"bytes,2,opt,name=chef_type,json=chefType,proto3" json:"chef_type,omitempty"`
-	// Descrption of the role.
+    // Descrption of the role.
 	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	// Role default attributes JSON.
 	DefaultAttributes string `protobuf:"bytes,4,opt,name=default_attributes,json=defaultAttributes,proto3" json:"default_attributes,omitempty"`
 	// Role override attributes JSON.
 	OverrideAttributes string `protobuf:"bytes,5,opt,name=override_attributes,json=overrideAttributes,proto3" json:"override_attributes,omitempty"`
-	// Json class name.
-	JsonClass string `protobuf:"bytes,6,opt,name=json_class,json=jsonClass,proto3" json:"json_class,omitempty"`
 	// Run list for the role.
 	RunList []string `protobuf:"bytes,7,rep,name=run_list,json=runList,proto3" json:"run_list,omitempty"`
 }
@@ -217,13 +213,6 @@ func (x *Role) GetName() string {
 	return ""
 }
 
-func (x *Role) GetChefType() string {
-	if x != nil {
-		return x.ChefType
-	}
-	return ""
-}
-
 func (x *Role) GetDescription() string {
 	if x != nil {
 		return x.Description
@@ -241,13 +230,6 @@ func (x *Role) GetDefaultAttributes() string {
 func (x *Role) GetOverrideAttributes() string {
 	if x != nil {
 		return x.OverrideAttributes
-	}
-	return ""
-}
-
-func (x *Role) GetJsonClass() string {
-	if x != nil {
-		return x.JsonClass
 	}
 	return ""
 }

--- a/api/external/infra_proxy/response/roles.proto
+++ b/api/external/infra_proxy/response/roles.proto
@@ -25,18 +25,14 @@ message RoleListItem {
 message Role {
     // Name of the role.
     string name = 1;
-    // Type of the chef object.
-    string chef_type = 2;
     // Descrption of the role.
-    string description = 3;
+    string description = 2;
     // Role default attributes JSON.
-    string default_attributes = 4;
+    string default_attributes = 3;
     // Role override attributes JSON.
-    string override_attributes = 5;
-    // Json class name.
-    string json_class = 6;
+    string override_attributes = 4;
     // Run list for the role.
-    repeated string run_list  = 7;
+    repeated string run_list  = 5;
 }
 
 message ExpandedRunList {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The JSON class and the chef object type make no sense. They're always just a role. Pretty pointless.

### :chains: Related Resources

### :+1: Definition of Done

API contains only useful information describing roles

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
