### PR TITLE
fixed manual upgrade private pipeline

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -763,7 +763,7 @@ steps:
 
   - label: "manual upgrade current -> master"
     command:
-      - integration/run_test integration/tests/manual_upgrade.sh
+      - GODEBUG=x509ignoreCN=0 integration/run_test integration/tests/manual_upgrade.sh
     timeout_in_minutes: 25
     expeditor:
       executor:

--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -763,7 +763,7 @@ steps:
 
   - label: "manual upgrade current -> master"
     command:
-      - GODEBUG=x509ignoreCN=0 integration/run_test integration/tests/manual_upgrade.sh
+      - integration/run_test integration/tests/manual_upgrade.sh
     timeout_in_minutes: 25
     expeditor:
       executor:

--- a/integration/tests/manual_upgrade.sh
+++ b/integration/tests/manual_upgrade.sh
@@ -34,6 +34,7 @@ do_deploy() {
     $upgrade_scaffold_bin serve "$test_manifest_path" "$upgrade_scaffold_pid_file" &
     sleep 5
     export CHEF_AUTOMATE_SKIP_MANIFEST_VERIFICATION=true
+    export GODEBUG=x509ignoreCN=0
     #shellcheck disable=SC2154
     echo -e "[load_balancer.v1.sys.service]\\nhttps_port = 4443" >> "$test_config_path"
     #shellcheck disable=SC2154


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Manual upgrade integration test in private pipeline was breaking due to golang not supporting common name feild anymore in ssl certificate. We had to add GODEBUG=x509ignoreCN=0 to enable support for that field

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
