### PR TITLE
Remove environment column from Policygroup nodes

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
@@ -41,7 +41,7 @@
           <chef-option value='nodes' data-cy="nodes-tab">Nodes</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      
+
       <section class="page-body" *ngIf="tabValue === 'policyfiles'">
         <div class="policyfiles-tab" *ngIf="!policyGroupDetailsLoading">
           <div class="spinner">
@@ -93,7 +93,6 @@
                   <chef-th class="no_border_th">IP Address</chef-th>
                   <chef-th class="no_border_th">Uptime</chef-th>
                   <chef-th class="no_border_th">Last Check-In</chef-th>
-                  <chef-th class="no_border_th">Environment</chef-th>
                 </chef-tr>
               </chef-thead>
               <chef-tbody>
@@ -107,7 +106,6 @@
                   <chef-td>{{node.ip_address === '' ? '--' : node.ip_address}}</chef-td>
                   <chef-td>{{node.uptime === '' ? '--' : node.uptime}}</chef-td>
                   <chef-td>{{timeFromNow(node.check_in)}}</chef-td>
-                  <chef-td>{{node.environment === '' ? '--' : node.environment}}</chef-td>
                 </chef-tr>
               </chef-tbody>
             </chef-table>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

I've noticed this in a bunch of places in Automate and I think there's a
misunderstanding with how Policyfiles work. If you use Policyfiles you
can't use environments/roles. They are incompatible methods of managing
nodes. So if you're listing nodes that are managed with policyfiles you
don't car what their environment is.

### :chains: Related Resources

### :+1: Definition of Done

Policygroups view makes sense for users that use Policyfiles.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
