### PR TITLE
Remove write-good lints from vale

### DIFF
--- a/components/docs-chef-io/.vale.ini
+++ b/components/docs-chef-io/.vale.ini
@@ -4,6 +4,7 @@
 
 StylesPath = tools/vale
 MinAlertLevel = suggestion
+SkippedScopes = code
 
 [*.md]
 BasedOnStyles = Microsoft, chef

--- a/components/docs-chef-io/.vale.ini
+++ b/components/docs-chef-io/.vale.ini
@@ -6,7 +6,7 @@ StylesPath = tools/vale
 MinAlertLevel = suggestion
 
 [*.md]
-BasedOnStyles = Microsoft, write-good, chef
+BasedOnStyles = Microsoft, chef
 
 Microsoft.Contractions = NO
 Microsoft.Headings = NO


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### :nut_and_bolt: Description: What code changed, and why?

The Vale write-good linter has most of the same lints as Microsoft. Removed write-good.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
