### PR TITLE
Meet58/a2ha ux changes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateHAWithoutCnfFile.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAWithoutCnfFile.go
@@ -16,7 +16,7 @@ func (h *haWithoutConfig) doDeployWork(args []string) error {
 }
 
 func (h *haWithoutConfig) doProvisionJob(args []string) error {
-	return status.Annotate(errors.New("config.toml file path expected as argument to run chef-automate provision-infra"), status.DeployError)
+	return status.Annotate(errors.New("config.toml file path expected as argument to run chef-automate provision-infrastructure"), status.DeployError)
 }
 
 func (h *haWithoutConfig) generateConfig() error {

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -36,7 +36,7 @@ var errMLSA = "Chef Software Terms of Service and Master License and Services Ag
 var errProvisonInfra = `Architecture does not match with the requested one. 
 If you want to provision cluster then you have to first run provision command.
 
-		chef-automate provision-infra
+		chef-automate provision-infrastructure
 
 After that you can run this command`
 

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -172,7 +172,7 @@ func init() {
 }
 
 var initConfigHACmd = &cobra.Command{
-	Use:   "init-config-ha",
+	Use:   "ha-init-config",
 	Short: "Initialize default config for Automate HA",
 	Long:  "Initialized default configuration for HA and save it to a file.",
 	Annotations: map[string]string{

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -133,7 +133,7 @@ Usage:
 
 Flags:
       --file string               File path to write the config (default "config.toml")
-  -h, --help                      help for init-config-ha
+  -h, --help                      help for ha-init-config
 
 Args: 
   aws				Generate initial automate high availability configuration for AWS deployment

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
@@ -7,7 +7,7 @@ import (
 
 func newProvisionInfraCmd() *cobra.Command {
 	var provisionInfraCmd = &cobra.Command{
-		Use:   "provision-infra",
+		Use:   "provision-infrastructure",
 		Short: "Provision Automate HA infra.",
 		Long:  "Provision infra for Automate HA deployment.",
 		Args:  cobra.RangeArgs(0, 1),

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHaTmpl.go
@@ -5,7 +5,7 @@ Usage:
 
 *** this command will only work with automate HA mode with AWS deployment ***
 
-chef-automate provision-infra <config toml file path> [OPTIONS]
+chef-automate provision-infrastructure <config toml file path> [OPTIONS]
 
 config file path:	
 	config toml file path

--- a/components/automate-cli/cmd/chef-automate/secretsHa.go
+++ b/components/automate-cli/cmd/chef-automate/secretsHa.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 var secretsCmd = &cobra.Command{
-	Use:   "secrets",
+	Use:   "ha-secrets",
 	Short: "Set secrets to Automate HA",
 	Long:  "Set secrets for Automate sudo password and admin password in HA mode.",
 	Annotations: map[string]string{

--- a/components/automate-cli/cmd/chef-automate/secretsHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/secretsHaTmpl.go
@@ -2,7 +2,7 @@ package main
 
 var secretsHelpDocs = `
 Usage:
-    chef-automate secrets SUBCOMMAND [ARG] ...
+    chef-automate ha-secrets SUBCOMMAND [ARG] ...
 Parameters:
     SUBCOMMAND                       subcommand
     [ARG] ...                        subcommand arguments

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -180,7 +180,7 @@ func init() {
 }
 
 var sshCommand = &cobra.Command{
-	Use:   "ssh",
+	Use:   "ha-ssh",
 	Short: "SSH into Automate HA servers",
 	Long:  "SSH into Automate HA servers",
 	Annotations: map[string]string{

--- a/components/automate-cli/cmd/chef-automate/workspaceHa.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceHa.go
@@ -14,7 +14,7 @@ func init() {
 }
 
 var workspaceCmd = &cobra.Command{
-	Use:   "workspace",
+	Use:   "ha-workspace",
 	Short: "Set workspace env for Automate HA.",
 	Long:  "Set up Automate HA cluster workspace.",
 	Annotations: map[string]string{

--- a/components/automate-cli/cmd/chef-automate/workspaceHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceHaTmpl.go
@@ -2,7 +2,7 @@ package main
 
 var workspaceCommandHelpDocs = `
 Usage:
-    chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ...
+    chef-automate ha-workspace [OPTIONS] SUBCOMMAND [ARG] ...
 Parameters:
     SUBCOMMAND                       subcommand
     [ARG] ...                        subcommand arguments

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate.yaml
@@ -39,7 +39,7 @@ see_also:
 - migrate-from-v1 - Migrate from Chef Automate v1
 - migrate-from-v1-status - Watch the status of the migration to Chef Automate 2
 - preflight-check - Perform preflight check
-- provision-infra - Provision Automate HA infra.
+- provision-infrastructure - Provision Automate HA infra.
 - restart-services - restart deployment services
 - secrets - Set secrets to Automate HA
 - service-versions - Retrieve the versions of the individual Chef Automate services

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_provision-infra.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_provision-infra.yaml
@@ -1,6 +1,6 @@
-name: chef-automate provision-infra
+name: chef-automate provision-infrastructure
 synopsis: Provision Automate HA infra.
-usage: chef-automate provision-infra [flags]
+usage: chef-automate provision-infrastructure [flags]
 description: Provision infra for Automate HA deployment.
 options:
 - name: channel
@@ -8,7 +8,7 @@ options:
 - name: help
   shorthand: h
   default_value: "false"
-  usage: help for provision-infra
+  usage: help for provision-infrastructure
 inherited_options:
 - name: debug
   shorthand: d

--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -2,13 +2,13 @@
 
 # SCENARIO 1
 
-If you are running chef-automate provision-infra and in between anything occure and provision get stopped then run below command to destroy that half part to start provision again.
+If you are running chef-automate provision-infrastructure and in between anything occure and provision get stopped then run below command to destroy that half part to start provision again.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/;terraform destroy -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate;cd $i;done`
 
 # SCENARIO 2
 
-If you have successfully done provision-infra and after that if you want to destroy infra then run below command in below order.
+If you have successfully done provision-infrastructure and after that if you want to destroy infra then run below command in below order.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
  


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Change a2ha command name line 'chef-automate ssh' would become ha-ssh. so ha prefix is added
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
