### PR TITLE
Show list of Reports in the Report panel

### DIFF
--- a/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
+++ b/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+
+const REPORT_LIST_API_URL = environment.download_report_list_url;
+
+@Injectable({ providedIn: 'root'})
+export class DownloadReportsService {
+  showOpenReport = false;
+  reportList = [];
+  private units = ['bytes', 'kb', 'mb', 'gb'];
+  constructor(private httpClient: HttpClient) {}
+
+  onReportOpenClick() {
+    this.handleReportList();
+    this.showOpenReport = true;
+  }
+
+  onReportCloseClick() {
+    this.showOpenReport = false;
+  }
+
+  handleReportList() {
+    this.fetchReportList().subscribe((responseData) => {
+      if (responseData && responseData['data'] && responseData['data'].length > 0) {
+        this.reportList = responseData['data'];
+        this.checkReportStatus();
+      } else {
+        this.reportList = [];
+      }
+    });
+  }
+
+  fetchReportList() {
+    const url = `${REPORT_LIST_API_URL}/requests`;
+    return this.httpClient.get(url);
+  }
+
+  checkReportStatus() {
+    const reportLength = this.reportList.length;
+    if (reportLength > 0) {
+      for (let i = 0; i < reportLength; i++) {
+        if (this.reportList[i].status === 'running') {
+          setTimeout(() => {
+            this.handleReportList();
+          }, 10000);
+          break;
+        }
+      }
+    }
+  }
+
+  byteConverter(value) {
+    value = value * 1; // convert string to number
+    let sizeIndex = 0;
+    let rem = value;
+    if (rem === 0) {
+      return 0;
+    }
+    do {
+      if (rem >= 1024) {
+        sizeIndex++;
+      }
+      rem = rem / 1024;
+    } while (rem >= 1024);
+    if (Math.floor(rem) === rem) {
+      return rem + this.units[sizeIndex];
+    }
+    return rem.toFixed(2) + this.units[sizeIndex];
+  }
+}

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -28,6 +28,7 @@
             <chef-click-outside (clickOutside)="hideDownloadDropdown()" omit="dropdown-toggle">
               <chef-button tertiary (click)="onDownloadOptPressed('json')">Download JSON</chef-button>
               <chef-button tertiary (click)="onDownloadOptPressed('csv')">Download CSV</chef-button>
+              <chef-button tertiary *ngIf="appConfigService.isLargeReportingEnabled" (click)="hideDownloadDropdown();downloadReportsService.onReportOpenClick()">Open Report</chef-button>
             </chef-click-outside>
           </chef-dropdown>
         </div>
@@ -165,6 +166,46 @@
         </ng-container>
         <chef-loading-spinner *ngIf="downloadInProgress" size="50"></chef-loading-spinner>
       </chef-modal>
+      <chef-side-panel class="reporting-download-side-panel" [visible]="downloadReportsService.showOpenReport">
+        <div class="side-panel-header">
+          <div class="header-text">
+            <h3><strong>Generated Reports</strong></h3>
+          </div>
+          <chef-button secondary (click)="downloadReportsService.onReportCloseClick()">
+            <chef-icon>close</chef-icon>
+          </chef-button>
+        </div>
+        <div class="side-panel-body">
+          <table class="table">
+            <tr class="table-header">
+              <th>Report</th>
+              <th>Size</th>
+              <th>Duration</th>
+            </tr>
+            <ng-container *ngIf="downloadReportsService.reportList.length > 0">
+              <tr *ngFor="let report of downloadReportsService.reportList; index as i">
+                <td [ngClass]="{'failed-status': report.status === 'failed', 'running-status': report.status === 'running', 'success-status': report.status === 'success'}">
+                  <app-time [time]='report.created_at'></app-time></td>
+                <td *ngIf="report.status === 'success'">{{ downloadReportsService.byteConverter(report.report_size) }}</td>
+                <ng-container *ngIf="report.status === 'failed'">
+                  <td [id]="'error-message-' + i" class="failed-status error-message">{{ report.err_message }}</td>
+                </ng-container>  
+                <td *ngIf="report.status === 'running'" class="running-status">In progress...</td>
+                <td *ngIf="report.status === 'success' || report.status === 'failed'">{{report.duration}}</td>
+                <ng-container *ngIf="report.status === 'failed'">
+                  <chef-tooltip
+                  [attr.for]="'error-message-' + i"
+                  position="top"
+                  delay="0">{{ report.err_message }}</chef-tooltip>
+                </ng-container>
+              </tr>
+            </ng-container>
+          </table>
+          <ng-container *ngIf="downloadReportsService.reportList.length === 0">
+            <h4 class="display4" class="no-reports-message">No reports are available to download.</h4>
+          </ng-container>
+        </div>
+      </chef-side-panel>
     </main>
   </div>
 </div>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -202,7 +202,7 @@
             </ng-container>
           </table>
           <ng-container *ngIf="downloadReportsService.reportList.length === 0">
