### PR TITLE
chef-automate provision-infra

### DIFF
--- a/components/automate-cli/cmd/chef-automate/provision-infra-ha-template.go
+++ b/components/automate-cli/cmd/chef-automate/provision-infra-ha-template.go
@@ -1,0 +1,7 @@
+package main
+
+var provisionInfraHelpDocs = `
+Usage:
+    chef-automate provision-infra
+Provision infra in respective infra service providers for HA mode of deployment.
+`

--- a/components/automate-cli/cmd/chef-automate/provision-infra-ha.go
+++ b/components/automate-cli/cmd/chef-automate/provision-infra-ha.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+)
+
+func newTestCmd() *cobra.Command {
+	var testCmd = &cobra.Command{
+		Use:   "provision-infra",
+		Short: "Provison automate HA infra.",
+		Long:  "Provison automate HA infra for automate HA deployment.",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE:  runTestCmd,
+	}
+
+	return testCmd
+}
+
+func runTestCmd(cmd *cobra.Command, args []string) error {
+	if isA2HADeployment() {
+		writer.Printf("prvisioning infra for automate HA \n")
+		args = append([]string{"provision"}, args...)
+		c := exec.Command("automate-cluster-ctl", args...)
+		c.Dir = "/hab/a2_deploy_workspace"
+		c.Stdin = os.Stdin
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		c.Stdout = &out
+		c.Stderr = &stderr
+		err := c.Run()
+		if err != nil {
+			writer.Printf(stderr.String())
+			return status.Wrap(err, status.CommandExecutionError, "")
+		}
+		writer.Print(out.String())
+		return err
+	} else {
+		return status.Wrap(errors.New("provision-infra only works for HA mode of automate"), status.ConfigError, "")
+	}
+
+}
+
+func init() {
+	RootCmd.AddCommand(newTestCmd())
+}

--- a/components/automate-cli/cmd/chef-automate/provision-infra-ha.go
+++ b/components/automate-cli/cmd/chef-automate/provision-infra-ha.go
@@ -37,12 +37,12 @@ func runTestCmd(cmd *cobra.Command, args []string) error {
 		err := c.Run()
 		if err != nil {
 			writer.Printf(stderr.String())
-			return status.Wrap(err, status.CommandExecutionError, "")
+			return status.Wrap(err, status.CommandExecutionError, provisionInfraHelpDocs)
 		}
 		writer.Print(out.String())
 		return err
 	} else {
-		return status.Wrap(errors.New("provision-infra only works for HA mode of automate"), status.ConfigError, "")
+		return status.Wrap(errors.New("provision-infra only works for HA mode of automate"), status.ConfigError, provisionInfraHelpDocs)
 	}
 
 }


### PR DESCRIPTION
chef-automate provision-infra new command mapping with automate-cluster-ctl provision command

### :nut_and_bolt: Description: What code changed, and why?

**chef-automate provision-infra**

which internally executes automate-cluster-ctl provision
it  provision infra for automate HA mode of deployment.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/5439

### :+1: Definition of Done

Dev done, Dev tested

### :athletic_shoe: How to Build and Test the Change

rebuild component/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
