### PR TITLE
Changes to use web ui key in all the Infra Proxy APIs for Cookbooks, Policy Files, Policy Groups, Clients 

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/create-chef-server-slider/create-chef-server-slider.component.html
@@ -151,12 +151,12 @@
                 (keyup)="handleInput($event)"
                 autofocus></textarea>
             </label>
-            <chef-error
+            <chef-error class="textarea-error"
             *ngIf="(webUIKeyForm.get('webui_key').hasError('required') || webUIKeyForm.get('webui_key').hasError('pattern')) && webUIKeyForm.get('webui_key').dirty">
             WEB UI KEY is required.
             </chef-error>
-            <span class="note_text">Note: A web UI Key is located <a href=''>Here</a>(Need Better Help Text).</span>
           </chef-form-field>
+          <span class="note_text">Note: A web UI Key is located <a href=''>Here</a>(Need Better Help Text).</span>
         </div>
         <div id="button-bar">
           <chef-button id="cancel-server-popup" tertiary [disabled]="creating" (click)="closeSeverSlider()">Cancel</chef-button>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
we need to add the changes in infra proxy APIs to use WebUI key instead of admin private key.
### :chains: Related Resources
https://github.com/chef/automate/issues/6280
### :+1: Definition of Done
I have added the changes in infra proxy APIs to use WebUI key instead of admin private key for the followings:
  - Cookbooks
  - Policy Files
  - Policy Groups
  - Clients
### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/infra-proxy-service
```
Steps to test:

1. Ensure Chef Infra Server is running. If it is not start it with ```start_chef_server```
2. Add the chef-server test environment credentials and extract the SERVER IDs
3. Test all the APIs of cookbooks, Policy Files, Policy Groups,Clients
4. If web ui key is available with server then APIs should use it.
5. In case it's not available then use org admin key.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
