### PR TITLE
added force flag and update upgrade_metadata json file 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -219,10 +219,13 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 }
 
 func pgMigrateExecutor() error {
-	err := getLatestPgPath()
-	if err != nil {
-		return err
+	if !migrateDataCmdFlags.skipStorageCheck  {
+		err := getLatestPgPath()
+		if err != nil ||  migrateDataCmdFlags.skipStorageCheck  {
+			return err
+		}
 	}
+
 
 	existDir, err := dirExists(NEW_PG_DATA_DIR)
 	if err != nil {
@@ -640,9 +643,10 @@ func calDiskSizeAndDirSize() (bool, error) {
 
 	dirSizeInMb := size / (1024 * 1024)
 
-	msg := fmt.Sprintf("Insufficient disk space for migration.\n %18s: %7d MB\n %18s: %7d MB\n",
+	msg := fmt.Sprintf("Insufficient disk space for migration.\n%s: %5d MB\n%s: %5d MB\n%s",
 		"Space Required", dirSizeInMb,
-		"Space Available", diskSpaceInMb)
+		"Space Available", diskSpaceInMb,
+		"To continue with less memory Please use --skip-storage-check")
 
 	if diskSpaceInMb > uint64(dirSizeInMb) {
 		return true, nil

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -151,6 +151,10 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 }
 
 func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
+	_, err := calDiskSizeAndDirSize()
+	if err != nil {
+		return err
+	}
 
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")
@@ -636,11 +640,13 @@ func calDiskSizeAndDirSize() (bool, error) {
 
 	dirSizeInMb := size / (1024 * 1024)
 
+	msg := fmt.Sprintf("Insufficient disk space for migration.\n %18s: %7d MB\n %18s: %7d MB\n",
+		"Space Required", dirSizeInMb,
+		"Space Available", diskSpaceInMb)
+
 	if diskSpaceInMb > uint64(dirSizeInMb) {
-		fmt.Println("disk space is greater than pgdata directory size")
 		return true, nil
 	} else {
-		fmt.Println("disk space is less than pgdata directory size")
-		return false, errors.New("Insufficient disk space")
+		return false, errors.New(msg)
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -123,7 +123,7 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")
 	} else if strings.ToLower(migrateDataCmdFlags.data) == "pg" {
-		ci := majorupgradechecklist.NewCRUDChecklist(AUTOMATE_VERSION)
+		ci := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
 
 		isExecuted, err := ci.ReadPostChecklistById("migrate_pg")
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -130,7 +130,6 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		if isExecuted {
-			fmt.Println(migrateDataCmdFlags.forceExecute)
 			if migrateDataCmdFlags.forceExecute {
 				isExecuted = false
 			} else {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -51,8 +51,8 @@ const (
 )
 
 func init() {
-	migrateCmd.AddCommand(newMigratePgCmd())
-	migrateCmd.AddCommand(newRemovePgDatadirCmd())
+	migrateCmd.AddCommand(newMigrateDataCmd())
+	migrateCmd.AddCommand(newClearDataCmd())
 	RootCmd.AddCommand(migrateCmd)
 }
 
@@ -62,30 +62,30 @@ var migrateCmd = &cobra.Command{
 	Hidden: true,
 }
 
-func newRemovePgDatadirCmd() *cobra.Command {
-	var removePgDatadirCmd = &cobra.Command{
+func newClearDataCmd() *cobra.Command {
+	var clearDataCmd = &cobra.Command{
 		Use:   "clear-data",
 		Short: "Chef Automate post-major-upgrade clear-data",
 		Long:  "Chef Automate post-major-upgrade to clear old pg data",
 		RunE:  runCleanup,
 	}
-	removePgDatadirCmd.PersistentFlags().StringVar(&ClearDataCmdFlags.data, "data", "", "data")
-	removePgDatadirCmd.PersistentFlags().BoolVarP(&ClearDataCmdFlags.autoAccept, "", "y", false, "auto-accept")
-	return removePgDatadirCmd
+	clearDataCmd.PersistentFlags().StringVar(&ClearDataCmdFlags.data, "data", "", "data")
+	clearDataCmd.PersistentFlags().BoolVarP(&ClearDataCmdFlags.autoAccept, "", "y", false, "auto-accept")
+	return clearDataCmd
 }
 
-func newMigratePgCmd() *cobra.Command {
-	var migratePgCmd = &cobra.Command{
+func newMigrateDataCmd() *cobra.Command {
+	var migrateDataCmd = &cobra.Command{
 		Use:   "migrate",
 		Short: "Chef Automate post-major-upgrade migrate",
 		Long:  "Chef Automate migrate. migrate can be used to migrate pg or migrate es",
-		RunE:  runMigratePgCmd,
+		RunE:  runMigrateDataCmd,
 	}
-	migratePgCmd.PersistentFlags().BoolVar(&migrateDataCmdFlags.check, "check", false, "check")
-	migratePgCmd.PersistentFlags().StringVar(&migrateDataCmdFlags.data, "data", "", "data")
-	migratePgCmd.PersistentFlags().BoolVarP(&migrateDataCmdFlags.autoAccept, "", "y", false, "auto-accept")
-	migratePgCmd.Flags().BoolVarP(&migrateDataCmdFlags.forceExecute, "force", "f", false, "fore-execute")
-	return migratePgCmd
+	migrateDataCmd.PersistentFlags().BoolVar(&migrateDataCmdFlags.check, "check", false, "check")
+	migrateDataCmd.PersistentFlags().StringVar(&migrateDataCmdFlags.data, "data", "", "data")
+	migrateDataCmd.PersistentFlags().BoolVarP(&migrateDataCmdFlags.autoAccept, "", "y", false, "auto-accept")
+	migrateDataCmd.Flags().BoolVarP(&migrateDataCmdFlags.forceExecute, "force", "f", false, "fore-execute")
+	return migrateDataCmd
 }
 
 func runCleanup(cmd *cobra.Command, args []string) error {
@@ -117,7 +117,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runMigratePgCmd(cmd *cobra.Command, args []string) error {
+func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -122,14 +122,7 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")
 	} else if strings.ToLower(migrateDataCmdFlags.data) == "pg" {
-		ci, err := majorupgradechecklist.NewChecklistManager(writer, validatedResp.TargetVersion, "")
-		if err != nil {
-			return status.Wrap(
-				err,
-				status.DeploymentServiceCallError,
-				"Request to start upgrade failed",
-			)
-		}
+		ci := majorupgradechecklist.NewCRUDChecklist("3")
 
 		isExecuted, err := ci.ReadPostChecklistById("migrate_pg")
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -34,6 +34,7 @@ var ClearDataCmdFlags = struct {
 var NEW_BIN_DIR = "/hab/pkgs/core/postgresql13/13.5/20220120092917/bin"
 
 const (
+	AUTOMATE_VERSION            = "3"
 	AUTOMATE_PG_MIGRATE_LOG_DIR = "/tmp"
 	OLD_PG_VERSION              = "9.6"
 	NEW_PG_VERSION              = "13.5"
@@ -122,7 +123,7 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")
 	} else if strings.ToLower(migrateDataCmdFlags.data) == "pg" {
-		ci := majorupgradechecklist.NewCRUDChecklist("3")
+		ci := majorupgradechecklist.NewCRUDChecklist(AUTOMATE_VERSION)
 
 		isExecuted, err := ci.ReadPostChecklistById("migrate_pg")
 		if err != nil {
@@ -260,7 +261,7 @@ func vacuumDb() error {
 	os.Setenv("PGSSLROOTCERT", PGSSLROOTCERT)
 
 	args := []string{
-		"/temp/analyze_new_cluster.sh",
+		AUTOMATE_PG_MIGRATE_LOG_DIR + "/analyze_new_cluster.sh",
 	}
 
 	err := executeCommand("/bin/sh", args, "")
@@ -284,9 +285,9 @@ func cleanUp() error {
 
 	args := []string{
 		"-rf",
-		"/temp/analyze_new_cluster.sh",
-		"/temp/delete_old_cluster.sh",
-		"/temp/pgmigrate.log",
+		AUTOMATE_PG_MIGRATE_LOG_DIR + "/analyze_new_cluster.sh",
+		AUTOMATE_PG_MIGRATE_LOG_DIR + "delete_old_cluster.sh",
+		AUTOMATE_PG_MIGRATE_LOG_DIR + "/pgmigrate.log",
 	}
 	err := executeCommand("rm", args, "")
 	if err != nil {
@@ -436,7 +437,7 @@ func checkUpdateMigration(check bool) error {
 		return err
 	}
 	if !check && err == nil {
-		ci := majorupgradechecklist.NewCRUDChecklist("3")
+		ci := majorupgradechecklist.NewCRUDChecklist(AUTOMATE_VERSION)
 		ci.UpdatePostChecklistFile("migrate_pg")
 	}
 	return nil
@@ -547,7 +548,7 @@ func promptCheckList(message string) error {
 		return err
 	}
 	if !strings.Contains(strings.ToUpper(response), "Y") {
-		return errors.New("canceled")
+		return errors.New("cancelled")
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -51,7 +51,7 @@ const (
 	PGSSLCERT                   = "/hab/svc/automate-postgresql/config/server.crt"
 	PGSSLKEY                    = "/hab/svc/automate-postgresql/config/server.key"
 	PGSSLROOTCERT               = "/hab/svc/automate-postgresql/config/root.crt"
-	OLD_BIN_DIR                 = "/hab/pkgs/core/postgresql/9.6.21/20211016180117/bin"
+	OLD_BIN_DIR                 = "/hab/pkgs/core/postgresql/9.6.24/20220218015755/bin"
 )
 
 func init() {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -131,7 +131,9 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 						isExecuted = false
 					}
 				}
-			} else {
+			}
+
+			if !isExecuted {
 				writer.Title("Deleting file created by pg_upgrade")
 				cleanUp()
 			}
@@ -217,12 +219,13 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 }
 
 func pgMigrateExecutor() error {
-	if !migrateDataCmdFlags.skipStorageCheck {
+	if !migrateDataCmdFlags.skipStorageCheck  {
 		err := getLatestPgPath()
-		if err != nil || migrateDataCmdFlags.skipStorageCheck {
+		if err != nil ||  migrateDataCmdFlags.skipStorageCheck  {
 			return err
 		}
 	}
+
 
 	existDir, err := dirExists(NEW_PG_DATA_DIR)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -628,7 +628,6 @@ func calDiskSizeAndDirSize() (bool, error) {
 		return false, err
 	}
 	diskSpaceInMb := v / 1024
-	fmt.Println(diskSpaceInMb)
 
 	size, err := sys.DirSize("/hab/svc/automate-postgresql/data/pgdata")
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -437,7 +437,7 @@ func checkUpdateMigration(check bool) error {
 		return err
 	}
 	if !check && err == nil {
-		ci := majorupgradechecklist.NewCRUDChecklist(AUTOMATE_VERSION)
+		ci := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
 		ci.UpdatePostChecklistFile("migrate_pg")
 	}
 	return nil

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -90,7 +90,7 @@ func newMigrateDataCmd() *cobra.Command {
 	migrateDataCmd.PersistentFlags().StringVar(&migrateDataCmdFlags.data, "data", "", "data")
 	migrateDataCmd.PersistentFlags().BoolVarP(&migrateDataCmdFlags.autoAccept, "", "y", false, "auto-accept")
 	migrateDataCmd.PersistentFlags().BoolVarP(&migrateDataCmdFlags.skipStorageCheck, "skip-storage-check", "s", false, "skip storage check")
-	migrateDataCmd.Flags().BoolVarP(&migrateDataCmdFlags.forceExecute, "force", "f", false, "fore-execute")
+	migrateDataCmd.Flags().BoolVarP(&migrateDataCmdFlags.forceExecute, "force", "f", false, "force-execute")
 	return migrateDataCmd
 }
 
@@ -131,9 +131,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 						isExecuted = false
 					}
 				}
-			}
-
-			if !isExecuted {
+			} else {
 				writer.Title("Deleting file created by pg_upgrade")
 				cleanUp()
 			}
@@ -219,13 +217,12 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 }
 
 func pgMigrateExecutor() error {
-	if !migrateDataCmdFlags.skipStorageCheck  {
+	if !migrateDataCmdFlags.skipStorageCheck {
 		err := getLatestPgPath()
-		if err != nil ||  migrateDataCmdFlags.skipStorageCheck  {
+		if err != nil || migrateDataCmdFlags.skipStorageCheck {
 			return err
 		}
 	}
-
 
 	existDir, err := dirExists(NEW_PG_DATA_DIR)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -104,10 +104,10 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 			return errors.New("data flag is required")
 		} else if strings.ToLower(ClearDataCmdFlags.data) == "pg" {
 			writer.Title("Deleting file created by pg_upgrade")
+			cleanUp()
 		} else {
 			return errors.New("please provide valid input for data flag")
 		}
-		cleanUp()
 
 	} else {
 		return errors.New(
@@ -123,7 +123,10 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 	if migrateDataCmdFlags.data == "" {
 		return errors.New("data flag is required")
 	} else if strings.ToLower(migrateDataCmdFlags.data) == "pg" {
-		ci := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
+		ci, err := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
+		if err != nil {
+			return err
+		}
 
 		isExecuted, err := ci.ReadPostChecklistById("migrate_pg")
 		if err != nil {
@@ -288,6 +291,7 @@ func cleanUp() error {
 		AUTOMATE_PG_MIGRATE_LOG_DIR + "/analyze_new_cluster.sh",
 		AUTOMATE_PG_MIGRATE_LOG_DIR + "delete_old_cluster.sh",
 		AUTOMATE_PG_MIGRATE_LOG_DIR + "/pgmigrate.log",
+		"/hab/svc/automate-postgresql/data/pgdata",
 	}
 	err := executeCommand("rm", args, "")
 	if err != nil {
@@ -437,7 +441,10 @@ func checkUpdateMigration(check bool) error {
 		return err
 	}
 	if !check && err == nil {
-		ci := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
+		ci, err := majorupgradechecklist.NewPostChecklistManager(AUTOMATE_VERSION)
+		if err != nil {
+			return err
+		}
 		ci.UpdatePostChecklistFile("migrate_pg")
 	}
 	return nil

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -164,8 +164,6 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 				err = pgMigrateExecutor()
 				if err != nil {
 					return err
-				} else {
-					ci.UpdatePostChecklistFile("migrate_pg")
 				}
 
 			} else {
@@ -436,6 +434,10 @@ func checkUpdateMigration(check bool) error {
 
 	if err != nil {
 		return err
+	}
+	if !check && err == nil {
+		ci := majorupgradechecklist.NewCRUDChecklist("3")
+		ci.UpdatePostChecklistFile("migrate_pg")
 	}
 	return nil
 }

--- a/lib/platform/sys/darwin.go
+++ b/lib/platform/sys/darwin.go
@@ -2,7 +2,11 @@
 
 package sys
 
-import "syscall"
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
 
 // SetUmask sets the process umask. Returns the old umask.
 func SetUmask(newUmask int) int {
@@ -40,6 +44,22 @@ func SpaceAvailForPath(path string) (uint64, error) {
 		return 0, err
 	}
 	return (uint64(stat.Bsize) * stat.Bavail) / 1024, nil
+}
+
+// DirSize return size of the directory in bytes
+// path.
+func DirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 }
 
 // SystemMemoryKB returns the total memory in KB. Unimplemented on

--- a/lib/platform/sys/linux.go
+++ b/lib/platform/sys/linux.go
@@ -4,11 +4,11 @@ package sys
 
 import (
 	"bytes"
-	"io/ioutil"
-	"syscall"
-
 	"github.com/pkg/errors"
-
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
 	"github.com/chef/automate/lib/proc"
 )
 
@@ -42,6 +42,22 @@ func SpaceAvailForPath(path string) (uint64, error) {
 		return 0, err
 	}
 	return (uint64(stat.Frsize) * stat.Bavail) / 1024, nil
+}
+
+// DirSize return size of the directory in bytes
+// path.
+func DirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 }
 
 // SystemMemoryKB returns the total system memory in KB

--- a/scripts/pgdata.sh
+++ b/scripts/pgdata.sh
@@ -41,7 +41,7 @@ ensure_key_ownership
 
 if [[ ! -f "/hab/svc/automate-postgresql/data/pgdata/PG_VERSION" ]]; then
   echo " Database does not exist, creating with 'initdb'"
-    /hab/pkgs/core/postgresql/9.6.21/20211016180117/bin/initdb -U automate \
+    /hab/pkgs/core/postgresql/9.6.24/20220218015755/bin/initdb -U automate \
     -E utf8 \
     -D /hab/svc/automate-postgresql/data/pgdata \
     --locale POSIX \


### PR DESCRIPTION
Signed-off-by: shaik80 <smudassi@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
In this PR force flag is added to migrate pg and the upgrade_metadata.json file is updated if pg migrated.


### :chains: Related Resources
https://chefio.atlassian.net/browse/SHIELD-16?atlOrigin=eyJpIjoiODUwMmQ1YjYwZmY3NGVmZjk4OWIzOTJlYzIyYzRhZTQiLCJwIjoiaiJ9

### :+1: Definition of Done
1. It should update JSON file if  pg migrate cmd is executed 
2. It should check pg migrate cmd is executed or not, if it is executed prompt message to force execute (Y/N)
3. To avoid prompt message -f flag can be used

### :athletic_shoe: How to Build and Test the Change
```
automate ✗   hab studio enter
[20][default:/src:0]# start_all_services 
[20][default:/src:0]# rebuild components/automate-deployment/
[20][default:/src:0]# rebuild components/automate-cli
[20][default:/src:0]# chef-automate upgrade run --major
[20][default:/src:0]# chef-automate upgrade status
[20][default:/src:0]# chef-automate post-major-upgrade migrate --data=PG -f
or 
[20][default:/src:0]# chef-automate post-major-upgrade migrate --data=PG
migrate_pg is already executed,do you want to force execute.
Press y to agree, n to disagree? [y/n]: y
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
