### PR TITLE
UI-API integration for web UI key

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-servers-list/chef-servers-list.component.ts
@@ -68,9 +68,7 @@ export class ChefServersListComponent implements OnInit, OnDestroy {
       ]]
     });
     this.webUIKeyForm = this.fb.group({
-      webui_key: ['', [Validators.required,
-        Validators.pattern(Regex.patterns.NON_BLANK)
-      ]]
+      webui_key: ['', [Validators.required]]
     });
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.html
@@ -151,22 +151,23 @@
                 (keyup)="handleInput($event)"
                 autofocus></textarea>
             </label>
-            <chef-error class="textarea-error"
-              *ngIf="webUIKeyForm.get('webui_key').hasError('required') && webUIKeyForm.get('webui_key').dirty">
-              WEB UI KEY is required.
+            <chef-error
+            *ngIf="(webUIKeyForm.get('webui_key').hasError('required') || webUIKeyForm.get('webui_key').hasError('pattern')) && webUIKeyForm.get('webui_key').dirty">
+            WEB UI KEY is required.
             </chef-error>
+            <span class="note_text">Note: A web UI Key is located <a href=''>Here</a>(Need Better Help Text).</span>
           </chef-form-field>
         </div>
-        <span class="note_text">Note: A web UI Key is located <span>Here</span>(Need Better Help Text).</span>
-       <div id="button-bar">
+        <div id="button-bar">
           <chef-button id="cancel-server-popup" tertiary [disabled]="creating" (click)="closeSeverSlider()">Cancel</chef-button>
-          <chef-button [disabled]="!createForm?.valid || webUIKeyForm?.valid || creating || conflictError || (selected === 'fqdn') ? !fqdnForm?.valid : !ipForm?.valid"
-            primaryt
+          <chef-button
+            [disabled]="!createForm?.valid || !webUIKeyForm?.valid || creating || conflictError || ((selected === 'fqdn') ? !fqdnForm?.valid : !ipForm?.valid)"
+            primary
             data-cy="add-button"
             id="create-button-object-modal"
             (click)="createChefServer()">
             <chef-loading-spinner *ngIf="creating"></chef-loading-spinner>
-            <span *ngIf="!creating">Add</span>
+            <span *ngIf="!creating">Add Chef Infra Server</span>
             <span *ngIf="creating">Adding Chef Infra Server ...</span>
           </chef-button>
         </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.spec.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.spec.ts
