### PR TITLE
Clarify support for Automate external data stores

### DIFF
--- a/components/docs-chef-io/content/automate/postgres_external_upgrade.md
+++ b/components/docs-chef-io/content/automate/postgres_external_upgrade.md
@@ -14,6 +14,12 @@ gh_repo = "automate"
 
 This guide covers upgrading services used by Chef Automate.
 
+{{< warning >}}
+
+None of this content indicates support for designing/installing custom topologies not managed by Chef products and not already covered in the docs. 
+
+{{< /warning >}}
+
 ## Upgrade Amazon RDS for PostgreSQL
 
 Amazon Web Services Relational Database Service (AWS RDS) should upgrade by Monday, January 17. Amazon is automatically migrating all AWS RDS customers from PostgreSQL from 9.6 to 13 starting Tuesday, January 18, 2022.


### PR DESCRIPTION
Designing custom installs is not the intent of this information

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :nut_and_bolt: Description: What code changed, and why?

Docs for external data stores are not intended to encourage designing custom systems

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*


All PRs **from Progress employees** should tick these if appropriate:

- [x] Docs added/updated? (all customer-facing changes)