### PR TITLE
Table script to store the last compliance telemetry reported date

### DIFF
--- a/components/compliance-service/dao/pgdb/migration/sql/41_create_telemetry.down.sql
+++ b/components/compliance-service/dao/pgdb/migration/sql/41_create_telemetry.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS telemetry;

--- a/components/compliance-service/dao/pgdb/migration/sql/41_create_telemetry.up.sql
+++ b/components/compliance-service/dao/pgdb/migration/sql/41_create_telemetry.up.sql
@@ -1,0 +1,8 @@
+-- create table telemetry to store the last complaiance telemtry reported date
+CREATE TABLE IF NOT EXISTS telemetry (
+  id                         text PRIMARY KEY,
+  last_telemetry_reported_at TIMESTAMPTZ NOT NULL,
+  created_at                 TIMESTAMPTZ NOT NULL,
+  updated_at                 TIMESTAMPTZ NOT NULL,
+  UNIQUE(last_telemetry_reported_at)
+);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Script for table to store the last compliance telemetry reported date
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5862
### :+1: Definition of Done
I have added script for the table 'telemetry' to store the last compliance telemetry reported date

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
