### PR TITLE
Selected type in dropdown is not shown properly in notification details page

### DIFF
--- a/components/automate-ui/src/app/pages/notification-details/notification-details.component.html
+++ b/components/automate-ui/src/app/pages/notification-details/notification-details.component.html
@@ -44,6 +44,7 @@
             <label>
               <span class="label">Webhook Type <span aria-hidden="true">*</span></span>
               <chef-select
+                *ngIf="notification.targetType != null"
                 (change)="changeSelectionForWebhookType($event)"
                 class="notification-select-menu"
                 [value]="notification.targetType">
@@ -59,6 +60,7 @@
             <label>
               <span class="label">Failure Type  <span aria-hidden="true">*</span></span>
               <chef-select
+                *ngIf="notification.ruleType != null"
                 (change)="setFailureType($event)"
                 class="notification-select-menu"
                 [value]="notification.ruleType">


### PR DESCRIPTION
Signed-off-by: shaik80 <smudassi@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

On the notification details page, the webhook Type and the Failure Type were not shown properly.
On page load users should see selected data in the dropdown list instead they were seeing empty data or the first item from the dropdown list
### :chains: Related Resources
#6140 
### :+1: Definition of Done
Now user should see the selected webhook Type and Failure Type on the page reload or shifting from the current page to the previous page
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab

```
### :white_check_mark: Checklist

Uploading Screen Recording 2021-11-16 at 2.31.39 PM.mov…


**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
#### Before code change
https://user-images.githubusercontent.com/47217471/141955224-aeed4b06-62dc-40a3-91f2-fd5b4ca827c3.mov
#### After code change
https://user-images.githubusercontent.com/47217471/141955437-928b9ccc-18ab-4e28-82d9-18437a44e3c6.mov


