### PR TITLE
Add 'Users' nav entry for user managment

### DIFF
--- a/components/docs-chef-io/content/automate/api_tokens.md
+++ b/components/docs-chef-io/content/automate/api_tokens.md
@@ -9,7 +9,7 @@ gh_repo = "automate"
     title = "API Tokens"
     identifier = "automate/users/api_tokens.md API Tokens"
     parent = "automate/users"
-    weight = 80
+    weight = 40
 +++
 
 ## Overview

--- a/components/docs-chef-io/content/automate/api_tokens.md
+++ b/components/docs-chef-io/content/automate/api_tokens.md
@@ -7,8 +7,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "API Tokens"
-    identifier = "automate/settings/api_tokens.md API Tokens"
-    parent = "automate/settings"
+    identifier = "automate/users/api_tokens.md API Tokens"
+    parent = "automate/users"
     weight = 80
 +++
 

--- a/components/docs-chef-io/content/automate/desktop.md
+++ b/components/docs-chef-io/content/automate/desktop.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Desktop Dashboard"
-    parent = "automate"
-    identifier = "automate/desktop.md Desktop Dashboard"
+    parent = "automate/applications"
+    identifier = "automate/applications/desktop.md Desktop Dashboard"
     weight = 50
 +++
 
@@ -40,7 +40,7 @@ Node counts in the _Desktop_ dashboard may include liveness agents.
 
 ### Daily Check-in
 
-The _Daily Check-in_ display shows a top-level view of daily desktop check-in statistics.  
+The _Daily Check-in_ display shows a top-level view of daily desktop check-in statistics.
 A bar graphic illustrates the proportion of desktops with `unknown` and `checked-in` statuses.
 Below the bar, boxes display counts of all desktops, desktops with an `unknown` status, and desktops with a `checked-in` status.
 `Checked-in` refers to desktops reporting into Chef Automate.

--- a/components/docs-chef-io/content/automate/iam_actions.md
+++ b/components/docs-chef-io/content/automate/iam_actions.md
@@ -7,14 +7,14 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "IAM Actions"
-    parent = "automate/authorization"
-    identifier = "automate/authorization/iam_actions.md IAM Actions"
+    parent = "automate/users/authorization"
+    identifier = "automate/users/authorization/iam_actions.md IAM Actions"
     weight = 30
 +++
 
 Reference the chart on this page when creating a *Role* to know which action grants access to what page in the browser.
 
-*IAM Action* lists the associated action or actions required to access that page in the browser. 
+*IAM Action* lists the associated action or actions required to access that page in the browser.
 Use `*` in these actions to give broad permissions to perform all associated actions such as get, list, create, delete, etc.
 Specify the action to restrict user access to the specific action.
 

--- a/components/docs-chef-io/content/automate/iam_v2_guide.md
+++ b/components/docs-chef-io/content/automate/iam_v2_guide.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "IAM Users Guide"
-    parent = "automate/authorization"
-    identifier = "automate/authorization/iam_v2_guide.md IAM Users Guide"
+    parent = "automate/users/authorization"
+    identifier = "automate/users/authorization/iam_v2_guide.md IAM Users Guide"
     weight = 20
 +++
 
@@ -374,7 +374,7 @@ To create a project that contains all Effortless Infra nodes, create a ingest ru
 
 ![](/images/automate/effortless-project-rule.png)
 
-The above rule matches on a node's Chef Infra Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Infra Server` attribute as `localhost`. 
+The above rule matches on a node's Chef Infra Server field, which is set to `localhost`. This rule works because all Effortless Infra nodes list the `Chef Infra Server` attribute as `localhost`.
 
 If desired, create subgroups of Effortless Infra nodes by adding a second condition that matches a specific `Chef Policy Name`.
 

--- a/components/docs-chef-io/content/automate/iam_v2_overview.md
+++ b/components/docs-chef-io/content/automate/iam_v2_overview.md
@@ -6,7 +6,8 @@ draft = false
 gh_repo = "automate"
 [menu]
   [menu.automate]
-    parent = "automate/authorization"
+    parent = "automate/users/authorization"
+    identifier = "automate/users/authorization/iam_v2_overview" 
     weight = 10
 +++
 

--- a/components/docs-chef-io/content/automate/ldap.md
+++ b/components/docs-chef-io/content/automate/ldap.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "LDAP"
-    parent = "automate/configuring_automate"
-    identifier = "automate/configuring_automate/ldap.md LDAP"
+    parent = "automate/users/authentication"
+    identifier = "automate/users/authentication/ldap.md LDAP"
     weight = 30
 +++
 

