### PR TITLE
ES upgrade to 6.8.21, AdoptOpenJDK version 11.0.13+8

### DIFF
--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -4,12 +4,12 @@
 pkg_name="automate-elasticsearch"
 pkg_description="Wrapper package for core/elasticsearch"
 pkg_origin="chef"
-pkg_version="6.8.14"
+pkg_version="6.8.21"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz"
-pkg_shasum=edcf3e951b91fcfb4a7bc0a0f2a58bce74c741dfd64c84c46d9777d75079d5c0
+pkg_shasum=ad4ecba186172eda803df6dcbc3ee8b92bd72b118464f5aefca35b9b357e6cc2
 
 pkg_build_deps=(
   core/patchelf

--- a/components/automate-openjdk/habitat/plan.sh
+++ b/components/automate-openjdk/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_name=automate-openjdk
 # Release archive https://jdk.java.net/archive/
 pkg_version=11.0.13+8
-pkg_source=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
+pkg_source=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 pkg_shasum=3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30
 pkg_filename=OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 pkg_dirname="jdk-${pkg_version}"

--- a/components/automate-openjdk/habitat/plan.sh
+++ b/components/automate-openjdk/habitat/plan.sh
@@ -9,9 +9,9 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_name=automate-openjdk
 # Release archive https://jdk.java.net/archive/
 pkg_version=11.0.12+7
-pkg_source=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz
-pkg_shasum=8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2
-pkg_filename=OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz
+pkg_source=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
+pkg_shasum=3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30
+pkg_filename=OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 pkg_dirname="jdk-${pkg_version}"
 pkg_license=("GPL-2.0-with-classpath-exception")
 pkg_description=('AdoptOpenJDK binaries are created from the unmodified source code at OpenJDK.')

--- a/components/automate-openjdk/habitat/plan.sh
+++ b/components/automate-openjdk/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_origin=chef
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_name=automate-openjdk
 # Release archive https://jdk.java.net/archive/
-pkg_version=11.0.12+7
+pkg_version=11.0.13+8
 pkg_source=https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz
 pkg_shasum=3b1c0c34be4c894e64135a454f2d5aaa4bd10aea04ec2fa0c0efe6bb26528e30
 pkg_filename=OpenJDK11U-jdk_x64_linux_hotspot_11.0.13_8.tar.gz


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. ElasticSearch version upgraded from 6.8.14 to 6.8.21
2. AdoptOpenJDK version upgraded from 11.0.12+7 to 11.0.13+8
3. Fixed some CVE issues appearing in log4j

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
[ElasticSearch 6.8.21 Release Notes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.21.html)
[Adoptium OpenJDK Release](https://adoptium.net/release_notes.html)

### :+1: Definition of Done
All things are building correctly and running fine.

### :athletic_shoe: How to Build and Test the Change
`hab studio enter`
`start_all_services`
```
rebuild components/automate-openjdk
rebuild components/automate-elasticsearch
rebuild components/authz-service
rebuild components/automate-gateway
rebuild components/compliance-service
rebuild components/config-mgmt-service
rebuild components/automate-cli
rebuild components/deployment-service
rebuild components/nodemanager-service
rebuild components/ingest-service
rebuild components/data-feed-service
rebuild components/event-feed-service
```
Wait for some time and then check if all services are up and running
`chef-automate status`

In UI test all following tab
1. Dashboards
2. Applications
3. Infrastructure
4. Compliance
you can check if all filters and data is coming.
Test plan doc: https://docs.google.com/spreadsheets/d/1AB3IzKCSge3jjZPxzFqCcIZwg2r7o5AEEs5ldX_B_B8/edit?usp=sharing
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable
After rebuilding all relevant services, check status of the services.
![chef-automate status](https://user-images.githubusercontent.com/4770182/108829264-f69b3d80-75ed-11eb-8c84-8f6ea743c662.png)