### PR TITLE
Fix various backup timeout problems for large EMEA customer

### DIFF
--- a/api/config/esgateway/config_request.go
+++ b/api/config/esgateway/config_request.go
@@ -72,7 +72,7 @@ func DefaultConfigRequest() *ConfigRequest {
 	c.V1.Sys.Ngx.Http.SslProtocols = w.String("TLSv1.2 TLSv1.3")
 	c.V1.Sys.Ngx.Http.SslCiphers = w.String(ac.InternalCipherSuite)
 	c.V1.Sys.Ngx.Http.SslVerifyDepth = w.Int32(2)
-	c.V1.Sys.Ngx.Http.ProxyReadTimeout = w.Int32(600)
+	c.V1.Sys.Ngx.Http.ProxyReadTimeout = w.Int32(7200)
 	c.V1.Sys.Ngx.Http.ProxySendTimeout = w.Int32(600)
 	c.V1.Sys.Ngx.Http.ProxySetHeaderHost = w.String("$http_host")
 

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -96,7 +96,7 @@ func init() {
 	backupCmd.PersistentFlags().StringVar(&backupCmdFlags.s3SessionToken, "s3-session-token", "", "The S3 session token when assuming an IAM role")
 	backupCmd.PersistentFlags().StringVar(&backupCmdFlags.gcsCredentialsPath, "gcs-credentials-path", "", "The path to the GCP service account json file")
 
-	createBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.createWaitTimeout, "wait-timeout", "t", 7200, "How long to wait for a operation to complete before raising an error")
+	createBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.createWaitTimeout, "wait-timeout", "t", 43200, "How long to wait for a operation to complete before raising an error")
 
 	listBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.listWaitTimeout, "wait-timeout", "t", 60, "How long to wait for a operation to complete before raising an error")
 
@@ -117,12 +117,12 @@ func init() {
 	restoreBackupCmd.PersistentFlags().StringVar(&backupCmdFlags.airgap, "airgap-bundle", "", "The artifact to use for an air-gapped installation")
 	restoreBackupCmd.PersistentFlags().BoolVarP(&backupCmdFlags.yes, "yes", "", false, "Agree to all prompts")
 	restoreBackupCmd.PersistentFlags().StringVar(&backupCmdFlags.sha256, "sha256", "", "The SHA256 checksum of the backup")
-	restoreBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.restoreWaitTimeout, "wait-timeout", "t", 7200, "How long to wait for a operation to complete before raising an error")
+	restoreBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.restoreWaitTimeout, "wait-timeout", "t", 43200, "How long to wait for a operation to complete before raising an error")
 	restoreBackupCmd.PersistentFlags().StringVar(&backupCmdFlags.patchConfigPath, "patch-config", "", "Path to patch config if required")
 	restoreBackupCmd.PersistentFlags().StringVar(&backupCmdFlags.setConfigPath, "set-config", "", "Path to set config if required")
 
 	deleteBackupCmd.PersistentFlags().BoolVar(&backupDeleteCmdFlags.yes, "yes", false, "Agree to all prompts")
-	deleteBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.deleteWaitTimeout, "wait-timeout", "t", 120, "How long to wait for a operation to complete before raising an error")
+	deleteBackupCmd.PersistentFlags().Int64VarP(&backupCmdFlags.deleteWaitTimeout, "wait-timeout", "t", 43200, "How long to wait for a operation to complete before raising an error")
 
 	if !isDevMode() {
 		_ = restoreBackupCmd.PersistentFlags().MarkHidden("override-origin")

--- a/components/automate-deployment/pkg/backup/operations.go
+++ b/components/automate-deployment/pkg/backup/operations.go
@@ -172,7 +172,7 @@ func (p *PathCopyOperation) Backup(backupCtx Context, om ObjectManifest, progCha
 		"src_path":  p.SrcPath,
 		"operation": "path_copy",
 		"action":    "backup",
-		"deadline":  backupCtxDeadline,
+		"deadline":  backupCtxDeadline.Format(time.RFC3339),
 	})
 	log.Info("Running backup operation")
 
