### PR TITLE
removed unused config keys

### DIFF
--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -15,13 +15,8 @@ ssh_user = "centos"
 # private ssh key file path to access instances
 ssh_key_file = "~/.ssh/A2HA.pem"
 # sudo_password = ""
-# logging_monitoring_management = ""
-# new_elk = ""
-# existing_elk_instance_ip ""
-# existing_elk_port ""
-# existing_elk_cert ""
-# existing_elk_username ""
-# existing_elk_password ""
+
+# DON'T MODIFY THE BELOW LINE (backup_mount)
 backup_mount = "/mnt/automate_backups"
 
 [automate.config]
@@ -105,13 +100,8 @@ ssh_user = "centos"
 # private ssh key file path to access instances
 ssh_key_file = "~/.ssh/A2HA.pem"
 sudo_password = ""
-# logging_monitoring_management = "{{ .LoggingMonitoringManagement }}"
-# new_elk = "{{ .NewElk }}"
-# existing_elk_instance_ip "{{ .ExistingElk }}"
-# existing_elk_port "{{ .ExistingElkPort }}"
-# existing_elk_cert "{{ .ExistingElkCert }}"
-# existing_elk_username "{{ .ExistingElkUsername }}"
-# existing_elk_password "{{ .ExistingElkPassword }}"
+
+# DON'T MODIFY THE BELOW LINE (backup_mount)
 backup_mount = "/mnt/automate_backups"
 
 [automate.config]


### PR DESCRIPTION
Signed-off-by: ArvinthC3000 <arvinth.chandrasekaran@progress.com>

### Description: 
As an Automate HA user, the user needs to see a clean config.toml file with no unused/commented config keys in it. Unused config keys are removed from both the AWS and existing infra config templates. Also added a comment for users mentioning not to modify the value of the `backup_mount` key in the config file.


### :chains: Related Resources
https://chefio.atlassian.net/browse/MADROX-80

### :+1: Definition of Done
It's dev done and tested

### :athletic_shoe: How to Build and Test the Change
$ build components/automate-cli
$ hab pkg install -bf results/punitmundra-automate-cli-0.1.0-<PACKAGE_TIME_STAMP>-linux.hart
$ chef-automate init-config-ha [aws/existing_infra]

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
