### PR TITLE
use dropdown for checkin history period

### DIFF
--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -18,20 +18,30 @@
     <div class="checkin-history-header">
       <h3>Check-in History</h3>
       <div class="heading-actions">
-        <chef-button secondary (click)="updateCheckInDays()">
-          <span>Last {{ (checkInNumDays === twoWeekNumDays ? 2 : 4) }} Weeks</span>
-          <chef-icon>expand_more</chef-icon>
-        </chef-button>
-        <chef-button secondary (click)="toggleDownloadDropdown()" class='download-dropdown-toggle'>
-          <span>Download</span>
-          <chef-icon>expand_more</chef-icon>
-        </chef-button>
-          <chef-dropdown class='download' [visible]="downloadDropdownVisible">
+        <div class="checkin-select">
+          <chef-button secondary (click)="toggleCheckInPeriodDropdown()" class='download-dropdown-toggle'>
+            <span>Last {{ (checkInNumDays === twoWeekNumDays ? 2 : 4) }} Weeks</span>
+            <chef-icon>expand_more</chef-icon>
+          </chef-button>
+            <chef-dropdown class='checkin-select-dropdown' [visible]="checkInPeriodDropdownVisible">
+              <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeCheckInPeriodDropdown()">
+                <chef-button tertiary (click)="updateCheckInDays(15)">Last 2 Weeks</chef-button>
+                <chef-button tertiary (click)="updateCheckInDays(29)">Last 4 Weeks</chef-button>
+              </chef-click-outside>
+            </chef-dropdown>
+        </div>
+        <div class="download-select">
+          <chef-button secondary (click)="toggleDownloadDropdown()" class='download-dropdown-toggle'>
+            <span>Download</span>
+            <chef-icon>expand_more</chef-icon>
+          </chef-button>
+          <chef-dropdown class='download-select-dropdown' [visible]="downloadDropdownVisible">
             <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeDownloadDropdown()">
               <chef-button tertiary (click)="onDownloadCheckInHistory('json')">JSON</chef-button>
               <chef-button tertiary (click)="onDownloadCheckInHistory('csv')">CSV</chef-button>
             </chef-click-outside>
           </chef-dropdown>
+        </div>
       </div>
     </div>
     <chef-table class="checkin-history-table grid">

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -25,8 +25,8 @@
           </chef-button>
             <chef-dropdown class='checkin-select-dropdown' [visible]="checkInPeriodDropdownVisible">
               <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeCheckInPeriodDropdown()">
-                <chef-button tertiary (click)="updateCheckInDays(this.twoWeekNumDays)">Last 2 Weeks</chef-button>
-                <chef-button tertiary (click)="updateCheckInDays(this.fourWeekNumDays)">Last 4 Weeks</chef-button>
+                <chef-button tertiary [ngClass]="{'selected': this.checkInNumDays === this.twoWeekNumDays}" (click)="updateCheckInDays(this.twoWeekNumDays)">Last 2 Weeks</chef-button>
+                <chef-button tertiary [ngClass]="{'selected': this.checkInNumDays === this.fourWeekNumDays}" (click)="updateCheckInDays(this.fourWeekNumDays)">Last 4 Weeks</chef-button>
               </chef-click-outside>
             </chef-dropdown>
         </div>

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.html
@@ -25,8 +25,8 @@
           </chef-button>
             <chef-dropdown class='checkin-select-dropdown' [visible]="checkInPeriodDropdownVisible">
               <chef-click-outside omit="download-dropdown-toggle" (clickOutside)="closeCheckInPeriodDropdown()">
