### PR TITLE
Storage functions for org users association

### DIFF
--- a/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
+++ b/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
@@ -225,7 +225,6 @@ func (p *postgres) updateOrgUserAssociation(ctx context.Context, serverID, orgID
 	if err != nil {
 		return storage.OrgUser{}, p.processError(err)
 	}
-
 	return orgUser, nil
 }
 
@@ -245,6 +244,5 @@ func (p *postgres) deleteOrgUserAssociation(ctx context.Context, serverID, orgID
 	if err != nil {
 		return storage.OrgUser{}, p.processError(err)
 	}
-
 	return orgUser, nil
 }

--- a/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
+++ b/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
@@ -216,11 +216,11 @@ func (p *postgres) updateOrgUserAssociation(ctx context.Context, serverID, orgID
 	nowTime := time.Now()
 	err := p.db.QueryRowContext(ctx,
 		`UPDATE org_users SET 
-		is_admin = $2, 
-		updated_at= $5
-		WHERE org_id=$1 and user_id = SELECT id FROM users u WHERE u.infra_server_username=$3 and u.server_id=$4
+		is_admin = $1, 
+		updated_at= $2
+		WHERE org_id=$3 and user_id = SELECT id FROM users u WHERE u.infra_server_username=$4 and u.server_id=$5
 		RETURNING id, org_id, user_id, is_admin, created_at, updated_at`,
-		orgID, isAdmin, username, serverID, nowTime).
+		isAdmin, nowTime, orgID, username, serverID).
 		Scan(&orgUser.ID, &orgUser.OrgId, &orgUser.UserID, &orgUser.IsAdmin, &orgUser.CreatedAt, &orgUser.UpdatedAt)
 	if err != nil {
 		return storage.OrgUser{}, p.processError(err)

--- a/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
+++ b/components/infra-proxy-service/storage/postgres/automate_infra_server_users.go
@@ -183,3 +183,68 @@ func (p *postgres) getUsers(ctx context.Context, q querier, serverID string) ([]
 	return users, nil
 }
 
+// StoreOrgUserAssociation: Inserts an entry of org users
+func (p *postgres) StoreOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	return p.insertOrgUserAssociation(ctx, serverID, orgID, username, isAdmin)
+}
+
+func (p *postgres) insertOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	var orgUser storage.OrgUser
+	nowTime := time.Now()
+	err := p.db.QueryRowContext(ctx,
+		`INSERT INTO org_users (
+		org_id, user_id, 
+		is_admin, 
+		created_at,updated_at)
+		VALUES ($1, SELECT id from users where infra_server_username=$2 and server_id=$3, $4, $5, $5)
+		RETURNING id, org_id, user_id, is_admin, created_at, updated_at`,
+		orgID, username, serverID, isAdmin, nowTime).
+		Scan(&orgUser.ID, &orgUser.OrgId, &orgUser.UserID, &orgUser.IsAdmin, &orgUser.CreatedAt, &orgUser.UpdatedAt)
+	if err != nil {
+		return storage.OrgUser{}, p.processError(err)
+	}
+	return orgUser, nil
+}
+
+// EditOrgUserAssociation: Updates an entry of org users
+func (p *postgres) EditOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	return p.updateOrgUserAssociation(ctx, serverID, orgID, username, isAdmin)
+}
+
+func (p *postgres) updateOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	var orgUser storage.OrgUser
+	nowTime := time.Now()
+	err := p.db.QueryRowContext(ctx,
+		`UPDATE org_users SET 
+		is_admin = $2, 
+		updated_at= $5
+		WHERE org_id=$1 and user_id = SELECT id FROM users u WHERE u.infra_server_username=$3 and u.server_id=$4
+		RETURNING id, org_id, user_id, is_admin, created_at, updated_at`,
+		orgID, isAdmin, username, serverID, nowTime).
+		Scan(&orgUser.ID, &orgUser.OrgId, &orgUser.UserID, &orgUser.IsAdmin, &orgUser.CreatedAt, &orgUser.UpdatedAt)
+	if err != nil {
+		return storage.OrgUser{}, p.processError(err)
+	}
+
+	return orgUser, nil
+}
+
+// DeleteOrgUserAssociation: Deletes an entry from org users
+func (p *postgres) DeleteOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	return p.deleteOrgUserAssociation(ctx, serverID, orgID, username, isAdmin)
+}
+
+func (p *postgres) deleteOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (storage.OrgUser, error) {
+	var orgUser storage.OrgUser
+	err := p.db.QueryRowContext(ctx,
+		`DELETE FROM org_users 
+		WHERE org_id=$1 and user_id = SELECT id FROM users u WHERE u.infra_server_username=$2 and u.server_id=$3
+		RETURNING id, org_id, user_id, is_admin, created_at, updated_at`,
+		orgID, username, serverID).
+		Scan(&orgUser.ID, &orgUser.OrgId, &orgUser.UserID, &orgUser.IsAdmin, &orgUser.CreatedAt, &orgUser.UpdatedAt)
+	if err != nil {
+		return storage.OrgUser{}, p.processError(err)
+	}
+
+	return orgUser, nil
+}

