### PR TITLE
Storage functions for the last compliance telemetry reported date

### DIFF
--- a/components/compliance-service/dao/pgdb/db.go
+++ b/components/compliance-service/dao/pgdb/db.go
@@ -112,6 +112,7 @@ func initTables(db *gorp.DbMap) {
 	db.AddTableWithName(profile{}, "profiles")
 	db.AddTableWithName(JobProfile{}, "jobs_profiles")
 	db.AddTableWithName(ResultsRow{}, "results")
+	db.AddTableWithName(Telemetry{}, "telemetry")
 }
 
 func createUUID() string {

--- a/components/compliance-service/dao/pgdb/telemetry.go
+++ b/components/compliance-service/dao/pgdb/telemetry.go
@@ -1,0 +1,69 @@
+package pgdb
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type Telemetry struct {
+	ID                      string
+	LastTelemetryReportedAt time.Time
+	CreatedAt               time.Time
+}
+
+// store last compliance telemetry reported timestamp
+func (trans *DBTrans) StoreTelemetry(ctx context.Context, lastTelemetryReportedAt time.Time) error {
+	telArr := make([]interface{}, 0)
+
+	tel := Telemetry{
+		ID:                      createUUID(),
+		LastTelemetryReportedAt: lastTelemetryReportedAt,
+		CreatedAt:               time.Now(),
+	}
+	telArr = append(telArr, tel)
+	err := trans.Insert(telArr...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get last compliance telemetry reported timestamp
+func (trans *DBTrans) GetTelemetry(ctx context.Context) (Telemetry, error) {
+	var t []Telemetry
+	stmt := `SELECT id,last_telemetry_reported_at, created_at from telemetry`
+	_, err := trans.Select(&t, stmt)
+	if err != nil {
+		return Telemetry{}, err
+	}
+	if len(t) > 0 {
+		return t[0], nil
+	}
+	return Telemetry{}, errors.New("Telemetry last reported entries not available")
+}
+
+// Update last compliance telemetry reported timestamp
+func (trans *DBTrans) UpdateTelemetry(ctx context.Context, lastTelemetryReportedAt time.Time) error {
+	tel := Telemetry{
+		LastTelemetryReportedAt: lastTelemetryReportedAt,
+	}
+	_, err := trans.Update(tel)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete last compliance telemetry reported timestamp
+func (trans *DBTrans) DeleteTelemetry(ctx context.Context, id string) error {
+	tel := Telemetry{
+		ID: id,
+	}
+	_, err := trans.Delete(tel)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Storage functions for the last compliance telemetry reported date

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/5877
### :+1: Definition of Done
I have added the storage functions for telemetry table about last compliance telemetry reported date
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