-            <h4 class="display4" class="no-reports-message">No reports are available to download.</h4>
+            <h4 class="display4 no-reports-message">No reports are available to download.</h4>
           </ng-container>
         </div>
       </chef-side-panel>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -176,11 +176,11 @@
           </chef-button>
         </div>
         <div class="side-panel-body">
-          <table class="table">
+          <table class="table" aria-label="download-report-list">
             <tr class="table-header">
-              <th>Report</th>
-              <th>Size</th>
-              <th>Duration</th>
+              <th scope="col">Report</th>
+              <th scope="col">Size</th>
+              <th scope="col">Duration</th>
             </tr>
             <ng-container *ngIf="downloadReportsService.reportList.length > 0">
               <tr *ngFor="let report of downloadReportsService.reportList; index as i">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
@@ -32,6 +32,7 @@ chef-subheading {
 
     .dropdown {
       right: 0;
+      z-index: 1;
     }
   }
 
@@ -258,4 +259,73 @@ chef-subheading {
 
 #download-modal {
   text-align: center;
+}
+
+.reporting-download-side-panel {
+
+  z-index: 10;
+  
+  .side-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1em;
+    background: $chef-white;
+    border-bottom: 1px solid $chef-grey;
+  
+    .header-icon {
+      font-size: 2em;
+      color: $chef-dark-grey;
+    }
+  
+    .header-text {
+      margin: 0 1em;
+      flex-grow: 1;
+      word-break: break-all;
+    }
+  }
+
+  .side-panel-body {
+     font-size: 14px;
+     background: $chef-white;
+
+     chef-tooltip {
+      width: 400px;
+      border: 1px solid $chef-grey;
+     }
+
+     .table {
+      width: 100%;
+     }
+
+     .table-header {
+      font-size: 16px;
+     }
+
+    .failed-status {
+      color: $status-error
+    }
+
+    .running-status {
+      color: $chef-dark-grey
+    }
+
+    .success-status {
+      color: $chef-primary-bright
+    }
+
+    .error-message {
+      white-space: nowrap; 
+      max-width: 30px; 
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: pointer;
+    }
+
+    .no-reports-message {
+      text-align: center;
+      border-bottom: 5px solid $chef-white;
+    }
+  }
+  
 }

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -38,6 +38,7 @@ import { AckDownloadReports } from 'app/entities/download-reports/download-repor
 import { CreateNotification } from 'app/entities/notifications/notification.actions';
 import { Type } from 'app/entities/notifications/notification.model';
 import { AppConfigService } from 'app/services/app-config/app-config.service';