--- a/components/infra-proxy-service/storage/postgres/migration/sql/06_user_management.up.sql
+++ b/components/infra-proxy-service/storage/postgres/migration/sql/06_user_management.up.sql
@@ -18,10 +18,12 @@ CREATE INDEX IF NOT EXISTS users_automate_user_id_index ON users (automate_user_
 
 -- create table org_users
 CREATE TABLE IF NOT EXISTS org_users (
-  id           TEXT PRIMARY KEY,
-  org_id       TEXT NOT NULL,
-  user_id      TEXT NOT NULL references users(id) ON DELETE RESTRICT, 
-  is_admin     BOOLEAN NOT NULL DEFAULT FALSE
+  id                        SERIAL PRIMARY KEY,
+  org_id                    TEXT NOT NULL,
+  user_id                   TEXT NOT NULL references users(id) ON DELETE CASCADE, 
+  is_admin                  BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at                TIMESTAMPTZ NOT NULL,
+  updated_at                TIMESTAMPTZ NOT NULL
 );
 CREATE INDEX IF NOT EXISTS org_users_org_id_index ON org_users (org_id);
 CREATE INDEX IF NOT EXISTS org_users_user_id_index ON org_users (user_id);

--- a/components/infra-proxy-service/storage/storage.go
+++ b/components/infra-proxy-service/storage/storage.go
@@ -24,12 +24,17 @@ type Storage interface {
 	EditOrg(ctx context.Context, id string, name string, adminUser string, serverID string, projects []string) (Org, error)
 	TouchOrg(ctx context.Context, id string, serverID string) (Org, error)
 
-	InsertUser(ctx context.Context, id, serverID, infraServerUsername, credentialID, Connector, automateUserID string, IsServerAdmin bool) (User, error)
+	InsertUser(ctx context.Context, id, serverID, infraServerUsername, credentialID, connector, automateUserID string, isServerAdmin bool) (User, error)
 	GetUser(ctx context.Context, id string) (User, error)
-	EditUser(ctx context.Context, id, serverID, infraServerUsername, credentialID, Connector, automateUserID string, IsServerAdmin bool) (User, error)
+	EditUser(ctx context.Context, id, serverID, infraServerUsername, credentialID, connector, automateUserID string, isServerAdmin bool) (User, error)
 	DeleteUser(ctx context.Context, id string) (User, error)
+
 	GetAutomateInfraServerUsers(ctx context.Context, serverId string) ([]User, error)
 	GetAutomateOrgUsers(ctx context.Context, orgId string) ([]OrgUser, error)
+
+	StoreOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (OrgUser, error)
+	EditOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (OrgUser, error)
+	DeleteOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (OrgUser, error)
 }
 
 type MigrationStorage interface {
@@ -130,9 +135,13 @@ type User struct {
 }
 
 type OrgUser struct {
+	ID                  int
 	OrgId               string
+	UserID              int
 	IsAdmin             bool
 	InfraServerUsername string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 type Migration struct {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Storage function for org users association

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-56

### :+1: Definition of Done
I have added storage function for the org users association in org_users table and also some constraints in the same table

### :athletic_shoe: How to Build and Test the Change

Steps to build:
 ```
   rebuild components/infra-proxy-service
  ```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
