### PR TITLE
Fixes for double time output

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -30,8 +30,8 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	c.Stdin = os.Stdin
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	c.Stdout = io.MultiWriter(os.Stdout, &out)
-	c.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	c.Stdout = io.MultiWriter(&out)
+	c.Stderr = io.MultiWriter(&stderr)
 	err := c.Run()
 	if err != nil {
 		writer.Printf(stderr.String())
@@ -39,10 +39,10 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	}
 	outStr, errStr := string(out.Bytes()), string(stderr.Bytes())
 	if len(outStr) > 0 {
-		writer.Printf("\nout:\n%s", outStr)
+		writer.Printf("\n%s\n", outStr)
 	}
 	if len(errStr) > 0 {
-		writer.Printf("\nerr:\n%s\n", errStr)
+		writer.Printf("\n%s\n", errStr)
 	}
 	//writer.Printf("%s command execution done, exiting\n", command)
 	writer.StopSpinner()
@@ -60,13 +60,11 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 			panic(err)
 		}
 	}
-	writer.Printf("%s command execution started \n\n\n", command)
+	//writer.Printf("%s command execution started \n\n\n", command)
 	args = append([]string{command}, args...)
 	c := exec.Command("automate-cluster-ctl", args...)
 	c.Dir = AUTOMATE_HA_WORKSPACE_DIR
 	c.Stdin = os.Stdin
-	var out bytes.Buffer
-	var stderr bytes.Buffer
 	outfile, err := os.Create(logFilePath)
 	if err != nil {
 		panic(err)
@@ -76,15 +74,7 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 	c.Stderr = outfile
 	err = c.Start()
 	if err != nil {
-		writer.Printf(stderr.String())
 		return status.Wrap(err, status.CommandExecutionError, helpDocs)
-	}
-	outStr, errStr := string(out.Bytes()), string(stderr.Bytes())
-	if len(outStr) > 0 {
-		writer.Printf("\nout:\n%s", outStr)
-	}
-	if len(errStr) > 0 {
-		writer.Printf("\nerr:\n%s\n", errStr)
 	}
 	writer.Printf("%s command execution inprogress with process id : %d, + \n storing log in %s \n", command, c.Process.Pid, logFilePath)
 	executed := make(chan struct{})
@@ -192,8 +182,8 @@ func executeShellCommand(command string, args []string) error {
 	c.Stdin = os.Stdin
 	var out bytes.Buffer
 	var stderr bytes.Buffer
-	c.Stdout = io.MultiWriter(os.Stdout, &out)
-	c.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	c.Stdout = io.MultiWriter(&out)
+	c.Stderr = io.MultiWriter(&stderr)
 	err := c.Run()
 	if err != nil {
 		writer.Printf(stderr.String())


### PR DESCRIPTION
fixes for double time output print

### :nut_and_bolt: Description: What code changed, and why?

Some of command mapping were showing output for double time, It is fixed now

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Dev done, Dev tested

### :athletic_shoe: How to Build and Test the Change

build component/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
