### PR TITLE
Upgrading refresh chef server components to 14.9.23 version

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -459,6 +459,8 @@ exceptions:
       reason:  Exception made by Chef Legal
     - name: core/ruby30
       reason: Ruby license (previously shipped in Automate 1)
+    - name: core/ruby27
+      reason:  Exception made for chef server upgrade
 
 
   ruby:

--- a/components/automate-cs-bookshelf/habitat/plan.sh
+++ b/components/automate-cs-bookshelf/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-bookshelf"
 pkg_description="Wrapper package for chef/bookshelf"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.10.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/bookshelf/14.4.4/20210520120637"
+  "${vendor_origin}/bookshelf/14.10.23/20211021174548"
 )
 
 pkg_binds=(

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -7,7 +7,7 @@ vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Chef-MLSA')
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.10.23"
 pkg_deps=(
   core/coreutils
   chef/mlsa
@@ -20,8 +20,8 @@ pkg_deps=(
   core/curl/7.68.0/20200601114640
   core/ruby26/2.6.5/20200404043345
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/chef-server-nginx/14.4.4/20210520121142"
-  "${vendor_origin}/chef-server-ctl/14.4.4/20210520120637"
+  "${vendor_origin}/chef-server-nginx/14.10.23/20211021175037"
+  "${vendor_origin}/chef-server-ctl/14.10.23/20211021174548"
 )
 
 pkg_bin_dirs=(bin)

--- a/components/automate-cs-oc-bifrost/habitat/plan.sh
+++ b/components/automate-cs-oc-bifrost/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-bifrost"
 pkg_description="Wrapper package for chef/oc_bifrost"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.10.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -15,7 +15,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_bifrost/14.4.4/20210520120641"
+  "${vendor_origin}/oc_bifrost/14.10.23/20211021174610"
 )
 
 pkg_binds=(

--- a/components/automate-cs-oc-erchef/habitat/plan.sh
+++ b/components/automate-cs-oc-erchef/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_name="automate-cs-oc-erchef"
 pkg_description="Wrapper package for chef/oc_erchef"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="14.4.4"
+pkg_version="14.10.23"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -16,7 +16,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_erchef/14.4.4/20210520120641"
+  "${vendor_origin}/oc_erchef/14.10.23/20211021174610"
 )
 
 pkg_build_deps=(

--- a/integration/tests/a1migration.sh
+++ b/integration/tests/a1migration.sh
@@ -46,7 +46,7 @@ do_test_deploy() {
     chef_server_migration_smoke_tests
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
 
     workflow_server_migration_smoke_tests
 }

--- a/integration/tests/chef_server.sh
+++ b/integration/tests/chef_server.sh
@@ -55,7 +55,7 @@ do_test_deploy() {
     umask 022
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
     test_chef_server_ctl
     test_knife
     test_cookbook_caching

--- a/integration/tests/chef_server_backup.sh
+++ b/integration/tests/chef_server_backup.sh
@@ -29,7 +29,7 @@ do_deploy() {
 do_test_deploy() {
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
     test_chef_server_ctl
     do_test_deploy_default
 }

--- a/integration/tests/chef_server_only.sh
+++ b/integration/tests/chef_server_only.sh
@@ -32,6 +32,6 @@ do_deploy() {
 do_test_deploy() {
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
     test_chef_server_ctl
 }

--- a/integration/tests/chef_server_upgrade.sh
+++ b/integration/tests/chef_server_upgrade.sh
@@ -24,7 +24,7 @@ do_deploy() {
 do_test_deploy() {
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
     test_chef_server_ctl
     test_knife
     do_test_deploy_default
@@ -33,7 +33,7 @@ do_test_deploy() {
 do_test_upgrade() {
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status
+    PATH="/hab/bin:/bin" chef-server-ctl test --smoke --skip-status --skip=response_headers
     test_chef_server_ctl
     test_knife
     do_test_upgrade_default

--- a/integration/tests/ha_chef_server.sh
+++ b/integration/tests/ha_chef_server.sh
@@ -174,7 +174,7 @@ EOH
 do_test_deploy() {
     ## skipping status test because of the missing file in automate - /etc/opscode/chef-server-running.json 
     ## adding smoke tag or else all the test will be considered skipping only the status test
-    hab pkg exec chef/automate-cs-nginx chef-server-ctl test --smoke --skip-status
+    hab pkg exec chef/automate-cs-nginx chef-server-ctl test --smoke --skip-status --skip=response_headers
 }
 
 do_cleanup() {


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Upgrading the chef server to latest version - 14.9.23. The components are pointing to the new refresh channel of habitat.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
