### PR TITLE
Fix compliance telemetry

### DIFF
--- a/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
+++ b/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
@@ -384,7 +384,7 @@ export class TelemetryService {
         .getComplianceStats();
       if (nodeUsageStats && Number(nodeUsageStats['days_since_last_post']) > 0) {
         const ackStats: NodeUsageAckStats = await this
-        .sendNodeStatsToTelemetry(nodeUsageStats, 'complianceCountsGlobal');
+        .sendNodeStatsToTelemetry(nodeUsageStats, 'complianceTargetCountsGlobal');
         await this.complianceStatsService.sendAcknowledgement(ackStats);
       }
     } catch (error) {

--- a/components/compliance-service/ingest/ingestic/mappings/mappings.go
+++ b/components/compliance-service/ingest/ingestic/mappings/mappings.go
@@ -30,7 +30,7 @@ const (
 	ComplianceCurrentTimeSeriesIndicesVersion = "7"
 	//ComplianceCurrentProfilesIndicesVersion allows us to know, for any version of compliance, what level we are at with our profiles and profiles-mappings indices
 	ComplianceCurrentProfilesIndicesVersion = "3"
-	ComplianceCurrentRunInfoVersion         = "1"
+	ComplianceCurrentRunInfoVersion         = "2"
 
 	compAndVersionTimeSeries = "comp-" + ComplianceCurrentTimeSeriesIndicesVersion
 	compAndVersionProfiles   = "comp-" + ComplianceCurrentProfilesIndicesVersion

--- a/components/compliance-service/ingest/pipeline/publisher/compliance.go
+++ b/components/compliance-service/ingest/pipeline/publisher/compliance.go
@@ -117,7 +117,7 @@ func insertInspecReportRunInfo(msg message.Compliance, client *ingestic.ESClient
 	go func() {
 		logrus.WithFields(logrus.Fields{"report_id": msg.Report.ReportUuid, "node_id": msg.Report.NodeUuid}).Debug("Ingesting inspec_report")
 		start := time.Now()
-		err := client.InsertComplianceRunInfo(msg.Ctx, msg.Report.ReportUuid, msg.Shared.EndTime)
+		err := client.InsertComplianceRunInfo(msg.Ctx, msg.Report.NodeUuid, msg.Shared.EndTime)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"error": err.Error()}).Error("Unable to ingest inspec_report object")
 			out <- err

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chef/automate/api/external/lib/errorutils"
 	"github.com/chef/automate/api/interservice/compliance/stats"
+	"github.com/chef/automate/components/compliance-service/ingest/ingestic/mappings"
 )
 
 //GetStatsSummary - Report #16
@@ -315,7 +316,7 @@ func (backend ES2Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelem
 	boolQuery := elastic.NewBoolQuery().
 		Must(rangeQueryThreshold)
 
-	count, err := client.Count("comp-1-run-info").Query(boolQuery).Do(context.Background())
+	count, err := client.Count(mappings.IndexNameComplianceRunInfo).Query(boolQuery).Do(context.Background())
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Compliance count for global telemetry was reporting the total report id instead of the uniq node/target id.

### :chains: Related Resources

### :+1: Definition of Done
- The count of resources should be returned when a fresh inspec report is ingested
- The count should not change when the inspec reports from the same node is ingested again

### :athletic_shoe: How to Build and Test the Change
- `rebuild components/automate-ui`
- `rebuild components/compliance-service`
- `start_all_services`
- `./linux_build -url <url> -token <token>  -numberOfElement=20 -concurrency=10 -data=node -i=100_comp_node_list.json -status=success`
- Check the count of nodes.
- The event reported should be `complianceTargetCountsGlobal`
- `/linux_build -url <url> -token <token> -numberOfElement=20 -concurrency=10 -data=node -o=100_comp_node_list.json -status=success`
- Check the count of nodes. The node count should be same.
- The event reported should be `complianceTargetCountsGlobal`
- 
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
