### PR TITLE
Chef server ctl external database support

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -891,8 +891,13 @@ paths = [
 plan_path = "components/automate-cs-nginx"
 paths = [
   "components/automate-cs-nginx/*",
+  "api/config/platform/*",
+  "api/config/shared/*",
   "lib/io/*",
+  "lib/platform/config/*",
+  "lib/proxy/*",
   "lib/secrets/*",
+  "lib/stringutils/*",
   "lib/user/*"
 ]
 

--- a/components/automate-cs-nginx/cmd/chef-server-ctl/ctl.go
+++ b/components/automate-cs-nginx/cmd/chef-server-ctl/ctl.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -79,7 +78,6 @@ const unsupportedNoAltFmt = "The command %q is not supported by the Chef Automat
 const unsupportedWithAltFmt = "The command %q is not supported by the Chef Automate Chef server. Instead, try\n    %s\n"
 
 func (c unsupported) Run([]string) error {
-	fmt.Println("::::::called in unsupported run")
 	if c.alternative == "" {
 		fmt.Printf(unsupportedNoAltFmt, c.name)
 	} else {
@@ -102,7 +100,6 @@ type wrapKnife struct {
 }
 
 func (c wrapKnife) Run(args []string) error {
-	fmt.Println("::::::called in wrap run")
 	// knife opc "org user" add
 	cmdArgs := append([]string{"opc"}, strings.Fields(c.cmdNoun)...)
 	cmdArgs = append(cmdArgs, c.cmdVerb)
@@ -243,9 +240,7 @@ func (c passthrough) Run(args []string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	time.Sleep(time.Millisecond * 500)
-	return err
+	return cmd.Run()
 }
 
 func (c passthrough) Hidden() bool     { return false }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Earlier automate-cs-nginx had hardcoded erchef and bifrost db uri in its codebase. Now we are dynamically creating the connection string to support both external and embedded database. We have also given options to pass custom connection string and custom service path.

### :chains: Related Resources

https://github.com/chef/automate/issues/4285

### :+1: Definition of Done

All chef-server-ctl commands should work properly
```
chef-server-ctl cleanup-bifrost
chef-server-ctl grant-server-admin-permissions admin
```

### :athletic_shoe: How to Build and Test the Change

- patch an external postgres database
- rebuild components/automate-cs-nginx
- Check if below commands are working:
```
chef-server-ctl user-create -f /tmp/admin.pem admin Admin User admin@example.com password;
chef-server-ctl cleanup-bifrost
chef-server-ctl grant-server-admin-permissions admin
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
