### PR TITLE
Exit message on deployment completion, Secrets issue fixes, Info & status formatting issue fixes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -20,13 +20,12 @@ import (
 
 const logFileSize int64 = 0
 
-var spinning bool = false
-
 func executeAutomateClusterCtlCommand(command string, args []string, helpDocs string) error {
 	if len(command) < 1 {
 		return errors.New("Invalid or empty command")
 	}
-	writer.Printf("%s command execution started \n\n\n", command)
+	//writer.Printf("%s command execution started \n\n\n", command)
+	writer.StartSpinner()
 	args = append([]string{command}, args...)
 	c := exec.Command("automate-cluster-ctl", args...)
 	c.Dir = "/hab/a2_deploy_workspace"
@@ -39,8 +38,6 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	if err != nil {
 		writer.Printf(stderr.String())
 		return status.Wrap(err, status.CommandExecutionError, helpDocs)
-	} else {
-		writer.Printf("No error in executing commands")
 	}
 	outStr, errStr := string(out.Bytes()), string(stderr.Bytes())
 	if len(outStr) > 0 {
@@ -49,7 +46,8 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	if len(errStr) > 0 {
 		writer.Printf("\nerr:\n%s\n", errStr)
 	}
-	writer.Printf("%s command execution done, exiting\n", command)
+	//writer.Printf("%s command execution done, exiting\n", command)
+	writer.StopSpinner()
 	return err
 }
 
@@ -91,20 +89,42 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 		writer.Printf("\nerr:\n%s\n", errStr)
 	}
 	writer.Printf("%s command execution inprogress with process id : %d, + \n storing log in %s \n", command, c.Process.Pid, logFilePath)
-	tailFile(logFilePath)
+	executed := make(chan struct{})
+	go tailFile(logFilePath, executed)
+	c.Process.Wait()
+	time.Sleep(5 * time.Second)
+	close(executed)
 	return err
 }
 