@@ -380,7 +380,7 @@ func (p *PathCopyOperation) Delete(backupCtx Context) error {
 		"base_path": basePath,
 		"operation": "path_copy",
 		"action":    "delete",
-		"deadline":  backupCtxDeadline,
+		"deadline":  backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 	deleteObjs, _, err := backupCtx.bucket.List(backupCtx.ctx, basePath, false)
 	if err != nil {
@@ -428,7 +428,7 @@ func (p *PathCopyOperation) Restore(backupCtx Context, serviceName string, verif
 		"base_path":  basePath,
 		"operation":  "path_copy",
 		"action":     "restore",
-		"deadline":   backupCtxDeadline,
+		"deadline":   backupCtxDeadline.Format(time.RFC3339),
 	})
 	log.Info("Running backup operation")
 
@@ -522,7 +522,7 @@ func (m *MetadataWriterOperation) Backup(backupCtx Context, om ObjectManifest, p
 		"backup_id": backupCtx.backupTask.TaskID(),
 		"operation": "metadata_writer",
 		"action":    "backup",
-		"deadline":  backupCtxDeadline,
+		"deadline":  backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	writer, err := backupCtx.bucket.NewWriter(backupCtx.ctx, objectName)
@@ -574,7 +574,7 @@ func (m *MetadataWriterOperation) Delete(backupCtx Context) error {
 		"object_path": objectPath,
 		"operation":   "metadata_writer",
 		"action":      "delete",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -654,7 +654,7 @@ func (c *CommandExecuteOperation) Backup(backupCtx Context, om ObjectManifest, p
 		"object_name": objectName,
 		"operation":   "command_execute",
 		"action":      "backup",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	err = c.cmdExecutor.Run(cmdToExec[0],
@@ -767,7 +767,7 @@ func (c *CommandExecuteOperation) Delete(backupCtx Context) error {
 		"object_path": objectPath,
 		"operation":   "command_execute",
 		"action":      "delete",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -825,7 +825,7 @@ func (d *DatabaseDumpOperation) Restore(backupCtx Context, serviceName string, v
 		"object_name": objectName,
 		"operation":   "database_dump",
 		"action":      "restore",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := verifier.ObjectValid(objectName); err != nil {
@@ -875,7 +875,7 @@ func (d *DatabaseDumpOperation) Delete(backupCtx Context) error {
 		"object_path": objectPath,
 		"operation":   "database_dump",
 		"action":      "delete",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -909,7 +909,7 @@ func (esop *ElasticsearchOperation) Backup(backupCtx Context, _ ObjectManifest, 
 		"multi_index_spec": esop.MultiIndexSpec,
 		"operation":        "elasticsearch_snapshot",
 		"action":           "backup",
-		"deadline":         backupCtxDeadline,
+		"deadline":         backupCtxDeadline.Format(time.RFC3339),
 	})
 	log.Info("Running backup operation")
 
@@ -950,7 +950,7 @@ func (esop *ElasticsearchOperation) Restore(backupCtx Context, serviceName strin
 		"service_name": esop.ServiceName,
 		"operation":    "elasticsearch_snapshot",
 		"action":       "restore",
-		"deadline":     backupCtxDeadline,
+		"deadline":     backupCtxDeadline.Format(time.RFC3339),
 	})
 	log.Info("Running backup operation")
 
@@ -994,7 +994,7 @@ func (esop *ElasticsearchOperation) Delete(backupCtx Context) error {
 		"service_name": esop.ServiceName,
 		"operation":    "elasticsearch_snapshot",
 		"action":       "delete",
-		"deadline":     backupCtxDeadline,
+		"deadline":     backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	conn, err := backupCtx.connFactory.DialContext(backupCtx.ctx, "es-sidecar-service", backupCtx.esSidecarInfo.Address())
@@ -1150,7 +1150,7 @@ func (d *DatabaseDumpOperationV2) Backup(backupCtx Context, om ObjectManifest, p
 		"object_name": objectName,
 		"operation":   "database_dump_v2",
 		"action":      "backup",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	// TODO(ssd) 2018-04-16: Pass the progress bar and context
@@ -1201,7 +1201,7 @@ func (d *DatabaseDumpOperationV2) Restore(backupCtx Context, serviceName string,
 		"object_name": objectName,
 		"operation":   "database_dump_v2",
 		"action":      "restore",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := verifier.ObjectValid(objectName); err != nil {
@@ -1251,7 +1251,7 @@ func (d *DatabaseDumpOperationV2) Delete(backupCtx Context) error {
 		"object_path": objectPath,
 		"operation":   "database_dump_v2",
 		"action":      "delete",
-		"deadline":    backupCtxDeadline,
+		"deadline":    backupCtxDeadline.Format(time.RFC3339),
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {

--- a/components/automate-deployment/pkg/backup/operations.go
+++ b/components/automate-deployment/pkg/backup/operations.go
@@ -50,7 +50,7 @@ var _ Operation = &testOperation{}
 
 // Backup executes a backup specification.
 func (t *testOperation) Backup(backupCtx Context, _ ObjectManifest, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -151,7 +151,7 @@ func (r *RsyncExclude) RsyncArgs() (flag, matcher string) {
 // Backup backs up a path using the defined fields on the struct and publishes
 // progress events to the progress channel.
 func (p *PathCopyOperation) Backup(backupCtx Context, om ObjectManifest, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -165,12 +165,14 @@ func (p *PathCopyOperation) Backup(backupCtx Context, om ObjectManifest, progCha
 
 	src := fmt.Sprintf("%s/", p.SrcPath)
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	log := logrus.WithFields(logrus.Fields{
 		"name":      p.Name,
 		"backup_id": backupCtx.backupTask.TaskID(),
 		"src_path":  p.SrcPath,
 		"operation": "path_copy",
 		"action":    "backup",
+		"deadline":  backupCtxDeadline,
 	})
 	log.Info("Running backup operation")
 
@@ -371,12 +373,14 @@ func (p *PathCopyOperation) Delete(backupCtx Context) error {
 
 	basePath := path.Join(path.Join(p.ObjectName...), "/")
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":      p.Name,
 		"backup_id": backupCtx.backupTask.TaskID(),
 		"base_path": basePath,
 		"operation": "path_copy",
 		"action":    "delete",
+		"deadline":  backupCtxDeadline,
 	}).Info("Running backup operation")
 	deleteObjs, _, err := backupCtx.bucket.List(backupCtx.ctx, basePath, false)
 	if err != nil {
@@ -399,7 +403,7 @@ func (p *PathCopyOperation) Delete(backupCtx Context) error {
 // Restore restores a path using the defined fields on the struct and publishes
 // progress events to the progress channel.
 func (p *PathCopyOperation) Restore(backupCtx Context, serviceName string, verifier ObjectVerifier, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -416,6 +420,7 @@ func (p *PathCopyOperation) Restore(backupCtx Context, serviceName string, verif
 
 	dstPath := p.SrcPath
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	log := logrus.WithFields(logrus.Fields{
 		"name":       p.Name,
 		"backup_id":  backupCtx.backupTask.TaskID(),
@@ -423,6 +428,7 @@ func (p *PathCopyOperation) Restore(backupCtx Context, serviceName string, verif
 		"base_path":  basePath,
 		"operation":  "path_copy",
 		"action":     "restore",
+		"deadline":   backupCtxDeadline,
 	})
 	log.Info("Running backup operation")
 
@@ -483,7 +489,7 @@ var _ Operation = &MetadataWriterOperation{}
 
 // Backup executes a backup specification.
 func (m *MetadataWriterOperation) Backup(backupCtx Context, om ObjectManifest, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -510,11 +516,13 @@ func (m *MetadataWriterOperation) Backup(backupCtx Context, om ObjectManifest, p
 
 	objectName := path.Join(path.Join(m.ObjectName...), metadataFileBaseName)
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":      m.Spec.Name,
 		"backup_id": backupCtx.backupTask.TaskID(),
 		"operation": "metadata_writer",
 		"action":    "backup",
+		"deadline":  backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	writer, err := backupCtx.bucket.NewWriter(backupCtx.ctx, objectName)
@@ -558,12 +566,15 @@ func (m *MetadataWriterOperation) Delete(backupCtx Context) error {
 	}
 
 	objectPath := path.Join(path.Join(m.ObjectName...), metadataFileBaseName)
+
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        m.Spec.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
 		"object_path": objectPath,
 		"operation":   "metadata_writer",
 		"action":      "delete",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -601,7 +612,7 @@ type Cmd struct {
 
 // Backup executes a backup specification.
 func (c *CommandExecuteOperation) Backup(backupCtx Context, om ObjectManifest, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -635,6 +646,7 @@ func (c *CommandExecuteOperation) Backup(backupCtx Context, om ObjectManifest, p
 		return errors.Wrapf(err, "failed to create writer for %s", objectName)
 	}
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        c.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
@@ -642,6 +654,7 @@ func (c *CommandExecuteOperation) Backup(backupCtx Context, om ObjectManifest, p
 		"object_name": objectName,
 		"operation":   "command_execute",
 		"action":      "backup",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	err = c.cmdExecutor.Run(cmdToExec[0],
@@ -676,7 +689,7 @@ func (c *CommandExecuteOperation) Backup(backupCtx Context, om ObjectManifest, p
 
 // Restore executes a backup specification.
 func (c *CommandExecuteOperation) Restore(backupCtx Context, serviceName string, verifier ObjectVerifier, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -747,12 +760,14 @@ func (c *CommandExecuteOperation) Delete(backupCtx Context) error {
 
 	objectPath := path.Join(path.Join(c.ObjectName...), c.Cmd.Name)
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        c.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
 		"object_path": objectPath,
 		"operation":   "command_execute",
 		"action":      "delete",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -787,7 +802,7 @@ func (d *DatabaseDumpOperation) Backup(backupCtx Context, om ObjectManifest, pro
 
 // Restore executes a backup operation.
 func (d *DatabaseDumpOperation) Restore(backupCtx Context, serviceName string, verifier ObjectVerifier, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -801,6 +816,7 @@ func (d *DatabaseDumpOperation) Restore(backupCtx Context, serviceName string, v
 
 	objectName := path.Join(path.Join(d.ObjectName...), fmt.Sprintf("%s.sql", d.Name))
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        d.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
@@ -809,6 +825,7 @@ func (d *DatabaseDumpOperation) Restore(backupCtx Context, serviceName string, v
 		"object_name": objectName,
 		"operation":   "database_dump",
 		"action":      "restore",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := verifier.ObjectValid(objectName); err != nil {
@@ -851,12 +868,14 @@ func (d *DatabaseDumpOperation) Delete(backupCtx Context) error {
 
 	objectPath := path.Join(path.Join(d.ObjectName...), fmt.Sprintf("%s.sql", d.Name))
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        d.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
 		"object_path": objectPath,
 		"operation":   "database_dump",
 		"action":      "delete",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {
@@ -883,12 +902,14 @@ var _ Operation = &ElasticsearchOperation{}
 func (esop *ElasticsearchOperation) Backup(backupCtx Context, _ ObjectManifest, progChan chan OperationProgress) error {
 	backupID := backupCtx.backupTask.TaskID()
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	log := logrus.WithFields(logrus.Fields{
 		"backup_id":        backupID,
 		"service_name":     esop.ServiceName,
 		"multi_index_spec": esop.MultiIndexSpec,
 		"operation":        "elasticsearch_snapshot",
 		"action":           "backup",
+		"deadline":         backupCtxDeadline,
 	})
 	log.Info("Running backup operation")
 
@@ -922,12 +943,14 @@ func (esop *ElasticsearchOperation) Backup(backupCtx Context, _ ObjectManifest, 
 func (esop *ElasticsearchOperation) Restore(backupCtx Context, serviceName string, verifier ObjectVerifier, progChan chan OperationProgress) error {
 	backupID := backupCtx.restoreTask.Backup.TaskID()
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	log := logrus.WithFields(logrus.Fields{
 		"backup_id":    backupID,
 		"restore_id":   backupCtx.restoreTask.TaskID(),
 		"service_name": esop.ServiceName,
 		"operation":    "elasticsearch_snapshot",
 		"action":       "restore",
+		"deadline":     backupCtxDeadline,
 	})
 	log.Info("Running backup operation")
 
@@ -965,11 +988,13 @@ func (esop *ElasticsearchOperation) Delete(backupCtx Context) error {
 
 	backupID := backupCtx.backupTask.TaskID()
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"backup_id":    backupID,
 		"service_name": esop.ServiceName,
 		"operation":    "elasticsearch_snapshot",
 		"action":       "delete",
+		"deadline":     backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	conn, err := backupCtx.connFactory.DialContext(backupCtx.ctx, "es-sidecar-service", backupCtx.esSidecarInfo.Address())
@@ -1091,7 +1116,7 @@ var _ Operation = &DatabaseDumpOperation{}
 
 // Backup executes a backup operation.
 func (d *DatabaseDumpOperationV2) Backup(backupCtx Context, om ObjectManifest, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -1118,12 +1143,14 @@ func (d *DatabaseDumpOperationV2) Backup(backupCtx Context, om ObjectManifest, p
 		UseCustomFormat:   true,
 	}
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        d.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
 		"object_name": objectName,
 		"operation":   "database_dump_v2",
 		"action":      "backup",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	// TODO(ssd) 2018-04-16: Pass the progress bar and context
@@ -1152,7 +1179,7 @@ func (d *DatabaseDumpOperationV2) Backup(backupCtx Context, om ObjectManifest, p
 
 // Restore executes a backup operation.
 func (d *DatabaseDumpOperationV2) Restore(backupCtx Context, serviceName string, verifier ObjectVerifier, progChan chan OperationProgress) error {
-	// Make the context isn't dead before we start the operation
+	// Make sure the context isn't dead before we start the operation
 	select {
 	case <-backupCtx.ctx.Done():
 		return backupCtx.ctx.Err()
@@ -1166,6 +1193,7 @@ func (d *DatabaseDumpOperationV2) Restore(backupCtx Context, serviceName string,
 
 	objectName := path.Join(path.Join(d.ObjectName...), fmt.Sprintf("%s.fc", d.Name))
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        d.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
@@ -1173,6 +1201,7 @@ func (d *DatabaseDumpOperationV2) Restore(backupCtx Context, serviceName string,
 		"object_name": objectName,
 		"operation":   "database_dump_v2",
 		"action":      "restore",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := verifier.ObjectValid(objectName); err != nil {
@@ -1215,12 +1244,14 @@ func (d *DatabaseDumpOperationV2) Delete(backupCtx Context) error {
 
 	objectPath := path.Join(path.Join(d.ObjectName...), fmt.Sprintf("%s.fc", d.Name))
 
+	backupCtxDeadline, _ := backupCtx.ctx.Deadline()
 	logrus.WithFields(logrus.Fields{
 		"name":        d.Name,
 		"backup_id":   backupCtx.backupTask.TaskID(),
 		"object_path": objectPath,
 		"operation":   "database_dump_v2",
 		"action":      "delete",
+		"deadline":    backupCtxDeadline,
 	}).Info("Running backup operation")
 
 	if err := backupCtx.bucket.Delete(backupCtx.ctx, []string{objectPath}); err != nil {

--- a/components/automate-deployment/pkg/backup/runner.go
+++ b/components/automate-deployment/pkg/backup/runner.go
@@ -573,7 +573,9 @@ func (r *Runner) startRestoreOperations(ctx context.Context) {
 	var err error
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(2 * time.Hour)
+		// With large node counts or large volumes of cloud targets, restores may take several hours
+		// TODO: Change this from hard coded duration to timeout supplied by chef-automate CLI
+		deadline = time.Now().Add(12 * time.Hour)
 	}
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 
@@ -997,7 +999,9 @@ func (r *Runner) startBackupOperations(ctx context.Context) {
 	var err error
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(2 * time.Hour)
+		// With large node counts or large volumes of cloud targets, backups may take several hours
+		// TODO: Change this from hard coded duration to timeout supplied by chef-automate CLI
+		deadline = time.Now().Add(12 * time.Hour)
 	}
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()

--- a/components/es-sidecar-service/pkg/elastic/snapshot.go
+++ b/components/es-sidecar-service/pkg/elastic/snapshot.go
@@ -32,8 +32,10 @@ const (
 	// deleteRetryInterval is the time to sleep between retrying snapshot deletes
 	deleteInterval = 5 * time.Second
 	// maxDeleteWaitTime is the maximum amount of time we'll wait for a delete to
-	// be acknowledged
-	maxDeleteWaitTime = 10 * time.Minute
+	// be acknowledged. Since the acknowledgement doesn't come from ES (6.8.1) until
+	// the deletion is complete, and deletions can take hours in deployments with a
+	// large number of nodes or cloud targets, we need this to be quite long
+	maxDeleteWaitTime = 12 * time.Hour
 )
 
 // BackupsConfig contains settings for Es snapshot repo type and options, as


### PR DESCRIPTION
### Fix various backup timeout problems

* Backup deletions fail after 10 minutes when ES snapshots are large even with -t 43200
* Backup creates fail after 2hrs when ES indices are large (>1TB) even with -t 43200
* Metadata writes (`metadata.json`, `checksums.json`) fail if they take longer than 5 sec

### Definition of Done

When a large customer in EMEA can successfully manage backups on a system with 75K nodes, 90 days retention and large (~4MB) compliance reports.

**All PRs** must tick these:

- [Y] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [Y] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [Y] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [Y] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [N] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
  - The original code is not perfectly DRY (damp?) but this is a minimal bugfix. 
- [Y] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [Y] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [N/A] Tests added/updated? (all new code needs new tests)
  - Code is not new... we are just changing deadlines and modifying logging
- [N/A] Docs added/updated? (all customer-facing changes)
  - Usage documentation is still valid
 
*Please add a note next to any checkbox above if you are NOT ticking it.*