--- a/components/docs-chef-io/content/automate/policies.md
+++ b/components/docs-chef-io/content/automate/policies.md
@@ -7,8 +7,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Policies"
-    identifier = "automate/settings/policies.md Policies"
-    parent = "automate/settings"
+    identifier = "automate/users/policies.md Policies"
+    parent = "automate/users"
     weight = 90
 +++
 

--- a/components/docs-chef-io/content/automate/policies.md
+++ b/components/docs-chef-io/content/automate/policies.md
@@ -9,7 +9,7 @@ gh_repo = "automate"
     title = "Policies"
     identifier = "automate/users/policies.md Policies"
     parent = "automate/users"
-    weight = 90
+    weight = 50
 +++
 
 ## Overview

--- a/components/docs-chef-io/content/automate/roles.md
+++ b/components/docs-chef-io/content/automate/roles.md
@@ -7,8 +7,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Roles"
-    identifier = "automate/settings/roles.md Roles"
-    parent = "automate/settings"
+    identifier = "automate/users/roles.md Roles"
+    parent = "automate/users"
     weight = 100
 +++
 
@@ -44,7 +44,7 @@ Ingest             | ingest        | infra:ingest:\*, compliance:profiles:get, c
 
 ### Custom Roles
 
-Custom roles are roles that any user with the permission for `iam:roles:update` can change. 
+Custom roles are roles that any user with the permission for `iam:roles:update` can change.
 In addition to the Chef-managed roles above, Chef Automate includes two custom roles by default.
 
 Role              | Description

--- a/components/docs-chef-io/content/automate/roles.md
+++ b/components/docs-chef-io/content/automate/roles.md
@@ -9,7 +9,7 @@ gh_repo = "automate"
     title = "Roles"
     identifier = "automate/users/roles.md Roles"
     parent = "automate/users"
-    weight = 100
+    weight = 60
 +++
 
 ## Overview

--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "SAML"
-    parent = "automate/configuring_automate"
-    identifier = "automate/configuring_automate/saml.md SAML"
+    parent = "automate/users/authentication"
+    identifier = "automate/users/saml.md SAML"
     weight = 50
 +++
 

--- a/components/docs-chef-io/content/automate/teams.md
+++ b/components/docs-chef-io/content/automate/teams.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Teams"
-    identifier = "automate/settings/teams.md Teams"
-    parent = "automate/settings"
+    identifier = "automate/users/teams.md Teams"
+    parent = "automate/users"
     weight = 70
 +++
 

--- a/components/docs-chef-io/content/automate/users.md
+++ b/components/docs-chef-io/content/automate/users.md
@@ -8,8 +8,8 @@ gh_repo = "automate"
 [menu]
   [menu.automate]
     title = "Users"
-    identifier = "automate/settings/users.md Users"
-    parent = "automate/settings"
+    identifier = "automate/users/users.md Users"
+    parent = "automate/users"
     weight = 60
 +++
 
@@ -17,7 +17,7 @@ gh_repo = "automate"
 
 Chef Automate supports three different types of users: local users, [LDAP users]({{< relref "ldap.md" >}}), and [SAML users]({{< relref "saml.md" >}}). Manage local users from the **Settings** tab.
 
-Local users can sign in and interact with the system independent of LDAP or SAML. 
+Local users can sign in and interact with the system independent of LDAP or SAML.
 Local users will have their Chef Automate sessions refreshed while their Chef Automate browser window remains open or until they sign out directly.
 
 Permission for the `iam:users` action is required to interact with users other than yourself. Any user that is part of the `admins` team or the `Administrator` policy will have this permission. Otherwise, [IAM custom policies]({{< relref "iam_v2_guide.md#creating-custom-policies" >}}) can be created to assign this permission.

--- a/components/docs-chef-io/content/automate/users.md
+++ b/components/docs-chef-io/content/automate/users.md
@@ -10,7 +10,7 @@ gh_repo = "automate"
     title = "Users"
     identifier = "automate/users/users.md Users"
     parent = "automate/users"
-    weight = 60
+    weight = 80
 +++
 
 ## Overview

--- a/components/docs-chef-io/static/automate-api-docs/all-apis.swagger.json
+++ b/components/docs-chef-io/static/automate-api-docs/all-apis.swagger.json
@@ -19,7 +19,7 @@
     },
     "license": {
       "name": "Apache 2.0",
-      "url": "https://github.com/chef/automate/blob/master/LICENSE"
+      "url": "https://github.com/chef/automate/blob/main/LICENSE"
     },
     "version": "version not set",
     "x-logo": {


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

This configures files for a 'Users' heading in the top-level of the product. The work came out of conversations with the field on the difficulty of quickly finding Auth, SAML, LDAP, Users, and Group/Org content in our docs.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
