### PR TITLE
automate-backend-elasticsearch and automate-backend-postgresql certificate path changes

### DIFF
--- a/components/automate-backend-elasticsearch/habitat/cert.sh
+++ b/components/automate-backend-elasticsearch/habitat/cert.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
  
 openssl genrsa -out MyRootCA.key 2048
- 
+
 openssl req -x509 -new -key MyRootCA.key -sha256 -out MyRootCA.pem -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefrootca'
- 
+
 openssl genrsa -out admin-pkcs12.key 2048
  
 openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "admin-pkcs12.key" -topk8 -out "admin.key" -nocrypt
@@ -16,31 +16,31 @@ openssl genrsa -out ssl-pkcs12.key 2048
  
 openssl pkcs8 -v1 "PBE-SHA1-3DES" -in "ssl-pkcs12.key" -topk8 -out "ssl.key" -nocrypt
  
-openssl req -new -key ssl.key -out ssl.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefadmin'
+openssl req -new -key ssl.key -out ssl.csr -subj '/C=US/ST=Washington/L=Seattle/O=Chef Software Inc/CN=chefnode'
  
 openssl x509 -req -in ssl.csr -CA MyRootCA.pem -CAkey MyRootCA.key -CAcreateserial -out ssl.pem -sha256
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # root pem cert that signed the two cert/key pairs below
-rootCA = """$(cat MyRootCA.key)"""
+rootCA = """$(cat MyRootCA.pem)"""
 EOF
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # Certificate used for admin actions against https://9200
 admin_cert = """$(cat admin.pem)"""
 EOF
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # the private key associated with the above pem cert
 admin_key = """$(cat admin.key)"""
 EOF
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # Certificate used for intracluster ssl on port 9300
 ssl_cert = """$(cat ssl.pem)"""
 EOF
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # the private key associated with the above pem cert
 ssl_key = """$(cat ssl.key)"""
 EOF

--- a/components/automate-backend-elasticsearch/habitat/plan.sh
+++ b/components/automate-backend-elasticsearch/habitat/plan.sh
@@ -9,14 +9,11 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
-  chef/mlsa
-  core/bash
-  core/procps-ng
-  core/openssl
+  chef/mlsa/1.0.1/20200421170200
+  core/bash/5.0.16/20200305233030
+  core/procps-ng/3.3.15/20200305231457
   "${UPSTREAM_PKG_IDENT}"
 )
-
-
 pkg_lib_dirs=(lib)
 
 pkg_exports=(

--- a/components/automate-backend-elasticsearch/habitat/plan.sh
+++ b/components/automate-backend-elasticsearch/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_deps=(
   chef/mlsa
   core/bash
   core/procps-ng
+  core/openssl
   "${UPSTREAM_PKG_IDENT}"
 )
 pkg_lib_dirs=(lib)

--- a/components/automate-backend-elasticsearch/habitat/plan.sh
+++ b/components/automate-backend-elasticsearch/habitat/plan.sh
@@ -9,9 +9,9 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_deps=(
-  chef/mlsa/1.0.1/20200421170200
-  core/bash/5.0.16/20200305233030
-  core/procps-ng/3.3.15/20200305231457
+  chef/mlsa
+  core/bash
+  core/procps-ng
   "${UPSTREAM_PKG_IDENT}"
 )
 pkg_lib_dirs=(lib)

--- a/components/automate-backend-pgleaderchk/habitat/hooks/run
+++ b/components/automate-backend-pgleaderchk/habitat/hooks/run
@@ -5,4 +5,4 @@ exec 2>&1
 # Required to allow common name feild in certificate. Feature soon to deprecated by 1.17
 export GODEBUG=x509ignoreCN=0
 
-exec pgleaderchk -c {{pkg.svc_config_path}}/config.toml serve
+exec automate-backend-pgleaderchk -c {{pkg.svc_config_path}}/config.toml serve

--- a/components/automate-backend-postgresql/habitat/cert.sh
+++ b/components/automate-backend-postgresql/habitat/cert.sh
@@ -12,17 +12,17 @@ openssl req -new -key ssl.key -out ssl.csr -subj '/C=US/ST=Washington/L=Seattle/
  
 openssl x509 -req -in ssl.csr -CA MyRootCA.pem -CAkey MyRootCA.key -CAcreateserial -out ssl.pem -sha256
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # server public cert used for ssl listener
 ssl_cert = """$(cat ssl.pem)"""
 EOF
  
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # server private key
 ssl_key = """$(cat ssl.key)"""
 EOF
 
-cat <<EOF >> default.toml
+cat <<EOF >> habitat/default.toml
 # issuer public cert that signed the above server public cert
-issuer_cert = """$(cat MyRootCA.key)"""
+issuer_cert = """$(cat MyRootCA.pem)"""
 EOF

--- a/components/automate-backend-postgresql/habitat/plan.sh
+++ b/components/automate-backend-postgresql/habitat/plan.sh
@@ -10,8 +10,8 @@ pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 
 pkg_deps=(
-  chef/mlsa/1.0.1/20200421170200
-  core/bash/5.0.16/20200305233030
+  chef/mlsa
+  core/bash
   "${UPSTREAM_PKG_IDENT}"
 )
 

--- a/components/automate-backend-postgresql/habitat/plan.sh
+++ b/components/automate-backend-postgresql/habitat/plan.sh
@@ -8,9 +8,10 @@ pkg_version="11.2"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
+
 pkg_deps=(
-  chef/mlsa
-  core/bash
+  chef/mlsa/1.0.1/20200421170200
+  core/bash/5.0.16/20200305233030
   "${UPSTREAM_PKG_IDENT}"
 )
 


### PR DESCRIPTION
Signed-off-by: FaizanSRE <ffulara@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
automate-backend-elasticsearch and automate-backend-postgresql certificate path changes 
In RootCA cert , key file was used instead of pem file and there were pinned some dependencies.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
