### PR TITLE
Add telemetry preference in localStorage if not exist

### DIFF
--- a/components/automate-ui/e2e/signin.e2e-spec.ts
+++ b/components/automate-ui/e2e/signin.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('Signin Process', () => {
         username: 'kilgore@kilgore.trout',
         groups: ['authors'],
         id_token: valid_id_token,
-        telemetry_enabled: null
+        telemetry_enabled: true
       };
       const actual = browser.executeScript(
         'return window.localStorage.getItem(\'chef-automate-user\');')

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.spec.ts
@@ -87,7 +87,7 @@ describe('ChefSessionService', () => {
           expect(service.username).toEqual('testchefuser');
           expect(service.groups).toEqual(['group1', 'group2', 'group3']);
           expect(service.id_token).toEqual('test_id_token');
-          expect(service.telemetry_enabled).toEqual(null);
+          expect(service.telemetry_enabled).toEqual(true);
         });
       });
     });

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -363,6 +363,10 @@ export class ChefSessionService implements CanActivate {
   }
 
   private userTelemetryStorageKey(): string {
+    const telemetryStorage = localStorage.getItem(`${this.uuid}-telemetry-enabled`);
+    if(isNull(telemetryStorage)) {
+      localStorage.setItem(`${this.uuid}-telemetry-enabled`, this.booleanToString(true));
+    }
     return !isNil(this.user) ? `${this.uuid}-telemetry-enabled` : null;
   }
 

--- a/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
+++ b/components/automate-ui/src/app/services/chef-session/chef-session.service.ts
@@ -364,7 +364,7 @@ export class ChefSessionService implements CanActivate {
 
   private userTelemetryStorageKey(): string {
     const telemetryStorage = localStorage.getItem(`${this.uuid}-telemetry-enabled`);
-    if(isNull(telemetryStorage)) {
+    if (isNull(telemetryStorage)) {
       localStorage.setItem(`${this.uuid}-telemetry-enabled`, this.booleanToString(true));
     }
     return !isNil(this.user) ? `${this.uuid}-telemetry-enabled` : null;


### PR DESCRIPTION
Signed-off-by: Venkatesh-rengasamy <vrengasa@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Add telemetry preference in localStorage if it is not exist.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Added telemetry preference in localStorage.

### :athletic_shoe: How to Build and Test the Change

Login into automate-ui -> righ click on browser and select inspect the element -> click Application tab in inspect window -> clear the local storage -> reload the page -> then you can see telemetry preference is enabled by default.

local storage key name -->  "******-telemetry-enabled"

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
