### PR TITLE
Added sync organization and user button

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -10,7 +10,7 @@
       </chef-breadcrumbs>
       <chef-page-header>
         <div class="meta-box">
-          <div class="summary-body">
+          <div class="summary-body first">
             <chef-heading data-cy="page-title">{{ server?.name }}</chef-heading>
             <ul>
               <li>
@@ -21,6 +21,10 @@
                 <span class="heading">IP Address</span>
                 <span>{{ server?.ip_address }}</span>
               </li>
+            </ul>
+          </div>
+          <div class="summary-body middle">
+            <ul>
               <li>
                 <span class="heading">Web UI Key</span>
                 <span *ngIf="validating" data-cy="valid-webui-key" class="webUIKeyStatus">Validating...</span>
@@ -34,7 +38,17 @@
                   >Update</a>
                 </span>
               </li>
+              <li>
+                <span class="heading">Org &amp; User last synced</span>
+                <span>Thu, Feb 04, 12:00:00 UTC</span>
+              </li>
             </ul>
+          </div>
+          <div class="summary-body last">
+            <app-authorized [allOf]="['/api/v0/infra/servers/{server_id}', 'put', [server?.id]]">
+              <chef-button id="sync-button" class="sync-button" secondary primary data-cy="sync-button">Sync Org and Users
+              </chef-button>
+            </app-authorized>
           </div>
         </div>
         <chef-tab-selector [value]="tabValue" (change)="onSelectedTab($event)">

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.scss
@@ -9,12 +9,25 @@ chef-page-header {
   border: 0.5px solid $chef-key-tab;
   border-radius: 4px;
   margin-bottom: 4em;
-  padding: 1em 0 4em;
+  padding: 1em 0 2em;
   background: $chef-white;
 
   .summary-body {
+    display: inline-block;
     font-size: 14px;
     padding: 0 1em;
+
+    &.first {
+      width: 33%;
+    }
+
+    &.middle {
+      width: 40%;
+    }
+
+    &.last {
+      width: 25%;
+    }
 
     .meta-head {
       text-transform: uppercase;
@@ -30,7 +43,7 @@ chef-page-header {
 
       li {
         display: flex;
-        margin-bottom: 5px;
+        margin-bottom: 15px;
 
         span {
           font-size: 14px;
@@ -40,7 +53,7 @@ chef-page-header {
           &.heading {
             display: inline-block;
             font-weight: bold;
-            width: 30%;
+            width: 50%;
           }
 
           &.webUIKeyStatus {
@@ -63,6 +76,11 @@ chef-page-header {
           height: 13.5px;
         }
       }
+    }
+
+    .sync-button {
+      float: right;
+      margin-bottom: 0;
     }
   }
 }

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -173,7 +173,7 @@ describe('Infra servers get api', () => {
             url: '/api/v0/infra/servers',
             body: {
                 fqdn: 'a2-dev.test',
-                id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                id: `${cypressPrefix}-test`,
                 ip_address: '127.0.0.1',
                 name: 'test'
             }
@@ -351,7 +351,7 @@ describe('Infra servers post api to create infra servers', () => {
                 url: '/api/v0/infra/servers',
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                    id: `${cypressPrefix}-test`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }
@@ -368,7 +368,7 @@ describe('Infra servers post api to create infra servers', () => {
                 failOnStatusCode: false,
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                    id: `${cypressPrefix}-test`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -19,8 +19,7 @@ describe('Infra servers list', () => {
         {
             effect: 'ALLOW',
             actions: [
-                'infra:infraServers:list',
-                'infra:nodes:list'
+                'infra:infraServers:list'
             ],
             projects: ['*']
         }]
@@ -36,8 +35,7 @@ describe('Infra servers list', () => {
         {
             effect: 'DENY',
             actions: [
-                'infra:infraServers:list',
-                'infra:nodes:list'
+                'infra:infraServers:list'
             ],
             projects: ['*']
         }]

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -173,7 +173,7 @@ describe('Infra servers get api', () => {
             url: '/api/v0/infra/servers',
             body: {
                 fqdn: 'a2-dev.test',
-                id: `${cypressPrefix}-test`,
+                id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                 ip_address: '127.0.0.1',
                 name: 'test'
             }
@@ -351,7 +351,7 @@ describe('Infra servers post api to create infra servers', () => {
                 url: '/api/v0/infra/servers',
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test`,
+                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }
@@ -368,7 +368,7 @@ describe('Infra servers post api to create infra servers', () => {
                 failOnStatusCode: false,
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test`,
+                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -175,7 +175,7 @@ describe('Infra servers get api', () => {
             url: '/api/v0/infra/servers',
             body: {
                 fqdn: 'a2-dev.test',
-                id: `${cypressPrefix}-test`,
+                id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                 ip_address: '127.0.0.1',
                 name: 'test'
             }
@@ -353,7 +353,7 @@ describe('Infra servers post api to create infra servers', () => {
                 url: '/api/v0/infra/servers',
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test`,
+                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }
@@ -370,7 +370,7 @@ describe('Infra servers post api to create infra servers', () => {
                 failOnStatusCode: false,
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test`,
+                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -175,7 +175,7 @@ describe('Infra servers get api', () => {
             url: '/api/v0/infra/servers',
             body: {
                 fqdn: 'a2-dev.test',
-                id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                id: `${cypressPrefix}-test`,
                 ip_address: '127.0.0.1',
                 name: 'test'
             }
@@ -353,7 +353,7 @@ describe('Infra servers post api to create infra servers', () => {
                 url: '/api/v0/infra/servers',
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                    id: `${cypressPrefix}-test`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }
@@ -370,7 +370,7 @@ describe('Infra servers post api to create infra servers', () => {
                 failOnStatusCode: false,
                 body: {
                     fqdn: 'a2-dev.test',
-                    id: `${cypressPrefix}-test-${Cypress.moment().format('MMDDYYhhmm')}`,
+                    id: `${cypressPrefix}-test`,
                     ip_address: '127.0.0.1',
                     name: 'test'
                 }

--- a/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
+++ b/e2e/cypress/integration/api/iam/infra_server_actions_integration.spec.ts
@@ -19,7 +19,8 @@ describe('Infra servers list', () => {
         {
             effect: 'ALLOW',
             actions: [
-                'infra:infraServers:list'
+                'infra:infraServers:list',
+                'infra:nodes:list'
             ],
             projects: ['*']
         }]
@@ -35,7 +36,8 @@ describe('Infra servers list', () => {
         {
             effect: 'DENY',
             actions: [
-                'infra:infraServers:list'
+                'infra:infraServers:list',
+                'infra:nodes:list'
             ],
             projects: ['*']
         }]


### PR DESCRIPTION
Signed-off-by: chaitali-mane cmane@progress.com

### :nut_and_bolt: Description: What code changed, and why?
Need to add a button for 'sync organization and users' for the new flow and need to change metadata UI.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/6556

### :+1: Definition of Done
Added a button for sync organization and users for the new flow.
Changed UI for metadata.

### :athletic_shoe: How to Build and Test the Change
```STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
```
Steps for Policy Groups tab:
Go To Infrastructure -> Chef Servers -> Click on any Chef Infra Server -> you can see changed metadata UI and new button added.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/71449322/149952584-98c6a9d5-f018-4cdf-a46f-6d48d87aa7dc.png)
