### PR TITLE
Switch automate-backend-elasticsidecar to Chefstyle

### DIFF
--- a/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/.rubocop.yml
+++ b/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Style/StringLiterals:
   Enabled: true

--- a/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/Gemfile
+++ b/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/Gemfile
@@ -7,4 +7,4 @@ gemspec
 
 gem "rake", "~> 13.0"
 
-gem "rubocop", "~> 1.7"
+gem "chefstyle", "~> 2.1"

--- a/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/Gemfile.lock
+++ b/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     bcrypt (3.1.16)
     chef-utils (17.3.48)
       concurrent-ruby
+    chefstyle (2.1.0)
+      rubocop (= 1.22.0)
     citrus (3.0.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -42,7 +44,7 @@ GEM
     method_source (1.0.0)
     mixlib-shellout (3.2.5)
       chef-utils
-    parallel (1.20.1)
+    parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
@@ -53,16 +55,16 @@ GEM
     rake (13.0.6)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.19.1)
+    rubocop (1.22.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.9.1, < 2.0)
+      rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.10.0)
+    rubocop-ast (1.12.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     toml-rb (2.0.1)
@@ -70,16 +72,15 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   automate-backend-elasticsidecar!
-  bundler
+  chefstyle (~> 2.1)
   rake (~> 13.0)
-  rubocop (~> 1.7)
 
 BUNDLED WITH
    2.1.2

--- a/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/automate-backend-elasticsidecar.gemspec
+++ b/components/automate-backend-elasticsidecar/habitat/automate-backend-elasticsidecar/automate-backend-elasticsidecar.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require_relative "lib/automate/backend/elasticsidecar/version"
 
@@ -14,9 +14,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"
-  
-  spec.add_runtime_dependency 'toml-rb'
-  spec.add_runtime_dependency 'mixlib-shellout'
-  spec.add_runtime_dependency 'pry'
+
+  spec.add_runtime_dependency "toml-rb"
+  spec.add_runtime_dependency "mixlib-shellout"
+  spec.add_runtime_dependency "pry"
 
 end


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Our ruby linting standard is Chefstyle not RuboCop.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
