### PR TITLE
es index for compliance run info

### DIFF
--- a/components/compliance-service/ingest/ingestic/mappings/comp-run-info.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-run-info.go
@@ -1,0 +1,33 @@
+package mappings
+
+// ComplianceRunInfo mapping used to create the `compliance-run-info index
+var ComplianceRunInfo= Mapping{
+	Index:      IndexNameComplianceRunInfo,
+	Type:       DocType,
+	Timeseries: false,
+	Mapping: `
+{
+  "template": "` + IndexNameComplianceRunInfo + `",
+  "settings": {
+    "index": {
+      "refresh_interval": "1s"
+    }
+  },
+  "mappings": {
+    "` + DocType + `": {
+      "properties": {
+        "node_uuid": {
+          "type": "keyword"
+        },
+        "first_run": {
+          "type": "date"
+        },
+        "last_run": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}
+	`,
+}

--- a/components/compliance-service/ingest/ingestic/mappings/mappings.go
+++ b/components/compliance-service/ingest/ingestic/mappings/mappings.go
@@ -18,6 +18,7 @@ var AllMappings = []Mapping{
 	ComplianceRepDate,
 	ComplianceSumDate,
 	ComplianceProfiles,
+	ComplianceRunInfo,
 }
 
 const (
@@ -29,12 +30,15 @@ const (
 	ComplianceCurrentTimeSeriesIndicesVersion = "7"
 	//ComplianceCurrentProfilesIndicesVersion allows us to know, for any version of compliance, what level we are at with our profiles and profiles-mappings indices
 	ComplianceCurrentProfilesIndicesVersion = "3"
+	ComplianceCurrentRunInfoVersion = "1"
 
 	compAndVersionTimeSeries = "comp-" + ComplianceCurrentTimeSeriesIndicesVersion
 	compAndVersionProfiles   = "comp-" + ComplianceCurrentProfilesIndicesVersion
+	compAndVersionRunInfo   = "comp-" + ComplianceCurrentRunInfoVersion
 
 	DocType       = "_doc"
 	IndexNameProf = compAndVersionProfiles + "-profiles"
+	IndexNameComplianceRunInfo = compAndVersionRunInfo + "-run-info"
 
 	IndexNameRep = compAndVersionTimeSeries + "-r"
 	IndexNameSum = compAndVersionTimeSeries + "-s"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
this pr implements the requirement described in issue: #5858 
Create an ES index to store the run information for Compliance reports

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
in hab:
`rebuild components/compliance-service/`
`start_all_services`

Once the services are all running, you may issue the following curl to see the es index template that was created:
`curl  --request GET 'localhost:10141/_template/comp-1-run-info'`

which will produce the following response:
```json
{
  "comp-1-run-info": {
    "order": 0,
    "index_patterns": [
      "comp-1-run-info"
    ],
    "settings": {
      "index": {
        "refresh_interval": "1s"
      }
    },
    "mappings": {
      "_doc": {
        "properties": {
          "last_run": {
            "type": "date"
          },
          "node_uuid": {
            "type": "keyword"
          },
          "first_run": {
            "type": "date"
          }
        }
      }
    },
    "aliases": {}
  }
}
```



### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
