### PR TITLE
Fixed 0-byte file with Chrome/Edge for CSV/JSON Download of Compliance Reports

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -694,10 +694,10 @@ describe('StatsService', () => {
         filters: filters,
         last24h: false
       };
-      const text = 'report';
+      let arraybuffer: ArrayBuffer;
 
-      service.downloadReport(type, reportQuery).subscribe(data => {
-        expect(data).toEqual(text);
+      service.downloadReport(type, reportQuery).subscribe((data: ArrayBuffer)  => {
+        expect(data).toEqual(arraybuffer);
         done();
       });
 
@@ -706,7 +706,7 @@ describe('StatsService', () => {
       expect(req.request.responseType).toEqual('arraybuffer');
       expect(req.request.body).toEqual({type, filters: service.formatFilters(reportQuery)});
 
-      req.flush(text);
+      req.flush(arraybuffer);
     });
   });
 });

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -694,7 +694,7 @@ describe('StatsService', () => {
         filters: filters,
         last24h: false
       };
-      let arraybuffer: ArrayBuffer;
+      var arraybuffer: ArrayBuffer;
 
       service.downloadReport(type, reportQuery).subscribe((data: ArrayBuffer)  => {
         expect(data).toEqual(arraybuffer);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -703,7 +703,7 @@ describe('StatsService', () => {
 
       const req = httpTestingController.expectOne(url);
       expect(req.request.method).toEqual('POST');
-      expect(req.request.responseType).toEqual('text');
+      expect(req.request.responseType).toEqual('arraybuffer');
       expect(req.request.body).toEqual({type, filters: service.formatFilters(reportQuery)});
 
       req.flush(text);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -694,7 +694,7 @@ describe('StatsService', () => {
         filters: filters,
         last24h: false
       };
-      var arraybuffer: ArrayBuffer;
+      const arraybuffer = new ArrayBuffer(16);
 
       service.downloadReport(type, reportQuery).subscribe((data: ArrayBuffer)  => {
         expect(data).toEqual(arraybuffer);

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -215,7 +215,7 @@ export class StatsService {
       map(({ reports, total }) => new ReportCollection(reports, total)));
   }
 
-  downloadReport(format: string, reportQuery: ReportQuery): Observable<any> {
+  downloadReport(format: string, reportQuery: ReportQuery): Observable<ArrayBuffer> {
     const url = `${CC_API_URL}/reporting/export`;
 
     // for export, we want to send the start_time as the beg of day of end time

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -215,7 +215,7 @@ export class StatsService {
       map(({ reports, total }) => new ReportCollection(reports, total)));
   }
 
-  downloadReport(format: string, reportQuery: ReportQuery): Observable<string> {
+  downloadReport(format: string, reportQuery: ReportQuery): Observable<any> {
     const url = `${CC_API_URL}/reporting/export`;
 
     // for export, we want to send the start_time as the beg of day of end time
@@ -223,7 +223,7 @@ export class StatsService {
     reportQuery.startDate = moment.utc(reportQuery.endDate).startOf('day');
 
     const body = { type: format, filters: this.formatFilters(reportQuery) };
-    return this.httpClient.post(url, body, { responseType: 'text' });
+    return this.httpClient.post(url, body, { responseType: 'arraybuffer' });
   }
 
   downloadNodeReport(fileFormat: reportFormat, reportQuery: ReportQuery): Observable<string> {


### PR DESCRIPTION
issue: https://chefio.atlassian.net/browse/KINETICS-63
### :nut_and_bolt: Description: What code changed, and why?
As an automate user, the user should be able to download the compliance report in JSON/CSV format using the chrome browser
### :chains: Related Resources
https://github.com/chef/automate/issues/5727
### :+1: Definition of Done
I have added changes to the buffer format to download the report with the buffer type.
### :athletic_shoe: How to Build and Test the Change
```
go-to compliance page --> click to download icon --> download dialog will be open, we have 2 options for downloading the file (Download JSON and Download CSV ) click on any of one link.

if you don't have much data, add the sample data first using the below command

chef_load_compliance_scans -D1 -N5000 -M1 -T500
```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
