### PR TITLE
Align the tooltip missing part in report panel (LCR)

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.scss
@@ -293,15 +293,25 @@ chef-subheading {
     chef-tooltip {
       width: 400px;
       border: 1px solid $chef-grey;
-     }
+    }
+
+    chef-tooltip.top {
+      transform: translate(-65%, calc(-100% - .75em));
+    }
+
+    chef-tooltip::after {
+      border-bottom: 1px solid $chef-grey;
+      border-right: 1px solid $chef-grey;
+      transform: translateX(275%) translateY(-50%) rotate(45deg);
+    }
 
     .table {
       width: 100%;
-     }
+    }
 
     .table-header {
       font-size: 16px;
-     }
+    }
 
     .failed-status {
       color: $status-error;


### PR DESCRIPTION
Signed-off-by: Venkatesh-rengasamy <vrengasa@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Align the tool-tip properly to show the entire message without missing any part of it.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

#6321

### :+1: Definition of Done

Aligned the tool-tip properly to show the entire message in the report panel.

### :athletic_shoe: How to Build and Test the Change

inside hab,

rebuild the following components if you are getting 404 not found error for "custom_settings.js" api in network tab when page refresh or after login.

rebuild components/automate-ui
rebuild components/automate-gateway/
rebuild components/automate-deployment/
start_all_services

Rebuild the following components:-

rebuild components/report-manager-minio-gateway/
rebuild components/report-manager-service/
rebuild components/compliance-service/
rebuild components/automate-gateway/
rebuild components/automate-cli/
rebuild components/automate-deployment/
start_all_services

create the config.toml file in /automate root folder. Add the below code in the file.
it enables the LCR configuration to test the new download flow.

[compliance.v1.sys.service]
upgrade_lcr = true

[global.v1.large_reporting]
enable_large_reporting = true

Then run these commands,
chef-automate config patch config.toml
chef_load_compliance_scans -D2 -N10 -M1 -T200

Login into automate-ui application, check the network tab -> "custom_settings.js" API returns -> large_reporting: { enable_large_reporting: true }. Click the compliance tab -> you can see the Report page -> you can see the download button near filter box -> click the download button -> you can see 'open report' menu is added in dropdown menu-> click either JSON or CSV format -> then click the open report menu -> it opens the side panel ->
you can see the download report with its status details -> if any of the report is failed then error message shown for individual report -> hover the error message -> you can see the tool-tip with error content properly.


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
