### PR TITLE
ES upgrade to 6.8.22

### DIFF
--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -4,12 +4,12 @@
 pkg_name="automate-elasticsearch"
 pkg_description="Wrapper package for core/elasticsearch"
 pkg_origin="chef"
-pkg_version="6.8.21"
+pkg_version="6.8.22"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz"
-pkg_shasum=ad4ecba186172eda803df6dcbc3ee8b92bd72b118464f5aefca35b9b357e6cc2
+pkg_shasum=540e274a980148323ef7033ba68f0a9883393ffd38983143bac0bbd69fa3f947
 
 pkg_build_deps=(
   core/patchelf


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. ElasticSearch version upgraded from 6.8.21 to 6.8.22
3. Fixed some CVE issues appearing in log4j

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
[ElasticSearch 6.8.22 Release Notes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.22.html)

### :+1: Definition of Done
All things are building correctly and running fine.

### :athletic_shoe: How to Build and Test the Change
`hab studio enter`
`start_all_services`
```
rebuild components/automate-elasticsearch
rebuild components/authz-service
rebuild components/automate-gateway
rebuild components/compliance-service
rebuild components/config-mgmt-service
rebuild components/automate-cli
rebuild components/deployment-service
rebuild components/nodemanager-service
rebuild components/ingest-service
rebuild components/data-feed-service
rebuild components/event-feed-service
```
Wait for some time and then check if all services are up and running
`chef-automate status`

In UI test all following tab
1. Dashboards
2. Applications
3. Infrastructure
4. Compliance
you can check if all filters and data is coming.
Test plan doc: https://docs.google.com/spreadsheets/d/1AB3IzKCSge3jjZPxzFqCcIZwg2r7o5AEEs5ldX_B_B8/edit?usp=sharing
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).