### PR TITLE
Node credential button fix

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.html
@@ -30,7 +30,7 @@
       <section class="page-body" *ngIf="tabValue === 'details'">
         <chef-loading-spinner *ngIf="nodeDetailsLoading" size="50"></chef-loading-spinner>
         <ng-container *ngIf="!nodeDetailsLoading" >
-        
+
         <form [formGroup]="updateForm">
           <div class="name-margin">
             <chef-form-field>
@@ -75,7 +75,7 @@
                 <chef-form-field>
                   <label for="sshUsername">SSH Username <span class="t-critical" aria-hidden="true">*</span></label>
                   <input chefInput id="sshUsername" formControlName="username" type="text" />
-                  <chef-error *ngIf="(sshForms.get('username').hasError('required') || sshForms.get('username').hasError('pattern')) && sshForms.get('username').dirty">
+                  <chef-error *ngIf="checkError('username',sshForms)">
                     SSH Username is required.
                   </chef-error>
                 </chef-form-field>
@@ -92,18 +92,18 @@
                 <chef-form-field *ngIf="passwordSelected === 'Password'">
                   <label for="sshPassword">SSH password <span class="t-critical" aria-hidden="true">*</span></label>
                   <input chefInput id="sshPassword" formControlName="password" type="password" placeholder="password for private ssh" />
-                  <chef-error *ngIf="(sshForms.get('password').hasError('required') || sshForms.get('password').hasError('pattern')) && sshForms.get('password').dirty">
+                  <chef-error *ngIf="checkError('password',sshForms)">
                     SSH Password is required.
                   </chef-error>
                 </chef-form-field>
               </div>
-              <div class="name-margin">              
+              <div class="name-margin">
                 <chef-form-field *ngIf="passwordSelected === 'RSA'">
                   <label for="key">RSA key <span class="t-critical" aria-hidden="true">*</span></label>
                   <textarea id="key" chefInput
                     rows="10" cols="100"
                     formControlName="key"></textarea>
-                    <chef-error *ngIf="(sshForms.get('key').hasError('required') || sshForms.get('key').hasError('pattern')) && sshForms.get('key').dirty">
+                    <chef-error *ngIf="checkError('key',sshForms)">
                       RSA Key is required.
                     </chef-error>
                 </chef-form-field>
@@ -116,7 +116,7 @@
                 <chef-form-field>
                   <label for="winrmUsername">WinRM Username <span class="t-critical" aria-hidden="true">*</span></label>
                   <input chefInput id="winrmUsername" formControlName="username" type="text" />
-                  <chef-error *ngIf="(winrmForms.get('username').hasError('required') || winrmForms.get('username').hasError('pattern')) && winrmForms.get('username').dirty">
+                  <chef-error *ngIf="checkError('username',winrmForms)">
                     WinRM Username is required.
                   </chef-error>
                 </chef-form-field>
@@ -125,11 +125,11 @@
                 <chef-form-field >
                   <label for="winrmPassword">WinRM password <span class="t-critical" aria-hidden="true">*</span></label>
                   <input chefInput id="winrmPassword" formControlName="password" type="password" placeholder="password for private ssh" />
-                  <chef-error *ngIf="(winrmForms.get('password').hasError('required') || winrmForms.get('password').hasError('pattern')) && winrmForms.get('password').dirty">
+                  <chef-error *ngIf="checkError('password',winrmForms)">
                     WinRM Password is required.
                   </chef-error>
                 </chef-form-field>
-              </div>         
+              </div>
             </form>
           </ng-container>
           <ng-container *ngIf="nodeCredential?.type === 'sudo'">
@@ -138,18 +138,18 @@
                 <chef-form-field>
                   <label for="sudopassword">Sudo Password <span class="t-critical" aria-hidden="true">*</span></label>
                   <input chefInput id="sudopassword" formControlName="password" type="text" />
-                  <chef-error *ngIf="(sudoForms.get('password').hasError('required') || sudoForms.get('password').hasError('pattern')) && sudoForms.get('password').dirty">
+                  <chef-error *ngIf="checkError('password',sudoForms)">
                     Sudo Password is required.
                   </chef-error>
                 </chef-form-field>
-              </div>            
+              </div>
             </form>
           </ng-container>
           <div class="button-bar">
             <chef-button [disabled]="isLoading  || !resetForm.dirty"
             primary inline (click)="saveNodeCredential(resetForm.value)">
               <chef-loading-spinner *ngIf="resetInProgress"></chef-loading-spinner>
-              <span *ngIf="resetInProgress">Saving...</span>
+              <span class="savingText" *ngIf="resetInProgress">Saving...</span>
               <span *ngIf="!resetInProgress">Save</span></chef-button>
             <span class="saved-note" *ngIf="resetSuccessful && !resetForm.dirty">All changes saved.</span>
           </div>

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.html
@@ -30,7 +30,6 @@
       <section class="page-body" *ngIf="tabValue === 'details'">
         <chef-loading-spinner *ngIf="nodeDetailsLoading" size="50"></chef-loading-spinner>
         <ng-container *ngIf="!nodeDetailsLoading" >