-                <chef-button tertiary (click)="updateCheckInDays(15)">Last 2 Weeks</chef-button>
-                <chef-button tertiary (click)="updateCheckInDays(29)">Last 4 Weeks</chef-button>
+                <chef-button tertiary (click)="updateCheckInDays(this.twoWeekNumDays)">Last 2 Weeks</chef-button>
+                <chef-button tertiary (click)="updateCheckInDays(this.fourWeekNumDays)">Last 4 Weeks</chef-button>
               </chef-click-outside>
             </chef-dropdown>
         </div>

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -35,19 +35,19 @@
 }
 
 .heading-actions {
-  position: relative;
   display: flex;
   flex-direction: row;
+  position: relative;
 
   .checkin-select, .download-select {
-    position: relative;
     margin-left: 5px;
+    position: relative;
 
     &-dropdown {
-    position: absolute;
-    right: 0;
-    width: 100%;
-    z-index: 1;
+      position: absolute;
+      right: 0;
+      width: 100%;
+      z-index: 1;
 
       chef-button {
         margin: 0;

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -59,13 +59,19 @@
         color: inherit;
         background-color: $chef-white;
 
+        &.selected {
+          background-color: #3864F2;
+          color: #FFFFFF;
+        }
+
         button {
           margin: 0;
           padding: 0;
         }
 
-        &:hover {
+        &:not(.selected):hover {
           cursor: pointer;
+          background-color: #DEE5FD;
         }
 
         &:last-child {

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.scss
@@ -36,32 +36,41 @@
 
 .heading-actions {
   position: relative;
+  display: flex;
+  flex-direction: row;
 
-  .download {
+  .checkin-select, .download-select {
+    position: relative;
+    margin-left: 5px;
+
+    &-dropdown {
     position: absolute;
     right: 0;
-    width: 114px;
+    width: 100%;
+    z-index: 1;
 
-    chef-button {
-      margin: 0;
-      font-size: 14px;
-      text-align: center;
-      padding: 5px 0;
-      border-bottom: 1px solid $chef-grey;
-      width: 100%;
-      color: inherit;
-
-      button {
+      chef-button {
         margin: 0;
-        padding: 0;
-      }
+        font-size: 14px;
+        text-align: center;
+        padding: 5px 0;
+        border-bottom: 1px solid $chef-grey;
+        width: 100%;
+        color: inherit;
+        background-color: $chef-white;
 
-      &:hover {
-        cursor: pointer;
-      }
+        button {
+          margin: 0;
+          padding: 0;
+        }
 
-      &:last-child {
-        border-bottom: none;
+        &:hover {
+          cursor: pointer;
+        }
+
+        &:last-child {
+          border-bottom: none;
+        }
       }
     }
   }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -50,7 +50,7 @@ export class DesktopDetailComponent {
   ) {}
 
   updateCheckInDays(value) {
-    this.toggleCheckInPeriodDropdown()
+    this.toggleCheckInPeriodDropdown();
     this.checkInNumDays = value;
     this.checkInNumDaysChanged.emit(value);
   }

--- a/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
+++ b/components/automate-ui/src/app/modules/desktop/desktop-detail/desktop-detail.component.ts
@@ -28,6 +28,7 @@ export class DesktopDetailComponent {
   public DateTime = DateTime;
   public showCheckinDebug = false;
   public downloadDropdownVisible = false;
+  public checkInPeriodDropdownVisible = false;
   public downloadInProgress = false;
   public downloadFailed = false;
   public twoWeekNumDays = 15; // 14 days + 1 offset
@@ -48,10 +49,18 @@ export class DesktopDetailComponent {
     private nodeRunsService: NodeRunsService
   ) {}
 
-  updateCheckInDays() {
-    const numDaysChanged =
-      this.checkInNumDays === this.twoWeekNumDays ? this.fourWeekNumDays : this.twoWeekNumDays;
-    this.checkInNumDaysChanged.emit(numDaysChanged);
+  updateCheckInDays(value) {
+    this.toggleCheckInPeriodDropdown()
+    this.checkInNumDays = value;
+    this.checkInNumDaysChanged.emit(value);
+  }
+
+  toggleCheckInPeriodDropdown() {
+    this.checkInPeriodDropdownVisible = !this.checkInPeriodDropdownVisible;
+  }
+
+  closeCheckInPeriodDropdown() {
+    this.checkInPeriodDropdownVisible = false;
   }
 
   onDownloadCheckInHistory(format) {


### PR DESCRIPTION
Signed-off-by: rishichawda <rishichawda@users.noreply.github.com>

### :nut_and_bolt: Description: What code changed, and why?

The Check-in history in node details on `/desktop` dashboard has a toggle for switching between the periods which looks like a dropdown. Updated it to be a dropdown as intended. Along with that, there are a couple of minor changes to the same container to be semantically make more sense (main wrapper (the "heading component" is now a flex box, dropdown isn't fixed width, both drop downs are wrapped in their own space rather than just thrown in into the main container)

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

resolve #6207 

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

The updated UI component

![updated-select-dropdown-color](https://user-images.githubusercontent.com/26366288/154946839-461c37f4-ac4f-4ae9-84a9-05d84206cd21.gif)



