### PR TITLE
Script added for table 'org_users'

### DIFF
--- a/components/infra-proxy-service/storage/postgres/migration/sql/05_user_management.down.sql
+++ b/components/infra-proxy-service/storage/postgres/migration/sql/05_user_management.down.sql
@@ -1,5 +1,8 @@
 -- drop column projects in servers table 
 ALTER TABLE servers DROP COLUMN projects;
 
+-- drop table org_users
+DROP TABLE IF EXISTS org_users;
+
 -- drop table users
 DROP TABLE IF EXISTS users;

--- a/components/infra-proxy-service/storage/postgres/migration/sql/05_user_management.up.sql
+++ b/components/infra-proxy-service/storage/postgres/migration/sql/05_user_management.up.sql
@@ -16,3 +16,13 @@ CREATE TABLE IF NOT EXISTS users (
   UNIQUE(infra_server_username,server_id)
 );
 CREATE INDEX IF NOT EXISTS users_automate_user_id_index ON users (automate_user_id);
+
+-- create table org_users
+CREATE TABLE IF NOT EXISTS org_users (
+  id           TEXT PRIMARY KEY,
+  org_id       TEXT NOT NULL references orgs(id) ON DELETE RESTRICT,
+  user_id      TEXT NOT NULL references users(id) ON DELETE RESTRICT, 
+  is_admin     BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS org_users_org_id_index ON org_users (org_id);
+CREATE INDEX IF NOT EXISTS org_users_user_id_index ON org_users (user_id);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
I have added the script for table 'org_users'
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5715
### :+1: Definition of Done
I have added script for the table 'org_users' in user management to map the users with organisation in automate

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
