### PR TITLE
Command mapping 5502 1

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs-ha-template.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs-ha-template.go
@@ -1,0 +1,17 @@
+package main
+
+var gatherLogsHelpDoc = `
+Usage:
+    chef-automate gather-logs
+
+Options:
+    -o, --ssh-options OPTIONS          Additional options to pass to ssh
+    -c, --sudo-command SUDO_COMMAND    Alternate command for sudo (default: "sudo")
+    -s, --sudo-options SUDO_OPTIONS    Additional options for remote sudo
+    -r, --remote-log-dir DIRECTORY     Where to temporarily store remote log files (default: "/var/tmp")
+    -l, --local-log-dir DIRECTORY      Where to store the logs locally (default: "/var/tmp")
+    -n, --log-lines NUMBER             How many journalctl lines to capture
+    -h, --help                         print help
+    -v, --verbose                      Enable verbose output
+    -c, --config-file CONFIG_FILE      Load settings from config file (default: "/root/workspace/a2-ha-backend/a2ha.rb")
+`

--- a/components/automate-cli/cmd/chef-automate/gather-logs-ha.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs-ha.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+)
+
+func executeHAGatherLogsA2HA(args []string) error {
+	writer.Printf("gathering A2HA logs \n")
+	args = append([]string{"gather-logs"}, args...)
+	c := exec.Command("automate-cluster-ctl", args...)
+	c.Dir = "/hab/a2_deploy_workspace"
+	c.Stdin = os.Stdin
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		writer.Printf(stderr.String())
+		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+gatherLogsHelpDoc)
+	}
+	writer.Print(out.String())
+	return err
+}

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -40,7 +40,6 @@ func newGatherLogsCmd() *cobra.Command {
 		Short: "Gather system diagnostics and logs",
 		Long:  "Collect system diagnostics and logs from Chef Automate and other services",
 		RunE:  runGatherLogsCmd,
-		Args:  cobra.RangeArgs(0, 1),
 	}
 
 	gatherLogsCmd.Flags().BoolVarP(

--- a/components/automate-cli/cmd/chef-automate/status-ha.go
+++ b/components/automate-cli/cmd/chef-automate/status-ha.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+)
+
+func executeHAStatus(args []string) error {
+	writer.Printf("getting status \n")
+	args = append([]string{"status"}, args...)
+	c := exec.Command("automate-cluster-ctl", args...)
+	c.Dir = "/hab/a2_deploy_workspace"
+	c.Stdin = os.Stdin
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	c.Stdout = &out
+	c.Stderr = &stderr
+	err := c.Run()
+	if err != nil {
+		writer.Printf(stderr.String())
+		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+statusHAHelpDocs)
+	}
+	writer.Print(out.String())
+	return err
+}

--- a/components/automate-cli/cmd/chef-automate/statusHaHelpDoc.go
+++ b/components/automate-cli/cmd/chef-automate/statusHaHelpDoc.go
@@ -1,0 +1,7 @@
+package main
+
+var statusHAHelpDocs = `
+Usage:
+    chef-automate status
+	shows status of services running.
+`

--- a/components/automate-cli/cmd/chef-automate/testHA.go
+++ b/components/automate-cli/cmd/chef-automate/testHA.go
@@ -1,0 +1,54 @@
+// Copyright © 2017 Chef Software
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+)
+
+func newTestCmd() *cobra.Command {
+	var testCmd = &cobra.Command{
+		Use:   "test",
+		Short: "Run automate HA smoke tests",
+		Long:  "Run smoke test for automate HA services.",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE:  runTestCmd,
+	}
+
+	return testCmd
+}
+
+func runTestCmd(cmd *cobra.Command, args []string) error {
+	if isA2HADeployment() {
+		writer.Printf("getting status \n")
+		args = append([]string{"test"}, args...)
+		c := exec.Command("automate-cluster-ctl", args...)
+		c.Dir = "/hab/a2_deploy_workspace"
+		c.Stdin = os.Stdin
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		c.Stdout = &out
+		c.Stderr = &stderr
+		err := c.Run()
+		if err != nil {
+			writer.Printf(stderr.String())
+			return status.Wrap(err, status.CommandExecutionError, "")
+		}
+		writer.Print(out.String())
+		return err
+	} else {
+		return status.Wrap(errors.New("Test command only work with HA mode of automate"), status.ConfigError, "")
+	}
+
+}
+
+func init() {
+	RootCmd.AddCommand(newTestCmd())
+}

--- a/components/automate-cli/cmd/chef-automate/testHA.go
+++ b/components/automate-cli/cmd/chef-automate/testHA.go
@@ -27,7 +27,7 @@ func newTestCmd() *cobra.Command {
 
 func runTestCmd(cmd *cobra.Command, args []string) error {
 	if isA2HADeployment() {
-		writer.Printf("getting status \n")
+		writer.Printf("executing smoke test for automate HA \n")
 		args = append([]string{"test"}, args...)
 		c := exec.Command("automate-cluster-ctl", args...)
 		c.Dir = "/hab/a2_deploy_workspace"

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
@@ -10,10 +10,10 @@ main {
     padding: 54px 54px;
 
     .flex-child {
-      display: flex;
-      flex-direction: row;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, 186px);
+      grid-column-gap: 66px;
       column-gap: 66px;
-      flex-wrap: wrap;
 
       .card {
         display: flex;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
command mapping for following commands
**gather-logs --> chef-automate gather-logs **

Usage:
    chef-automate gather-logs

Options:
    -o, --ssh-options OPTIONS          Additional options to pass to ssh
    -c, --sudo-command SUDO_COMMAND    Alternate command for sudo (default: "sudo")
    -s, --sudo-options SUDO_OPTIONS    Additional options for remote sudo
    -r, --remote-log-dir DIRECTORY     Where to temporarily store remote log files (default: "/var/tmp")
    -l, --local-log-dir DIRECTORY      Where to store the logs locally (default: "/var/tmp")
    -n, --log-lines NUMBER             How many journalctl lines to capture
    -h, --help                         print help
    -v, --verbose                      Enable verbose output
    -c, --config-file CONFIG_FILE      Load settings from config file (default: "/root/workspace/a2-ha-backend/a2ha.rb")

** status --> chef-automate status **

Usage:
    chef-automate status
	shows status of services running.


** test --> chef-automate test **
used to run automate ha smoke test cases manually

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/5502

### :+1: Definition of Done

Dev Done, coding and dev manual testing

### :athletic_shoe: How to Build and Test the Change

rebuild component/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