@@ -87,7 +87,7 @@ describe('CreateChefServerSliderComponent', () => {
         expect(createForm.valid).toBeFalsy();
         expect(fqdnForm.valid).toBeFalsy();
         expect(ipForm.valid).toBeFalsy();
-        expect(webUIKeyForm).toBeFalsy();
+        expect(webUIKeyForm.valid).toBeFalsy();
       });
 
       it('when name is missing', () => {

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-groups-list/policy-groups-list.component.html
@@ -13,7 +13,10 @@
             'organizations', orgId, 'policyGroups', policyGroup.policy_group]">{{policyGroup.policy_group}}</a>
           </app-authorized>
         </chef-td>
-        <chef-td>{{policyGroup.occurrence}}</chef-td>
+        <chef-td>
+          <app-authorized [allOf]="['/api/v0/infra/servers/{server_id}/orgs/{org_id}/policygroups/{name}', 'get', [serverId, orgId, policyGroup.policy_group]]">{{policyGroup.occurrence}}
+          </app-authorized>
+          </chef-td>
       </chef-tr>
   </chef-tbody>
 </chef-table>

--- a/e2e/cypress/integration/api/iam/infra_clients_actions.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_clients_actions.spec.ts
@@ -115,14 +115,14 @@ describe('Infra Clients get', () => {
 describe('Infra Clients create', () => {
     let withInfraServersClientCreateActionToken = '';
     let withoutInfraServersClientCreateActionToken = '';
-    
+
         const cypressPrefix = 'infra-server-client-actions-create';
         const policyId1 = `${cypressPrefix}-pol-1-${Cypress.moment().format('MMDDYYhhmm')}`;
         const policyId2 = `${cypressPrefix}-pol-2-${Cypress.moment().format('MMDDYYhhmm')}`;
         const tokenId1 = `${cypressPrefix}-token-1-${Cypress.moment().format('MMDDYYhhmm')}`;
         const tokenId2 = `${cypressPrefix}-token-2-${Cypress.moment().format('MMDDYYhhmm')}`;
         const objectsToCleanUp = ['tokens', 'policies'];
-    
+
         const withInfraServersClientCreatePolicy = {
         id: policyId1,
         name: tokenId1,
@@ -137,8 +137,8 @@ describe('Infra Clients create', () => {
                 projects: ['*']
             }]
         };
-    
-    
+
+
         const withoutInfraServersClientCreatePolicy = {
             id: policyId2,
             name: tokenId2,
@@ -153,10 +153,10 @@ describe('Infra Clients create', () => {
                 projects: ['*']
             }]
         };
-    
+
         before(() => {
             cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -168,7 +168,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     withInfraServersClientCreateActionToken = resp.body.token.value;
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -177,7 +177,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     expect(resp.status).to.equal(200);
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -189,7 +189,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     withoutInfraServersClientCreateActionToken = resp.body.token.value;
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -199,11 +199,11 @@ describe('Infra Clients create', () => {
                     expect(resp.status).to.equal(200);
                 });
             });
-    
+
         after(() => {
             cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
         });
-    
+
         it('client post returns 200 when create actions is allowed', () => {
             cy.request({
                 headers: { 'api-token': withInfraServersClientCreateActionToken },
@@ -215,12 +215,12 @@ describe('Infra Clients create', () => {
                     org_id: 'test-org',
                     server_id: 'local-dev',
                     validator: true
-                },
+                }
                 }).then((resp) => {
                     assert.equal(resp.status, 200);
                 });
         });
-    
+
         it('clients post returns 403 when create actions is denied', () => {
             cy.request({
                 headers: { 'api-token': withoutInfraServersClientCreateActionToken },
@@ -243,14 +243,14 @@ describe('Infra Clients create', () => {
     describe('Infra Reset Client Key', () => {
         let withInfraServersClientResetActionToken = '';
         let withoutInfraServersClientResetActionToken = '';
-    
+
         const cypressPrefix = 'infra-server-client-actions-reset';
         const policyId1 = `${cypressPrefix}-pol-1-${Cypress.moment().format('MMDDYYhhmm')}`;
         const policyId2 = `${cypressPrefix}-pol-2-${Cypress.moment().format('MMDDYYhhmm')}`;
         const tokenId1 = `${cypressPrefix}-token-1-${Cypress.moment().format('MMDDYYhhmm')}`;
         const tokenId2 = `${cypressPrefix}-token-2-${Cypress.moment().format('MMDDYYhhmm')}`;
         const objectsToCleanUp = ['tokens', 'policies'];
-    
+
         const withInfraServersClientResetPolicy = {
         id: policyId1,
         name: tokenId1,
@@ -265,8 +265,8 @@ describe('Infra Clients create', () => {
                 projects: ['*']
             }]
         };
-    
-    
+
+
         const withoutInfraServersClientResetPolicy = {
             id: policyId2,
             name: tokenId2,
@@ -281,10 +281,10 @@ describe('Infra Clients create', () => {
                 projects: ['*']
             }]
         };
-    
+
         before(() => {
             cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -296,7 +296,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     withInfraServersClientResetActionToken = resp.body.token.value;
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -305,7 +305,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     expect(resp.status).to.equal(200);
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -317,7 +317,7 @@ describe('Infra Clients create', () => {
                 }).then((resp) => {
                     withoutInfraServersClientResetActionToken = resp.body.token.value;
                 });
-    
+
             cy.request({
                 headers: { 'api-token': Cypress.env('ADMIN_TOKEN') },
                 method: 'POST',
@@ -327,11 +327,11 @@ describe('Infra Clients create', () => {
                     expect(resp.status).to.equal(200);
                 });
             });
-    
+
         after(() => {
             cy.cleanupIAMObjectsByIDPrefixes(cypressPrefix, objectsToCleanUp);
         });
-    
+
         it('client put returns 403 when update actions is denied', () => {
             cy.request({
                 headers: { 'api-token': withoutInfraServersClientResetActionToken },
@@ -342,7 +342,7 @@ describe('Infra Clients create', () => {
                     assert.equal(resp.status, 403);
                 });
         });
-    
+
         it('client put returns 200 when update actions is allowed', () => {
             cy.request({
                 headers: { 'api-token': withInfraServersClientResetActionToken },

--- a/e2e/cypress/integration/api/iam/node_actions.spec.ts
+++ b/e2e/cypress/integration/api/iam/node_actions.spec.ts
@@ -339,5 +339,5 @@ describe('Nodes delete', () => {
             });
     });
 
- 
+
 });


### PR DESCRIPTION
Signed-off-by: chaitali-mane cmane@progress.com

### :nut_and_bolt: Description: What code changed, and why?
Need to add a code for the WebUI key in the create the chef-server slider.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/6350

### :+1: Definition of Done
Add a code for the WebUI key in the create the chef-server slider.
 
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
Steps for Policy Groups tab:
Go To Infrastructure -> Chef Servers -> Click on 'Add Chef Infra Server' -> slider will open.

### :white_check_mark: Checklist
**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/71449322/146200990-a073e52b-f655-41f6-a9a8-7333a3ad8012.mp4

