### PR TITLE
Clarify A2 external database commitments

### DIFF
--- a/components/docs-chef-io/content/automate/postgresql.md
+++ b/components/docs-chef-io/content/automate/postgresql.md
@@ -16,6 +16,12 @@ draft = false
 
 You can configure Chef Automate to use external PostgreSQL clusters that are not deployed via Chef Automate itself.
 
+{{< warning >}}
+
+However, none of this content indicates support for designing/installing custom topologies not managed by Chef products and not already covered in the docs. When you make the choice to run external systems, you become responsible for the maintenance/management/upgrades/etc for those systems. Production systems should be installed using a product that does the install, is responsible for maintaining the config and data over time, and that is aware of the current state of the entire system. This content makes none of those guarantees.
+
+{{< /warning >}}
+
 ## Configuring an External PostgreSQL Database
 
 These configuration directions are intended for in the initial deployment of Chef Automate.


### PR DESCRIPTION
Designing custom installs is not the intent of this information

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :nut_and_bolt: Description: What code changed, and why?

Docs for external data stores are not intended to encourage designing custom systems, especially in production

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*


All PRs **from Progress employees** should tick these if appropriate:

- [x] Docs added/updated? (all customer-facing changes)