### PR TITLE
added new flags for accepting MSLA from user

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -18,6 +18,7 @@ import (
 var configCmdFlags = struct {
 	overwriteFile bool
 	timeout       int64
+	acceptMLSA    bool
 }{}
 
 func init() {
@@ -26,6 +27,8 @@ func init() {
 	configCmd.AddCommand(setConfigCmd)
 
 	showConfigCmd.Flags().BoolVarP(&configCmdFlags.overwriteFile, "overwrite", "o", false, "Overwrite existing config.toml")
+
+	configCmd.PersistentFlags().BoolVarP(&configCmdFlags.acceptMLSA, "yes", "y", false, "Do not prompt for confirmation; accept defaults and continue")
 
 	configCmd.PersistentFlags().Int64VarP(&configCmdFlags.timeout, "timeout", "t", 10, "Request timeout in seconds")
 
@@ -125,15 +128,17 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		then automate cluster ctl deploy will patch the config to automate
 	*/
 	if isA2HARBFileExist() {
-		response, err := writer.Prompt(`If you have created any new bundles using upgrade commands and not deployed it, 
-		this command will deploy that new airgap bundle with patching of configuration. 
-		Press y to agree, n to to disagree? [y/n]`)
-		if err != nil {
-			return err
-		}
+		if !configCmdFlags.acceptMLSA {
+			response, err := writer.Prompt(`If you have created any new bundles using upgrade commands and not deployed it, 
+			this command will deploy that new airgap bundle with patching of configuration. 
+			Press y to agree, n to to disagree? [y/n]`)
+			if err != nil {
+				return err
+			}
 
-		if !strings.Contains(response, "y") {
-			return errors.New("canceled Patching")
+			if !strings.Contains(response, "y") {
+				return errors.New("canceled Patching")
+			}
 		}
 		input, err := ioutil.ReadFile(args[0])
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/deploy.go
+++ b/components/automate-cli/cmd/chef-automate/deploy.go
@@ -61,6 +61,7 @@ var deployCmdFlags = struct {
 	enableWorkflow                  bool
 	products                        []string
 	bootstrapBundlePath             string
+	userAuth                        bool
 }{}
 
 // deployCmd represents the new command
@@ -168,6 +169,12 @@ func newDeployCmd() *cobra.Command {
 		"bootstrap-bundle",
 		"",
 		"Path to bootstrap bundle")
+	cmd.PersistentFlags().BoolVarP(
+		&deployCmdFlags.userAuth,
+		"yes",
+		"y",
+		false,
+		"Do not prompt for confirmation; accept defaults and continue")
 
 	if !isDevMode() {
 		for _, flagName := range []string{
@@ -210,6 +217,9 @@ func runDeployCmd(cmd *cobra.Command, args []string) error {
 				status.ConfigError,
 				"Merging command flag overrides into Chef Automate config failed",
 			)
+		}
+		if deployCmdFlags.userAuth {
+			deployCmdFlags.acceptMLSA = deployCmdFlags.userAuth
 		}
 		if len(deployCmdFlags.channel) > 0 && (deployCmdFlags.channel == "dev" || deployCmdFlags.channel == "current") {
 			writer.Printf("deploying with channel : %s \n", deployCmdFlags.channel)

--- a/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
+++ b/components/automate-cli/cmd/chef-automate/provisionInfraHa.go
@@ -24,6 +24,12 @@ func newProvisionInfraCmd() *cobra.Command {
 		"airgap-bundle",
 		"",
 		"Path to an airgap install bundle")
+	provisionInfraCmd.PersistentFlags().BoolVarP(
+		&deployCmdFlags.acceptMLSA,
+		"yes",
+		"y",
+		false,
+		"Do not prompt for confirmation; accept defaults and continue")
 
 	return provisionInfraCmd
 }

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -33,6 +33,7 @@ var upgradeRunCmdFlags = struct {
 	skipDeploy           bool
 	isMajorUpgrade       bool
 	versionsPath         string
+	acceptMLSA           bool
 }{}
 
 var upgradeRunCmd = &cobra.Command{
@@ -181,12 +182,14 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 	if (upgradeRunCmdFlags.upgradefrontends && upgradeRunCmdFlags.upgradebackends) || (upgradeRunCmdFlags.upgradefrontends && upgradeRunCmdFlags.upgradeairgapbundles) || (upgradeRunCmdFlags.upgradebackends && upgradeRunCmdFlags.upgradeairgapbundles) {
 		return status.New(status.InvalidCommandArgsError, "you cannot use 2 flags together ")
 	}
-	response, err := writer.Prompt("Installation will get updated to latest version if already not running on newer version press y to agree, n to to disagree? [y/n]")
-	if err != nil {
-		return err
-	}
-	if !strings.Contains(response, "y") {
-		return errors.New("canceled upgrade")
+	if !upgradeRunCmdFlags.acceptMLSA {
+		response, err := writer.Prompt("Installation will get updated to latest version if already not running on newer version press y to agree, n to to disagree? [y/n]")
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(response, "y") {
+			return errors.New("canceled upgrade")
+		}
 	}
 
 	if offlineMode {
@@ -386,6 +389,12 @@ func init() {
 		"skip-deploy",
 		false,
 		"will only upgrade and not deploy the bundle")
+	upgradeRunCmd.PersistentFlags().BoolVarP(
+		&upgradeRunCmdFlags.acceptMLSA,
+		"yes",
+		"y",
+		false,
+		"Do not prompt for confirmation; accept defaults and continue")
 
 	upgradeRunCmd.PersistentFlags().BoolVar(
 		&upgradeRunCmdFlags.isMajorUpgrade,


### PR DESCRIPTION
Signed-off-by: Arvinth C <54614142+ArvinthC3000@users.noreply.github.com>

### Description:
For Automate HA as a product, the user wants to add the -y argument enabled for all the Automate HA command in order to avoid explicit input of -y during the various commands execution for agreeing to License and user concern. A new flag is been added for the following subcommands and arguments. 

- provision-infra
- deploy
- upgrade
- patch

#### Flag: 
Name: yes
Short-hand: y
Type: boolean (default: false)
Description: Bypass the prompt for the user agreeing to continue

#### Note
1. Above code changes don't affect the workflow Automate as a standalone product (find the observation below).
2. However deploy command in Automate/AutomateHA have a pre-existing flag to bypass user prompt(--accept-terms-and-mlsa). Both --yes/-y and --accept-terms-and-mlsa will work, the reason for adding '--yes/-y' being, for the user to have a unified flag. Let me know if there is a need to discuss that or to get a better understanding.

#### Observation in Automate workflow

Commands | Updated behavior | Original behavior | Comment
-- | -- | -- | --
Deploy | 1. Adding "-y/--yes" not showing any error2. Still prompt for user concern | 1. Adding "-y/--yes" showing 'unknown flag' error | Doesn't change the flow of Automate standalone
Patch | 1. No user concern prompt2. Adding "-y/--yes" not showing any error | 1. No user concern prompt | Doesn't change the flow
Upgrade | 1. No user concern prompt2. Adding "-y/--yes" not showing any error | 1. No user concern prompt | Doesn't change the flow



### :chains: Related Resources
Story Link: https://chefio.atlassian.net/browse/MADROX-79

### :+1: Definition of Done
Dev-done and tested 👍 

### :athletic_shoe: How to Build and Test the Change
Replace existing automate-cli with the following bundle `punitmundra/automate-cli/0.1.0/20220310081652`
and run any of the above-mentioned subcommands/arguments

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
