### PR TITLE
adding dev channel support for deployment

### DIFF
--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -25,6 +25,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   option ["-n", "--skip-changes"], :flag, "Only show what changes are needed, don't apply them"
   option ["-s", "--skip-deploy"], :flag, "Skip the deploy step, this this if you only want to update terraform plans or airgap bundles."
   option ["-t", "--timeout"], 'MINUTES', "Set timeout value for commands to finish running", default: 10
+  option ["-c", "--dev"], :flag, "Downloads the dev channel manifest"
 
   def valid_bundle?
     tf_aib_valid?
@@ -39,7 +40,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   end
 
   def need_bundle?
-    !valid_bundle? || upgrade_airgap_bundles?
+    !valid_bundle? || upgrade_airgap_bundles? || dev?
   end
   
   def need_FE_upgrade?
@@ -68,7 +69,7 @@ class AutomateClusterSetup < AutomateCluster::Command
       status = run_make_cmd('bundle', command_opts)
 
       if status.error? || !valid_bundle?
-        logger.error "Error encountered generating FE airgap bundles"
+        logger.error "Error encountered generating airgap bundles"
         logger.error "STDOUT: #{status.stdout}" unless status.stdout.empty?
         logger.error "STDERR: #{status.stderr}" unless status.stderr.empty?
         spin.error "Failed to generate airgap bundles"
@@ -79,6 +80,24 @@ class AutomateClusterSetup < AutomateCluster::Command
     end if need_bundle?
  
   end
+
+  def generate_dev_bundle
+    wait_while 'Generating airgap bundles for dev channel ', true do |spin|
+      status = run_make_cmd('bundle-dev', command_opts)
+
+      if status.error? || !valid_bundle?
+        logger.error "Error encountered generating  airgap bundles"
+        logger.error "STDOUT: #{status.stdout}" unless status.stdout.empty?
+        logger.error "STDERR: #{status.stderr}" unless status.stderr.empty?
+        spin.error "Failed to generate airgap bundles"
+        exit 1
+      end
+
+      valid_bundle?
+    end if need_bundle?
+ 
+  end
+
 
   def upgrade_FE_bundle
     wait_while 'upgrading FE airgap bundle', true do |spin|
@@ -105,7 +124,7 @@ class AutomateClusterSetup < AutomateCluster::Command
         logger.error "Error encountered generating BE airgap bundles"
         logger.error "STDOUT: #{status.stdout}" unless status.stdout.empty?
         logger.error "STDERR: #{status.stderr}" unless status.stderr.empty?
-        spin.error "Failed to upgrade FE airgap bundles"
+        spin.error "Failed to upgrade BE airgap bundles"
         exit 1
       end
 
@@ -176,7 +195,9 @@ class AutomateClusterSetup < AutomateCluster::Command
       exit 1
     end
 
-    if upgrade_frontends? 
+    if dev?
+        generate_dev_bundle
+    elsif upgrade_frontends? 
         upgrade_FE_bundle
     elsif upgrade_backends?
         upgrade_BE_bundle

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -23,12 +23,14 @@ export BUNDLE_TYPE=
 export BACKENDAIB_TFVARS=
 export FRONTENDAIB_TFVARS=
 export TARBALL_PATH=
+export CHANNEL=current
 TEMP_DIR=/tmp
 export TEMP_BUNDLE_FILE=$TEMP_DIR/bundle.aib.$$.$RANDOM
 export TEMP_TAR_FILE=$TEMP_DIR/my.aib.$$.$RANDOM
 export MANIFEST_TFVARS="terraform/a2ha_manifest.auto.tfvars"
 export BACKENDAIB=
 export PACKAGES_INFO="/tmp/packages.info"
+
 # Helper Functions
 echo_env() {
     echo "=============================================="
@@ -82,6 +84,7 @@ trap clean_up SIGHUP SIGINT SIGTERM ERR
 airgap_bundle_create() {
   original_aib_path="${TEMP_BUNDLE_FILE}"
   args=('airgap' 'bundle' 'create')
+  args+=('-c' "${CHANNEL}")
   args+=("${original_aib_path}")
   # printf '%s\n' "Running: ${CHEF_AUTOMATE_BIN_PATH} ${args[*]}"
   if "${CHEF_AUTOMATE_BIN_PATH}" "${args[@]}" > /tmp/thelog.log; then
@@ -173,7 +176,7 @@ do_tasks() {
 if [ $# -eq 0 ]; then
   usage
 fi
-while getopts ":b:d:t:w:o:h:v:q:" opt; do
+while getopts ":b:d:t:w:o:h:v:q:c:" opt; do
   case "${opt}" in
     d)
       export CHEF_AUTOMATE_BIN_PATH=${OPTARG}
@@ -195,6 +198,9 @@ while getopts ":b:d:t:w:o:h:v:q:" opt; do
       ;;
     q)
       export BACKENDAIB_TFVARS=${OPTARG}
+      ;;
+    c)
+      export CHANNEL=${OPTARG}
       ;;
     h)
       usage

--- a/terraform/a2ha-terraform/deployment-makefile/Makefile
+++ b/terraform/a2ha-terraform/deployment-makefile/Makefile
@@ -59,6 +59,12 @@ $(BUNDLEAIB):
 	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 && \
 	  $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
 
+$(BUNDLEAIBDEV):
+	@echo "# Updating FE and BE component package versions from dev channel " && \
+		$(AIRGAP_SH) -t all -c dev -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)  && \
+	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 && \
+	  $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+
 $(FRONTENDAIB):
 	@echo "# Updating FE component package versions: $(FRONTENDAIB_TFVARS)" && \
 		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS) && \
@@ -75,6 +81,9 @@ $(HABITAT_TFVARS):
 
 ## Create both frontend and backend .aib
 bundle: $(BUNDLEAIB)
+
+## Create both frontend and backend .aib from dev channel
+bundle-dev: $(BUNDLEAIBDEV)
 
 ## Create a frontend .aib
 fe-bundle: $(FRONTENDAIB)

--- a/terraform/a2ha-terraform/deployment-makefile/Makefile
+++ b/terraform/a2ha-terraform/deployment-makefile/Makefile
@@ -7,6 +7,7 @@ TMPOUT = '/tmp/make.out'
 REPO_ROOT = $(shell pwd)
 DATESTAMP := $(shell date +"%Y%m%d%H%M%S")
 BUNDLEAIB = $(TERRAFORM_PATH)/transfer_files/bundle-$(DATESTAMP).aib
+BUNDLEAIBDEV = $(TERRAFORM_PATH)/transfer_files/bundle-dev-$(DATESTAMP).aib
 BACKENDAIB = $(TERRAFORM_PATH)/transfer_files/backend-$(DATESTAMP).aib
 BACKENDAIB_TFVARS = $(shell pwd)/terraform/a2ha_aib_be.auto.tfvars
 FRONTENDAIB = $(TERRAFORM_PATH)/transfer_files/frontend-$(DATESTAMP).aib


### PR DESCRIPTION
Signed-off-by: FaizanSRE <ffulara@msystechnologies.com>
This Pr will add --dev flag in automate-cluster-ctl which will help us to download dev channel manifest and create airgap bundle for that packages.
This will only available for testing dev packages 

### :nut_and_bolt: Description: What code changed, and why?
automate-cluster-ctl deploy --dev

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
