### PR TITLE
create json before services are up

### DIFF
--- a/components/automate-deployment/pkg/majorupgradechecklist/checklist_manager.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/checklist_manager.go
@@ -15,7 +15,7 @@ func NewChecklistManager(writer cli.FormatWriter, version string) (ChecklistMana
 	major, _ := GetMajorVersion(version)
 
 	switch major {
-	case "3":
+	case "3", "4", "5", "6", "7", "8":
 		return NewV3ChecklistManager(writer, version), nil
 	default:
 		return nil, status.Errorf(status.UpgradeError, "invalid major version")

--- a/components/automate-deployment/pkg/majorupgradechecklist/checklist_manager.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/checklist_manager.go
@@ -15,7 +15,7 @@ func NewChecklistManager(writer cli.FormatWriter, version string) (ChecklistMana
 	major, _ := GetMajorVersion(version)
 
 	switch major {
-	case "3", "4", "5", "6", "7", "8":
+	case "3":
 		return NewV3ChecklistManager(writer, version), nil
 	default:
 		return nil, status.Errorf(status.UpgradeError, "invalid major version")

--- a/components/automate-deployment/pkg/server/server.go
+++ b/components/automate-deployment/pkg/server/server.go
@@ -1411,14 +1411,7 @@ func (s *server) doConverge(
 		defer os.Setenv(isUpgradeMajorEnv, "false")
 
 		eDeploy.waitForConverge(task)
-		// TODO: We need some way to know that the hab supervisor has called
-		// the right hooks on each service before we check the status. Otherwise,
-		// we can run into cases where we check the status of the services
-		// before hab has applied all changes.
-		eDeploy.ensureStatus(context.Background(), s.deployment.NotSkippedServiceNames(), s.ensureStatusTimeout)
 
-		errHandler(eDeploy.err)
-		// json file
 		if os.Getenv(isUpgradeMajorEnv) == "true" {
 			var err error
 			ci, err := majorupgradechecklist.NewPostChecklistManager(s.deployment.CurrentReleaseManifest.Version())
@@ -1430,6 +1423,13 @@ func (s *server) doConverge(
 				errHandler(err)
 			}
 		}
+		// TODO: We need some way to know that the hab supervisor has called
+		// the right hooks on each service before we check the status. Otherwise,
+		// we can run into cases where we check the status of the services
+		// before hab has applied all changes.
+		eDeploy.ensureStatus(context.Background(), s.deployment.NotSkippedServiceNames(), s.ensureStatusTimeout)
+
+		errHandler(eDeploy.err)
 	}()
 
 	return task, nil


### PR DESCRIPTION
Signed-off-by: shaik80 <sh.mudassir98@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?

when you are upgrading automate, the upgrade_metadata.json file should create before services are up
### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
