### PR TITLE
Css fix for gap between flex children in Safari

### DIFF
--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
@@ -12,10 +12,6 @@ main {
     padding: 54px 54px;
 
     .flex-child {
-      // display: flex;
-      // flex-direction: row;
-      // // column-gap: 66px;
-      // flex-wrap: wrap;
       display: grid;
       grid-template-columns: repeat(auto-fill, 186px);
       grid-column-gap: 66px;

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
@@ -1,8 +1,6 @@
 @import "~styles/variables";
 @import '../shared/slide-panel';
 
-.flex-child > * + * { margin-left: 8rem;}
-
 main {
   margin: 0 32px 32px 32px;
 

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
@@ -1,6 +1,8 @@
 @import "~styles/variables";
 @import '../shared/slide-panel';
 
+.flex-child > * + * { margin-left: 8rem;}
+
 main {
   margin: 0 32px 32px 32px;
 
@@ -10,10 +12,14 @@ main {
     padding: 54px 54px;
 
     .flex-child {
-      display: flex;
-      flex-direction: row;
+      // display: flex;
+      // flex-direction: row;
+      // // column-gap: 66px;
+      // flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, 186px);
+      grid-column-gap: 66px;
       column-gap: 66px;
-      flex-wrap: wrap;
 
       .card {
         display: flex;


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Before:
<img width="1018" alt="Screenshot 2021-09-09 at 1 32 56 PM" src="https://user-images.githubusercontent.com/59958706/132647525-13184702-5cf5-451f-8068-8048842a06c0.png">

After:
<img width="1018" alt="Screenshot 2021-09-09 at 1 33 25 PM" src="https://user-images.githubusercontent.com/59958706/132647591-719b24b5-ac70-4976-97ab-d1594b8c8591.png">


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
