### PR TITLE
Removed extra space in Node Run list tab

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.scss
@@ -331,10 +331,7 @@ div#button-env {
   }
 
   .attr {
-    width: 98%;
-    margin-left: 28px;
-    margin-right: 33px;
-    margin-top: 16px;
+    width: 100%;
     background: $chef-white;
     border: 1px solid $chef-key-tab;
     box-sizing: border-box;
@@ -369,7 +366,6 @@ div#button-env {
   }
 
   .label {
-    margin-left: 39px;
     height: 20px;
     left: 200px;
     top: 238px;
@@ -381,13 +377,11 @@ div#button-env {
   }
 
   .default {
-    margin-top: 29px;
     max-width: 25%;
   }
 
   .label-items {
-    margin-bottom: 16px;
-    height: 55px;
+    height: 30px;
   }
 
   .version-dropdown {


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
on infra views node details page have `Run list` tab, UI is not same as another tab, some extra side space is there, we need to remove this extra space.
### :chains: Related Resources
https://github.com/chef/automate/issues/5256
### :+1: Definition of Done
I have added some CSS changes to fix this.
### :athletic_shoe: How to Build and Test the Change

- Go to Node tab
- From node list click any node
- click on Run list tab
- where you see side space is extra
- ### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![run-list-height](https://user-images.githubusercontent.com/12297653/143864970-df8b0dd8-c12a-4a0d-add7-572bbdba2633.png)

