### PR TITLE
Amazon S3 Integration UI #5581

### DIFF
--- a/components/automate-ui/src/app/entities/destinations/destination.model.ts
+++ b/components/automate-ui/src/app/entities/destinations/destination.model.ts
@@ -14,3 +14,29 @@ export interface EnableDestination {
   id: string;
   enable: boolean;
 }
+
+export const regions = [
+  { name: 'US East (Ohio) us-east-2', code: 'us-east-2' },
+  { name: 'US East (N. Virginia) us-east-1', code: 'us-east-1' },
+  { name: 'US West (N. California) us-west-1', code: 'us-west-1' },
+  { name: 'US West (Oregon) us-west-2', code: 'us-west-2' },
+  { name: 'Africa (Cape Town) af-south-1', code: 'af-south-1' },
+  { name: 'Asia Pacific (Hong Kong) ap-east-1', code: 'ap-east-1' },
+  { name: 'Asia Pacific (Mumbai) ap-south-1', code: 'ap-south-1' },
+  { name: 'Asia Pacific (Osaka) ap-northeast-3', code: 'ap-northeast-3' },
+  { name: 'Asia Pacific (Seoul) ap-northeast-2', code: 'ap-northeast-2' },
+  { name: 'Asia Pacific (Singapore) ap-northeast-2', code: 'ap-northeast-2' },
+  { name: 'Asia Pacific (Sydney) ap-southeast-2', code: 'ap-southeast-2' },
+  { name: 'Asia Pacific (Tokyo) ap-northeast-1', code: 'ap-northeast-1' },
+  { name: 'Canada (Central) ca-central-1', code: 'ca-central-1' },
+  { name: 'China (Beijing) cn-north-1', code: 'cn-north-1' },
+  { name: 'China (Ningxia) cn-northwest-1', code: 'cn-northwest-1' },
+  { name: 'Europe (Frankfurt) eu-central-1', code: 'eu-central-1' },
+  { name: 'Europe (Ireland) eu-west-1', code: 'eu-west-1' },
+  { name: 'Europe (London) eu-west-2', code: 'eu-west-2' },
+  { name: 'Europe (Milan) eu-south-1', code: 'eu-south-1' },
+  { name: 'Europe (Paris) eu-west-3', code: 'eu-west-3' },
+  { name: 'Europe (Stockholm) eu-north-1', code: 'eu-north-1' },
+  { name: 'Middle East (Bahrain) me-south-1', code: 'me-south-1' },
+  { name: 'South America (São Paulo) sa-east-1', code: 'sa-east-1' },
+];

--- a/components/automate-ui/src/app/entities/destinations/destination.model.ts
+++ b/components/automate-ui/src/app/entities/destinations/destination.model.ts
@@ -38,5 +38,5 @@ export const regions = [
   { name: 'Europe (Paris) eu-west-3', code: 'eu-west-3' },
   { name: 'Europe (Stockholm) eu-north-1', code: 'eu-north-1' },
   { name: 'Middle East (Bahrain) me-south-1', code: 'me-south-1' },
-  { name: 'South America (São Paulo) sa-east-1', code: 'sa-east-1' },
+  { name: 'South America (São Paulo) sa-east-1', code: 'sa-east-1' }
 ];

--- a/components/automate-ui/src/app/entities/destinations/destination.requests.ts
+++ b/components/automate-ui/src/app/entities/destinations/destination.requests.ts
@@ -166,7 +166,7 @@ export class DestinationRequests {
       { url, 'header': {value} });
   }
 
