### PR TITLE
Add an air-gapped Manage section

### DIFF
--- a/components/docs-chef-io/content/automate/airgapped_manage.md
+++ b/components/docs-chef-io/content/automate/airgapped_manage.md
@@ -1,0 +1,21 @@
+## Overview
+
+Normally, an Automate system has a list of Chef sites it will need access to in order to check for and perform upgrades.
+When a system is configured to refer only to generated bundles as a source of new packages for upgrades, this is called air-gapped mode.
+
+In an Automate system, that air-gapped behavior is determined by the presence of the following file:
+
+`/hab/svc/deployment-service/data/airgap/manifest.json`
+
+## Return to automatic Internet upgrades
+
+You can follow these steps to return an air-gapped system to the standard behavior, where it contacts Chef provided sites on the Internet to update itself automatically.
+
+shell```
+
+systemctl stop chef-automate.service
+
+rm -f /hab/svc/deployment-service/data/airgap/manifest.json
+
+systemctl start chef-automate.service
+```


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Docs: Show an example of reconfiguring an Automate system to do updates in the default, over the Internet way.

This page should probably go under the left side nav like Chef Automate->Manage->Airgapped as a section that could be expanded if there were multiple pages about airgapped management. One item for now is perfectly fine.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [D] Docs added/updated? (all customer-facing changes)
