### PR TITLE
Table script for add telemetry table in application services 

### DIFF
--- a/components/applications-service/pkg/storage/postgres/schema/sql/17_create_telemetry.down.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/17_create_telemetry.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS telemetry;

--- a/components/applications-service/pkg/storage/postgres/schema/sql/18_create_telemetry.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/18_create_telemetry.up.sql
@@ -1,0 +1,6 @@
+-- create table telemetry to store the last hab supervisor telemtry reported date
+CREATE TABLE IF NOT EXISTS telemetry (
+  id                         text PRIMARY KEY,
+  last_telemetry_reported_at TIMESTAMPTZ NOT NULL,
+  created_at                 TIMESTAMPTZ NOT NULL
+);


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
we need to add the telemetry table to store the last hab supervisor telemetry reported date.
### :chains: Related Resources
https://github.com/chef/automate/issues/5934
### :+1: Definition of Done
I have added a script to store the last hab supervisor telemetry reported date.
### :athletic_shoe: How to Build and Test the Change
to check this table you need to rebuild the application-service component 
```
 rebuild components/applications-service/
```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
