### PR TITLE
show loader when click on download link

### DIFF
--- a/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
+++ b/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ReportType } from './download-reports.model';
 import { Store } from '@ngrx/store';
@@ -22,6 +22,8 @@ export class DownloadReportsService implements OnDestroy {
   reportListSubscription: Subscription;
   notificationItems = {};
   retryLongPoll = 0;
+  private subject = new Subject();
+  obs$ = this.subject.asObservable();
   private units = ['bytes', 'kb', 'mb', 'gb'];
   constructor(private httpClient: HttpClient,
     private store: Store<NgrxStateAtom>) {
@@ -123,7 +125,7 @@ export class DownloadReportsService implements OnDestroy {
     const format = report.report_type;
     const filename = this.getFilename(report.created_at) + '.' + format;
     this.downloadReport(report.acknowledgement_id).subscribe((data) => {
-      console.log(data);
+      this.subject.next('close'); // close the loader
       const types = { 'json': 'application/json', 'csv': 'text/csv' };
       const type = types[format];
       const blob = new Blob([data], { type });

--- a/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
+++ b/components/automate-ui/src/app/entities/download-reports/download-reports.service.ts
@@ -125,13 +125,14 @@ export class DownloadReportsService implements OnDestroy {
     const format = report.report_type;
     const filename = this.getFilename(report.created_at) + '.' + format;
     this.downloadReport(report.acknowledgement_id).subscribe((data) => {
-      this.subject.next('close'); // close the loader
+      this.closeLoader();
       const types = { 'json': 'application/json', 'csv': 'text/csv' };
       const type = types[format];
       const blob = new Blob([data], { type });
       saveAs(blob, filename);
     }, (error) => {
       console.log(error);
+      this.closeLoader();
       this.store.dispatch(new CreateNotification({
         type: Type.error,
         message: 'Download failed.'
@@ -167,6 +168,10 @@ export class DownloadReportsService implements OnDestroy {
       return rem + this.units[sizeIndex];
     }
     return rem.toFixed(2) + this.units[sizeIndex];
+  }
+
+  closeLoader() {
+    this.subject.next('close'); // close the loader
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.html
@@ -186,7 +186,7 @@
               <tr *ngFor="let report of downloadReportsService.reportList; index as i" [ngClass]="{'json': report.report_type === 'json', 'csv': report.report_type === 'csv'}">
                 <ng-container>
                   <td *ngIf="report.status === 'success'" class="success-status">
-                    <a (click)="downloadReportsService.onLinkToDownload(report)" class="download-link">
+                    <a (click)="showDownloadStatus();downloadReportsService.onLinkToDownload(report)" class="download-link">
                       <app-time [time]='report.created_at'></app-time>
                     </a>
                   </td>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -256,6 +256,10 @@ export class ReportingComponent implements OnInit, OnDestroy {
         }
         return filter;
       })));
+
+    this.downloadReportsService.obs$.subscribe(() => {
+      this.hideDownloadStatus();
+    });
   }
 
   ngOnDestroy() {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -13,7 +13,7 @@ import {
   OnDestroy
 } from '@angular/core';
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, Subscription } from 'rxjs';
 import * as moment from 'moment/moment';
 import {
   StatsService,
@@ -189,6 +189,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
   // Used to notify all subscriptions to unsubscribe
   // http://stackoverflow.com/a/41177163/319074
   private isDestroyed: Subject<boolean> = new Subject<boolean>();
+  private downloadReportsSubscription: Subscription;
 
   constructor(
     private router: Router,
@@ -257,7 +258,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
         return filter;
       })));
 
-    this.downloadReportsService.obs$.subscribe(() => {
+    this.downloadReportsSubscription = this.downloadReportsService.obs$.subscribe(() => {
       this.hideDownloadStatus();
     });
   }
@@ -265,6 +266,9 @@ export class ReportingComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.isDestroyed.next(true);
     this.isDestroyed.complete();
+    if (this.downloadReportsSubscription) {
+      this.downloadReportsSubscription.unsubscribe();
+    }
   }
 
   toggleDownloadDropdown() {


### PR DESCRIPTION
Signed-off-by: Venkatesh-rengasamy <vrengasa@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Show loader when you click on download link inside open reports panel.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

#6429

### :+1: Definition of Done

loader popup shown when you click on download link inside open reports panel.

### :athletic_shoe: How to Build and Test the Change

inside hab,

rebuild the following components if you are getting 404 not found error for "custom_settings.js" api in network tab when page refresh or after login.

    rebuild components/automate-ui
    rebuild components/automate-gateway/
    rebuild components/automate-deployment/
    start_all_services

Rebuild the following components:-

    rebuild components/report-manager-minio-gateway/
    rebuild components/report-manager-service/
    rebuild components/compliance-service/
    rebuild components/automate-gateway/
    rebuild components/automate-cli/
    rebuild components/automate-deployment/
    start_all_services

create the config.toml file in /automate root folder. Add the below code in the file.
it enables the LCR configuration to test the new download flow.

[global.v1.large_reporting]
enable_large_reporting = true

Then run these commands,
chef-automate config patch config.toml
chef_load_compliance_scans -D2 -N10 -M1 -T200

Login into automate-ui application, check the network tab -> "custom_settings.js" API returns -> large_reporting: { enable_large_reporting: true }. Click the compliance tab -> you can see the Report page -> you can see the download button near filter box -> click the download button -> you can see 'open report' menu is added in dropdown menu-> click either JSON or CSV format -> then click the open report menu -> it opens the side panel ->
you can see the download report with its status details in the panel -> once report get success status then hyperlink enabled to download the report -> click the hyperlink then immediately loader shown until download completes.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