-func tailFile(logFilePath string) {
+func tailFile(logFilePath string, executed chan struct{}) {
+	writer.Println("Starting tail function")
 	time.Sleep(1 * time.Second)
 	t, err := tail.TailFile(logFilePath, tail.Config{Follow: true, MustExist: true})
 	if err != nil {
 		writer.Printf(err.Error())
 		return
 	}
-	go showSpinnerForTailChangesWaiting(logFilePath)
-	for line := range t.Lines {
-		writer.Println(line.Text)
+	var spinning bool = false
+	for {
+		select {
+		case <-executed:
+			writer.Println("Exiting as execution process completed")
+			t.Stop()
+			return
+		case line := <-t.Lines:
+			if spinning {
+				writer.StopSpinner()
+				spinning = false
+			}
+			writer.Println(line.Text)
+		default:
+			if !spinning {
+				writer.StartSpinner()
+				spinning = true
+			}
+		}
+
 	}
 }
 
@@ -177,8 +197,6 @@ func executeShellCommand(command string, args []string) error {
 	if err != nil {
 		writer.Printf(stderr.String())
 		return status.Wrap(err, status.CommandExecutionError, "")
-	} else {
-		writer.Printf("No error in executing commands")
 	}
 	outStr, errStr := string(out.Bytes()), string(stderr.Bytes())
 	if len(outStr) > 0 {
@@ -189,21 +207,6 @@ func executeShellCommand(command string, args []string) error {
 	}
 	writer.Printf("%s command execution done, exiting\n", command)
 	return err
-}
-
-func showSpinnerForTailChangesWaiting(logFile string) {
-	for {
-		if checkIfFileExist(logFile) {
-			time.Sleep(2 * time.Minute)
-			if getFileSize(logFile) == logFileSize && !spinning {
-				writer.StartSpinner()
-			} else if spinning && getFileSize(logFile) != logFileSize {
-				writer.StopSpinner()
-			} else {
-				writer.Print("")
-			}
-		}
-	}
 }
 
 func getFileSize(path string) int64 {

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -35,7 +35,7 @@ func (a *awsDeployment) doProvisionJob(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = executeSecretsInitCommand(a.config.Architecture.ConfigInitials.SecretsStoreFile)
+	err = executeSecretsInitCommand(a.config.Architecture.ConfigInitials.SecretsKeyFile)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -24,7 +24,7 @@ func (e *existingInfra) doDeployWork(args []string) error {
 	if err != nil {
 		return err
 	}
-	err = executeSecretsInitCommand(e.config.Architecture.ConfigInitials.SecretsStoreFile)
+	err = executeSecretsInitCommand(e.config.Architecture.ConfigInitials.SecretsKeyFile)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -116,7 +116,7 @@ var gatherLogsCmdFlags = struct {
 
 func runGatherLogsCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
-		return executeAutomateClusterCtlCommand("gather-logs", args, gatherLogsHelpDoc)
+		return executeAutomateClusterCtlCommandAsync("gather-logs", args, gatherLogsHelpDoc)
 	}
 	// Ensure we can write to any user given log locations
 	overridePath := ""

--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -24,7 +24,7 @@ backup_mount "{{ .Architecture.ConfigInitials.BackupMount }}"
 automate do
   # admin_password "{{ .Automate.Config.AdminPassword }}"
   ### Leave commented out if using AWS infrastructure
-  # fqdn "{{ .Automate.Config.Fqdn }}"
+  fqdn "{{ .Automate.Config.Fqdn }}"
   instance_count {{ .Automate.Config.InstanceCount }}
   ### Uncomment and set this value if the teams service
   ### port (default: 10128) conflicts with another service.

--- a/components/automate-cli/cmd/chef-automate/info-ha.go
+++ b/components/automate-cli/cmd/chef-automate/info-ha.go
@@ -3,11 +3,6 @@
 package main
 
 import (
-	"bytes"
-	"os"
-	"os/exec"
-
-	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/spf13/cobra"
 )
 
@@ -18,8 +13,8 @@ func init() {
 
 var infoCmd = &cobra.Command{
 	Use:   "info",
-	Short: "InFo about automate HA",
-	Long:  "Info for automate HA cluster",
+	Short: "Info about Automate HA",
+	Long:  "Info for Automate HA cluster",
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 	},
@@ -27,23 +22,5 @@ var infoCmd = &cobra.Command{
 }
 
 func runInfoConfigCmd(cmd *cobra.Command, args []string) error {
-	return executeInfoCommand()
-}
-
-func executeInfoCommand() error {
-	writer.Printf("Automate HA info \n")
-	c := exec.Command("automate-cluster-ctl", "info")
-	c.Dir = "/hab/a2_deploy_workspace"
-	c.Stdin = os.Stdin
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	c.Stdout = &out
-	c.Stderr = &stderr
-	err := c.Run()
-	if err != nil {
-		writer.Printf(stderr.String())
-		return status.Wrap(err, status.CommandExecutionError, "please refer \n"+infoHelpDocs)
-	}
-	writer.Print(out.String())
-	return err
+	return executeAutomateClusterCtlCommand("info", args, infoHelpDocs)
 }

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -176,7 +176,7 @@ func init() {
 
 var initConfigHACmd = &cobra.Command{
 	Use:   "init-config-ha",
-	Short: "Initialize default config for HA",
+	Short: "Initialize default config for Automate HA",
 	Long:  "Initialized default configuration for HA and save it to a file.",
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -6,8 +6,8 @@ const haAwsConfigTemplate = `
 # successfully create a new Chef Automate HA instances with default settings.
 
 [architecture.aws]
-secrets_key_file = "secrets.json"
-secrets_store_file = "/hab/a2_deploy_workspace/secrets.key"
+secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"
+secrets_store_file = "/hab/a2_deploy_workspace/secrets.json"
 architecture = "aws"
 workspace_path = "/hab/a2_deploy_workspace"
 # ssh user name for ssh login to instance like default user for centos will centos or for red-hat will be ec2-user
@@ -85,7 +85,7 @@ const haExistingNodesConfigTemplate = `
 
 [architecture.existing_infra]
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"
-secrets_store_file = "secrets.json"
+secrets_store_file = "/hab/a2_deploy_workspace/secrets.json"
 architecture = "existing_nodes"
 workspace_path = "/hab/a2_deploy_workspace"
 ssh_user = "centos"
@@ -104,7 +104,7 @@ backup_mount = "/mnt/automate_backups"
 [automate.config]
 # admin_password = ""
 # automate load balancer fqdn IP or path
-# fqdn = ""
+fqdn = ""
 instance_count = "1"
 # teams_port = ""
 config_file = "configs/automate.toml"

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
@@ -8,8 +8,8 @@ import (
 func newProvisionInfraCmd() *cobra.Command {
 	var provisionInfraCmd = &cobra.Command{
 		Use:   "provision-infra",
-		Short: "Provison automate HA infra.",
-		Long:  "Provison automate HA infra for automate HA deployment.",
+		Short: "Provision Automate HA infra.",
+		Long:  "Provision infra for Automate HA deployment.",
 		Args:  cobra.RangeArgs(0, 1),
 		RunE:  runProvisionInfraCmd,
 	}

--- a/components/automate-cli/cmd/chef-automate/secretsHa.go
+++ b/components/automate-cli/cmd/chef-automate/secretsHa.go
@@ -3,6 +3,9 @@
 package main
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/spf13/cobra"
 )
@@ -14,8 +17,8 @@ func init() {
 
 var secretsCmd = &cobra.Command{
 	Use:   "secrets",
-	Short: "set secrets to automate HA",
-	Long:  "set secrets for automate sudo password and admin password in HA mode.",
+	Short: "Set secrets to Automate HA",
+	Long:  "Set secrets for Automate sudo password and admin password in HA mode.",
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 	},
@@ -24,6 +27,33 @@ var secretsCmd = &cobra.Command{
 }
 
 func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
+	operation := ""
+	for _, v := range args {
+		if v == "init" {
+			operation = "init"
+			break
+		}
+		if v == "set" {
+			operation = "set"
+			break
+		}
+	}
+	if operation == "init" {
+		response, err := writer.Prompt("your key might get rotated, Would you like to create a new key or rotate the existing credentials? y/n")
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(response, "y") {
+			return errors.New("canceled secrets init")
+		}
+	}
+	if operation == "set" {
+		response, err := writer.Prompt("Enter secret: ")
+		if err != nil {
+			return err
+		}
+		args = append(args, response)
+	}
 	return executeSecretsCommand(args)
 }
 

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -181,8 +181,8 @@ func init() {
 
 var sshCommand = &cobra.Command{
 	Use:   "ssh",
-	Short: "ssh into automate HA servers",
-	Long:  "ssh into automate HA servers",
+	Short: "SSH into Automate HA servers",
+	Long:  "SSH into Automate HA servers",
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 	},

--- a/components/automate-cli/cmd/chef-automate/testHA.go
+++ b/components/automate-cli/cmd/chef-automate/testHA.go
@@ -17,8 +17,8 @@ Usage:
 func newTestCmd() *cobra.Command {
 	var testCmd = &cobra.Command{
 		Use:   "test",
-		Short: "Run automate HA smoke tests",
-		Long:  "Run smoke test for automate HA services.",
+		Short: "Run Automate HA smoke tests",
+		Long:  "Run smoke test for Automate HA services.",
 		Args:  cobra.RangeArgs(0, 1),
 		RunE:  runTestCmd,
 	}

--- a/components/automate-cli/cmd/chef-automate/workspaceHa.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceHa.go
@@ -14,8 +14,8 @@ func init() {
 
 var workspaceCmd = &cobra.Command{
 	Use:   "workspace",
-	Short: "set workspace env for automate HA.",
-	Long:  "set up automate ha cluster workspace.",
+	Short: "Set workspace env for Automate HA.",
+	Long:  "Set up Automate HA cluster workspace.",
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 	},

--- a/components/automate-cluster-ctl/lib/cluster/secrets.rb
+++ b/components/automate-cluster-ctl/lib/cluster/secrets.rb
@@ -44,7 +44,7 @@ module AutomateCluster
       if File.exist?(key_file)
         key = File.read(key_file)
       else
-        AutomateCluster.logger.warn "Secret storage has not been configured yet, please run `automate-cluster-ctl secrets init`"
+        AutomateCluster.logger.warn "Secret storage has not been configured yet, please run `chef-automate secrets init`"
         key = generate_key
       end
 

--- a/components/automate-cluster-ctl/libexec/cluster-info
+++ b/components/automate-cluster-ctl/libexec/cluster-info
@@ -39,7 +39,9 @@ class AutomateClusterInfo < AutomateCluster::Command
     puts table.render(:basic,
                       multiline: true,
                       padding: [0,0,0,0],
-                      alignments: [:right, :left])
+                      alignments: [:right, :left],
+                      column_widths: 200,
+                      resize: true)
   end
 end
 

--- a/components/automate-cluster-ctl/libexec/cluster-secrets
+++ b/components/automate-cluster-ctl/libexec/cluster-secrets
@@ -49,9 +49,10 @@ class AutomateClusterSecretsSet < AutomateCluster::SubCommand
   option ['-f', '--file'], 'FILE', 'Load value from file'
 
   parameter "NAME", "Name of secret to save", attribute_name: :name
+  parameter "PASSWORD", "Password secret to save", attribute_name: :pass
 
   def execute
-    secret_store[name] = get_value
+    secret_store[name] = pass
     secret_store.save(secrets_store_file)
   rescue AutomateCluster::SecretsError => e
     AutomateCluster.logger.error e.message, cmd: 'secrets set'
@@ -93,12 +94,7 @@ class AutomateClusterSecretsInit < AutomateCluster::SubCommand
 
     if File.exist?(secrets_store_file)
       AutomateCluster.logger.warn "An existing secrets store was found, existing secrets will be rotated using a new key"
-      unless prompt.no?("Would you like to create a new key and rotate the existing credentials?")
         rotate_existing = true
-      else
-        AutomateCluster.logger.info("Canceled secrets init")
-        exit 1
-      end
     end
 
     if rotate_existing
@@ -122,7 +118,7 @@ class AutomateClusterSecretsInit < AutomateCluster::SubCommand
 
   def show_help_info
     puts <<~EOF
-For more help on how to use the manage secrets run #{term.green("automate-cluster-ctl secrets --help")}
+For more help on how to use the manage secrets run #{term.green("chef-automate secrets --help")}
     EOF
   end
 

--- a/components/automate-cluster-ctl/libexec/cluster-status
+++ b/components/automate-cluster-ctl/libexec/cluster-status
@@ -137,7 +137,7 @@ class AutomateClusterStatus < AutomateCluster::Command
   end
 
   def render_fancy_table(headers, data, opts = {})
-    opts.merge!({ multiline: true, padding: [0,1,0,1], alignments: [:left, :left]})
+    opts.merge!({ multiline: true, padding: [0,1,0,1], alignments: [:left, :left], width: 100})
 
     table = TTY::Table.new(headers, data)
     puts table.render(:ascii, opts)

--- a/terraform/a2ha-terraform/reference_architectures/aws/outputs.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/outputs.tf
@@ -26,3 +26,6 @@ output "postgresql_private_ips" {
   value = formatlist("%s", module.aws.postgresql_private_ips)
 }
 
+output "press" {
+  value = "Cltr + c to exit if processes not exited"
+}

--- a/terraform/a2ha-terraform/reference_architectures/aws/outputs.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/outputs.tf
@@ -26,6 +26,6 @@ output "postgresql_private_ips" {
   value = formatlist("%s", module.aws.postgresql_private_ips)
 }
 
-output "press" {
-  value = "Cltr + c to exit if processes not exited"
+output "user" {
+  value = "action item Press ctrl + c to exit if processes not exited"
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Exit message once deployment or provisioning completed,
Showing Spinner for long waiting tail log refresh
Showing Spinner for each command execution
Take user confirmation on Secrets init
Take user Password or input for Secrets Set sudo_password/ fe_sudo_password, be_sudo_password
Fixes formating issue for status command
Fixes formating issue for info command

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
