### PR TITLE
Secrets-init, --channel in existing-infra, config.toml default values, existing-infra deployment issue

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -115,6 +115,13 @@ func bootstrapEnv(dm deployManager) error {
 		}
 	}
 	conf := new(dc.AutomateConfig)
+	if err := mergeFlagOverrides(conf); err != nil {
+		return status.Wrap(
+			err,
+			status.ConfigError,
+			"Merging command flag overrides into Chef Automate config failed",
+		)
+	}
 	manifestProvider := manifest.NewLocalHartManifestProvider(
 		mc.NewDefaultClient(conf.Deployment.GetV1().GetSvc().GetManifestDirectory().GetValue()),
 		conf.Deployment.GetV1().GetSvc().GetHartifactsPath().GetValue(),
@@ -143,4 +150,12 @@ func checkIfFileExist(path string) bool {
 		return true
 	}
 	return false
+}
+
+func executeSecretsInitCommand(secretsKeyFilePath string) error {
+	if !checkIfFileExist(secretsKeyFilePath) {
+		writer.Printf("doing secrets init  \n")
+		return executeSecretsCommand([]string{"init"})
+	}
+	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -35,6 +35,10 @@ func (a *awsDeployment) doProvisionJob(args []string) error {
 	if err != nil {
 		return err
 	}
+	err = executeSecretsInitCommand(a.config.Architecture.ConfigInitials.SecretsKeyFile)
+	if err != nil {
+		return err
+	}
 	writer.Printf("provisioning infra for automate HA \n\n\n\n")
 	args = args[1:]
 	args = append(args, "-y")

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -22,9 +22,13 @@ func newExistingInfa(configPath string) *existingInfra {
 func (e *existingInfra) doDeployWork(args []string) error {
 	var err = bootstrapEnv(e)
 	if err != nil {
-		err = executeDeployment()
+		return err
 	}
-	return err
+	err = executeSecretsInitCommand(e.config.Architecture.ConfigInitials.SecretsKeyFile)
+	if err != nil {
+		return err
+	}
+	return executeDeployment()
 }
 
 func (e *existingInfra) doProvisionJob(args []string) error {

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -86,9 +86,9 @@ const haExistingNodesConfigTemplate = `
 [architecture.existing_infra]
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"
 secrets_store_file = "secrets.json"
-architecture = "aws"
+architecture = "existing_nodes"
 workspace_path = "/hab/a2_deploy_workspace"
-ssh_user = "existing_infra"
+ssh_user = "centos"
 # private ssh key file path to access instances
 ssh_key_file = "~/.ssh/A2HA.pem"
 sudo_password = ""

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
@@ -14,6 +14,12 @@ func newProvisionInfraCmd() *cobra.Command {
 		RunE:  runProvisionInfraCmd,
 	}
 
+	provisionInfraCmd.PersistentFlags().StringVar(
+		&deployCmdFlags.channel,
+		"channel",
+		"",
+		"Release channel to deploy all services from")
+
 	return provisionInfraCmd
 }
 

--- a/components/automate-cli/cmd/chef-automate/secretsHa.go
+++ b/components/automate-cli/cmd/chef-automate/secretsHa.go
@@ -24,6 +24,10 @@ var secretsCmd = &cobra.Command{
 }
 
 func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
+	return executeSecretsCommand(args)
+}
+
+func executeSecretsCommand(args []string) error {
 	if isA2HARBFileExist() {
 		if len(args) == 0 {
 			writer.Print("please refer \n" + secretsHelpDocs)


### PR DESCRIPTION
--channel support for provision-infra command, secrets init in case secret key file is not generated, config.toml file defualt value changes, existing-infra deployment issue

### :nut_and_bolt: Description: What code changed, and why?

during our testing on A2HA to automate migraion we found some of feature is required to add...
-- channel support for provision-infra command,
-- secrets init in case secret key file is not generated,
-- config.toml file defualt value changes,
-- existing-infra deployment issue

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/5914

### :+1: Definition of Done

Dev Done, Dev Tested

### :athletic_shoe: How to Build and Test the Change

rebuild component/automate-deployment
rebuild component/automate-cli


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
