### PR TITLE
Adding chef-server Fqdn to UI

### DIFF
--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -38,6 +38,7 @@ end
 ###############################################################
 chef_server do
   instance_count {{ .ChefServer.Config.InstanceCount }}
+  chef_lb_fqdn "{{ .Architecture.ConfigInitials.ChefLbfqdn }}"
 end
 
 ###############################################################

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -128,6 +128,7 @@ type ExistingInfraConfigToml struct {
 			ExistingElkUsername         string `toml:"existing_elk_username"`
 			ExistingElkPassword         string `toml:"existing_elk_password"`
 			BackupMount                 string `toml:"backup_mount"`
+			ChefLbfqdn                  string `toml:"chef_lb_fqdn"`
 			HabitatUIDGid               string `toml:"habitat_uid_gid"`
 		} `toml:"existing_infra"`
 	} `toml:"architecture"`

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -103,6 +103,7 @@ sudo_password = ""
 
 # DON'T MODIFY THE BELOW LINE (backup_mount)
 backup_mount = "/mnt/automate_backups"
+chef_lb_fqdn = ""
 
 [automate.config]
 # admin_password = ""

--- a/components/automate-cluster-ctl/lib/cluster/config.rb
+++ b/components/automate-cluster-ctl/lib/cluster/config.rb
@@ -71,6 +71,7 @@ module AutomateCluster
 
     config_context :chef_server do
       default :instance_count, 1
+      default :chef_lb_fqdn
     end
 
     config_context :elasticsearch do

--- a/components/automate-cluster-ctl/templates/terraform.tfvars.erb
+++ b/components/automate-cluster-ctl/templates/terraform.tfvars.erb
@@ -116,6 +116,7 @@ vsphere_linux_template = "<%= config.vsphere.linux_template %>"
 <% if config.architecture == 'existing_nodes' %>
 # Existing nodes
 ################################################################################
+existing_chef_server_fqdn = "<%= config.chef_server.chef_lb_fqdn %>"
 existing_elasticsearch_ips = <%= config.existing_nodes.elasticsearch_ips %>
 existing_automate_private_ips = <%= config.existing_nodes.automate_private_ips %>
 existing_chef_server_private_ips = <%= config.existing_nodes.chef_server_private_ips %>

--- a/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/README.md
+++ b/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/README.md
@@ -1,0 +1,4 @@
+# ADD Chef server to Chef Automate UI
+This module will add all chef-servers in HA deployment to Automate UI after deployment is completed
+
+This module will create a token with admin policy and add chef-server entries on Chef-automate UI

--- a/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/files/create-api-token.sh
+++ b/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/files/create-api-token.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function create_token() {
+  timestamp=$(date +%s)
+  sudo chef-automate iam token create admin.$timestamp --admin > /var/tmp/token
+  sudo touch /var/tmp/token-generated.Done
+}
+
+function add_chef_server(){
+export endpoint="$1"
+export token=`cat /var/tmp/token`
+export chef_fqdn="$2"
+
+json_data=$( echo "{ \"id\": \"chef-server\", \"name\": \"chef-server\", \"fqdn\": \"$chef_fqdn\", \"ip_address\": \"\" }")
+
+curl -k -H "api-token:$token" https://$endpoint/api/v0/infra/servers -d "$json_data"
+}
+
+if [ -e /var/tmp/token-generated.Done ]
+then
+   echo "This is an upgrade scenario, where token is already generated and chef-server is added to Automate UI"
+else
+   create_token 
+   add_chef_server $1 $2
+fi

--- a/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/inputs.tf
+++ b/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/inputs.tf
@@ -1,0 +1,33 @@
+variable "automate-fqdn" {
+  default = ""
+}
+
+variable "chef-server-fqdn" {
+  default = ""
+}
+
+variable "chef_ips" {
+  default = [] 
+}
+
+variable "private_ips" {
+  default = []
+}
+
+variable "ssh_key_file" {
+}
+
+variable "ssh_user" {
+  default = "centos"
+}
+
+variable "ssh_user_sudo_password" {
+}
+
+variable "sudo_cmd" {
+  default = "sudo"
+}
+
+variable "tmp_path" {
+  default = "/var/tmp"
+}

--- a/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/main.tf
+++ b/terraform/a2ha-terraform/modules/add_chef_server_to_a2_ui/main.tf
@@ -1,0 +1,22 @@
+resource "null_resource" "add_chef_server_fqdn_to_ui" {
+  count = 1
+
+  connection {
+    user        = var.ssh_user
+    private_key = file(var.ssh_key_file)
+    host        = var.private_ips[0]
+  }
+
+  provisioner "file" {
+    destination = "${var.tmp_path}/create-api-token.sh"
+    source = "${path.module}/files/create-api-token.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod 0700 ${var.tmp_path}/create-api-token.sh",
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S ${var.tmp_path}/create-api-token.sh ${var.automate-fqdn} ${var.chef-server-fqdn}",
+    ]
+  }
+
+}

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -263,3 +263,16 @@ module "chef_server" {
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
 }
+
+module "add_chef_server_to_a2_ui" {
+  source                        = "./modules/add_chef_server_to_a2_ui"
+  private_ips                     = var.existing_automate_private_ips
+  ssh_key_file                    = var.ssh_key_file
+  ssh_user                        = var.ssh_user
+  ssh_user_sudo_password          = local.fe_sudo_password
+  sudo_cmd                        = var.sudo_cmd
+  automate-fqdn                   = var.automate_fqdn
+  chef-server-fqdn                = var.existing_chef_server_fqdn
+
+  depends_on = [module.chef_server]
+}

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/variables.tf
@@ -14,6 +14,10 @@ variable "existing_chef_server_private_ips" {
   default = []
 }
 
+variable "existing_chef_server_fqdn" {
+  default = []
+}
+
 variable "existing_elasticsearch_ips" {
   default = []
 }


### PR DESCRIPTION
Signed-off-by: FaizanSRE <ffulara@msystechnologies.com>

### :nut_and_bolt: Description: What code changed, and why?
This will add chef-server on automate UI, after the deployment is completed.

We have added new module add_chef_server_to_a2_ui which will create an admin token and then will add chef-server to automate UI using chef-server LB FQDN

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Build package automate-ha-deployment
build components/automate-backend-deployment
And use this package for deployment while using Chef-automate HA Deployment

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
