### PR TITLE
SELinux is not recommended with Automate

### DIFF
--- a/components/docs-chef-io/content/automate/system_requirements.md
+++ b/components/docs-chef-io/content/automate/system_requirements.md
@@ -14,6 +14,10 @@ gh_repo = "automate"
     weight = 20
 +++
 
+## System Config
+
+SELinux must be in permissive mode or disabled for ALL Chef software to work. Chef does not test, nor maintain any configurations that are guaranteed to work within SELinux in Enforcing mode
+
 ## Hardware
 
 Chef Automate requires a minimum of


### PR DESCRIPTION
SELinux is not guaranteed to work, nor is it tested with Automate.

We recommend it be set to Permissive or disabled when installing and operating Chef software like Automate

Signed-off-by: Sean Horn <horn@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Statement about Automate's compatibility with SElinux

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Docs added/updated? (all customer-facing changes)
