### PR TITLE
Soft fail A1 to A2 upgrade

### DIFF
--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -33,6 +33,7 @@ steps:
     env:
       HAB_ORIGIN: chef
     timeout_in_minutes: 30
+    soft_fail: true
     expeditor:
       secrets:
         A1_LICENSE:


### PR DESCRIPTION
Signed-off-by: Kallol Roy <karoy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Automate nightly pipeline has been failing for sometime now for the A1 to A2 migration 
Since A1 is pretty old and should be end of support, moving this to soft fail

### :chains: Related Resources

### :+1: Definition of Done
- All the pipelines should be green

### :athletic_shoe: How to Build and Test the Change
- Run the nightly main pipeline 
- The pipeline should be green and this pipeline should be skipped

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
