### PR TITLE
added changes to block the status check of server before create and u…

### DIFF
--- a/components/infra-proxy-service/server/servers.go
+++ b/components/infra-proxy-service/server/servers.go
@@ -45,10 +45,10 @@ func (s *Server) CreateServer(ctx context.Context, req *request.CreateServer) (*
 		serverHost = req.GetIpAddress()
 	}
 
-	_, err = s.infraServerStatusChecker.GetInfraServerStatus(serverHost)
-	if err != nil {
-		return nil, err
-	}
+	//_, err = s.infraServerStatusChecker.GetInfraServerStatus(serverHost)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	server, err := s.service.Storage.StoreServer(ctx, req.Id, req.Name, req.Fqdn, req.IpAddress)
 	if err != nil {
@@ -155,10 +155,10 @@ func (s *Server) UpdateServer(ctx context.Context, req *request.UpdateServer) (*
 		serverHost = req.GetIpAddress()
 	}
 
-	_, err = s.infraServerStatusChecker.GetInfraServerStatus(serverHost)
-	if err != nil {
-		return nil, err
-	}
+	//_, err = s.infraServerStatusChecker.GetInfraServerStatus(serverHost)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	server, err := s.service.Storage.EditServer(ctx, req.Id, req.Name, req.Fqdn, req.IpAddress)
 	if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We need to remove the infra server status check using the create/update server API calls 
### :chains: Related Resources
https://github.com/chef/automate/issues/5758
### :+1: Definition of Done
I have added the changes to remove check the status check of the server before create/update server API calls.
### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/infra-proxy-service
rebuild components/automate-gateway
```
then you need to navigate the chef-infra-server. --> click to `Add Chef Infra Server`
try some valid or invalid Fqdn or IP address.
example - example.com, xyz.com
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
