### PR TITLE
show graceful error for invalid bastion

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -10,3 +10,4 @@ const (
 const AUTOMATE_HA_RUN_LOG_DIR = "/hab/a2_deploy_workspace/logs"
 const AUTOMATE_HA_WORKSPACE_DIR = "/hab/a2_deploy_workspace"
 const AUTOMATE_HA_AUTOMATE_CONFIG_FILE = "/hab/a2_deploy_workspace/configs/automate.toml"
+const AUTOMATE_HA_INVALID_BASTION = "invalid bastion, to run this command use automate bastion"

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -10,4 +10,4 @@ const (
 const AUTOMATE_HA_RUN_LOG_DIR = "/hab/a2_deploy_workspace/logs"
 const AUTOMATE_HA_WORKSPACE_DIR = "/hab/a2_deploy_workspace"
 const AUTOMATE_HA_AUTOMATE_CONFIG_FILE = "/hab/a2_deploy_workspace/configs/automate.toml"
-const AUTOMATE_HA_INVALID_BASTION = "invalid bastion, to run this command use automate bastion"
+const AUTOMATE_HA_INVALID_BASTION = "Invalid bastion, to run this command use automate bastion"

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	ptoml "github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
 )
 
 type awsDeployment struct {
@@ -42,7 +43,10 @@ func (a *awsDeployment) doProvisionJob(args []string) error {
 	writer.Printf("provisioning infra for automate HA \n\n\n\n")
 	args = args[1:]
 	args = append(args, "-y")
-	return executeAutomateClusterCtlCommandAsync("provision", args, provisionInfraHelpDocs)
+	if isA2HARBFileExist() {
+		return executeAutomateClusterCtlCommandAsync("provision", args, provisionInfraHelpDocs)
+	}
+	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }
 
 func (a *awsDeployment) generateConfig() error {

--- a/components/automate-cli/cmd/chef-automate/deployHa.go
+++ b/components/automate-cli/cmd/chef-automate/deployHa.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 func executeDeployment(args []string) error {
@@ -17,5 +19,8 @@ func executeDeployment(args []string) error {
 	}
 	args = append(args[:indexOfConfig], args[indexOfConfig+1:]...)
 	args = append(args, "-y")
-	return executeAutomateClusterCtlCommandAsync("deploy", args, automateHADeployHelpDocs)
+	if isA2HARBFileExist() {
+		return executeAutomateClusterCtlCommandAsync("deploy", args, automateHADeployHelpDocs)
+	}
+	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }

--- a/components/automate-cli/cmd/chef-automate/info-ha.go
+++ b/components/automate-cli/cmd/chef-automate/info-ha.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 )
 
@@ -22,5 +24,8 @@ var infoCmd = &cobra.Command{
 }
 
 func runInfoConfigCmd(cmd *cobra.Command, args []string) error {
-	return executeAutomateClusterCtlCommand("info", args, infoHelpDocs)
+	if isA2HARBFileExist() {
+		return executeAutomateClusterCtlCommand("info", args, infoHelpDocs)
+	}
+	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }

--- a/components/automate-cli/cmd/chef-automate/secretsHa.go
+++ b/components/automate-cli/cmd/chef-automate/secretsHa.go
@@ -27,6 +27,9 @@ var secretsCmd = &cobra.Command{
 }
 
 func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
+	if !isA2HARBFileExist() {
+		return errors.New(AUTOMATE_HA_INVALID_BASTION)
+	}
 	operation := ""
 	for _, v := range args {
 		if v == "init" {
@@ -54,6 +57,7 @@ func runSecretsConfigCmd(cmd *cobra.Command, args []string) error {
 		}
 		args = append(args, response)
 	}
+
 	return executeSecretsCommand(args)
 }
 

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -190,6 +190,9 @@ var sshCommand = &cobra.Command{
 }
 
 func runSshCommand(cmd *cobra.Command, args []string) error {
+	if !isA2HARBFileExist() {
+		return errors.New(AUTOMATE_HA_INVALID_BASTION)
+	}
 	infra, err := getAutomateHAInfraDetails()
 	if err != nil {
 		return err

--- a/components/automate-cli/cmd/chef-automate/testHA.go
+++ b/components/automate-cli/cmd/chef-automate/testHA.go
@@ -30,9 +30,8 @@ func runTestCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
 		return executeAutomateClusterCtlCommand("test", args, testHAHelpDocs)
 	} else {
-		return status.Wrap(errors.New("Test command only work with HA mode of automate"), status.ConfigError, testHAHelpDocs)
+		return status.Wrap(errors.New(AUTOMATE_HA_INVALID_BASTION), status.ConfigError, testHAHelpDocs)
 	}
-
 }
 
 func init() {

--- a/components/automate-cli/cmd/chef-automate/workspaceHa.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceHa.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -30,5 +31,5 @@ func runWorkspaceCmd(cmd *cobra.Command, args []string) error {
 		}
 		return executeAutomateClusterCtlCommand("workspace", args, workspaceCommandHelpDocs)
 	}
-	return status.New(status.InvalidCommandArgsError, workspaceCommandHelpDocs)
+	return status.Wrap(errors.New(AUTOMATE_HA_INVALID_BASTION), status.InvalidCommandArgsError, workspaceCommandHelpDocs)
 }


### PR DESCRIPTION
As all mapped HA command is part of automate, sometime user might try to run automate HA command in non HA env, we have to show graceful error instead of system failure error.

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Dev tested, Dev done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