+import { DownloadReportsService } from 'app/entities/download-reports/download-reports.service';
 
 @Component({
   templateUrl: './reporting.component.html',
@@ -198,7 +199,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private layoutFacade: LayoutFacadeService,
     private store: Store<NgrxStateAtom>,
-    private appConfigService: AppConfigService
+    public appConfigService: AppConfigService,
+    public downloadReportsService: DownloadReportsService
   ) {}
 
   private getAllUrlParameters(): Observable<Chicklet[]> {

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -7,16 +7,25 @@ import { StatsService } from './stats.service';
 import * as moment from 'moment/moment';
 import { environment } from '../../../../../environments/environment';
 import { ReportQuery } from './report-query.service';
+import { AppConfigService } from 'app/services/app-config/app-config.service';
 
 const COMPLIANCE_URL = environment.compliance_url;
+
+class MockAppConfigService {
+  get isLargeReportingEnabled(): boolean {
+    return false;
+  }
+}
 
 describe('StatsService', () => {
   let httpTestingController: HttpTestingController;
   let service: StatsService;
+  let appConfigService: AppConfigService;
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         { provide: ChefSessionService, useClass: MockChefSessionService },
+        { provide: AppConfigService, useClass: MockAppConfigService },
         StatsService
       ],
       imports: [
@@ -26,6 +35,7 @@ describe('StatsService', () => {
     });
 
     service = TestBed.inject(StatsService);
+    appConfigService = TestBed.inject(AppConfigService);
     httpTestingController = TestBed.inject(HttpTestingController);
   });
 
@@ -682,8 +692,12 @@ describe('StatsService', () => {
 
   describe('downloadReport()', () => {
     it('fetches a report export as text', done => {
-      // const url = `${COMPLIANCE_URL}/reporting/export`; // needed for LCR later
-      const url = `${COMPLIANCE_URL}/reporting/reportmanager/export`;
+      let url = '';
+      if (appConfigService.isLargeReportingEnabled) {
+        url = `${COMPLIANCE_URL}/reporting/reportmanager/export`;
+      } else {
+        url = `${COMPLIANCE_URL}/reporting/export`;
+      }
       const type = 'csv';
       const endDate = moment('2017-01-31T00:00:00Z').utcOffset(0);
       const startDate = moment('2017-01-01T00:00:00Z').utcOffset(0);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -271,6 +271,24 @@ export class StatsService {
     return 'passed';
   }
 
+  getSingleReport(reportID: string, reportQuery: ReportQuery): Observable<any> {
+    const url = `${CC_API_URL}/reporting/reports/id/${reportID}`;
+    const formatted = this.formatFilters(reportQuery);
+    const body = { filters: formatted };
+
+    return this.httpClient.post<any>(url, body).pipe(
+      map((data) => {
+        data.profiles.forEach(p => {
+          p.controls.forEach(c => {
+            // precalculate overall control status from results
+            c.results = c.results || [];
+            c.status = this.getControlStatus(c);
+          });
+        });
+        return omitBy(data, isNil);
+      }));
+  }
+
   private checkIfWaived(waivedStatus: string): boolean {
     return waivedStatus === 'yes_run' || waivedStatus === 'yes';
   }

--- a/components/automate-ui/src/environments/environment.no_auth.ts
+++ b/components/automate-ui/src/environments/environment.no_auth.ts
@@ -18,6 +18,7 @@ export const environment = {
     user_preference_url: '/api/v0/user-settings',
     compliance_stats_url: '/api/v0/compliance/reporting/stats',
     client_runs_stats_url: '/api/v0/cfgmgmt/telemetry',
+    download_report_list_url: '/api/v0/reportmanager',
     // TODO:eng-ex remove elasticsearch_url when all es requests go through config-mgmt
     // don't forget to remove it from the proxy
     elasticsearch_url: '/api/v0/elasticsearch',

--- a/components/automate-ui/src/environments/environment.prod.ts
+++ b/components/automate-ui/src/environments/environment.prod.ts
@@ -25,6 +25,7 @@ export const environment = {
   user_preference_url: '/api/v0/user-settings',
   compliance_stats_url: '/api/v0/compliance/reporting/stats',
   client_runs_stats_url: '/api/v0/cfgmgmt/telemetry',
+  download_report_list_url: '/api/v0/reportmanager',
   elasticsearch_url: '/api/v0/elasticsearch',
   notifier_url: '/api/v0/notifications',
   data_feed_url: '/api/v0/datafeed',

--- a/components/automate-ui/src/environments/environment.ts
+++ b/components/automate-ui/src/environments/environment.ts
@@ -31,6 +31,7 @@ export const environment = {
   user_preference_url: '/api/v0/user-settings',
   compliance_stats_url: '/api/v0/compliance/reporting/stats',
   client_runs_stats_url: '/api/v0/cfgmgmt/telemetry',
+  download_report_list_url: '/api/v0/reportmanager',
   // TODO:eng-ex remove elasticsearch_url when all es requests go through config-mgmt
   // don't forget to remove it from the proxy
   elasticsearch_url: '/api/v0/elasticsearch',


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Add open report menu item in download-dropdown button and show list of download-reports with its status in the Report panel when you click the open report.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

#6191, #6193

### :+1: Definition of Done

Fetched the dowload-reports with its status and shown in the report panel(side panel) when you click open report menu. 

### :athletic_shoe: How to Build and Test the Change

inside hab,

rebuild the following components if you are getting 404 not found error for "custom_settings.js" api in network tab when page refresh or after login.
- rebuild components/automate-ui
- rebuild components/automate-gateway/
- rebuild components/automate-deployment/
- start_all_services

Rebuild the following components:-
- rebuild components/report-manager-minio-gateway/
- rebuild components/report-manager-service/
- rebuild components/compliance-service/
- rebuild components/automate-gateway/
- rebuild components/automate-cli/
- rebuild components/automate-deployment/
- start_all_services

create the config.toml file in /automate root folder. Add the below code in the file.
it enables the LCR configuration to test the new download flow.

[compliance.v1.sys.service]
upgrade_lcr = true

[global.v1.large_reporting]
enable_large_reporting = true

Then run these commands,
chef-automate config patch config.toml
chef_load_compliance_scans -D2 -N10 -M1 -T200

Login into automate-ui application, check the network tab -> "custom_settings.js" API returns -> large_reporting: { enable_large_reporting: true }. Click the compliance tab -> you can see the Report page -> you can see the download button near filter box -> click the download button -> you can see 'open report' menu is added in dropdown menu-> click either JSON or CSV format -> then click the open report menu -> it opens the side panel -> 
you can see the download report with its status details in the panel.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
