### PR TITLE
Arvinth/airgap bundle path

### DIFF
--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -138,5 +138,5 @@ variable "teams_port" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -138,5 +138,5 @@ variable "teams_port" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -138,5 +138,5 @@ variable "teams_port" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -178,5 +178,5 @@ variable "tags" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -178,5 +178,5 @@ variable "tags" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -178,5 +178,5 @@ variable "tags" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/curator/inputs.tf
+++ b/terraform/a2ha-terraform/modules/curator/inputs.tf
@@ -53,5 +53,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/curator/inputs.tf
+++ b/terraform/a2ha-terraform/modules/curator/inputs.tf
@@ -53,5 +53,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/curator/inputs.tf
+++ b/terraform/a2ha-terraform/modules/curator/inputs.tf
@@ -53,5 +53,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
+++ b/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
@@ -65,5 +65,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
+++ b/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
@@ -65,5 +65,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
+++ b/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
@@ -65,5 +65,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/habitat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/habitat/inputs.tf
@@ -62,5 +62,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/habitat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/habitat/inputs.tf
@@ -62,5 +62,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/habitat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/habitat/inputs.tf
@@ -62,5 +62,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/journalbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/kibana/inputs.tf
+++ b/terraform/a2ha-terraform/modules/kibana/inputs.tf
@@ -61,5 +61,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/kibana/inputs.tf
+++ b/terraform/a2ha-terraform/modules/kibana/inputs.tf
@@ -61,5 +61,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/kibana/inputs.tf
+++ b/terraform/a2ha-terraform/modules/kibana/inputs.tf
@@ -61,5 +61,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
+++ b/terraform/a2ha-terraform/modules/metricbeat/inputs.tf
@@ -60,5 +60,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/postgresql/inputs.tf
+++ b/terraform/a2ha-terraform/modules/postgresql/inputs.tf
@@ -93,5 +93,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/postgresql/inputs.tf
+++ b/terraform/a2ha-terraform/modules/postgresql/inputs.tf
@@ -93,5 +93,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/postgresql/inputs.tf
+++ b/terraform/a2ha-terraform/modules/postgresql/inputs.tf
@@ -93,5 +93,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/system/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system/inputs.tf
@@ -33,5 +33,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/modules/system/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system/inputs.tf
@@ -33,5 +33,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/system/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system/inputs.tf
@@ -33,5 +33,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/system/main.tf
+++ b/terraform/a2ha-terraform/modules/system/main.tf
@@ -8,6 +8,20 @@ locals {
     postgresql_archive_disk_fs_path    = var.postgresql_archive_disk_fs_path
   })
 }
+resource "null_resource" "create_temp_path" {
+
+  count = var.instance_count
+
+  connection {
+    user        = var.ssh_user
+    private_key = file(var.ssh_key_file)
+    host        = var.private_ips[count.index]
+  }
+
+  provisioner "remote-exec" {
+    inline = [ "sudo mkdir -p ${var.tmp_path}", "sudo chown -R ${var.ssh_user}:${var.ssh_user} ${var.tmp_path}" ]
+   }
+}
 
 resource "null_resource" "system_base_provisioning" {
   count = var.instance_count
@@ -39,5 +53,6 @@ resource "null_resource" "system_base_provisioning" {
       "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S ${var.tmp_path}/tunables.sh",
     ]
   }
+
 }
 

--- a/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
@@ -24,5 +24,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/var/automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
@@ -24,5 +24,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }

--- a/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system_hardening/inputs.tf
@@ -24,5 +24,5 @@ variable "sudo_cmd" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/tmp"
 }

--- a/terraform/a2ha-terraform/variables_common.tf
+++ b/terraform/a2ha-terraform/variables_common.tf
@@ -228,7 +228,7 @@ variable "teams_port" {
 }
 
 variable "tmp_path" {
-  default = "/home"
+  default = "/var/automate-ha"
 }
 
 variable "sudo_password" {

--- a/terraform/a2ha-terraform/variables_common.tf
+++ b/terraform/a2ha-terraform/variables_common.tf
@@ -228,7 +228,7 @@ variable "teams_port" {
 }
 
 variable "tmp_path" {
-  default = "/var/tmp"
+  default = "/home"
 }
 
 variable "sudo_password" {


### PR DESCRIPTION
Signed-off-by: Arvinth C <54614142+ArvinthC3000@users.noreply.github.com>

### Description: 
In Automate HA, the user wants to avoid using /var/tmp for placing scripts and bundles after deployment. New changes will now place scripts and bundles inside /var/automate-ha.

### :chains: Related Resources
Story Link: https://chefio.atlassian.net/browse/MADROX-53

### :+1: Definition of Done
It's dev done and tested

### :athletic_shoe: How to Build and Test the Change
Install following hab package in bastion server `punitmundra/automate-ha-deployment/0.1.0/20220321134353`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
