### PR TITLE
Config Patch command mapping 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -9,3 +9,4 @@ const (
 
 const AUTOMATE_HA_RUN_LOG_DIR = "/hab/a2_deploy_workspace/logs"
 const AUTOMATE_HA_WORKSPACE_DIR = "/hab/a2_deploy_workspace"
+const AUTOMATE_HA_AUTOMATE_CONFIG_FILE = "/hab/a2_deploy_workspace/configs/automate.toml"


### PR DESCRIPTION
config patch-command mapping

### :nut_and_bolt: Description: What code changed, and why?

to patch automate config in A2HA mode, we need to have config patch command mapping

**chef-automate config patch </path/to/autoamte-config.toml>**

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/5708

### :+1: Definition of Done

Dev Done, Dev Tested

### :athletic_shoe: How to Build and Test the Change

rebuild/build component/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
