### PR TITLE
terraform output for exiting node for ssh

### DIFF
--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/outputs.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/outputs.tf
@@ -47,7 +47,7 @@ output "automate_ssh" {
     "ssh -i %s %s@%s",
     var.ssh_key_file,
     var.ssh_user,
-    var.existing_automate_ips,
+    var.existing_automate_private_ips,
   )
 }
 
@@ -56,7 +56,7 @@ output "chef_server_ssh" {
     "ssh -i %s %s@%s",
     var.ssh_key_file,
     var.ssh_user,
-    var.existing_chef_server_ips,
+    var.existing_chef_server_private_ips,
   )
 }
 
@@ -65,7 +65,7 @@ output "postgresql_ssh" {
     "ssh -i %s %s@%s",
     var.ssh_key_file,
     var.ssh_user,
-    var.existing_postgresql_ips,
+    var.existing_postgresql_private_ips,
   )
 }
 


### PR DESCRIPTION
terraform output for exiting node for ssh

### :nut_and_bolt: Description: What code changed, and why?

Terraform output in existing infra deployment don't contain ssh info for following servers...

chef-server
automate
postgersql
due to this chef-automate ssh is also failing as it use terraform.tfstate file

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://app.zenhub.com/workspaces/the-delta-quadrant-5fc7c4c3922dc10021323fa6/issues/chef/automate/6261

### :+1: Definition of Done

Dev Done

### :athletic_shoe: How to Build and Test the Change

build automate-backend-deployment

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
