### PR TITLE
Associate Project with every organisation

### DIFF
--- a/components/infra-proxy-service/cmd/infra-proxy-service/commands/serve.go
+++ b/components/infra-proxy-service/cmd/infra-proxy-service/commands/serve.go
@@ -86,6 +86,8 @@ func serve(cmd *cobra.Command, args []string) {
 	}
 	authzClient := authz.NewAuthorizationServiceClient(authzConn)
 
+	authzProjectClient := authz.NewProjectsServiceClient(authzConn)
+
 	if cfg.SecretsAddress == "" {
 		fail(errors.New("missing required config secrets_address"))
 	}
@@ -97,7 +99,7 @@ func serve(cmd *cobra.Command, args []string) {
 	// get secrets client
 	secretsClient := secrets.NewSecretsServiceClient(secretsConn)
 
-	service, err := service.Start(l, migrationConfig, connFactory, secretsClient, authzClient)
+	service, err := service.Start(l, migrationConfig, connFactory, secretsClient, authzClient, authzProjectClient)
 	if err != nil {
 		fail(errors.Wrap(err, "could not initialize storage"))
 	}

--- a/components/infra-proxy-service/config/service.go
+++ b/components/infra-proxy-service/config/service.go
@@ -87,6 +87,8 @@ func ConfigFromViper(configFile string) (*service.Service, error) {
 	}
 	authzClient := authz.NewAuthorizationServiceClient(authzConn)
 
+	authzProjectClient := authz.NewProjectsServiceClient(authzConn)
+
 	if cfg.SecretsAddress == "" {
 		fail(errors.New("missing required config secrets_address"))
 	}
@@ -98,7 +100,7 @@ func ConfigFromViper(configFile string) (*service.Service, error) {
 	// gets secrets client
 	secretsClient := secrets.NewSecretsServiceClient(secretsConn)
 
-	service, err := service.Start(l, migrationConfig, connFactory, secretsClient, authzClient)
+	service, err := service.Start(l, migrationConfig, connFactory, secretsClient, authzClient, authzProjectClient)
 	if err != nil {
 		fail(errors.Wrap(err, "could not initialize storage"))
 	}

--- a/components/infra-proxy-service/service/service.go
+++ b/components/infra-proxy-service/service/service.go
@@ -18,25 +18,27 @@ import (
 
 // Service holds the internal state and configuration of the Infra proxy service.
 type Service struct {
-	Logger      logger.Logger
-	ConnFactory *secureconn.Factory
-	Storage     storage.Storage
-	Secrets     secrets.SecretsServiceClient
+	Logger       logger.Logger
+	ConnFactory  *secureconn.Factory
+	Storage      storage.Storage
+	Secrets      secrets.SecretsServiceClient
+	AuthzProject authz.ProjectsServiceClient
 }
 
 // Start returns an instance of Service that connects to a postgres storage backend.
 func Start(l logger.Logger, migrationsConfig migration.Config, connFactory *secureconn.Factory, secretsClient secrets.SecretsServiceClient,
-	authzClient authz.AuthorizationServiceClient) (*Service, error) {
+	authzClient authz.AuthorizationServiceClient, authzProjectClient authz.ProjectsServiceClient) (*Service, error) {
 	p, err := postgres.New(l, migrationsConfig, authzClient)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Service{
-		Logger:      l,
-		ConnFactory: connFactory,
-		Storage:     p,
-		Secrets:     secretsClient,
+		Logger:       l,
+		ConnFactory:  connFactory,
+		Storage:      p,
+		Secrets:      secretsClient,
+		AuthzProject: authzProjectClient,
 	}, nil
 }
 

--- a/components/infra-proxy-service/test/test.go
+++ b/components/infra-proxy-service/test/test.go
@@ -112,6 +112,8 @@ func SetupInfraProxyService(ctx context.Context,
 
 	authzClient := authz.NewAuthorizationServiceClient(authzConn)
 
+	authzProjectClient := authz.NewProjectsServiceClient(authzConn)
+
 	secretsClient := secrets.NewMockSecretsServiceClient(gomock.NewController(t))
 
 	l, err := logger.NewLogger("text", "debug")
@@ -120,7 +122,7 @@ func SetupInfraProxyService(ctx context.Context,
 	migrationConfig, err := migrationConfigIfPGTestsToBeRun(l, "../storage/postgres/migration/sql")
 	require.NoError(t, err)
 
-	serviceRef, err := service.Start(l, *migrationConfig, connFactory, secretsClient, authzClient)
+	serviceRef, err := service.Start(l, *migrationConfig, connFactory, secretsClient, authzClient, authzProjectClient)
 
 	if err != nil {
 		t.Fatalf("could not create server: %s", err)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When a organisation is migrated from the chef server to automate, an IAM project needs to be linked with it. 
So added the call to project create service to create the project with the name of serverId_orgID, every time the organisation is stored in the database the project is created with the name having all the policies as editors, viewer, owner.

Similar changes as https://github.com/chef/automate/pull/6518

### :chains: Related Resources
https://github.com/chef/automate/issues/6380


### :+1: Definition of Done
Project is created and stored in database at the time of migration

### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/infra-proxy-service
rebuild components/automate-gateway
```
Steps to test:

1. Ensure Chef Infra Server is running. If it is not start it with ```start_chef_server```
2. Add the chef-server test environment credentials and extract the SERVER IDs

Request
This is a get request.
```curl -sSkH "api-token: $(get_admin_token)" 'https://a2-dev.test/api/v0/infra/servers/SERVER_ID/infraserverorgs'```

Response

```
{
    "orgs": [
        {
            "id": "test",
            "name": "test",
            "admin_user": "",
            "credential_id": "",
            "server_id": "serverId",
            "projects": ["serverID_test"]
        }
    ]
}
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
