### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/components/automate-cli/pkg/docs/yaml_docs_test.go
+++ b/components/automate-cli/pkg/docs/yaml_docs_test.go
@@ -15,16 +15,15 @@ import (
 
 var _ = fmt.Sprintf("stop bothering me")
 
-func newTmpDir() (string, func()) {
-	tmpDir, _ := ioutil.TempDir("", "statusTmpDir")
+func newTmpDir(t testing.TB) string {
+	tmpDir := t.TempDir()
 	os.MkdirAll(tmpDir, os.ModePerm)
-	return tmpDir, func() { os.RemoveAll(tmpDir) }
+	return tmpDir
 }
 
 func TestStatusDocToYamlFile(t *testing.T) {
 	t.Run("writes doc to YAML file", func(t *testing.T) {
-		tmpDir, cleanup := newTmpDir()
-		defer cleanup()
+		tmpDir := newTmpDir(t)
 
 		doc := newStatusDoc()
 		path := filepath.Join(tmpDir, "errors.yaml")
@@ -65,8 +64,7 @@ func parseResult(t *testing.T, tmpDir string) cmdDoc {
 
 func TestGenYamlTree(t *testing.T) {
 	t.Run("creates some yaml for an empty command", func(t *testing.T) {
-		tmpDir, cleanup := newTmpDir()
-		defer cleanup()
+		tmpDir := newTmpDir(t)
 
 		cmd := basicCmd()
 		err := GenYamlTree(cmd, tmpDir)
@@ -78,8 +76,7 @@ func TestGenYamlTree(t *testing.T) {
 		assert.Equal(t, "example-for-test", docFromFile.Name)
 	})
 	t.Run("includes flags in the yaml output", func(t *testing.T) {
-		tmpDir, cleanup := newTmpDir()
-		defer cleanup()
+		tmpDir := newTmpDir(t)
 
 		cmd := basicCmd()
 
@@ -109,8 +106,7 @@ func TestGenYamlTree(t *testing.T) {
 		assert.Equal(t, "default_value", actualOpt.DefaultValue)
 	})
 	t.Run("does not include hidden flags in the yaml output", func(t *testing.T) {
-		tmpDir, cleanup := newTmpDir()
-		defer cleanup()
+		tmpDir := newTmpDir(t)
 
 		cmd := basicCmd()
 

--- a/components/automate-cli/pkg/selfupdater/executablecache/cache_test.go
+++ b/components/automate-cli/pkg/selfupdater/executablecache/cache_test.go
@@ -1,8 +1,6 @@
 package executablecache
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,9 +18,7 @@ const testVersionOld = "20180522150600"
 const testVersionOlder = "20180522150500"
 
 func TestExecutableCacheRoundTrip(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "TestExecutableCache")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	ec := New(WithCacheDir(tmpdir))
 	exists, err := ec.Exists(testVersion)
@@ -44,9 +40,7 @@ func TestExecutableCacheRoundTrip(t *testing.T) {
 }
 
 func TestExecutableCacheRoundLatest(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "TestExecutableCache")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	ec := New(WithCacheDir(tmpdir))
 	exists, err := ec.Exists(testVersion)

--- a/components/automate-cli/pkg/selfupdater/selfupdater_test.go
+++ b/components/automate-cli/pkg/selfupdater/selfupdater_test.go
@@ -2,8 +2,6 @@ package selfupdater
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -36,9 +34,7 @@ func (m *mockUpdateSource) ExpectExecutableFetch(ctx context.Context, desiredVer
 
 func TestExecutableIsFetchedAndCachedWhenUpdateRequired(t *testing.T) {
 	ctx := context.Background()
-	tmpdir, err := ioutil.TempDir("", "TestExecutableCache")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	executablecache := executablecache.New(executablecache.WithCacheDir(tmpdir))
 	updateSource := &mockUpdateSource{}
 	updateSource.ExpectExecutableFetch(ctx, "1", "#!/bin/sh\n")
@@ -59,9 +55,7 @@ func TestExecutableIsFetchedAndCachedWhenUpdateRequired(t *testing.T) {
 
 func TestExecutableIsTakenFromCacheIfExists(t *testing.T) {
 	ctx := context.Background()
-	tmpdir, err := ioutil.TempDir("", "TestExecutableCache")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	executablecache := executablecache.New(executablecache.WithCacheDir(tmpdir))
 	updateSource := &mockUpdateSource{}
 	updateSource.ExpectExecutableFetch(ctx, "1", "#!/bin/sh\n")
@@ -72,7 +66,7 @@ func TestExecutableIsTakenFromCacheIfExists(t *testing.T) {
 		myVersion:       "0",
 	}
 
-	_, err = updater.NextExecutable(ctx)
+	_, err := updater.NextExecutable(ctx)
 	require.NoError(t, err)
 
 	_, err = updater.NextExecutable(ctx)
@@ -84,9 +78,7 @@ func TestExecutableIsTakenFromCacheIfExists(t *testing.T) {
 
 func TestNextExecutableIsNotAvailableWhenVersionsMatch(t *testing.T) {
 	ctx := context.Background()
-	tmpdir, err := ioutil.TempDir("", "TestExecutableCache")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	executablecache := executablecache.New(executablecache.WithCacheDir(tmpdir))
 	updateSource := &mockUpdateSource{}
 	updateSource.ExpectExecutableFetch(ctx, "1", "#!/bin/sh\n")

--- a/components/automate-deployment/pkg/a1upgrade/a1upgrade_compat_test.go
+++ b/components/automate-deployment/pkg/a1upgrade/a1upgrade_compat_test.go
@@ -115,8 +115,7 @@ func TestLocalBackupDirectoryDoesNotExist(t *testing.T) {
 }
 
 func TestLocalBackupDirectoryExistsAndIsEmpty(t *testing.T) {
-	testDir, _ := ioutil.TempDir("", "TestEmptyBackupDir")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	checker := NewCompatChecker()
 	err := checker.BackupConfigured("fs", false, testDir, "")
@@ -128,10 +127,9 @@ func TestLocalBackupDirectoryExistsAndIsEmpty(t *testing.T) {
 }
 
 func TestLocalBackupDirNonEmpty(t *testing.T) {
-	testDir, _ := ioutil.TempDir("", "TestBackupDir")
+	testDir := t.TempDir()
 	testFile, _ := ioutil.TempFile(testDir, "TestFile")
 	defer os.Remove(testFile.Name())
-	defer os.Remove(testDir)
 
 	checker := NewCompatChecker()
 	err := checker.BackupConfigured("fs", false, testDir, "")
@@ -203,11 +201,10 @@ func TestWorkflowGitReposDirDoesNotExist(t *testing.T) {
 }
 
 func TestWorkflowGitReposDirExistWithData(t *testing.T) {
-	gitReposDir, _ := ioutil.TempDir("", "TestGitReposDir")
+	gitReposDir := t.TempDir()
 	// Create a subdirectory of the workflow directory so that the workflow
 	// directory will be non-empty. We don't use this subdirectory otherwise.
 	_, _ = ioutil.TempDir(gitReposDir, "WorkflowSubdir")
-	defer os.RemoveAll(gitReposDir)
 
 	checker := NewCompatChecker()
 	err := checker.WorkflowGitReposValid(gitReposDir)
@@ -219,8 +216,7 @@ func TestWorkflowGitReposDirExistWithData(t *testing.T) {
 
 // @afiune Do we care if the git_repos dir is empty?
 func TestWorkflowGitReposDirExistWithNOData(t *testing.T) {
-	gitReposDir, _ := ioutil.TempDir("", "TestGitReposDir")
-	defer os.Remove(gitReposDir)
+	gitReposDir := t.TempDir()
 
 	checker := NewCompatChecker()
 	err := checker.WorkflowGitReposValid(gitReposDir)
@@ -232,11 +228,9 @@ func TestWorkflowGitReposDirExistWithNOData(t *testing.T) {
 
 func TestRunningMarketplaceImage(t *testing.T) {
 	t.Run("the config is invalid when chef-marketplace is installed", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		testDir := path.Join(testDirBase, "chef-marketplace")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.RemoveAll(testDirBase)
 
 		checker := NewCompatChecker()
 		err := checker.RunningMarketplaceImage(path.Dir(testDir))
@@ -245,12 +239,10 @@ func TestRunningMarketplaceImage(t *testing.T) {
 	})
 
 	t.Run("the config is valid when chef-marketplace is not installed", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		// some other omnibus package that is not explicitly banned
 		testDir := path.Join(testDirBase, "chef-client")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.Remove(testDir)
 
 		checker := NewCompatChecker()
 		err := checker.RunningMarketplaceImage(path.Dir(testDir))
@@ -454,11 +446,9 @@ func TestCSBookshelfConfigValid(t *testing.T) {
 
 func TestUnsupportedCSAddOnsNotUsed(t *testing.T) {
 	t.Run("the config is invalid when chef-manage is used", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		testDir := path.Join(testDirBase, "chef-manage")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.RemoveAll(testDirBase)
 
 		checker := NewCompatChecker()
 		err := checker.UnsupportedCSAddOnsNotUsed(path.Dir(testDir))
@@ -467,11 +457,9 @@ func TestUnsupportedCSAddOnsNotUsed(t *testing.T) {
 	})
 
 	t.Run("the config is invalid when opscode-push-jobs-server is used", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		testDir := path.Join(testDirBase, "opscode-push-jobs-server")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.Remove(testDir)
 
 		checker := NewCompatChecker()
 		err := checker.UnsupportedCSAddOnsNotUsed(path.Dir(testDir))
@@ -480,11 +468,9 @@ func TestUnsupportedCSAddOnsNotUsed(t *testing.T) {
 	})
 
 	t.Run("the config is invalid when opscode-reporting is used", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		testDir := path.Join(testDirBase, "opscode-reporting")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.Remove(testDir)
 
 		checker := NewCompatChecker()
 		err := checker.UnsupportedCSAddOnsNotUsed(path.Dir(testDir))
@@ -493,11 +479,9 @@ func TestUnsupportedCSAddOnsNotUsed(t *testing.T) {
 	})
 
 	t.Run("the config is invalid when opscode-analytics is used", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		testDir := path.Join(testDirBase, "opscode-analytics")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.Remove(testDir)
 
 		checker := NewCompatChecker()
 		err := checker.UnsupportedCSAddOnsNotUsed(path.Dir(testDir))
@@ -506,12 +490,10 @@ func TestUnsupportedCSAddOnsNotUsed(t *testing.T) {
 	})
 
 	t.Run("the config is valid when no unsupported add-ons are used", func(t *testing.T) {
-		testDirBase, _ := ioutil.TempDir("", "")
+		testDirBase := t.TempDir()
 		// some other omnibus package that is not explicitly banned
 		testDir := path.Join(testDirBase, "chef-client")
 		_ = os.Mkdir(testDir, 0755)
-
-		defer os.Remove(testDir)
 
 		checker := NewCompatChecker()
 		err := checker.UnsupportedCSAddOnsNotUsed(path.Dir(testDir))

--- a/components/automate-deployment/pkg/a1upgrade/fileutils_test.go
+++ b/components/automate-deployment/pkg/a1upgrade/fileutils_test.go
@@ -14,9 +14,7 @@ import (
 
 func TestIsEmptyDir(t *testing.T) {
 	t.Run("it returns true if the path is an empty directory", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "FileUtilsTestDir")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		res, err := a1upgrade.IsEmptyDir(tmpdir)
 		require.NoError(t, err)
@@ -24,9 +22,7 @@ func TestIsEmptyDir(t *testing.T) {
 	})
 
 	t.Run("it returns false if the path is a nonempty directory", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "FileutilsTestDir")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 		ioutil.WriteFile(filepath.Join(tmpdir, "testfile"), []byte("test context"), os.ModePerm)
 
 		res, err := a1upgrade.IsEmptyDir(tmpdir)

--- a/components/automate-deployment/pkg/a1upgrade/generate_cfg_test.go
+++ b/components/automate-deployment/pkg/a1upgrade/generate_cfg_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestGenerateMigrationOverrideConfig(t *testing.T) {
-	tmpDir, cleanup := newTestTempDir(t, "migration-override")
-	defer cleanup()
+	tmpDir := t.TempDir()
 
 	certPath := newTestTempFile(t, tmpDir, "user.crt", "cert-value")
 	keyPath := newTestTempFile(t, tmpDir, "user.key", "key-value")
@@ -63,8 +62,7 @@ func TestGenerateMigrationOverrideConfig(t *testing.T) {
 func TestGetFrontendTLSCreds(t *testing.T) {
 	t.Run("User provided SSL Cert and Key exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "user-provided-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 
 		certPath := newTestTempFile(t, tmpDir, "user.crt", "cert-value")
 		keyPath := newTestTempFile(t, tmpDir, "user.key", "key-value")
@@ -85,8 +83,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("User provided SSL Cert and Key exist and uses file:// uri", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "user-provided-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 
 		certPath := newTestTempFile(t, tmpDir, "user.crt", "cert-value")
 		keyPath := newTestTempFile(t, tmpDir, "user.key", "key-value")
@@ -107,8 +104,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("User provided SSL Cert doesn't exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "user-provided-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 
 		certPath := filepath.Join(tmpDir, "user.crt")
 		keyPath := newTestTempFile(t, tmpDir, "user.key", "key-value")
@@ -125,8 +121,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("User provided SSL Key doesn't exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "user-provided-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 
 		certPath := newTestTempFile(t, tmpDir, "user.crt", "cert-value")
 		keyPath := filepath.Join(tmpDir, "user.key")
@@ -143,8 +138,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("Self-signed SSL Cert and Key exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "self-signed-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 		caDir := filepath.Join(tmpDir, "ca")
 		err := os.MkdirAll(caDir, 0755)
 		require.NoError(t, err, "Failed to create fake nginx ca dir")
@@ -165,8 +159,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("Self-signed SSL Cert doesn't exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "self-signed-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 		caDir := filepath.Join(tmpDir, "ca")
 		err := os.MkdirAll(caDir, 0755)
 		require.NoError(t, err, "Failed to create fake nginx ca dir")
@@ -181,8 +174,7 @@ func TestGetFrontendTLSCreds(t *testing.T) {
 	})
 	t.Run("Self-signed SSL Key doesn't exist", func(t *testing.T) {
 		r := newMockDeliveryRunning(t)
-		tmpDir, cleanup := newTestTempDir(t, "self-signed-ssl-cert")
-		defer cleanup()
+		tmpDir := t.TempDir()
 		caDir := filepath.Join(tmpDir, "ca")
 		err := os.MkdirAll(caDir, 0755)
 		require.NoError(t, err, "Failed to create fake nginx ca dir")
@@ -365,14 +357,6 @@ func newMockChefServerRunnig(t *testing.T) *ChefServerRunning {
 	require.NoError(t, err, "failed to load chef-server-running.json")
 
 	return config.ChefServerRunning
-}
-
-func newTestTempDir(t *testing.T, msg string) (string, func()) {
-	tempdir, err := ioutil.TempDir("", msg)
-	require.NoError(t, err, "could not create temporary test directory")
-	f := func() { os.RemoveAll(tempdir) }
-
-	return tempdir, f
 }
 
 func newTestTempFile(t *testing.T, dirName, name, value string) string {

--- a/components/automate-deployment/pkg/airgap/cache_test.go
+++ b/components/automate-deployment/pkg/airgap/cache_test.go
@@ -3,7 +3,6 @@ package airgap
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -15,10 +14,7 @@ import (
 )
 
 func TestFileCache(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "a2-install-bundle-test")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	cacher := fileCacher{cacheDir: tmpdir}
 	t.Run("non existing file is not cached", func(t *testing.T) {
 		assert.False(t, cacher.IsCached("does-not-exist"))
@@ -48,10 +44,7 @@ func TestFileCache(t *testing.T) {
 }
 
 func TestKeyCache(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "a2-install-bundle-test")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	keyCache := NewKeyCache(tmpdir)
 
@@ -73,10 +66,7 @@ func TestKeyCache(t *testing.T) {
 }
 
 func TestHartifactCache(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "a2-install-bundle-test")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	hartCache := NewHartifactCache(tmpdir)
 

--- a/components/automate-deployment/pkg/airgap/install_bundle_test.go
+++ b/components/automate-deployment/pkg/airgap/install_bundle_test.go
@@ -74,9 +74,7 @@ func TestRoundTrip(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tmpdir, err := ioutil.TempDir("", "a2-install-bundle-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	workspaceDir := path.Join(tmpdir, "workspace")
 	manifestFile := path.Join(tmpdir, "manifest.json")
@@ -84,7 +82,7 @@ func TestRoundTrip(t *testing.T) {
 	unpackRoot := path.Join(tmpdir, "unpack")
 	unpackRootHartsOnly := path.Join(tmpdir, "unpack_harts")
 
-	err = ioutil.WriteFile(manifestFile, []byte(sampleManifest), 0644)
+	err := ioutil.WriteFile(manifestFile, []byte(sampleManifest), 0644)
 	require.NoError(t, err)
 
 	progress := newCreateInstallBundleProgressCollector()

--- a/components/automate-deployment/pkg/backup/artifact_repo_property_test.go
+++ b/components/automate-deployment/pkg/backup/artifact_repo_property_test.go
@@ -359,9 +359,7 @@ func TestArtifactRepo(t *testing.T) {
 	parameters.MaxSize = 80
 	properties := gopter.NewProperties(parameters)
 
-	baseDir, err := ioutil.TempDir("", "artifact-repo-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(baseDir)
+	baseDir := t.TempDir()
 
 	repoCommands := &commands.ProtoCommands{
 		NewSystemUnderTestFunc: func(initialState commands.State) commands.SystemUnderTest {

--- a/components/automate-deployment/pkg/backup/bucket_test.go
+++ b/components/automate-deployment/pkg/backup/bucket_test.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -212,12 +211,8 @@ func (suite *BucketTestSuite) AfterTest(suiteName, testName string) {
 func TestFilesystemBucket(t *testing.T) {
 	suite.Run(t, &BucketTestSuite{
 		beforeTest: func(suite *BucketTestSuite) {
-			tmpDir, err := ioutil.TempDir("", "fs-bucket-test")
-			suite.Require().NoError(err)
+			tmpDir := t.TempDir()
 			suite.locationSpec = FilesystemLocationSpecification{Path: tmpDir}
-			suite.afterTest = func(*BucketTestSuite) {
-				os.RemoveAll(tmpDir)
-			}
 		},
 	})
 }

--- a/components/automate-deployment/pkg/bootstrapbundle/bundle_creator_test.go
+++ b/components/automate-deployment/pkg/bootstrapbundle/bundle_creator_test.go
@@ -172,9 +172,7 @@ func TestAllowMissingBootstrapSpec(t *testing.T) {
 }
 
 func TestRoundTrip(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "a2-bootstrap-bundle-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	bundleCreator := createBundleCreator(t)
 
@@ -216,7 +214,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	err = bundleCreator.Create(metadata, b)
+	err := bundleCreator.Create(metadata, b)
 	require.NoError(t, err)
 
 	err = bundleUnpacker.Unpack(b)

--- a/components/automate-deployment/pkg/manifest/client/path_test.go
+++ b/components/automate-deployment/pkg/manifest/client/path_test.go
@@ -3,7 +3,6 @@ package client_test
 import (
 	"context"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -28,11 +27,9 @@ var goodA2Manifest = `
 }`
 
 func TestDirectoryGetCurrentManifest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "DirectoryManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(path.Join(dir, "current.json"), []byte(goodV1Manifest), 0700)
+	err := ioutil.WriteFile(path.Join(dir, "current.json"), []byte(goodV1Manifest), 0700)
 	require.NoError(t, err, "writing test data")
 
 	client := client.NewPathClient(dir)
@@ -49,23 +46,19 @@ func TestDirectoryGetCurrentManifest(t *testing.T) {
 }
 
 func TestDirectoryGetCurrentManifestWhenDoesntExist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "DirectoryManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	client := client.NewPathClient(dir)
-	_, err = client.GetCurrentManifest(context.Background(), "current")
+	_, err := client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
 	_, ok := err.(*manifest.NoSuchManifestError)
 	require.True(t, ok, "error should be a NoSuchManifestError")
 }
 
 func TestDirectoryGetCurrentManifestWhenInvalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "DirectoryManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(path.Join(dir, "current.json"), []byte("::::::"), 0700)
+	err := ioutil.WriteFile(path.Join(dir, "current.json"), []byte("::::::"), 0700)
 	require.NoError(t, err, "writing test data")
 
 	client := client.NewPathClient(dir)
@@ -76,13 +69,11 @@ func TestDirectoryGetCurrentManifestWhenInvalid(t *testing.T) {
 }
 
 func TestFileGetCurrentManifestA2(t *testing.T) {
-	dir, err := ioutil.TempDir("", "FileManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	filename := path.Join(dir, "manifest.json")
 	client := client.NewPathClient(filename)
 
-	err = ioutil.WriteFile(filename, []byte(goodA2Manifest), 0700)
+	err := ioutil.WriteFile(filename, []byte(goodA2Manifest), 0700)
 	require.NoError(t, err, "writing test data")
 
 	manifest, err := client.GetCurrentManifest(context.Background(), "current")
@@ -115,13 +106,11 @@ func TestFileGetCurrentManifestA2(t *testing.T) {
 }
 
 func TestFileGetCurrentManifestV1(t *testing.T) {
-	dir, err := ioutil.TempDir("", "FileManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	filename := path.Join(dir, "manifest.json")
 	client := client.NewPathClient(filename)
 
-	err = ioutil.WriteFile(filename, []byte(goodV1Manifest), 0700)
+	err := ioutil.WriteFile(filename, []byte(goodV1Manifest), 0700)
 	require.NoError(t, err, "writing test data")
 
 	manifest, err := client.GetCurrentManifest(context.Background(), "current")
@@ -137,26 +126,22 @@ func TestFileGetCurrentManifestV1(t *testing.T) {
 }
 
 func TestFileGetCurrentManifestWhenDoesntExist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "FileManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	filename := path.Join(dir, "manifest.json")
 	client := client.NewPathClient(filename)
-	_, err = client.GetCurrentManifest(context.Background(), "current")
+	_, err := client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
 	_, ok := err.(*manifest.NoSuchManifestError)
 	require.True(t, ok, "error should be a NoSuchManifestError")
 }
 
 func TestFileGetCurrentManifestWhenInvalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "FileManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := path.Join(dir, "manifest.json")
 	client := client.NewPathClient(filename)
 
-	err = ioutil.WriteFile(filename, []byte("::::::"), 0700)
+	err := ioutil.WriteFile(filename, []byte("::::::"), 0700)
 	_, err = client.GetCurrentManifest(context.Background(), "current")
 	require.Error(t, err)
 	_, ok := err.(*manifest.InvalidSchemaError)
@@ -164,12 +149,10 @@ func TestFileGetCurrentManifestWhenInvalid(t *testing.T) {
 }
 
 func TestFileGetManifest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "DirectoryManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := path.Join(dir, "manifest.json")
-	err = ioutil.WriteFile(filename, []byte(goodV1Manifest), 0700)
+	err := ioutil.WriteFile(filename, []byte(goodV1Manifest), 0700)
 	require.NoError(t, err, "writing test data")
 
 	client := client.NewPathClient(filename)
@@ -186,11 +169,9 @@ func TestFileGetManifest(t *testing.T) {
 }
 
 func TestDirectoryGetManifest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "DirectoryManifestProviderTest")
-	require.NoError(t, err, "creating temporary manifest dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
-	err = ioutil.WriteFile(path.Join(dir, "20180207073125.json"), []byte(goodV1Manifest), 0700)
+	err := ioutil.WriteFile(path.Join(dir, "20180207073125.json"), []byte(goodV1Manifest), 0700)
 	require.NoError(t, err, "writing test data")
 
 	client := client.NewPathClient(dir)

--- a/components/automate-deployment/pkg/manifest/provider_test.go
+++ b/components/automate-deployment/pkg/manifest/provider_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -422,11 +421,9 @@ var versions = `
 `
 
 func TestGetAllVersionsFromPath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "VersionsFromFileTest")
-	assert.NoError(t, err, "creating temporary dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	filename := path.Join(dir, "versions.json")
-	err = ioutil.WriteFile(filename, []byte(versions), 0700)
+	err := ioutil.WriteFile(filename, []byte(versions), 0700)
 	assert.NoError(t, err, "writing test data")
 
 	resp, err := GetAllVersions(context.Background(), "", filename)

--- a/components/automate-deployment/pkg/preflight/test_probe_test.go
+++ b/components/automate-deployment/pkg/preflight/test_probe_test.go
@@ -10,18 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestTempDir(t *testing.T) (string, func()) {
-	t.Helper()
-	tempdir, err := ioutil.TempDir("", "test-probe")
-	require.NoError(t, err, "could not create temporary test directory")
-	f := func() { os.RemoveAll(tempdir) }
-
-	return tempdir, f
-}
-
 func TestLocalProbeFileThings(t *testing.T) {
-	tmpdir, cleanup := newTestTempDir(t)
-	defer cleanup()
+	tmpdir := t.TempDir()
 
 	testData := []byte("blah")
 	filePath := path.Join(tmpdir, "file")

--- a/components/automate-deployment/pkg/server/server_test.go
+++ b/components/automate-deployment/pkg/server/server_test.go
@@ -4,7 +4,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -232,8 +231,7 @@ func TestConvergeDisabled(t *testing.T) {
 	svr.serverConfig = &Config{}
 
 	t.Run("disabled when disable file exists", func(t *testing.T) {
-		tempDir, _ := ioutil.TempDir("", "converge-disabled")
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 		disableFile := filepath.Join(tempDir, "converge_disabled")
 		// create the file
 		os.OpenFile(disableFile, os.O_RDONLY|os.O_CREATE, 0750)
@@ -243,8 +241,7 @@ func TestConvergeDisabled(t *testing.T) {
 	})
 
 	t.Run("enabled when disable file does not exist", func(t *testing.T) {
-		tempDir, _ := ioutil.TempDir("", "converge-disabled")
-		defer os.RemoveAll(tempDir)
+		tempDir := t.TempDir()
 		disableFile := filepath.Join(tempDir, "converge_disabled")
 
 		svr.serverConfig.ConvergeDisableFile = disableFile

--- a/components/automate-deployment/pkg/target/local_target_test.go
+++ b/components/automate-deployment/pkg/target/local_target_test.go
@@ -139,8 +139,7 @@ func TestServiceConfigureFails(t *testing.T) {
 
 // TODO ideally we will more fully test this function
 func TestServiceConfigureSucceeds(t *testing.T) {
-	testDir, _ := ioutil.TempDir("", "TestServiceConfigureFails")
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	h := NewLocalTarget(false)
 	h.HabBaseDir = testDir
@@ -371,8 +370,7 @@ func TestInstallHabitat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tgt, mockExec, finish := setupTestLocalTarget(t)
 
-			tempDir, _ := ioutil.TempDir("", "TestInstallHab")
-			defer os.Remove(tempDir)
+			tempDir := t.TempDir()
 			tgt.HabBaseDir = tempDir
 
 			tt.mockFun(t, mockExec, tempDir)
@@ -659,13 +657,10 @@ func TestLocalTarget_InstallService(t *testing.T) {
 
 func TestRemoveService(t *testing.T) {
 	tgt, mockExec, finish := setupTestLocalTarget(t)
-	tempDir, _ := ioutil.TempDir("", "TestRemoveService")
+	tempDir := t.TempDir()
 	tgt.HabBaseDir = tempDir
 
-	defer func() {
-		os.RemoveAll(tempDir)
-		finish(t)
-	}()
+	defer finish(t)
 
 	testPkgDir := filepath.Join(tempDir, "pkgs", "origin", "name")
 	os.MkdirAll(testPkgDir, os.ModePerm)
@@ -698,10 +693,8 @@ func TestRemoveServicePkgDeleteFails(t *testing.T) {
 	tgt, mockExec, finish := setupTestLocalTarget(t)
 	defer finish(t)
 
-	tempDir, _ := ioutil.TempDir("", "TestRemoveService")
+	tempDir := t.TempDir()
 	tgt.HabBaseDir = tempDir
-
-	defer os.RemoveAll(tempDir)
 
 	testPkgDir := filepath.Join(tempDir, "pkgs", "origin", "name")
 	os.MkdirAll(testPkgDir, 0400)
@@ -744,8 +737,7 @@ func TestGetUserToml(t *testing.T) {
 	pkg := habpkg.New("bar", "foo")
 
 	t.Run("returns an empty string if the file does not exist", func(t *testing.T) {
-		tempDir, _ := ioutil.TempDir("", "TestServiceConfigureFails")
-		defer os.Remove(tempDir)
+		tempDir := t.TempDir()
 
 		h := NewLocalTarget(false)
 		h.HabBaseDir = tempDir
@@ -755,8 +747,7 @@ func TestGetUserToml(t *testing.T) {
 	})
 
 	t.Run("returns the user toml if it exists", func(t *testing.T) {
-		tempDir, _ := ioutil.TempDir("", "TestServiceConfigureFails")
-		defer os.Remove(tempDir)
+		tempDir := t.TempDir()
 
 		h := NewLocalTarget(false)
 		h.HabBaseDir = tempDir

--- a/components/automate-gateway/gateway/clients_test.go
+++ b/components/automate-gateway/gateway/clients_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,8 +93,7 @@ func TestDialWithNoEndpoints(t *testing.T) {
 // Assert that we can initialize a null backend and a clients factory and that
 // the null backend returns no errors.
 func TestDialWithNoEndpointsAndNullBackendSock(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "null_backend_test")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	sockName := "backend.sock"
 	sockPath := filepath.Join(tmpDir, sockName)
@@ -116,7 +114,7 @@ func TestDialWithNoEndpointsAndNullBackendSock(t *testing.T) {
 		os.RemoveAll(tmpDir)
 	}()
 
-	err = svr.startNullBackendServer()
+	err := svr.startNullBackendServer()
 	require.NoError(t, err)
 
 	f, err := NewClientsFactory(clientCfg, connFactory)

--- a/components/automate-gateway/gateway/server_test.go
+++ b/components/automate-gateway/gateway/server_test.go
@@ -43,9 +43,7 @@ external_fqdn = "{{.Fqdn}}"
     target = "{{.LicenseTarget}}"
     secure = {{.LicenseSecure}}
 `
-	tempDir, err := ioutil.TempDir("", "config-from-viper-test")
-	require.NoError(t, err, "could not create temporary test directory")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	testConfig := struct {
 		Host          string
@@ -76,7 +74,7 @@ external_fqdn = "{{.Fqdn}}"
 	tomlPath := filepath.Join(tempDir, "config.toml")
 	tmpl := template.Must(template.New("Config").Parse(cfgTemplate))
 	var rendered bytes.Buffer
-	err = tmpl.Execute(&rendered, testConfig)
+	err := tmpl.Execute(&rendered, testConfig)
 	require.NoError(t, err, "Failed to render test config template into string")
 	err = ioutil.WriteFile(tomlPath, rendered.Bytes(), 0755)
 	require.NoError(t, err, fmt.Sprintf("Failed to create %s", tomlPath))

--- a/components/automate-platform-tools/cmd/secrets-helper/secrets_helper_test.go
+++ b/components/automate-platform-tools/cmd/secrets-helper/secrets_helper_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,16 +28,13 @@ type testSecretsHelper struct {
 
 func setupSecretsHelper(t *testing.T) *testSecretsHelper {
 	h := &testSecretsHelper{}
-	tmpDir, err := ioutil.TempDir("", "secrets-helper-test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	tmpDir := t.TempDir()
 
 	h.tmpDir = tmpDir
 	cmd := exec.Command("go", "build", "-o", h.BinPath(), "./secrets-helper.go")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("Failed to build secrets-helper: %s", err.Error())
 	}

--- a/lib/io/fileutils/access_linux_test.go
+++ b/lib/io/fileutils/access_linux_test.go
@@ -1,7 +1,6 @@
 package fileutils
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -105,12 +104,7 @@ func TestReadable(t *testing.T) {
 	})
 
 	t.Run("readable success", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "TestReadable")
-		require.NoError(t, err, "creating temporary dir")
-		defer func() {
-			os.Chmod(dir, os.FileMode(0777))
-			os.RemoveAll(dir)
-		}()
+		dir := t.TempDir()
 
 		me, err := user.Current()
 		require.NoError(t, err)
@@ -218,12 +212,7 @@ func TestWritable(t *testing.T) {
 	})
 
 	t.Run("writable success", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "TestWritable")
-		require.NoError(t, err, "creating temporary dir")
-		defer func() {
-			os.Chmod(dir, os.FileMode(0777))
-			os.RemoveAll(dir)
-		}()
+		dir := t.TempDir()
 
 		me, err := user.Current()
 		require.NoError(t, err)
@@ -373,12 +362,7 @@ func TestExecutable(t *testing.T) {
 	})
 
 	t.Run("executable success", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "TestExecutable")
-		require.NoError(t, err, "creating temporary dir")
-		defer func() {
-			os.Chmod(dir, os.FileMode(0777))
-			os.RemoveAll(dir)
-		}()
+		dir := t.TempDir()
 
 		me, err := user.Current()
 		require.NoError(t, err)
@@ -393,16 +377,14 @@ func TestExecutable(t *testing.T) {
 	})
 
 	t.Run("executable parent missing exec", func(t *testing.T) {
-		parent, err := ioutil.TempDir("", "TestExecutableParent")
-		require.NoError(t, err, "creating temporary dir")
+		parent := t.TempDir()
 		defer func() {
 			os.Chmod(parent, os.FileMode(0777))
-			os.RemoveAll(parent)
 		}()
 
 		child := path.Join(parent, "child")
 		reader := strings.NewReader("child body")
-		err = AtomicWrite(child, reader, WithAtomicWriteFileMode(0777))
+		err := AtomicWrite(child, reader, WithAtomicWriteFileMode(0777))
 		require.NoError(t, err)
 
 		// Make the parent not executable
@@ -515,12 +497,7 @@ func TestReadWritable(t *testing.T) {
 	})
 
 	t.Run("read/writable success", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "TestReadWritable")
-		require.NoError(t, err, "creating temporary dir")
-		defer func() {
-			os.Chmod(dir, os.FileMode(0777))
-			os.RemoveAll(dir)
-		}()
+		dir := t.TempDir()
 
 		me, err := user.Current()
 		require.NoError(t, err)
@@ -670,12 +647,7 @@ func TestReadWriteExecutable(t *testing.T) {
 	})
 
 	t.Run("read/write/exec success", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "TestReadWriteExecutable")
-		require.NoError(t, err, "creating temporary dir")
-		defer func() {
-			os.Chmod(dir, os.FileMode(0777))
-			os.RemoveAll(dir)
-		}()
+		dir := t.TempDir()
 
 		me, err := user.Current()
 		require.NoError(t, err)
@@ -690,16 +662,14 @@ func TestReadWriteExecutable(t *testing.T) {
 	})
 
 	t.Run("read/write/exec parent missing exec", func(t *testing.T) {
-		parent, err := ioutil.TempDir("", "TestReadWriteExecutable")
-		require.NoError(t, err, "creating temporary dir")
+		parent := t.TempDir()
 		defer func() {
 			os.Chmod(parent, os.FileMode(0777))
-			os.RemoveAll(parent)
 		}()
 
 		child := path.Join(parent, "foo")
 		reader := strings.NewReader("child body")
-		err = AtomicWrite(child, reader, WithAtomicWriteFileMode(0777))
+		err := AtomicWrite(child, reader, WithAtomicWriteFileMode(0777))
 		require.NoError(t, err)
 
 		// Make the parent not executable

--- a/lib/io/fileutils/atomic_write_test.go
+++ b/lib/io/fileutils/atomic_write_test.go
@@ -16,13 +16,11 @@ import (
 )
 
 func TestAtomicWriteSuccess(t *testing.T) {
-	dir, err := ioutil.TempDir("", "AtomicWriteTest")
-	require.NoError(t, err, "creating temporary dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := path.Join(dir, "foo")
 	reader := strings.NewReader("bar")
-	err = fileutils.AtomicWrite(filename, reader)
+	err := fileutils.AtomicWrite(filename, reader)
 	require.NoError(t, err)
 	data, err := ioutil.ReadFile(filename)
 	require.NoError(t, err)
@@ -30,16 +28,14 @@ func TestAtomicWriteSuccess(t *testing.T) {
 }
 
 func TestAtomicWriteExecutableSuccess(t *testing.T) {
-	dir, err := ioutil.TempDir("", "AtomicWriteTest")
-	require.NoError(t, err, "creating temporary dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := path.Join(dir, "foo")
 	reader := strings.NewReader(`#!/bin/bash
 
 		echo bar
 	`)
-	err = fileutils.AtomicWrite(filename, reader, fileutils.WithAtomicWriteFileMode(0755))
+	err := fileutils.AtomicWrite(filename, reader, fileutils.WithAtomicWriteFileMode(0755))
 	require.NoError(t, err)
 	cmd := exec.Command(filename)
 	data, err := cmd.CombinedOutput()
@@ -48,13 +44,11 @@ func TestAtomicWriteExecutableSuccess(t *testing.T) {
 }
 
 func TestAtomicWriteFail(t *testing.T) {
-	dir, err := ioutil.TempDir("", "AtomicWriteTest")
-	require.NoError(t, err, "creating temporary dir")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := path.Join(dir, "foo")
 	reader := iotest.TimeoutReader(iotest.OneByteReader(strings.NewReader("bar")))
-	err = fileutils.AtomicWrite(filename, reader)
+	err := fileutils.AtomicWrite(filename, reader)
 	require.Error(t, err)
 	_, err = os.Stat(filename)
 	assert.True(t, os.IsNotExist(err), "The file should not have been created because there was an error")

--- a/lib/io/fileutils/copy_dir_test.go
+++ b/lib/io/fileutils/copy_dir_test.go
@@ -14,9 +14,7 @@ import (
 
 func TestCopyDir(t *testing.T) {
 	t.Run("it fails when src directory isn't a directory", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcData := []byte("src data")
 		srcPath := path.Join(tmpDir, "src")
@@ -27,9 +25,7 @@ func TestCopyDir(t *testing.T) {
 	})
 
 	t.Run("it recursively copies files", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join(tmpDir, "src")
 		dstDir := filepath.Join(tmpDir, "dst")
@@ -62,9 +58,7 @@ func TestCopyDir(t *testing.T) {
 	})
 
 	t.Run("it recursively copies directories to given depth", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join(tmpDir, "src")
 		dstDir := filepath.Join(tmpDir, "dst")
@@ -96,9 +90,7 @@ func TestCopyDir(t *testing.T) {
 	})
 
 	t.Run("it doesn't recursively copy with no recursive set", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join(tmpDir, "src")
 		dstDir := filepath.Join(tmpDir, "dst")
@@ -122,9 +114,7 @@ func TestCopyDir(t *testing.T) {
 	})
 
 	t.Run("it fails when the dest directory exists", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join(tmpDir, "src")
 		dstDir := filepath.Join(tmpDir, "dst")
@@ -136,9 +126,7 @@ func TestCopyDir(t *testing.T) {
 	})
 
 	t.Run("it overwrites dest files when overwrite is set", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "TestCopyDir")
-		defer os.RemoveAll(tmpDir)
-		require.NoError(t, err)
+		tmpDir := t.TempDir()
 
 		srcDir := filepath.Join(tmpDir, "src")
 		dstDir := filepath.Join(tmpDir, "dst")
@@ -160,7 +148,7 @@ func TestCopyDir(t *testing.T) {
 
 		require.NoError(t, fileutils.CopyDir(srcDir, dstDir, fileutils.Overwrite()))
 
-		file1DataDst, err = ioutil.ReadFile(file1PathDst)
+		file1DataDst, err := ioutil.ReadFile(file1PathDst)
 		require.NoError(t, err)
 		file2DataDst, err = ioutil.ReadFile(file2PathDst)
 		require.NoError(t, err)

--- a/lib/io/fileutils/copy_file_test.go
+++ b/lib/io/fileutils/copy_file_test.go
@@ -2,7 +2,6 @@ package fileutils_test
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -13,8 +12,7 @@ import (
 
 func TestCopyFile(t *testing.T) {
 	t.Run("it copies the file", func(t *testing.T) {
-		d1, d2, cleanup := setupCopy(t)
-		defer cleanup()
+		d1, d2 := setupCopy(t)
 
 		srcData := []byte("test data")
 		srcPath := path.Join(d1, "src")
@@ -27,8 +25,7 @@ func TestCopyFile(t *testing.T) {
 	})
 
 	t.Run("it fails when file exists", func(t *testing.T) {
-		d1, d2, cleanup := setupCopy(t)
-		defer cleanup()
+		d1, d2 := setupCopy(t)
 
 		srcData := []byte("src data")
 		srcPath := path.Join(d1, "src")
@@ -40,8 +37,7 @@ func TestCopyFile(t *testing.T) {
 	})
 
 	t.Run("it copies over existing file when overwrite is set", func(t *testing.T) {
-		d1, d2, cleanup := setupCopy(t)
-		defer cleanup()
+		d1, d2 := setupCopy(t)
 
 		srcData := []byte("src data")
 		srcPath := path.Join(d1, "src")
@@ -56,21 +52,9 @@ func TestCopyFile(t *testing.T) {
 	})
 }
 
-func setupCopy(t *testing.T) (string, string, func()) {
-	tmpDir, err := ioutil.TempDir("", "TestCopy1")
-	if err != nil {
-		t.Fatal("creating temp dir")
-		os.RemoveAll(tmpDir)
-	}
+func setupCopy(t *testing.T) (string, string) {
+	tmpDir := t.TempDir()
+	tmpDir2 := t.TempDir()
 
-	tmpDir2, err := ioutil.TempDir("", "TestCopy2")
-	if err != nil {
-		t.Fatal("creating temp dir")
-		os.RemoveAll(tmpDir2)
-	}
-
-	return tmpDir, tmpDir2, func() {
-		_ = os.RemoveAll(tmpDir)
-		_ = os.RemoveAll(tmpDir2)
-	}
+	return tmpDir, tmpDir2
 }

--- a/lib/io/fileutils/fileutils_test.go
+++ b/lib/io/fileutils/fileutils_test.go
@@ -14,9 +14,7 @@ import (
 
 func TestPathExist(t *testing.T) {
 	t.Run("it returns true if the path exists", func(t *testing.T) {
-		tmpdir, err := ioutil.TempDir("", "FileUtilsTestDir")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpdir)
+		tmpdir := t.TempDir()
 
 		res, err := fileutils.PathExists(tmpdir)
 		require.NoError(t, err)
@@ -31,15 +29,13 @@ func TestPathExist(t *testing.T) {
 }
 
 func TestIsSymlink(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "FileUtilsTestDir")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testData := []byte("test data")
 	filePath := path.Join(tmpdir, "file")
 	ioutil.WriteFile(filePath, testData, 0700)
 	symlinkPath := path.Join(tmpdir, "symlink")
-	err = os.Symlink(filePath, symlinkPath)
+	err := os.Symlink(filePath, symlinkPath)
 	require.NoError(t, err)
 
 	t.Run("it returns true for a symlink", func(t *testing.T) {

--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -3,7 +3,6 @@ package pg_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -157,7 +156,7 @@ func TestImport(t *testing.T) {
 		mockDB.On("Close").Return(nil)
 		pg.CurrentDBProvider = provider
 
-		tmpDataDir, _ := ioutil.TempDir("", "DatabaseExporterTestDir")
+		tmpDataDir := t.TempDir()
 
 		mockExec := command.NewMockExecutor(t)
 		exporter := pg.DatabaseExporter{
@@ -168,7 +167,6 @@ func TestImport(t *testing.T) {
 		}
 
 		cleanup := func() {
-			os.RemoveAll(tmpDataDir)
 			pg.CurrentDBProvider = pg.DefaultDBProvider
 		}
 

--- a/lib/secrets/secrets_test.go
+++ b/lib/secrets/secrets_test.go
@@ -2,7 +2,6 @@ package secrets_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -37,17 +36,14 @@ func TestSecretNameFromString(t *testing.T) {
 }
 
 func TestDiskSecretStore(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "secret-store-tests")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
-	require.NoError(t, err, "failed to create temporary directory")
 	uid := os.Getuid()
 	gid := os.Getgid()
-	require.NoError(t, err, "failed to look up running user")
 	dataDir := filepath.Join(tmpDir, "data-dir")
 
 	dataStore := secrets.NewDiskStore(dataDir, uid, gid)
-	err = dataStore.Initialize()
+	err := dataStore.Initialize()
 	require.NoError(t, err, "failed to initialize")
 
 	t.Run("init creates the data directory with mode 0700", func(t *testing.T) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
A testing cleanup. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

### :chains: Related Resources

Reference: https://pkg.go.dev/testing#T.TempDir

### :+1: Definition of Done

No leftover temporary directories after the tests have finished. This should be done automatically by `T.TempDir` unless an error occurred while removing the directory.

### :athletic_shoe: How to Build and Test the Change

Run Go tests

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
