### PR TITLE
Reverting compliance and chef run info es index ingestion

### DIFF
--- a/components/compliance-service/ingest/ingestic/mappings/mappings.go
+++ b/components/compliance-service/ingest/ingestic/mappings/mappings.go
@@ -18,7 +18,7 @@ var AllMappings = []Mapping{
 	ComplianceRepDate,
 	ComplianceSumDate,
 	ComplianceProfiles,
-	ComplianceRunInfo,
+	//ComplianceRunInfo,
 }
 
 const (

--- a/components/compliance-service/ingest/pipeline/publisher/compliance.go
+++ b/components/compliance-service/ingest/pipeline/publisher/compliance.go
@@ -55,7 +55,7 @@ func storeCompliance(in <-chan message.Compliance, out chan<- message.Compliance
 		}
 		errChannels = append(errChannels, insertInspecSummary(msg, client))
 		errChannels = append(errChannels, insertInspecReport(msg, client))
-		errChannels = append(errChannels, insertInspecReportRunInfo(msg, client))
+		//errChannels = append(errChannels, insertInspecReportRunInfo(msg, client))
 
 		for err := range merge(errChannels...) {
 			if err != nil {

--- a/components/ingest-service/backend/elastic/mappings/mappings.go
+++ b/components/ingest-service/backend/elastic/mappings/mappings.go
@@ -29,7 +29,7 @@ var AllMappings = []Mapping{
 	NodeState,
 	ConvergeHistory,
 	NodeAttribute,
-	NodeRunInfo,
+	//	NodeRunInfo,
 }
 
 // Mapping type is the representation of an ES mapping, it contains

--- a/components/ingest-service/pipeline/chef_run.go
+++ b/components/ingest-service/pipeline/chef_run.go
@@ -47,7 +47,7 @@ func NewChefRunPipeline(client backend.Client, authzClient authz.ProjectsService
 			publisher.BuildBulkRunPublisher(client, chefIngestRunPipelineConfig.MaxNumberOfBundledMsgs),
 			chefIngestRunPipelineConfig.NumberOfPublishers,
 			chefIngestRunPipelineConfig.MaxNumberOfBundledMsgs),
-		publisher.BuildChefRunDateInfo(client, chefIngestRunPipelineConfig.NumberOfPublishers),
+		//	publisher.BuildChefRunDateInfo(client, chefIngestRunPipelineConfig.NumberOfPublishers),
 		processor.CountRuns(&counter),
 	)
 

--- a/components/ingest-service/pipeline/publisher/chef_run.go
+++ b/components/ingest-service/pipeline/publisher/chef_run.go
@@ -39,8 +39,9 @@ func ChefRun(in <-chan message.ChefRun, client backend.Client, out chan<- messag
 		runc := insertChefRun(msg, client)
 		nodec := insertNode(msg, client)
 		attrc := insertNodeAttribute(msg, client)
-		runInfo := insertNodeInfo(msg, client)
-		errc := merge(runc, nodec, attrc, runInfo)
+		//runInfo := insertNodeInfo(msg, client)
+		//errc := merge(runc, nodec, attrc, runInfo)
+		errc := merge(runc, nodec, attrc)
 
 		for err := range errc {
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Automate latest release has seen some unprecedented errors at the customer end.
This PR is to revert the code changes made in compliance and ingest-service

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
- hab studio enter
- rebuild components/compliance-service/
- rebuild components/ingest-service/
- start_all_services

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