-
         <form [formGroup]="updateForm">
           <div class="name-margin">
             <chef-form-field>

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.scss
@@ -109,10 +109,13 @@ chef-loading-spinner {
 
 .page-body {
   chef-loading-spinner {
-    display: block;
-    margin: 100px auto;
+    display: contents;
     width: 100px;
   }
+}
+
+.savingText {
+  margin-left: 15px;
 }
 
 .version-dropdown {

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
@@ -171,15 +171,15 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
       this.nodeCredential = this.saveCred.getNodeCredentialCreate(data);
     }
     if (!this.checkError(
-          'password',
-          data.type === 'ssh' ? this.sshForms
-          : data.type === 'winrm' ? this.winrmForms
-          : this.sudoForms
-        ) || (!this.checkError(
-          'username',
-          data.type === 'ssh' ? this.sshForms
-          : data.type === 'winrm' ? this.winrmForms
-          : ''
+        'password',
+        data.type === 'ssh' ? this.sshForms
+        : data.type === 'winrm' ? this.winrmForms
+        : this.sudoForms
+      ) || (!this.checkError(
+        'username',
+        data.type === 'ssh' ? this.sshForms
+        : data.type === 'winrm' ? this.winrmForms
+        : ''
     ))) {
       this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
       if (data.type !== 'sudo') {

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
@@ -171,22 +171,22 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
       this.nodeCredential = this.saveCred.getNodeCredentialCreate(data);
     }
     if (!this.checkError(
-        'password',
-        data.type === 'ssh' ? this.sshForms
-        : data.type === 'winrm' ? this.winrmForms
-        : this.sudoForms
+          'password',
+          data.type === 'ssh' ? this.sshForms
+          : data.type === 'winrm' ? this.winrmForms
+          : this.sudoForms
         ) || (!this.checkError(
-        'username',
-        data.type === 'ssh' ? this.sshForms
-        : data.type === 'winrm' ? this.winrmForms
-        : ''
-        ))) {
-          this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
-          if (data.type !== 'sudo') {
-            this.resetForm.controls[data.type]['controls']['username'].setValue('');
-          }
-          this.resetForm.controls[data.type]['controls']['password'].setValue('');
-        }
+          'username',
+          data.type === 'ssh' ? this.sshForms
+          : data.type === 'winrm' ? this.winrmForms
+          : ''
+    ))) {
+      this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
+      if (data.type !== 'sudo') {
+        this.resetForm.controls[data.type]['controls']['username'].setValue('');
+      }
+      this.resetForm.controls[data.type]['controls']['password'].setValue('');
+    }
 }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
@@ -195,6 +195,6 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
   }
 
   checkError(field: string , type: any) {
-   return  ((type.get(field).hasError('required') || type.get(field).hasError('pattern')) && type.get(field).dirty) && type.get(field).value !== '';
+    return ((type.get(field).hasError('required') || type.get(field).hasError('pattern')) && type.get(field).dirty) && type.get(field).value !== '';
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
@@ -170,19 +170,19 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
       this.resetInProgress = true;
       this.nodeCredential = this.saveCred.getNodeCredentialCreate(data);
     }
-    if(!this.checkError(
+    if (!this.checkError(
         'password',
-        data.type == 'ssh' ? this.sshForms
-        : data.type == 'winrm' ? this.winrmForms
+        data.type === 'ssh' ? this.sshForms
+        : data.type === 'winrm' ? this.winrmForms
         : this.sudoForms
         ) || (!this.checkError(
         'username',
-        data.type == 'ssh' ? this.sshForms
-        : data.type == 'winrm' ? this.winrmForms
+        data.type === 'ssh' ? this.sshForms
+        : data.type === 'winrm' ? this.winrmForms
         : ''
         ))) {
           this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
-          if(data.type != 'sudo') {
+          if (data.type !== 'sudo') {
             this.resetForm.controls[data.type]['controls']['username'].setValue('');
           }
           this.resetForm.controls[data.type]['controls']['password'].setValue('');
@@ -195,6 +195,7 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
   }
 
   checkError(field: string , type: any) {
-    return ((type.get(field).hasError('required') || type.get(field).hasError('pattern')) && type.get(field).dirty) && type.get(field).value !== '';
+    return (((type.get(field).hasError('required') || type.get(field).hasError('pattern'))
+    && type.get(field).dirty) && type.get(field).value !== '');
   }
 }

--- a/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+node-credentials/node-credential-details/node-credential-details.component.ts
@@ -170,12 +170,31 @@ export class NodeCredentialDetailsScreenComponent implements OnInit, OnDestroy {
       this.resetInProgress = true;
       this.nodeCredential = this.saveCred.getNodeCredentialCreate(data);
     }
-    this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
-    this.resetForm.reset();
-  }
+    if(!this.checkError(
+        'password',
+        data.type == 'ssh' ? this.sshForms
+        : data.type == 'winrm' ? this.winrmForms
+        : this.sudoForms
+        ) || (!this.checkError(
+        'username',
+        data.type == 'ssh' ? this.sshForms
+        : data.type == 'winrm' ? this.winrmForms
+        : ''
+        ))) {
+          this.store.dispatch(new UpdateNodeCredential(this.nodeCredential));
+          if(data.type != 'sudo') {
+            this.resetForm.controls[data.type]['controls']['username'].setValue('');
+          }
+          this.resetForm.controls[data.type]['controls']['password'].setValue('');
+        }
+}
 
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+  }
+
+  checkError(field: string , type: any) {
+   return  ((type.get(field).hasError('required') || type.get(field).hasError('pattern')) && type.get(field).dirty) && type.get(field).value !== '';
   }
 }


### PR DESCRIPTION
Signed-off-by: Shivangi Singh <shisingh@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Bug : 1. Save button for 'Reset credentials' for the node credential tab should work fine for all -: sudo, ssh and winrm.
2.Save button css should be changed.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
fix button issue and loading when we change cred for second time in node credential tab : #6078 

### :+1: Definition of Done
1. Save button for 'Reset credentials' for the node credential tab should work fine for all -: sudo, ssh and winrm.
2.Save button css for reset credentials should be corrected.

### :athletic_shoe: How to Build and Test the Change

```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab

```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/87964433/142135017-bc3cba9f-7271-4c31-8134-e793b4a24567.mov

