### PR TITLE
Bump Elasticsearch 6.8.22 -> 6.8.23

### DIFF
--- a/components/automate-elasticsearch/habitat/plan.sh
+++ b/components/automate-elasticsearch/habitat/plan.sh
@@ -5,12 +5,12 @@
 pkg_name="automate-elasticsearch"
 pkg_description="Wrapper package for core/elasticsearch"
 pkg_origin="chef"
-pkg_version="6.8.22"
+pkg_version="6.8.23"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 pkg_upstream_url="https://www.chef.io/automate"
 pkg_source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${pkg_version}.tar.gz"
-pkg_shasum=540e274a980148323ef7033ba68f0a9883393ffd38983143bac0bbd69fa3f947
+pkg_shasum=424af91f838f9e5f13e0292f97cbd6333535450291a621d761bd479dfc2dff78
 
 pkg_build_deps=(
   core/patchelf


### PR DESCRIPTION
Elasticsearch 6.8.23 updates to log4j 2.17.1 which addresses CVE-2021-44832