-  public testDestinationForMinio(data: any): Observable<Object> {
+  public testDestinationForStorage(data: any): Observable<Object> {
     return this.http.post(encodeURI(
       this.joinToDataFeedUrl(['destinations', 'test'])),
       { ...data });

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
@@ -126,9 +126,9 @@
         <div class="input-margin" *ngIf="showFields.region && showSelect">
           <div class="name-margin">
             <label for="version">Region *</label>
-            <div class="version-dropdown">
+            <div class="version-dropdown dropdown-menu">
               <chef-select #reg [value]="dropDownVal" (change)="dropDownChangeHandlers(reg.value)" data-cy="select-auth-type">
-                <chef-option *ngFor="let region of awsRegions" value="{{region.code}}""  data-cy="select-access-token">{{region.name}}</chef-option>
+                <chef-option *ngFor="let region of awsRegions" value="{{region.code}}"  data-cy="select-access-token">{{region.name}}</chef-option>
               </chef-select>
             </div>
           </div>

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
@@ -38,9 +38,6 @@
             <div class="container image-footer">
               <h3 class="bolder-font">{{item.name}}</h3>
             </div>
-            <div class="overlay" *ngIf="item.name !== 'Minio' && item.name !=='Amazon S3'">
-              <div class="text">Coming Soon</div>
-            </div>
           </div>
         </div>
     </div>

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
@@ -4,7 +4,7 @@
       <chef-button class="arrow-btn" secondary (click)="returnToMenu()" data-cy="close-data-feed-button">
         <chef-icon>arrow_back</chef-icon>
       </chef-button>
-    </div>  
+    </div>
     <h1 slot="title" class="bolder-font" *ngIf="!integrationSelected">Choose a Data Feed Integration</h1>
     <h1 slot="title" class="bolder-font" data-cy="title-integration" *ngIf="integrationSelected">{{integTitle}}</h1>
     <chef-button class="close" secondary (click)="closeCreateSlider()" data-cy="close-feed-button">
@@ -25,7 +25,7 @@
           <div class="card" (click)="selectIntegration(item.name)" *ngFor="let item of integrations.webhook" [attr.data-cy]="item.name">
             <img src="/assets/img/{{item.asset}}.png" alt="Avatar">
             <div class="container image-footer">
-              <h3 class="bolder-font">{{item.name}}</h3> 
+              <h3 class="bolder-font">{{item.name}}</h3>
             </div>
           </div>
         </div>
@@ -36,9 +36,9 @@
           <div class="card" (click)="selectIntegration(item.name)" *ngFor="let item of integrations.storage" [attr.data-cy]="item.name">
             <img src="/assets/img/{{item.asset}}.png" alt="Avatar">
             <div class="container image-footer">
-              <h3 class="bolder-font">{{item.name}}</h3> 
+              <h3 class="bolder-font">{{item.name}}</h3>
             </div>
-            <div class="overlay" *ngIf="item.name !== 'Minio'">
+            <div class="overlay" *ngIf="item.name !== 'Minio' && item.name !=='Amazon S3'">
               <div class="text">Coming Soon</div>
             </div>
           </div>
@@ -123,6 +123,16 @@
             </div>
           </div>
         </div>
+        <div class="input-margin" *ngIf="showFields.region && showSelect">
+          <div class="name-margin">
+            <label for="version">Region *</label>
+            <div class="version-dropdown">
+              <chef-select #reg [value]="dropDownVal" (change)="dropDownChangeHandlers(reg.value)" data-cy="select-auth-type">
+                <chef-option *ngFor="let region of awsRegions" value={{region.code}}  data-cy="select-access-token">{{region.name}}</chef-option>
+              </chef-select>
+            </div>
+          </div>
+        </div>
         <div class="input-margin" *ngIf="showTokenInput('tokenType')" [ngClass]="{'customtokentypeblock' : showFields.customToken}">
           <chef-form-field>
             <label>
@@ -130,7 +140,7 @@
               <div class="input-and-btn">
                 <input
                   chefInput
-                  formControlName="tokenType" 
+                  formControlName="tokenType"
                   type="text"
                   data-cy="add-token-type"
                   id="token-type-input"
@@ -153,7 +163,7 @@
               <span class="label">Token <span aria-hidden="true">*</span></span>
               <input
                 chefInput
-                formControlName="token" 
+                formControlName="token"
                 type="text"
                 data-cy="add-token"
                 id="token-input"
@@ -175,7 +185,7 @@
               <span class="label">Username <span aria-hidden="true">*</span></span>
               <input
                 chefInput
-                formControlName="username" 
+                formControlName="username"
                 type="text"
                 data-cy="add-username"
                 id="username-input"
@@ -197,7 +207,7 @@
               <span class="label">Password <span aria-hidden="true">*</span></span>
               <input
                 chefInput
-                formControlName="password" 
+                formControlName="password"
                 type="password"
                 data-cy="add-password"
                 id="password-input"
@@ -261,7 +271,7 @@
               <span class="label">Access Key <span aria-hidden="true">*</span></span>
               <input
                 chefInput
-                formControlName="accessKey" 
+                formControlName="accessKey"
                 type="password"
                 data-cy="add-access-key"
                 id="accessKey-input"
@@ -283,7 +293,7 @@
               <span class="label">Secret Key <span aria-hidden="true">*</span></span>
               <input
                 chefInput
-                formControlName="secretKey" 
+                formControlName="secretKey"
                 type="password"
                 data-cy="add-secret-key"
                 id="secretKey-input"
@@ -298,7 +308,7 @@
               Secret Key is invalid.
             </chef-error>
           </chef-form-field>
-        </div>    
+        </div>
         <div class="input-margin">
           <div class="button-bar">
             <chef-button data-cy="test-button" id="testConnection" (click)="testConnection()" primary [disabled]="!validateForm()">
@@ -308,7 +318,7 @@
             </chef-button>
           </div>
         </div>
-        <hr>      
+        <hr>
         <div class="button-bar">
           <chef-button id="cancel-server-popup" (click)="returnToMenu()" tertiary>Cancel</chef-button>
           <chef-button [disabled]="!validateForm()"

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.html
@@ -128,7 +128,7 @@
             <label for="version">Region *</label>
             <div class="version-dropdown">
               <chef-select #reg [value]="dropDownVal" (change)="dropDownChangeHandlers(reg.value)" data-cy="select-auth-type">
-                <chef-option *ngFor="let region of awsRegions" value={{region.code}}  data-cy="select-access-token">{{region.name}}</chef-option>
+                <chef-option *ngFor="let region of awsRegions" value="{{region.code}}""  data-cy="select-access-token">{{region.name}}</chef-option>
               </chef-select>
             </div>
           </div>

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.scss
@@ -1,5 +1,5 @@
 @import "~styles/variables";
-@import '../shared/slide-panel';
+@import "../shared/slide-panel";
 
 main {
   margin: 0 32px 32px 32px;
@@ -36,8 +36,8 @@ main {
           overflow: hidden;
           width: 100%;
           height: 0;
-          transition: .5s ease;
-          opacity: 0.80;
+          transition: 0.5s ease;
+          opacity: 0.8;
           font-weight: 900;
           letter-spacing: 1.2px;
 
@@ -212,7 +212,7 @@ app-notification {
   border-bottom: 0.5px solid $chef-key-tab;
 
   h1 {
-    margin: .40em 0;
+    margin: 0.4em 0;
     flex-grow: 2;
     text-align: left;
     font-weight: bold;
@@ -250,4 +250,12 @@ app-notification {
 ::ng-deep [panelClass="chef-dropdown"] {
   font-size: inherit;
   font-weight: 100;
+}
+
+.dropdown-menu {
+
+  ::ng-deep chef-dropdown {
+    max-height: 256px;
+    overflow: scroll;
+  }
 }

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.spec.ts
@@ -89,6 +89,7 @@ describe('DataFeedCreateComponent', () => {
     const userName = 'test123';
     const password = 'test123';
     const header = '{“test”:”123”}';
+    const region = 'region1';
     const destination = <Destination> {
       id: '1',
       name: 'new data feed',
@@ -248,6 +249,41 @@ describe('DataFeedCreateComponent', () => {
       expect(component.createForm.controls['accessKey'].value).toBe(null);
       expect(component.createForm.controls['secretKey'].value).toBe(null);
     });
+
+    it('should be valid when all fields are filled out for S3', () => {
+      component.name = jasmine.createSpyObj('name', ['nativeElement']);
+      component.name.nativeElement = { focus: () => {} };
+      component.selectIntegration('Amazon S3');
+      component.createForm.controls['name'].setValue(destination.name);
+      component.createForm.controls['bucketName'].setValue(bucketName);
+      component.createForm.controls['accessKey'].setValue(accessKey);
+      component.createForm.controls['secretKey'].setValue(secretKey);
+      expect(component.validateForm()).toBeTruthy();
+    });
+
+    it('Dropdown is populated for S3', () => {
+      expect(component.dropDownVal).toBe(null);
+      component.dropDownChangeHandlers(region);
+      expect(component.dropDownVal).toBe(region);
+    });
+
+    it('slider resets name, bucketname , accessKey and secretkey to empty string for S3', () => {
+      component.createForm.controls['name'].setValue('any');
+      component.createForm.controls['bucketName'].setValue('any');
+      component.createForm.controls['accessKey'].setValue('any');
+      component.createForm.controls['secretKey'].setValue('any');
+      component.slidePanel();
+      component.name = jasmine.createSpyObj('name', ['nativeElement']);
+      component.name.nativeElement = { focus: () => {} };
+      component.selectIntegration('Amazon S3');
+      expect(component.createForm.controls['name'].value).toBe(null);
+      expect(component.createForm.controls['bucketName'].value).toBe(null);
+      expect(component.createForm.controls['accessKey'].value).toBe(null);
+      expect(component.createForm.controls['secretKey'].value).toBe(null);
+    });
+
+
+
   });
 
   describe('create data feed form validation', () => {

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.spec.ts
@@ -253,7 +253,7 @@ describe('DataFeedCreateComponent', () => {
     it('should be valid when all fields are filled out for S3', () => {
       component.name = jasmine.createSpyObj('name', ['nativeElement']);
       component.name.nativeElement = { focus: () => {} };
-      component.selectIntegration('Amazon S3');
+      component.selectIntegration('S3');
       component.createForm.controls['name'].setValue(destination.name);
       component.createForm.controls['bucketName'].setValue(bucketName);
       component.createForm.controls['accessKey'].setValue(accessKey);

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -71,14 +71,14 @@ export class DataFeedCreateComponent {
 
   public integrations = {
     webhook: [
-      { name: WebhookIntegrationTypes.SERVICENOW, asset: 'servicenow' },
-      { name: WebhookIntegrationTypes.SPLUNK, asset: 'splunk' },
-      { name: WebhookIntegrationTypes.ELK_KIBANA, asset: 'elk' },
-      { name: WebhookIntegrationTypes.CUSTOM, asset: 'custom' }
+      {name: WebhookIntegrationTypes.SERVICENOW, asset: 'servicenow'},
+      {name: WebhookIntegrationTypes.SPLUNK, asset: 'splunk'},
+      {name: WebhookIntegrationTypes.ELK_KIBANA, asset: 'elk'},
+      {name: WebhookIntegrationTypes.CUSTOM, asset: 'custom'}
     ],
     storage: [
-      { name: StorageIntegrationTypes.MINIO, asset: 'minio' },
-      { name: StorageIntegrationTypes.AMAZON_S3, asset: 's3' }
+      {name: StorageIntegrationTypes.MINIO, asset: 'minio'},
+      {name: StorageIntegrationTypes.AMAZON_S3, asset: 's3'}
     ]
   };
 

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -376,7 +376,7 @@ export class DataFeedCreateComponent {
   }
 
   public showUserPassInput(field: string) {
-    return (this.showFields[field] &&this.authSelected === AuthTypes.USERNAMEANDPASSWORD);
+    return (this.showFields[field] && this.authSelected === AuthTypes.USERNAMEANDPASSWORD);
   }
 
   public validateHeaders(customHeaders: string): void {

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -273,7 +273,6 @@ export class DataFeedCreateComponent {
 
   public dropDownChangeHandlers(val: string) {
     this.dropDownVal = val;
-    console.log(val);
   }
 
   public testConnection() {
@@ -373,16 +372,11 @@ export class DataFeedCreateComponent {
   }
 
   public showTokenInput(field: string) {
-    return (
-      this.showFields[field] && this.authSelected === AuthTypes.ACCESSTOKEN
-    );
+    return (this.showFields[field] && this.authSelected === AuthTypes.ACCESSTOKEN);
   }
 
   public showUserPassInput(field: string) {
-    return (
-      this.showFields[field] &&
-      this.authSelected === AuthTypes.USERNAMEANDPASSWORD
-    );
+    return (this.showFields[field] &&this.authSelected === AuthTypes.USERNAMEANDPASSWORD);
   }
 
   public validateHeaders(customHeaders: string): void {

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -10,6 +10,7 @@ import {
 import { FormGroup } from '@angular/forms';
 import { Revision } from 'app/entities/revisions/revision.model';
 import { Regex } from 'app/helpers/auth/regex';
+import { regions } from 'app/entities/destinations/destination.model';
 
 export enum WebhookIntegrationTypes {
   SERVICENOW = 'ServiceNow',
@@ -38,9 +39,7 @@ export enum IntegrationTypes {
   templateUrl: './data-feed-create.component.html',
   styleUrls: ['./data-feed-create.component.scss']
 })
-
 export class DataFeedCreateComponent {
-
   @Input() createForm: FormGroup;
   @Output() saveDestinationEvent = new EventEmitter<any>();
   @Output() testDestinationEvent = new EventEmitter<any>();
@@ -67,17 +66,19 @@ export class DataFeedCreateComponent {
   public notificationShow = false;
   public notificationMessage = '';
   public notificationType = 'error';
+  public dropDownVal = null;
+  public awsRegions = regions;
 
   public integrations = {
     webhook: [
-      {name: WebhookIntegrationTypes.SERVICENOW, asset: 'servicenow'},
-      {name: WebhookIntegrationTypes.SPLUNK, asset: 'splunk'},
-      {name: WebhookIntegrationTypes.ELK_KIBANA, asset: 'elk'},
-      {name: WebhookIntegrationTypes.CUSTOM, asset: 'custom'}
+      { name: WebhookIntegrationTypes.SERVICENOW, asset: 'servicenow' },
+      { name: WebhookIntegrationTypes.SPLUNK, asset: 'splunk' },
+      { name: WebhookIntegrationTypes.ELK_KIBANA, asset: 'elk' },
+      { name: WebhookIntegrationTypes.CUSTOM, asset: 'custom' }
     ],
     storage: [
-      {name: StorageIntegrationTypes.MINIO, asset: 'minio'},
-      {name: StorageIntegrationTypes.AMAZON_S3, asset: 's3'}
+      { name: StorageIntegrationTypes.MINIO, asset: 'minio' },
+      { name: StorageIntegrationTypes.AMAZON_S3, asset: 's3' }
     ]
   };
 
@@ -112,7 +113,8 @@ export class DataFeedCreateComponent {
   set testErrorSetter(val: boolean) {
     let errorString: string;
     if (this.integTitle === StorageIntegrationTypes.MINIO) {
-      errorString = 'Unable to connect: check endpoint, bucket name, access key and secret key.';
+      errorString =
+        'Unable to connect: check endpoint, bucket name, access key and secret key.';
     } else if (this.authSelected === AuthTypes.USERNAMEANDPASSWORD) {
       errorString = 'Unable to connect: check URL, username and password.';
     } else if (this.authSelected === AuthTypes.ACCESSTOKEN) {
@@ -122,7 +124,7 @@ export class DataFeedCreateComponent {
     this.showNotification(val, errorString, 'error');
   }
 
-  public showNotification(show: boolean, message: string , type: string) {
+  public showNotification(show: boolean, message: string, type: string) {
     setTimeout(() => {
       this.notificationShow = show;
     });
@@ -162,16 +164,19 @@ export class DataFeedCreateComponent {
   }
 
   showFieldWebhook() {
-    Object.keys(this.showFields).forEach(v => this.showFields[v] = false);
-    this.showFields = {...this.showFields, ...{
-      name: true,
-      url: true,
-      authSelector: true,
-      tokenType: true,
-      token: true,
-      username: true,
-      password: true
-    }};
+    Object.keys(this.showFields).forEach((v) => (this.showFields[v] = false));
+    this.showFields = {
+      ...this.showFields,
+      ...{
+        name: true,
+        url: true,
+        authSelector: true,
+        tokenType: true,
+        token: true,
+        username: true,
+        password: true
+      }
+    };
   }
 
   updateHeaderCheckbox(event: boolean): void {
@@ -181,15 +186,18 @@ export class DataFeedCreateComponent {
   }
 
   showFieldStorage() {
-    Object.keys(this.showFields).forEach(v => this.showFields[v] = false);
-    this.showFields = {...this.showFields, ...{
-      name: true,
-      endpoint: true,
-      region: true,
-      bucketName: true,
-      accessKey: true,
-      secretKey: true
-    }};
+    Object.keys(this.showFields).forEach((v) => (this.showFields[v] = false));
+    this.showFields = {
+      ...this.showFields,
+      ...{
+        name: true,
+        endpoint: true,
+        region: true,
+        bucketName: true,
+        accessKey: true,
+        secretKey: true
+      }
+    };
   }
 
   public selectIntegration(integration: string) {
@@ -239,6 +247,14 @@ export class DataFeedCreateComponent {
         this.showFieldStorage();
         this.showFields.region = false;
         this.integrationSelected = true;
+        break;
+      }
+      case StorageIntegrationTypes.AMAZON_S3: {
+        this.dropDownVal = 'us-east-2';
+        this.showFieldStorage();
+        this.showFields.endpoint = false;
+        this.integrationSelected = true;
+        break;
       }
     }
   }
@@ -255,16 +271,21 @@ export class DataFeedCreateComponent {
     this.authSelected = type;
   }
 
+  public dropDownChangeHandlers(val: string) {
+    this.dropDownVal = val;
+    console.log(val);
+  }
+
   public testConnection() {
     this.testInProgress = true;
     this.testDestinationEvent.emit({
       name: this.integTitle,
-      auth: this.authSelected
+      auth: this.authSelected,
+      region: this.dropDownVal
     });
   }
 
   public validateForm() {
-
     switch (this.integTitle) {
       case WebhookIntegrationTypes.SERVICENOW:
       case WebhookIntegrationTypes.SPLUNK:
@@ -274,21 +295,23 @@ export class DataFeedCreateComponent {
         // for servicenow, splunk, elk and custom
         switch (this.authSelected) {
           case AuthTypes.ACCESSTOKEN: {
-            if (this.createForm.get('name').valid && this.createForm.get('url').valid &&
-              this.createForm.get('tokenType').valid && this.createForm.get('token').valid) {
-                if (this.integTitle === WebhookIntegrationTypes.CUSTOM && this.headerChecked &&
-                  this.validHeadersValue && this.flagHeaders) {
-                  return true;
-                } else if (this.integTitle === WebhookIntegrationTypes.CUSTOM &&
-                  !this.headerChecked && this.flagHeaders) {
-                  return true;
-                } else if (this.integTitle !== WebhookIntegrationTypes.CUSTOM) {
-                  return true;
-                }
+          if (this.createForm.get('name').valid && this.createForm.get('url').valid &&
+            this.createForm.get('tokenType').valid && this.createForm.get('token').valid) {
+            if (this.integTitle === WebhookIntegrationTypes.CUSTOM && this.headerChecked &&
+            this.validHeadersValue && this.flagHeaders) {
+            return true;
+            } else if (this.integTitle === WebhookIntegrationTypes.CUSTOM &&
+            !this.headerChecked && this.flagHeaders) {
+            return true;
+            } else if (this.integTitle !== WebhookIntegrationTypes.CUSTOM) {
+            return true;
+            }
             }
             break;
-          }
+            }
+
           case AuthTypes.USERNAMEANDPASSWORD: {
+
             if (this.createForm.get('name').valid && this.createForm.get('url').valid &&
               this.createForm.get('username').valid && this.createForm.get('password').valid) {
               if (this.integTitle === WebhookIntegrationTypes.CUSTOM && this.headerChecked &&
@@ -307,9 +330,24 @@ export class DataFeedCreateComponent {
       }
       case StorageIntegrationTypes.MINIO: {
         // handling minio
-        if (this.createForm.get('name').valid && this.createForm.get('endpoint').valid &&
-          this.createForm.get('bucketName').valid && this.createForm.get('accessKey').valid &&
-          this.createForm.get('secretKey').valid) {
+        if (
+          this.createForm.get('name').valid &&
+          this.createForm.get('endpoint').valid &&
+          this.createForm.get('bucketName').valid &&
+          this.createForm.get('accessKey').valid &&
+          this.createForm.get('secretKey').valid
+        ) {
+          return true;
+        }
+        break;
+      }
+      case StorageIntegrationTypes.AMAZON_S3: {
+        if (
+          this.createForm.get('name').valid &&
+          this.createForm.get('bucketName').valid &&
+          this.createForm.get('accessKey').valid &&
+          this.createForm.get('secretKey').valid
+        ) {
           return true;
         }
       }
@@ -321,7 +359,8 @@ export class DataFeedCreateComponent {
     this.saveInProgress = true;
     this.saveDestinationEvent.emit({
       name: this.integTitle,
-      auth: this.authSelected
+      auth: this.authSelected,
+      region: this.dropDownVal
     });
   }
 
@@ -334,11 +373,16 @@ export class DataFeedCreateComponent {
   }
 
   public showTokenInput(field: string) {
-    return this.showFields[field] && this.authSelected === AuthTypes.ACCESSTOKEN;
+    return (
+      this.showFields[field] && this.authSelected === AuthTypes.ACCESSTOKEN
+    );
   }
 
   public showUserPassInput(field: string) {
-    return this.showFields[field] && this.authSelected === AuthTypes.USERNAMEANDPASSWORD;
+    return (
+      this.showFields[field] &&
+      this.authSelected === AuthTypes.USERNAMEANDPASSWORD
+    );
   }
 
   public validateHeaders(customHeaders: string): void {

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -21,7 +21,7 @@ export enum WebhookIntegrationTypes {
 
 export enum StorageIntegrationTypes {
   MINIO = 'Minio',
-  AMAZON_S3 = 'Amazon S3'
+  AMAZON_S3 = 'S3'
 }
 
 export enum AuthTypes {

--- a/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed-create/data-feed-create.component.ts
@@ -297,18 +297,18 @@ export class DataFeedCreateComponent {
           case AuthTypes.ACCESSTOKEN: {
           if (this.createForm.get('name').valid && this.createForm.get('url').valid &&
             this.createForm.get('tokenType').valid && this.createForm.get('token').valid) {
-            if (this.integTitle === WebhookIntegrationTypes.CUSTOM && this.headerChecked &&
-            this.validHeadersValue && this.flagHeaders) {
-            return true;
+              if (this.integTitle === WebhookIntegrationTypes.CUSTOM && this.headerChecked &&
+                this.validHeadersValue && this.flagHeaders) {
+                return true;
             } else if (this.integTitle === WebhookIntegrationTypes.CUSTOM &&
-            !this.headerChecked && this.flagHeaders) {
-            return true;
+              !this.headerChecked && this.flagHeaders) {
+              return true;
             } else if (this.integTitle !== WebhookIntegrationTypes.CUSTOM) {
             return true;
             }
             }
             break;
-            }
+          }
 
           case AuthTypes.USERNAMEANDPASSWORD: {
 

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -95,20 +95,20 @@ describe('DataFeedComponent', () => {
     const accessKey = 'test123';
     const secretKey = 'test123';
     const headers = 'test:123';
-    const destination = <Destination> {
-      id: '1',
-      name: 'new data feed',
-      secret: 'testSecret',
-      url: 'http://foo.com'
-    };
-    const destinationwithHeader = <Destination> {
+    const region = 'region1';
+    const destination = <Destination>{
       id: '1',
       name: 'new data feed',
       secret: 'testSecret',
       url: 'http://foo.com',
-      headers: 'test:123'
     };
-
+    const destinationwithHeader = <Destination>{
+      id: '1',
+      name: 'new data feed',
+      secret: 'testSecret',
+      url: 'http://foo.com',
+      headers: 'test:123',
+    };
 
     beforeEach(() => {
       store = TestBed.inject(Store);
@@ -140,11 +140,12 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['password'].setValue(password);
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
 
       store.dispatch(new CreateDestinationSuccess(destination));
-      component.sortedDestinations$.subscribe(destinations => {
+      component.sortedDestinations$.subscribe((destinations) => {
         expect(destinations).toContain(destination);
       });
     });
@@ -159,11 +160,12 @@ describe('DataFeedComponent', () => {
 
       component.saveDestination({
         auth: AuthTypes.ACCESSTOKEN,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
 
       store.dispatch(new CreateDestinationSuccess(destination));
-      component.sortedDestinations$.subscribe(destinations => {
+      component.sortedDestinations$.subscribe((destinations) => {
         expect(destinations).toContain(destination);
       });
     });
@@ -172,18 +174,21 @@ describe('DataFeedComponent', () => {
       spyOnProperty(component.createChild, 'saveDone', 'set');
 
       component.createDataFeedForm.controls['name'].setValue(destination.name);
-      component.createDataFeedForm.controls['endpoint'].setValue(destination.url);
+      component.createDataFeedForm.controls['endpoint'].setValue(
+        destination.url
+      );
       component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
 
       component.saveDestination({
         auth: null,
-        name: StorageIntegrationTypes.MINIO
+        name: StorageIntegrationTypes.MINIO,
+        region: null
       });
 
       store.dispatch(new CreateDestinationSuccess(destination));
-      component.sortedDestinations$.subscribe(destinations => {
+      component.sortedDestinations$.subscribe((destinations) => {
         expect(destinations).toContain(destination);
       });
     });
@@ -200,7 +205,8 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['password'].setValue(password);
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
 
       const conflict = <HttpErrorResponse>{
@@ -225,7 +231,8 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['password'].setValue(password);
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
 
       const error = <HttpErrorResponse>{
@@ -249,18 +256,23 @@ describe('DataFeedComponent', () => {
       spyOn(component['store'], 'dispatch');
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
 
       expect(component['store'].dispatch).toHaveBeenCalledWith(
-        new CreateDestination({
-          name: component.createDataFeedForm.controls['name'].value.trim(),
-          url: component.createDataFeedForm.controls['url'].value.trim(),
-          integration_types: IntegrationTypes.WEBHOOK,
-          services: WebhookIntegrationTypes.SERVICENOW
-        }, JSON.stringify({
-          Authorization: 'Basic ' + btoa(username + ':' + password)
-        }), null)
+        new CreateDestination(
+          {
+            name: component.createDataFeedForm.controls['name'].value.trim(),
+            url: component.createDataFeedForm.controls['url'].value.trim(),
+            integration_types: IntegrationTypes.WEBHOOK,
+            services: WebhookIntegrationTypes.SERVICENOW
+          },
+          JSON.stringify({
+            Authorization: 'Basic ' + btoa(username + ':' + password)
+          }),
+          null
+        )
       );
     });
 
@@ -275,18 +287,23 @@ describe('DataFeedComponent', () => {
       spyOn(component['store'], 'dispatch');
       component.saveDestination({
         auth: AuthTypes.ACCESSTOKEN,
-        name: WebhookIntegrationTypes.SPLUNK
+        name: WebhookIntegrationTypes.SPLUNK,
+        region: null
       });
 
       expect(component['store'].dispatch).toHaveBeenCalledWith(
-        new CreateDestination({
-          name: component.createDataFeedForm.controls['name'].value.trim(),
-          url: component.createDataFeedForm.controls['url'].value.trim(),
-          integration_types: IntegrationTypes.WEBHOOK,
-          services: WebhookIntegrationTypes.SPLUNK
-        }, JSON.stringify({
-          Authorization: 'Bearer' + ' ' + token
-        }), null)
+        new CreateDestination(
+          {
+            name: component.createDataFeedForm.controls['name'].value.trim(),
+            url: component.createDataFeedForm.controls['url'].value.trim(),
+            integration_types: IntegrationTypes.WEBHOOK,
+            services: WebhookIntegrationTypes.SPLUNK
+          },
+          JSON.stringify({
+            Authorization: 'Bearer' + ' ' + token
+          }),
+          null
+        )
       );
     });
 
@@ -294,7 +311,9 @@ describe('DataFeedComponent', () => {
       spyOnProperty(component.createChild, 'saveDone', 'set');
 
       component.createDataFeedForm.controls['name'].setValue(destination.name);
-      component.createDataFeedForm.controls['endpoint'].setValue(destination.url);
+      component.createDataFeedForm.controls['endpoint'].setValue(
+        destination.url
+      );
       component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
@@ -302,26 +321,35 @@ describe('DataFeedComponent', () => {
       spyOn(component['store'], 'dispatch');
       component.saveDestination({
         auth: null,
-        name: StorageIntegrationTypes.MINIO
+        name: StorageIntegrationTypes.MINIO,
+        region: null
       });
 
       expect(component['store'].dispatch).toHaveBeenCalledWith(
-        new CreateDestination({
-          name: component.createDataFeedForm.controls['name'].value.trim(),
-          url: component.createDataFeedForm.controls['endpoint'].value.trim(),
-          integration_types: IntegrationTypes.STORAGE,
-          services: StorageIntegrationTypes.MINIO,
-          meta_data: [
-            {
-              key: 'bucket',
-              value: component.createDataFeedForm.controls['bucketName'].value.trim()
-            }
-          ]
-        }, null,
-        {
-          accessKey: component.createDataFeedForm.controls['accessKey'].value.trim(),
-          secretKey: component.createDataFeedForm.controls['secretKey'].value.trim()
-        })
+        new CreateDestination(
+          {
+            name: component.createDataFeedForm.controls['name'].value.trim(),
+            url: component.createDataFeedForm.controls['endpoint'].value.trim(),
+            integration_types: IntegrationTypes.STORAGE,
+            services: StorageIntegrationTypes.MINIO,
+            meta_data: [
+              {
+                key: 'bucket',
+                value:
+                  component.createDataFeedForm.controls[
+                    'bucketName'
+                  ].value.trim()
+              }
+            ]
+          },
+          null,
+          {
+            accessKey:
+              component.createDataFeedForm.controls['accessKey'].value.trim(),
+            secretKey:
+              component.createDataFeedForm.controls['secretKey'].value.trim()
+          }
+        )
       );
     });
 
@@ -331,22 +359,25 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['username'].setValue(username);
       component.createDataFeedForm.controls['password'].setValue(password);
       spyOn(component, 'revealUrlStatus');
-      spyOn(component['datafeedRequests'], 'testDestinationWithHeaders')
-      .and.returnValue(of([]));
+      spyOn(
+        component['datafeedRequests'],
+        'testDestinationWithHeaders'
+      ).and.returnValue(of([]));
       component.sendTestForDataFeed({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.SERVICENOW
+        name: WebhookIntegrationTypes.SERVICENOW,
+        region: null
       });
       const userToken = JSON.stringify({
         Authorization: 'Basic ' + btoa(username + ':' + password)
       });
 
-      expect(component['datafeedRequests']
-      .testDestinationWithHeaders).toHaveBeenCalledWith(
-        destination.url,
-        userToken
+      expect(
+        component['datafeedRequests'].testDestinationWithHeaders
+      ).toHaveBeenCalledWith(destination.url, userToken);
+      expect(component.revealUrlStatus).toHaveBeenCalledWith(
+        UrlTestState.Success
       );
-      expect(component.revealUrlStatus).toHaveBeenCalledWith(UrlTestState.Success);
     });
 
     it('on test success for Splunk and check dispatched store data', () => {
@@ -355,26 +386,33 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['tokenType'].setValue('Bearer');
       component.createDataFeedForm.controls['token'].setValue(token);
       spyOn(component, 'revealUrlStatus');
-      spyOn(component['datafeedRequests'], 'testDestinationWithHeaders')
-      .and.returnValue(throwError([]));
+      spyOn(
+        component['datafeedRequests'],
+        'testDestinationWithHeaders'
+      ).and.returnValue(throwError([]));
       component.sendTestForDataFeed({
         auth: AuthTypes.ACCESSTOKEN,
-        name: WebhookIntegrationTypes.SPLUNK
+        name: WebhookIntegrationTypes.SPLUNK,
+        region: null
       });
-      expect(component['datafeedRequests']
-      .testDestinationWithHeaders).toHaveBeenCalledWith(
+      expect(
+        component['datafeedRequests'].testDestinationWithHeaders
+      ).toHaveBeenCalledWith(
         destination.url,
         JSON.stringify({
           Authorization: 'Bearer' + ' ' + token
         })
       );
-      expect(component.revealUrlStatus).toHaveBeenCalledWith(UrlTestState.Failure);
+      expect(component.revealUrlStatus).toHaveBeenCalledWith(
+        UrlTestState.Failure
+      );
     });
 
     it('on test success for Minio and check dispatched store data', () => {
-
       component.createDataFeedForm.controls['name'].setValue(destination.name);
-      component.createDataFeedForm.controls['endpoint'].setValue(destination.url);
+      component.createDataFeedForm.controls['endpoint'].setValue(
+        destination.url
+      );
       component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
@@ -382,16 +420,21 @@ describe('DataFeedComponent', () => {
       spyOn(component['datafeedRequests'], 'testDestinationForMinio');
       component.sendTestForDataFeed({
         auth: null,
-        name: StorageIntegrationTypes.MINIO
+        name: StorageIntegrationTypes.MINIO,
+        region: null
       });
 
-      expect(component['datafeedRequests']
-      .testDestinationForMinio).toHaveBeenCalledWith({
+      expect(
+        component['datafeedRequests'].testDestinationForMinio
+      ).toHaveBeenCalledWith({
         url: destination.url,
         aws: {
-          access_key: component.createDataFeedForm.controls['accessKey'].value.trim(),
-          secret_access_key: component.createDataFeedForm.controls['secretKey'].value.trim(),
-          bucket: component.createDataFeedForm.controls['bucketName'].value.trim()
+          access_key:
+            component.createDataFeedForm.controls['accessKey'].value.trim(),
+          secret_access_key:
+            component.createDataFeedForm.controls['secretKey'].value.trim(),
+          bucket:
+            component.createDataFeedForm.controls['bucketName'].value.trim()
         }
       });
     });
@@ -399,7 +442,7 @@ describe('DataFeedComponent', () => {
     it('add Headers for Custom dataFeed', () => {
       component.createDataFeedForm.controls['headers'].setValue(headers);
       const headerJson = component.addHeadersforCustomDataFeed(headers);
-      expect(headerJson).toEqual({test : '123'});
+      expect(headerJson).toEqual({ test: '123' });
     });
 
     it('on success, closes slider and adds new custom data feed with username-password', () => {
@@ -412,10 +455,11 @@ describe('DataFeedComponent', () => {
 
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.CUSTOM
+        name: WebhookIntegrationTypes.CUSTOM,
+        region: null
       });
       store.dispatch(new CreateDestinationSuccess(destinationwithHeader));
-      component.sortedDestinations$.subscribe(destinations => {
+      component.sortedDestinations$.subscribe((destinations) => {
         expect(destinations).toContain(destinationwithHeader);
       });
     });
@@ -429,10 +473,11 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['headers'].setValue(headers);
       component.saveDestination({
         auth: AuthTypes.ACCESSTOKEN,
-        name: WebhookIntegrationTypes.CUSTOM
+        name: WebhookIntegrationTypes.CUSTOM,
+        region: null
       });
       store.dispatch(new CreateDestinationSuccess(destination));
-      component.sortedDestinations$.subscribe(destinations => {
+      component.sortedDestinations$.subscribe((destinations) => {
         expect(destinations).toContain(destination);
       });
     });
@@ -446,19 +491,18 @@ describe('DataFeedComponent', () => {
       spyOn(component['datafeedRequests'], 'testDestinationWithHeaders');
       component.sendTestForDataFeed({
         auth: AuthTypes.ACCESSTOKEN,
-        name: WebhookIntegrationTypes.CUSTOM
+        name: WebhookIntegrationTypes.CUSTOM,
+        region: null
       });
       const userToken = JSON.stringify({
         Authorization: 'Bearer' + ' ' + token
       });
       const headersJson = component.addHeadersforCustomDataFeed(headers);
-      const headersVal = {...headersJson, ...JSON.parse(userToken)};
+      const headersVal = { ...headersJson, ...JSON.parse(userToken) };
 
-      expect(component['datafeedRequests']
-      .testDestinationWithHeaders).toHaveBeenCalledWith(
-        destination.url,
-        JSON.stringify(headersVal)
-      );
+      expect(
+        component['datafeedRequests'].testDestinationWithHeaders
+      ).toHaveBeenCalledWith(destination.url, JSON.stringify(headersVal));
     });
 
     it('on test success for Custom now and check dispatched store data', () => {
@@ -470,19 +514,18 @@ describe('DataFeedComponent', () => {
       spyOn(component['datafeedRequests'], 'testDestinationWithHeaders');
       component.sendTestForDataFeed({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.CUSTOM
+        name: WebhookIntegrationTypes.CUSTOM,
+        region: null
       });
       const userToken = JSON.stringify({
         Authorization: 'Basic ' + btoa(username + ':' + password)
       });
       const headersJson = component.addHeadersforCustomDataFeed(headers);
-      const headersVal = {...headersJson, ...JSON.parse(userToken)};
+      const headersVal = { ...headersJson, ...JSON.parse(userToken) };
 
-      expect(component['datafeedRequests']
-      .testDestinationWithHeaders).toHaveBeenCalledWith(
-        destination.url,
-        JSON.stringify(headersVal)
-      );
+      expect(
+        component['datafeedRequests'].testDestinationWithHeaders
+      ).toHaveBeenCalledWith(destination.url, JSON.stringify(headersVal));
     });
 
     it('on success, adds new data feed ELK and check dispatched store dat', () => {
@@ -496,18 +539,23 @@ describe('DataFeedComponent', () => {
       spyOn(component['store'], 'dispatch');
       component.saveDestination({
         auth: AuthTypes.USERNAMEANDPASSWORD,
-        name: WebhookIntegrationTypes.ELK_KIBANA
+        name: WebhookIntegrationTypes.ELK_KIBANA,
+        region: null
       });
 
       expect(component['store'].dispatch).toHaveBeenCalledWith(
-        new CreateDestination({
-          name: component.createDataFeedForm.controls['name'].value.trim(),
-          url: component.createDataFeedForm.controls['url'].value.trim(),
-          integration_types: IntegrationTypes.WEBHOOK,
-          services: WebhookIntegrationTypes.ELK_KIBANA
-        }, JSON.stringify({
-          Authorization: 'Basic ' + btoa(username + ':' + password)
-        }), null)
+        new CreateDestination(
+          {
+            name: component.createDataFeedForm.controls['name'].value.trim(),
+            url: component.createDataFeedForm.controls['url'].value.trim(),
+            integration_types: IntegrationTypes.WEBHOOK,
+            services: WebhookIntegrationTypes.ELK_KIBANA
+          },
+          JSON.stringify({
+            Authorization: 'Basic ' + btoa(username + ':' + password)
+          }),
+          null
+        )
       );
     });
 
@@ -518,18 +566,94 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['password'].setValue(password);
       spyOn(component['datafeedRequests'], 'testDestinationWithHeaders');
       component.sendTestForDataFeed({
-      auth: AuthTypes.USERNAMEANDPASSWORD,
-      name: WebhookIntegrationTypes.ELK_KIBANA
+        auth: AuthTypes.USERNAMEANDPASSWORD,
+        name: WebhookIntegrationTypes.ELK_KIBANA,
+        region: null
       });
       const userToken = JSON.stringify({
-      Authorization: 'Basic ' + btoa(username + ':' + password)
+        Authorization: 'Basic ' + btoa(username + ':' + password)
       });
-      expect(component['datafeedRequests']
-      .testDestinationWithHeaders).toHaveBeenCalledWith(
-      destination.url,
-      userToken
+      expect(
+        component['datafeedRequests'].testDestinationWithHeaders
+      ).toHaveBeenCalledWith(destination.url, userToken);
+    });
+
+    it('on save success for s3 and check dispatched store data', () => {
+      spyOnProperty(component.createChild, 'saveDone', 'set');
+
+      component.createDataFeedForm.controls['name'].setValue(destination.name);
+      component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
+      component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
+      component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
+
+      spyOn(component['store'], 'dispatch');
+      component.saveDestination({
+        auth: null,
+        name: StorageIntegrationTypes.AMAZON_S3,
+        region: region
+      });
+
+      expect(component['store'].dispatch).toHaveBeenCalledWith(
+        new CreateDestination(
+          {
+            name: component.createDataFeedForm.controls['name'].value.trim(),
+            url: 'null',
+            integration_types: IntegrationTypes.STORAGE,
+            services: StorageIntegrationTypes.AMAZON_S3,
+            meta_data: [
+              {
+                key: 'bucket',
+                value:
+                  component.createDataFeedForm.controls[
+                    'bucketName'
+                  ].value.trim()
+              },
+              {
+                key: 'region',
+                value: region
+              }
+            ]
+          },
+          null,
+          {
+            accessKey:
+              component.createDataFeedForm.controls['accessKey'].value.trim(),
+            secretKey:
+              component.createDataFeedForm.controls['secretKey'].value.trim()
+          }
+        )
       );
+    });
+
+    it('on test success for S3 and check dispatched store data', () => {
+      component.createDataFeedForm.controls['name'].setValue(destination.name);
+      component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
+      component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
+      component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
+
+      spyOn(component['datafeedRequests'], 'testDestinationForMinio');
+      component.sendTestForDataFeed({
+        auth: null,
+        name: StorageIntegrationTypes.AMAZON_S3,
+        region: region
+      });
+
+      expect(
+        component['datafeedRequests'].testDestinationForMinio
+      ).toHaveBeenCalledWith({
+        url: 'null',
+        aws: {
+          access_key:
+            component.createDataFeedForm.controls['accessKey'].value.trim(),
+          secret_access_key:
+            component.createDataFeedForm.controls['secretKey'].value.trim(),
+          bucket:
+            component.createDataFeedForm.controls['bucketName'].value.trim(),
+          region: region
+        }
+      });
     });
   });
 
-});
+
+  });

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -412,7 +412,7 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
 
-      spyOn(component['datafeedRequests'], 'testDestinationForMinio');
+      spyOn(component['datafeedRequests'], 'testDestinationForStorage');
       component.sendTestForDataFeed({
         auth: null,
         name: StorageIntegrationTypes.MINIO,
@@ -420,7 +420,7 @@ describe('DataFeedComponent', () => {
       });
 
       expect(
-        component['datafeedRequests'].testDestinationForMinio
+        component['datafeedRequests'].testDestinationForStorage
       ).toHaveBeenCalledWith({
         url: destination.url,
         aws: {
@@ -626,7 +626,7 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
 
-      spyOn(component['datafeedRequests'], 'testDestinationForMinio');
+      spyOn(component['datafeedRequests'], 'testDestinationForStorage');
       component.sendTestForDataFeed({
         auth: null,
         name: StorageIntegrationTypes.AMAZON_S3,
@@ -634,7 +634,7 @@ describe('DataFeedComponent', () => {
       });
 
       expect(
-        component['datafeedRequests'].testDestinationForMinio
+        component['datafeedRequests'].testDestinationForStorage
       ).toHaveBeenCalledWith({
         url: 'null',
         aws: {

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.spec.ts
@@ -100,14 +100,14 @@ describe('DataFeedComponent', () => {
       id: '1',
       name: 'new data feed',
       secret: 'testSecret',
-      url: 'http://foo.com',
+      url: 'http://foo.com'
     };
     const destinationwithHeader = <Destination>{
       id: '1',
       name: 'new data feed',
       secret: 'testSecret',
       url: 'http://foo.com',
-      headers: 'test:123',
+      headers: 'test:123'
     };
 
     beforeEach(() => {
@@ -174,9 +174,7 @@ describe('DataFeedComponent', () => {
       spyOnProperty(component.createChild, 'saveDone', 'set');
 
       component.createDataFeedForm.controls['name'].setValue(destination.name);
-      component.createDataFeedForm.controls['endpoint'].setValue(
-        destination.url
-      );
+      component.createDataFeedForm.controls['endpoint'].setValue(destination.url);
       component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
@@ -311,9 +309,7 @@ describe('DataFeedComponent', () => {
       spyOnProperty(component.createChild, 'saveDone', 'set');
 
       component.createDataFeedForm.controls['name'].setValue(destination.name);
-      component.createDataFeedForm.controls['endpoint'].setValue(
-        destination.url
-      );
+      component.createDataFeedForm.controls['endpoint'].setValue(destination.url);
       component.createDataFeedForm.controls['bucketName'].setValue(bucketName);
       component.createDataFeedForm.controls['accessKey'].setValue(accessKey);
       component.createDataFeedForm.controls['secretKey'].setValue(secretKey);
@@ -372,9 +368,10 @@ describe('DataFeedComponent', () => {
         Authorization: 'Basic ' + btoa(username + ':' + password)
       });
 
-      expect(
-        component['datafeedRequests'].testDestinationWithHeaders
-      ).toHaveBeenCalledWith(destination.url, userToken);
+      expect(component['datafeedRequests']
+      .testDestinationWithHeaders).toHaveBeenCalledWith(
+        destination.url,
+        userToken);
       expect(component.revealUrlStatus).toHaveBeenCalledWith(
         UrlTestState.Success
       );
@@ -386,10 +383,8 @@ describe('DataFeedComponent', () => {
       component.createDataFeedForm.controls['tokenType'].setValue('Bearer');
       component.createDataFeedForm.controls['token'].setValue(token);
       spyOn(component, 'revealUrlStatus');
-      spyOn(
-        component['datafeedRequests'],
-        'testDestinationWithHeaders'
-      ).and.returnValue(throwError([]));
+      spyOn(component['datafeedRequests'], 'testDestinationWithHeaders')
+      .and.returnValue(throwError([]));
       component.sendTestForDataFeed({
         auth: AuthTypes.ACCESSTOKEN,
         name: WebhookIntegrationTypes.SPLUNK,

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -92,7 +92,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
       headers: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       bucketName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       accessKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      secretKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
+      secretKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
     });
   }
 
@@ -177,7 +177,8 @@ export class DataFeedComponent implements OnInit, OnDestroy {
         return headersJson;
   }
 
-  public sendTestForDataFeed(event: {name: string, auth: string}): void {
+
+  public sendTestForDataFeed(event: {name: string, auth: string, region: string}): void {
     let testConnectionObservable: Observable<Object> = null;
 
     switch (event.name) {
@@ -231,16 +232,38 @@ export class DataFeedComponent implements OnInit, OnDestroy {
       }
       case StorageIntegrationTypes.MINIO: {
         // handling minio
-        const targetUrl: string = this.createDataFeedForm.controls['endpoint'].value;
+        const targetUrl: string =
+          this.createDataFeedForm.controls['endpoint'].value;
         const data = {
           url: targetUrl,
           aws: {
-            access_key: this.createDataFeedForm.controls['accessKey'].value.trim(),
-            secret_access_key: this.createDataFeedForm.controls['secretKey'].value.trim(),
-            bucket: this.createDataFeedForm.controls['bucketName'].value.trim()
+            access_key:
+              this.createDataFeedForm.controls['accessKey'].value.trim(),
+            secret_access_key:
+              this.createDataFeedForm.controls['secretKey'].value.trim(),
+            bucket: this.createDataFeedForm.controls['bucketName'].value.trim(),
           }
         };
-        testConnectionObservable = this.datafeedRequests.testDestinationForMinio(data);
+        testConnectionObservable =
+          this.datafeedRequests.testDestinationForMinio(data);
+          break;
+      }
+      case StorageIntegrationTypes.AMAZON_S3: {
+        const data = {
+          url: 'null',
+          aws: {
+            access_key:
+              this.createDataFeedForm.controls['accessKey'].value.trim(),
+            secret_access_key:
+              this.createDataFeedForm.controls['secretKey'].value.trim(),
+            bucket: this.createDataFeedForm.controls['bucketName'].value.trim(),
+            region: event.region
+          }
+        };
+        console.log('region is', event.region);
+        console.log(data)
+        testConnectionObservable =
+          this.datafeedRequests.testDestinationForMinio(data);
       }
     }
     if (testConnectionObservable != null) {
@@ -265,7 +288,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
     this.createChild.slidePanel();
   }
 
-  public saveDestination(event: {name: string, auth: string}) {
+  public saveDestination(event: {name: string, auth: string, region: string}) {
 
     let destinationObj: CreateDestinationPayload,
         headers: string,
@@ -332,14 +355,46 @@ export class DataFeedComponent implements OnInit, OnDestroy {
           meta_data: [
             {
               key: 'bucket',
-              value: this.createDataFeedForm.controls['bucketName'].value.trim()
+              value:
+                this.createDataFeedForm.controls['bucketName'].value.trim(),
+            },
+          ],
+        };
+        const accessKey: string =
+          this.createDataFeedForm.controls['accessKey'].value.trim();
+        const secretKey: string =
+          this.createDataFeedForm.controls['secretKey'].value.trim();
+        storage = { accessKey, secretKey };
+        headers = null;
+        break;
+      }
+      case StorageIntegrationTypes.AMAZON_S3: {
+        destinationObj = {
+          name: this.createDataFeedForm.controls['name'].value.trim(),
+          url: 'null',
+          integration_types: IntegrationTypes.STORAGE,
+          services: event.name,
+          meta_data: [
+            {
+              key: 'bucket',
+              value:
+                this.createDataFeedForm.controls['bucketName'].value.trim()
+            },
+            {
+              key: 'region',
+              value: event.region
             }
           ]
         };
-        const accessKey: string = this.createDataFeedForm.controls['accessKey'].value.trim();
-        const secretKey: string = this.createDataFeedForm.controls['secretKey'].value.trim();
-        storage = {accessKey, secretKey};
+        console.log('Region in save is ',event.region)
+        console.log('destinationobject',destinationObj)
+        const accessKey: string =
+          this.createDataFeedForm.controls['accessKey'].value.trim();
+        const secretKey: string =
+          this.createDataFeedForm.controls['secretKey'].value.trim();
+        storage = { accessKey, secretKey };
         headers = null;
+        break;
       }
     }
     if (destinationObj && (headers || storage)) {

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -242,7 +242,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
             bucket: this.createDataFeedForm.controls['bucketName'].value.trim()
           }
         };
-        testConnectionObservable = this.datafeedRequests.testDestinationForMinio(data);
+        testConnectionObservable = this.datafeedRequests.testDestinationForStorage(data);
           break;
       }
       case StorageIntegrationTypes.AMAZON_S3: {
@@ -255,7 +255,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
             region: event.region
           }
         };
-        testConnectionObservable = this.datafeedRequests.testDestinationForMinio(data);
+        testConnectionObservable = this.datafeedRequests.testDestinationForStorage(data);
       }
     }
     if (testConnectionObservable != null) {

--- a/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
+++ b/components/automate-ui/src/app/pages/data-feed/data-feed.component.ts
@@ -92,7 +92,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
       headers: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       bucketName: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
       accessKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
-      secretKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]],
+      secretKey: ['', [Validators.required, Validators.pattern(Regex.patterns.NON_BLANK)]]
     });
   }
 
@@ -237,33 +237,25 @@ export class DataFeedComponent implements OnInit, OnDestroy {
         const data = {
           url: targetUrl,
           aws: {
-            access_key:
-              this.createDataFeedForm.controls['accessKey'].value.trim(),
-            secret_access_key:
-              this.createDataFeedForm.controls['secretKey'].value.trim(),
-            bucket: this.createDataFeedForm.controls['bucketName'].value.trim(),
+            access_key: this.createDataFeedForm.controls['accessKey'].value.trim(),
+            secret_access_key: this.createDataFeedForm.controls['secretKey'].value.trim(),
+            bucket: this.createDataFeedForm.controls['bucketName'].value.trim()
           }
         };
-        testConnectionObservable =
-          this.datafeedRequests.testDestinationForMinio(data);
+        testConnectionObservable = this.datafeedRequests.testDestinationForMinio(data);
           break;
       }
       case StorageIntegrationTypes.AMAZON_S3: {
         const data = {
           url: 'null',
           aws: {
-            access_key:
-              this.createDataFeedForm.controls['accessKey'].value.trim(),
-            secret_access_key:
-              this.createDataFeedForm.controls['secretKey'].value.trim(),
+            access_key: this.createDataFeedForm.controls['accessKey'].value.trim(),
+            secret_access_key: this.createDataFeedForm.controls['secretKey'].value.trim(),
             bucket: this.createDataFeedForm.controls['bucketName'].value.trim(),
             region: event.region
           }
         };
-        console.log('region is', event.region);
-        console.log(data)
-        testConnectionObservable =
-          this.datafeedRequests.testDestinationForMinio(data);
+        testConnectionObservable = this.datafeedRequests.testDestinationForMinio(data);
       }
     }
     if (testConnectionObservable != null) {
@@ -355,15 +347,12 @@ export class DataFeedComponent implements OnInit, OnDestroy {
           meta_data: [
             {
               key: 'bucket',
-              value:
-                this.createDataFeedForm.controls['bucketName'].value.trim(),
-            },
-          ],
+              value: this.createDataFeedForm.controls['bucketName'].value.trim()
+            }
+          ]
         };
-        const accessKey: string =
-          this.createDataFeedForm.controls['accessKey'].value.trim();
-        const secretKey: string =
-          this.createDataFeedForm.controls['secretKey'].value.trim();
+        const accessKey: string = this.createDataFeedForm.controls['accessKey'].value.trim();
+        const secretKey: string = this.createDataFeedForm.controls['secretKey'].value.trim();
         storage = { accessKey, secretKey };
         headers = null;
         break;
@@ -377,8 +366,7 @@ export class DataFeedComponent implements OnInit, OnDestroy {
           meta_data: [
             {
               key: 'bucket',
-              value:
-                this.createDataFeedForm.controls['bucketName'].value.trim()
+              value: this.createDataFeedForm.controls['bucketName'].value.trim()
             },
             {
               key: 'region',
@@ -386,12 +374,8 @@ export class DataFeedComponent implements OnInit, OnDestroy {
             }
           ]
         };
-        console.log('Region in save is ',event.region)
-        console.log('destinationobject',destinationObj)
-        const accessKey: string =
-          this.createDataFeedForm.controls['accessKey'].value.trim();
-        const secretKey: string =
-          this.createDataFeedForm.controls['secretKey'].value.trim();
+        const accessKey: string = this.createDataFeedForm.controls['accessKey'].value.trim();
+        const secretKey: string = this.createDataFeedForm.controls['secretKey'].value.trim();
         storage = { accessKey, secretKey };
         headers = null;
         break;

--- a/e2e/cypress/integration/ui/settings/data-feed/data-feed-create.spec.ts
+++ b/e2e/cypress/integration/ui/settings/data-feed/data-feed-create.spec.ts
@@ -71,7 +71,9 @@ describe('chef datafeed', () => {
       cy.get('app-notification.info').should('be.visible');
       cy.get('app-notification.info chef-icon').click();
       cy.contains('Data Feeds').click();
-      cy.get('chef-table chef-tbody chef-td').contains('cytest' + date).should('exist');
+      cy.get('chef-table chef-tbody chef-td')
+        .contains('cytest' + date)
+        .should('exist');
     });
 
     it('create data feed splunk', () => {
@@ -327,6 +329,50 @@ describe('chef datafeed', () => {
       cy.get('app-data-feed-create').scrollTo('top');
       cy.get('.data-feed-slider app-notification.info').should('be.visible');
       cy.get('.data-feed-slider app-notification.info chef-icon').click();
+      cy.get('[data-cy=close-feed-button]').click();
+    });
+
+    it('create data feed for S3', () => {
+      cy.get('[data-cy=create-data-feed]').click();
+      cy.get('[data-cy="Amazon S3"]').click();
+      cy.get('[data-cy=add-name]').type(name + reusableDate);
+      cy.get('[data-cy=add-bucket-name]').type(bucketName);
+      cy.get('[data-cy=add-access-key]').type(accessKey);
+      cy.get('[data-cy=add-secret-key]').type(secretKey);
+      cy.get('[data-cy=add-button]').click();
+      cy.get('app-notification.info').should('be.visible');
+      cy.get('app-notification.info chef-icon').click();
+      cy.contains('Data Feeds').click();
+      cy.get('chef-table chef-tbody chef-td').contains('cytest' + reusableDate).should('exist');
+    });
+
+    it('error in creating data feed for S3', () => {
+      cy.get('[data-cy=create-data-feed]').click();
+      cy.get('[data-cy="Amazon S3"]').click();
+      cy.get('[data-cy=add-name]').type(name + reusableDate);
+      cy.get('[data-cy=add-bucket-name]').type(bucketName);
+      cy.get('[data-cy=add-access-key]').type(accessKey);
+      cy.get('[data-cy=add-secret-key]').type(secretKey);
+      cy.get('[data-cy=add-button]').click();
+      cy.get('app-data-feed-create').scrollTo('top');
+      cy.get('.data-feed-slider app-notification.error').should('be.visible');
+      cy.get('.data-feed-slider app-notification.error chef-icon').click();
+      cy.get('[data-cy=close-feed-button]').click();
+    });
+
+    it('test faliure in data feed S3', () => {
+      const date = Date.now();
+      cy.get('[data-cy=create-data-feed]').click();
+      cy.get('app-data-feed-create').scrollTo('bottom');
+      cy.get('[data-cy="Amazon S3"]').click();
+      cy.get('[data-cy=add-name]').type(name + date);
+      cy.get('[data-cy=add-bucket-name]').type(bucketName);
+      cy.get('[data-cy=add-access-key]').type(accessKey);
+      cy.get('[data-cy=add-secret-key]').type(secretKey);
+      cy.get('[data-cy=test-button]').click();
+      cy.get('app-data-feed-create').scrollTo('top');
+      cy.get('.data-feed-slider app-notification.error').should('be.visible');
+      cy.get('.data-feed-slider app-notification.error chef-icon').click();
       cy.get('[data-cy=close-feed-button]').click();
     });
   });

--- a/e2e/cypress/integration/ui/settings/data-feed/data-feed-create.spec.ts
+++ b/e2e/cypress/integration/ui/settings/data-feed/data-feed-create.spec.ts
@@ -71,9 +71,7 @@ describe('chef datafeed', () => {
       cy.get('app-notification.info').should('be.visible');
       cy.get('app-notification.info chef-icon').click();
       cy.contains('Data Feeds').click();
-      cy.get('chef-table chef-tbody chef-td')
-        .contains('cytest' + date)
-        .should('exist');
+      cy.get('chef-table chef-tbody chef-td').contains('cytest' + date).should('exist');
     });
 
     it('create data feed splunk', () => {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Amazon S3 is enabled. The modal that pops up helps us to test connection to any S3 bucket as well as enable us to save that in the data feed table.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
Data Feeds UI: S9: New S3 Integration Overlay  #5581 

### :+1: Definition of Done

- Amazon S3 options is shown
- Form should open on clicking S3  integration
- Test connection should be working
- Save integration should be working

### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

make serve

To run cypress test
cd e2e
npm run cypress:local

Type feat to enable data-feed
Navigate to settings/data-feeds
```



### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[](url)

https://user-images.githubusercontent.com/87964433/133587656-3aeb003f-ed4e-49af-9e99-f81123aa51d4.mov

