### PR TITLE
Disabled edit button if databag item is encrypted.

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
@@ -82,7 +82,11 @@
                           <chef-icon class="material-icons">delete</chef-icon>
                           <span>Delete</span>
                         </chef-button>
-                        <chef-button tertiary class="action right-button-box" (click)="startUpdateDataBagItem(item, selectedItemDetails)">
+                        <chef-button
+                          tertiary
+                          class="action right-button-box"
+                          (click)="startUpdateDataBagItem(item, selectedItemDetails)"
+                          [disabled]="editDisable">
                           <chef-icon class="material-icons">mode_edit</chef-icon>
                           <span>Edit</span>
                         </chef-button>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -49,6 +49,7 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
   public dataBagItemToDelete: DataBagItems;
   public deleteModalVisible = false;
   public deleting = false;
+  public editDisable = false;
   public openDataBagModal = new EventEmitter<void>();
   public openEditDataBagItemModal = new EventEmitter<void>();
   public openDataBagItemModal = new EventEmitter<void>();
@@ -117,6 +118,16 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
       .subscribe(([_getDataBagItemDetailsSt, dataBagItemDetailsState]) => {
         this.selectedItemDetails = JSON.parse(dataBagItemDetailsState.data);
         delete this.selectedItemDetails['id'];
+        this.editDisable = false;
+        for (const item in this.selectedItemDetails) {
+          if (this.selectedItemDetails[item]) {
+            for (const property in this.selectedItemDetails[item]) {
+              if (property === 'encrypted_data' || property === 'cipher') {
+                this.editDisable = true;
+              }
+            }
+          }
+        }
         this.dataBagsItemDetailsLoading = false;
       });
   }


### PR DESCRIPTION
Signed-off-by: Himanshi Chhabra <hchhabra@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Need to disable the edit button if we have data bag item as encrypted 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#5045 

### :+1: Definition of Done
Disabled edit button if we have data bag item as encrypted 
### :athletic_shoe: How to Build and Test the Change

```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
To add data https://github.com/chef/automate/blob/master/dev-docs/adding-data/adding_test_data.md#adding-data-to-infra-views
To add encrypted databag : 
1. inside hab studio run local dev server: 
    -  start_chef_server
    - infra_service_load_chef_repo
    - converge_policyfile_chef_client
  
2. inside chef-workstation:
     go to chef-startef/ chef-repo folder then run these commands:
             - openssl rand -base64 512 | tr -d '\r\n' > ~/encrypted_data_bag_secret
             - knife data bag create admins
             - knife data bag create admins encrypted-test --secret-file ~/encrypted_data_bag_secret
             - in nano file add "password": "roots" -> then CTRL+o , CTRL +x
3. In UI: 
    - Go To Infrastructure -> Chef Servers -> click server -> click org -> go to databag tab -> click ```admins``` -> click encrypted-test -> **edit button is disable.**
   

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/61003053/133995121-0c152a6a-7efe-4cfc-9fbf-42697822ca3c.mp4



