### PR TITLE
upgrading chef server components to 14.9.23 version

### DIFF
--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-bookshelf"
 pkg_description="Wrapper package for chef/bookshelf"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.9.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/14.4.4/20210520120637"
+  "${vendor_origin}/bookshelf/14.9.23/20210909193039"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -7,7 +7,7 @@ vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.9.23"
 pkg_deps=(
   core/coreutils
   chef/mlsa
@@ -20,8 +20,8 @@ pkg_deps=(
   core/curl/7.68.0/20200601114640
   core/ruby26/2.6.5/20200404043345
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/14.4.4/20210520121142"
-  "${vendor_origin}/chef-server-ctl/14.4.4/20210520120637"
+  "${vendor_origin}/chef-server-nginx/14.9.23/20210909193621"
+  "${vendor_origin}/chef-server-ctl/14.9.23/20210909193039"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-bifrost"
 pkg_description="Wrapper package for chef/oc_bifrost"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.9.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/14.4.4/20210520120641"
+  "${vendor_origin}/oc_bifrost/14.9.23/20210909193045"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-erchef"
 pkg_description="Wrapper package for chef/oc_erchef"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.9.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/14.4.4/20210520120641"
+  "${vendor_origin}/oc_erchef/14.9.23/20210909193046"
 )
 
 pkg_build_deps=(


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Upgrading the chef server to latest version - 14.9.23. The components are pointing to the usual stable channel of habitat.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
