### PR TITLE
Kinetics 62 enable strict transport security header for all the service endpoints

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -249,6 +249,7 @@ paths = [
   "lib/cereal/*",
   "lib/config/*",
   "lib/grpc/*",
+  "lib/httputils/*",
   "lib/io/*",
   "lib/license/*",
   "lib/platform/command/*",

--- a/components/automate-dex/habitat/plan.sh
+++ b/components/automate-dex/habitat/plan.sh
@@ -39,7 +39,7 @@ do_before() {
 do_unpack() {
   git clone "https://github.com/chef/dex-1" "$GOPATH/src/github.com/chef/dex-1"
   ( cd "$GOPATH/src/github.com/chef/dex-1" || exit
-    git checkout add_hsts_header
+    git checkout add_request_validators
   )
 }
 

--- a/components/automate-dex/habitat/plan.sh
+++ b/components/automate-dex/habitat/plan.sh
@@ -39,7 +39,7 @@ do_before() {
 do_unpack() {
   git clone "https://github.com/chef/dex-1" "$GOPATH/src/github.com/chef/dex-1"
   ( cd "$GOPATH/src/github.com/chef/dex-1" || exit
-    git checkout add_request_validators
+    git checkout add_hsts_header
   )
 }
 

--- a/components/automate-gateway/gateway/server.go
+++ b/components/automate-gateway/gateway/server.go
@@ -480,7 +480,7 @@ func (s *Server) startHTTPServer() error {
 	uri := fmt.Sprintf("%s:%d", s.Config.Hostname, s.Config.Port)
 	s.httpServer = &http.Server{
 		Addr:    uri,
-		Handler: httputils.Handler(mux),
+		Handler: httputils.HSTSHandler(mux),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{*s.serviceKeyPair},
 			NextProtos:   []string{"h2"},

--- a/components/automate-gateway/gateway/server.go
+++ b/components/automate-gateway/gateway/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chef/automate/components/automate-gateway/pkg/nullbackend"
 	"github.com/chef/automate/lib/grpc/debug/debug_api"
 	"github.com/chef/automate/lib/grpc/secureconn"
+	"github.com/chef/automate/lib/httputils"
 	"github.com/chef/automate/lib/tracing"
 )
 
@@ -479,7 +480,7 @@ func (s *Server) startHTTPServer() error {
 	uri := fmt.Sprintf("%s:%d", s.Config.Hostname, s.Config.Port)
 	s.httpServer = &http.Server{
 		Addr:    uri,
-		Handler: mux,
+		Handler: httputils.Handler(mux),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{*s.serviceKeyPair},
 			NextProtos:   []string{"h2"},

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -231,7 +231,6 @@ http {
       proxy_pass https://automate-gateway;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -244,7 +243,6 @@ http {
       proxy_pass https://automate-gateway;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -258,7 +256,6 @@ http {
       proxy_pass https://automate-gateway/api/v0/events/data-collector;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -271,7 +268,6 @@ http {
       proxy_pass https://automate-gateway/api/v0/compliance/profiles/; # TODO does this append? Is this tested?
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -288,7 +284,6 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       add_header x-xss-protection "1; mode=block" always;
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
       add_header Content-Security-Policy "default-src 'self';frame-ancestors 'self';";
@@ -301,7 +296,6 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       add_header x-xss-protection "1; mode=block" always;
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
       add_header Content-Security-Policy "default-src 'self';frame-ancestors 'self';";
       {{/if ~}}
@@ -317,7 +311,6 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "private"; # allow caching, but no sharing of cached data
       add_header x-xss-protection "1; mode=block" always;
-      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
     }
 

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -288,7 +288,7 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       add_header x-xss-protection "1; mode=block" always;
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
       add_header Content-Security-Policy "default-src 'self';frame-ancestors 'self';";

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -231,7 +231,7 @@ http {
       proxy_pass https://automate-gateway;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -244,7 +244,7 @@ http {
       proxy_pass https://automate-gateway;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -258,7 +258,7 @@ http {
       proxy_pass https://automate-gateway/api/v0/events/data-collector;
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -271,7 +271,7 @@ http {
       proxy_pass https://automate-gateway/api/v0/compliance/profiles/; # TODO does this append? Is this tested?
       # Required to make persistent connections happen
       proxy_set_header Connection "";
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header x-xss-protection "1; mode=block" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
@@ -301,7 +301,7 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       add_header x-xss-protection "1; mode=block" always;
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       {{#if ../cfg.ngx.http.enable_csp_header ~}}
       add_header Content-Security-Policy "default-src 'self';frame-ancestors 'self';";
       {{/if ~}}
@@ -317,7 +317,7 @@ http {
       add_header X-Frame-Options sameorigin; # forbid other <iframe>ing
       add_header Cache-Control "private"; # allow caching, but no sharing of cached data
       add_header x-xss-protection "1; mode=block" always;
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+      #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
     }
 

--- a/components/automate-ui/habitat/config/nginx.conf
+++ b/components/automate-ui/habitat/config/nginx.conf
@@ -65,6 +65,7 @@ http {
     root {{pkg.path}}/dist;
     location / {
       try_files $uri $uri/ /;
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     }
   }
 }

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -206,7 +206,7 @@ func (s *Server) initHandlers() {
 	r := mux.NewRouter()
 
 	//Middleware intercepter for HSTS
-	r.Use(httputils.AddHSTSHeader)
+	r.Use(httputils.HSTSMiddleware)
 
 	r.HandleFunc("/health", s.healthHandler).Methods("GET")
 	r.HandleFunc("/new", s.newHandler).Methods("GET")

--- a/components/session-service/server/server.go
+++ b/components/session-service/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/chef/automate/components/session-service/oidc"
 	"github.com/chef/automate/lib/db"
 	"github.com/chef/automate/lib/grpc/secureconn"
+	"github.com/chef/automate/lib/httputils"
 	"github.com/chef/automate/lib/logger"
 	util "github.com/chef/automate/lib/oidc"
 	"github.com/chef/automate/lib/tls/certs"
@@ -203,6 +204,10 @@ func initStore(pgDB *sql.DB) (scs.Store, error) {
 
 func (s *Server) initHandlers() {
 	r := mux.NewRouter()
+
+	//Middleware intercepter for HSTS
+	r.Use(httputils.AddHSTSHeader)
+
 	r.HandleFunc("/health", s.healthHandler).Methods("GET")
 	r.HandleFunc("/new", s.newHandler).Methods("GET")
 	r.HandleFunc("/refresh", s.refreshHandler).

--- a/lib/httputils/hsts.go
+++ b/lib/httputils/hsts.go
@@ -64,7 +64,7 @@ func HSTSHandler(next http.Handler) *HSTS {
 }
 
 //Add HSTS response header for https calls and redirect if call is over http
-func (h *HSTS) AddHSTSHeaderAndRedirect(w http.ResponseWriter, r *http.Request) {
+func (h *HSTS) addHSTSHeaderAndRedirect(w http.ResponseWriter, r *http.Request) {
 	if isHTTPS(r, h.AcceptXForwardedProtoHeader) {
 		w.Header().Add("Strict-Transport-Security", createHeaderValue(h.MaxAge, h.SendPreloadDirective))
 
@@ -83,13 +83,13 @@ func (h *HSTS) AddHSTSHeaderAndRedirect(w http.ResponseWriter, r *http.Request) 
 }
 
 //Only add HSTS response header for https calls and doesn't redirect if call is over http
-func (h *HSTS) AddHSTSHeader(w http.ResponseWriter, r *http.Request) {
+func (h *HSTS) addHSTSHeader(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Strict-Transport-Security", createHeaderValue(h.MaxAge, h.SendPreloadDirective))
 	h.next.ServeHTTP(w, r)
 }
 
 func (h *HSTS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.AddHSTSHeader(w, r)
+	h.addHSTSHeader(w, r)
 }
 
 //HSTS middleware

--- a/lib/httputils/hsts.go
+++ b/lib/httputils/hsts.go
@@ -1,0 +1,88 @@
+package httputils
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type HSTSHandler struct {
+	// MaxAge sets the duration that the HSTS is valid for.
+	MaxAge time.Duration
+	// HostOverride provides a host to the redirection URL in the case that the system is behind a load balancer
+	// which doesn't provide the X-Forwarded-Host HTTP header (e.g. an Amazon ELB).
+	HostOverride string
+	// Decides whether to accept the X-Forwarded-Proto header as proof of SSL.
+	AcceptXForwardedProtoHeader bool
+	// SendPreloadDirective sets whether the preload directive should be set. The directive allows browsers to
+	// confirm that the site should be added to a preload list. (see https://hstspreload.appspot.com/)
+	SendPreloadDirective bool
+}
+
+func isHTTPS(r *http.Request, acceptXForwardedProtoHeader bool) bool {
+	// Added by common load balancers which do TLS offloading.
+	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "https" {
+		return true
+	}
+	// If the X-Forwarded-Proto was set upstream as HTTP, then the request came in without TLS.
+	if acceptXForwardedProtoHeader && r.Header.Get("X-Forwarded-Proto") == "http" {
+		return false
+	}
+	// Set by some middleware.
+	if r.URL.Scheme == "https" {
+		return true
+	}
+	// Set when the Go server is running HTTPS itself.
+	if r.TLS != nil && r.TLS.HandshakeComplete {
+		return true
+	}
+	return false
+}
+
+func createHeaderValue(maxAge time.Duration, sendPreloadDirective bool) string {
+	builder := strings.Builder{}
+	builder.WriteString("max-age=")
+	builder.WriteString(strconv.Itoa(int(maxAge.Seconds())))
+	builder.WriteString("; includeSubDomains")
+	if sendPreloadDirective {
+		builder.WriteString("; preload")
+	}
+	return builder.String()
+}
+
+func initHandler() *HSTSHandler {
+	return &HSTSHandler{
+		MaxAge:                      time.Hour * 24 * 730, //2 years; ie. 730 days; ie. 63072000 seconds
+		AcceptXForwardedProtoHeader: true,
+		SendPreloadDirective:        false,
+	}
+}
+
+//Add HSTS response header for https calls and redirect if call is over http
+func AddHSTSHeaderAndRedirect(next http.Handler) http.Handler {
+	h := initHandler()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isHTTPS(r, h.AcceptXForwardedProtoHeader) {
+			w.Header().Add("Strict-Transport-Security", createHeaderValue(h.MaxAge, h.SendPreloadDirective))
+			next.ServeHTTP(w, r)
+		} else {
+			if h.HostOverride != "" {
+				r.URL.Host = h.HostOverride
+			} else if !r.URL.IsAbs() {
+				r.URL.Host = r.Host
+			}
+			r.URL.Scheme = "https"
+			http.Redirect(w, r, r.URL.String(), http.StatusMovedPermanently)
+		}
+	})
+}
+
+//Only add HSTS response header for https calls and doesn't redirect if call is over http
+func AddHSTSHeader(next http.Handler) http.Handler {
+	h := initHandler()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Strict-Transport-Security", createHeaderValue(h.MaxAge, h.SendPreloadDirective))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/lib/httputils/hsts.go
+++ b/lib/httputils/hsts.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+//Add HSTS header to response
+//See: https://github.com/chef/automate/issues/5698
 type HSTS struct {
 	next http.Handler
 	// MaxAge sets the duration that the HSTS is valid for.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Added HSTS response headers in some services listed by customer. These services are:

- 2000 automate-gateway
- 10115 session-service
- 10161 automate-ui (nginx: master)

- 10117 dex (related PR: https://github.com/chef/dex-1/pull/45)

- ~~10143 backup-gateway (minio)~~

Note: Fix for MinIO service is dependent on upcoming refresh of [core/minio](https://github.com/chef-base-plans/minio) package which is planned for the current quarter (Refer to PR: https://github.com/chef-base-plans/minio/pull/5 and https://github.com/minio/minio/pull/12256).

Also removed HSTS from load balancer for above services due to duplicate HSTS headers.

### :chains: Related Resources
Related issue: https://github.com/chef/automate/issues/5698
Customer bug: https://github.com/chef/customer-bugs/issues/471

### :+1: Definition of Done
All above 4 services running on ports (10115, 2000, 10161, 10117) should have HSTS ie. Strict-Transport-Security response header.

### :athletic_shoe: How to Build and Test the Change
Rebuild the required components ie. session-service, automate-gateway, automate-ui and automate-load-balancer.
Testing can be done via UI or doing curl request inside hab studio. Ex:

- curl -X GET -i https://localhost:10115/health --insecure
- curl -X GET -i https://localhost:2000/api/v0/gateway/health --insecure
- curl -X GET -i https://localhost:10161/ --insecure
- curl -X GET -i https://localhost:10117/dex/healthz --insecure

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
