### PR TITLE
set the HAB_BLDR_CHANNEL to dev just for builds

### DIFF
--- a/.studio/common
+++ b/.studio/common
@@ -200,7 +200,9 @@ document "build" <<EOF
 EOF
 function build() {
   local hab_build
-  HAB_BLDR_CHANNEL=dev
+  #set HAB_BLDR_CHANNEL to dev as part of the hab package refresh
+  local HAB_BLDR_CHANNEL=dev
+  
   # Support for hab v.0.63.0
   if [ -f /bin/build ]; then
     hab_build=/bin/build


### PR DESCRIPTION
Signed-off-by: Rick Marry <rmarry@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
this is a follow up to pr 5741 where for hab package refresh, we need to set one env var to dev but just for builds.. we do so by making it a local var

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
