### PR TITLE
Store the unique id for every deployment in DB

### DIFF
--- a/components/license-control-service/migrations/001_deployment.up.sql
+++ b/components/license-control-service/migrations/001_deployment.up.sql
@@ -3,7 +3,8 @@ BEGIN;
 -- create table deployment
 CREATE TABLE IF NOT EXISTS deployment (
   id          TEXT PRIMARY KEY,
-  created_at  TIMESTAMPTZ NOT NULL
+  created_at  TIMESTAMPTZ NOT NULL,
+  updated_at  TIMESTAMPTZ NOT NULL
 );
 
 COMMIT;

--- a/components/license-control-service/pkg/storage/storage.go
+++ b/components/license-control-service/pkg/storage/storage.go
@@ -282,6 +282,10 @@ func (m *MemBackend) SetLicense(ctx context.Context, s string) error {
 	return nil
 }
 
+func (m *MemBackend) StoreDeployment(context.Context, string) error {
+	return nil
+}
+
 //StoreDeployment stores the deployment info in the DB
 func (p *PGBackend) StoreDeployment(ctx context.Context, id string) error {
 	err := Transact(p, func(tx *DBTrans) error {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Store the unique id for every deployment in DB

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5613

### :+1: Definition of Done
I have added changes to store the deployment id in DB at the start of license control service

### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/license-control-service
```
Steps to test:

1. To start the services use, ```start_all_services```
2. Check the deployment id entry in ```deployment``` table of ```chef_license_control_service``` database
3. For the next start of license control service, this entry will be updated with unique id
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
