### PR TITLE
Fixed reset client modal width on scroll

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-client-modal/create-client-modal.component.scss
@@ -183,7 +183,7 @@ chef-modal.create-client-modal {
       height: 297px;
       width: 100%;
       line-height: 20px;
-      letter-spacing: 0.25px;
+      letter-spacing: 0.05px;
       padding: 1.5em;
     }
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.html
@@ -1,4 +1,4 @@
-<chef-modal [visible]="visible" (closeModal)="closeCreateModal()" class="reset-client-modal">
+<chef-modal [visible]="visible" (closeModal)="closeCreateModal()" [ngClass]="[ isReset ? 'reset-modal' : 'reset-client-modal'] ">
   <div class="flex-container">
     <div *ngIf="!isReset" class="reset-div">
       <div class="left-box">
@@ -27,8 +27,7 @@
       <h2 slot="title">Reset Client</h2>
       <div class="detail">
         <div class="icon-wrap"><i></i></div>
-        <p>The key has been reset. This key is not stored by the Chef Infra server, so please make <br/>
-          sure to copy or download it somewhere safe.</p>
+        <p>The key has been reset. This key is not stored by the Chef Infra <br/>server, so please make sure to copy or download it somewhere <br/>safe.</p>
       </div>
       <div class="key-tab-body">
         <chef-snippet [code]="privateKey" lang="json"></chef-snippet>

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.scss
@@ -1,6 +1,7 @@
 @import "~styles/variables";
 
-chef-modal.reset-client-modal {
+
+chef-modal {
 
   [slot=title] {
     font-style: normal;
@@ -99,7 +100,7 @@ chef-modal.reset-client-modal {
           width: 16px;
           background-image: url('/assets/img/icon-check-circle.png');
           position: absolute;
-          top: -30px;
+          top: -51px;
           left: 8px;
         }
 
@@ -136,7 +137,9 @@ chef-modal.reset-client-modal {
       }
     }
   }
+}
 
+chef-modal.reset-client-modal {
   ::ng-deep {
     .modal {
       box-shadow: 0px 0px 30px 0px #CCC;
@@ -255,4 +258,80 @@ chef-modal.reset-client-modal {
 
   }
 
+}
+
+chef-modal.reset-modal {
+  ::ng-deep {
+    .modal {
+      box-shadow: 0px 0px 30px 0px $light-grey;
+      max-width: 528px;
+      min-width: 528px;
+      outline: none;
+
+      chef-button {
+        &.close {
+          border: none;
+          color: $chef-black;
+          margin-right: 22px;
+          margin-top: 16px;
+
+          &:hover, &:focus {
+            background: none;
+            outline: none;
+          }
+        }
+
+        button {
+          line-height: 20px;
+          letter-spacing: 0.5px;
+
+          &:focus {
+            outline: none;
+            border: 0.5px solid $chef-primary-bright;
+            border-radius: 4px;
+          }
+        }
+
+        .cancel-button.hydrated {
+          background: none;
+        }
+      }
+
+      chef-checkbox {
+        &[aria-checked=false] .check-wrap {
+          border-color: $chef-primary-bright;
+        }
+
+        &:focus {
+          outline: none;
+          border: 0.5px solid $chef-primary-bright;
+          border-radius: 4px;
+        }
+
+        .label-wrap {
+          margin-left: 8px;
+        }
+
+        .check-wrap {
+          width: 16px;
+          min-width: 16px;
+          height: 16px;
+        }
+      }
+    }
+
+    .modal-overlay {
+      background-color: $chef-white;
+      opacity: 0.5;
+    }
+
+    chef-snippet pre {
+      font-size: 12px;
+      height: 297px;
+      width: 100%;
+      line-height: 20px;
+      letter-spacing: 0.25px;
+      padding: 1.5em;
+    }
+  }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/reset-client-key/reset-client-key.component.scss
@@ -330,7 +330,7 @@ chef-modal.reset-modal {
       height: 297px;
       width: 100%;
       line-height: 20px;
-      letter-spacing: 0.25px;
+      letter-spacing: 0.05px;
       padding: 1.5em;
     }
   }


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
on the client details page, we have 2 modal popups, the first is for reset confirmation and the second is for resetting the key, we need to set the different widths for both the modals.
### :chains: Related Resources
https://github.com/chef/automate/issues/5288
### :+1: Definition of Done
I have added CSS changes to set different widths for both of the modals.
### :athletic_shoe: How to Build and Test the Change
Steps for Client tab:

- Go To Infrastructure -> Chef Servers -> click server name-> click org name -> Go to Client tab --> click on create client button
- Go To Infrastructure -> Chef Servers -> click server name-> click org name -> Go to Client tab --> click on any client --> click on reset Key button --> in modal reset key

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicabl
![client-reset](https://user-images.githubusercontent.com/12297653/143899362-09751e10-320a-4789-b969-c971ff65ef10.png)
e
