### PR TITLE
Arvinth/accept mlsa flag

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -131,6 +131,8 @@ func tailFile(logFilePath string, executed chan struct{}) {
 }
 
 func bootstrapEnv(dm deployManager) error {
+
+	writer.Printf("deployCmdFlags.confirmationFromUser: %s \n", deployCmdFlags.userAuth )
 	if !deployCmdFlags.acceptMLSA {
 		agree, err := writer.Confirm(promptMLSA)
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -130,13 +130,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
 
 		if !configCmdFlags.acceptMLSA {
-			response, err := writer.Prompt(`If you have created any new bundles using upgrade commands and not deployed it, 
-			this command will deploy that new airgap bundle with patching of configuration. 
-			Press y to agree, n to to disagree? [y/n]`)
+			response, err := writer.Prompt(`If you have created any new bundles using upgrade commands and not deployed it, this command will deploy that new airgap bundle with patching of configuration. Press y to agree, n to to disagree? [y/n]`)
 			if err != nil {
 				return err
 			}
-			
+
 			if !strings.Contains(response, "y") {
 				return errors.New("canceled Patching")
 			}

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -61,7 +61,7 @@ var deployCmdFlags = struct {
 	enableWorkflow                  bool
 	products                        []string
 	bootstrapBundlePath             string
-	userAuth            bool
+	userAuth            						bool 				// Defining new key for user's MLSA to add '-y' flag
 }{}
 
 // deployCmd represents the new command

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -218,6 +218,9 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 				"Merging command flag overrides into Chef Automate config failed",
 			)
 		}
+		if deployCmdFlags.userAuth {
+    	deployCmdFlags.acceptMLSA = deployCmdFlags.userAuth
+  	}
 		if len(deployCmdFlags.channel) > 0 && (deployCmdFlags.channel == "dev" || deployCmdFlags.channel == "current") {
 			writer.Printf("deploying with channel : %s \n", deployCmdFlags.channel)
 			args = append(args, "--"+deployCmdFlags.channel)
@@ -230,9 +233,6 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 	writer.Printf("Automate deployment non HA mode proceeding...")
-	// if deployCmdFlags.confirmationFromUser {
-  //   deployCmdFlags.acceptMLSA = deployCmdFlags.confirmationFromUser
-  // }
 	if !deployCmdFlags.acceptMLSA {
 		agree, err := writer.Confirm(promptMLSA)
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -230,7 +230,6 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 	writer.Printf("Automate deployment non HA mode proceeding...")
-	writer.Printf("deployCmdFlags.confirmationFromUser: ", deployCmdFlags.userAuth )
 	// if deployCmdFlags.confirmationFromUser {
   //   deployCmdFlags.acceptMLSA = deployCmdFlags.confirmationFromUser
   // }

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -61,6 +61,7 @@ var deployCmdFlags = struct {
 	enableWorkflow                  bool
 	products                        []string
 	bootstrapBundlePath             string
+	userAuth            bool
 }{}
 
 // deployCmd represents the new command
@@ -168,6 +169,12 @@ func newDeployCmd() *cobra.Command {
 		"bootstrap-bundle",
 		"",
 		"Path to bootstrap bundle")
+	cmd.PersistentFlags().BoolVarP(
+		&deployCmdFlags.userAuth,
+		"yes",
+		"y",
+		false,
+		"Do not prompt for confirmation; accept defaults and continue")
 
 	if !isDevMode() {
 		for _, flagName := range []string{
@@ -223,6 +230,10 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 	writer.Printf("Automate deployment non HA mode proceeding...")
+	writer.Printf("deployCmdFlags.confirmationFromUser: ", deployCmdFlags.userAuth )
+	// if deployCmdFlags.confirmationFromUser {
+  //   deployCmdFlags.acceptMLSA = deployCmdFlags.confirmationFromUser
+  // }
 	if !deployCmdFlags.acceptMLSA {
 		agree, err := writer.Confirm(promptMLSA)
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
@@ -24,6 +24,12 @@ func newProvisionInfraCmd() *cobra.Command {
 		"airgap-bundle",
 		"",
 		"Path to an airgap install bundle")
+	provisionInfraCmd.PersistentFlags().BoolVarP(
+		&deployCmdFlags.acceptMLSA,
+		"yes",
+		"y",
+		false,
+		"Do not prompt for confirmation; accept defaults and continue")
 
 	return provisionInfraCmd
 }

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_config_patch.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_config_patch.yaml
@@ -2,25 +2,29 @@ name: chef-automate config patch
 synopsis: patch the Chef Automate configuration
 usage: chef-automate config patch path/to/config.toml [flags]
 description: |
-  Apply a partial Chef Automate configuration to the deployment. It will take the partial configuration, merge it with the existing configuration, and apply and required changes.
+    Apply a partial Chef Automate configuration to the deployment. It will take the partial configuration, merge it with the existing configuration, and apply and required changes.
 options:
-- name: help
-  shorthand: h
-  default_value: "false"
-  usage: help for patch
+    - name: help
+      shorthand: h
+      default_value: 'false'
+      usage: help for patch
+    - name: yes
+      shorthand: y
+      default_value: 'false'
+      usage: Agree to update to latest version
 inherited_options:
-- name: debug
-  shorthand: d
-  default_value: "false"
-  usage: Enable debug output
-- name: no-check-version
-  default_value: "false"
-  usage: Disable version check
-- name: result-json
-  usage: Write command result as JSON to PATH
-- name: timeout
-  shorthand: t
-  default_value: "10"
-  usage: Request timeout in seconds
+    - name: debug
+      shorthand: d
+      default_value: 'false'
+      usage: Enable debug output
+    - name: no-check-version
+      default_value: 'false'
+      usage: Disable version check
+    - name: result-json
+      usage: Write command result as JSON to PATH
+    - name: timeout
+      shorthand: t
+      default_value: '10'
+      usage: Request timeout in seconds
 see_also:
-- chef-automate config - Chef Automate configuration
+    - chef-automate config - Chef Automate configuration


### PR DESCRIPTION
Signed-off-by: ArvinthC3000 <arvinth.chandrasekaran@progress.com>

### Description: What code changed, and why?
For Automate HA as a product, the user wants to add the -y argument enabled for all the Automate HA command in order to avoid explicit input of -y during the various commands execution for agreeing to License and user concern. A new flag is been added for the following subcommands and arguments. 

- provision-infra
- deploy
- upgrade
- patch

Flag: 
Name: yes
Short-hand: y
Type: boolean
Description: Bypass the prompt for the user agreeing to continue

### :chains: Related Resources
Story Link: https://chefio.atlassian.net/browse/MADROX-79

### :+1: Definition of Done
Dev-done and tested 👍 

### :athletic_shoe: How to Build and Test the Change
Replace existing automate-cli with the following bundle `punitmundra/automate-cli/0.1.0/20220310081652`
and run any of the above mentioned subcommands/arguments

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
