### PR TITLE
Akrishna/ec2 vagrantfile fix

### DIFF
--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -254,6 +254,7 @@ EC2HOSTNAME=`curl -Ss http://169.254.169.254/latest/meta-data/public-hostname`
 sed -i "s/fqdn = .*/fqdn = '$EC2HOSTNAME'/" dev/config.toml
 sed -i "s/heapsize = .*/heapsize = '#{ENV['ES_HEAP_SIZE']}g'/" dev/config.toml
 echo "#{automate_license}" > dev/license.jwt
+chown -R ubuntu:ubuntu /home/ubuntu/automate
 SCRIPT
 
 $enter_hab_studio = <<SCRIPT

--- a/ec2/Vagrantfile
+++ b/ec2/Vagrantfile
@@ -77,7 +77,7 @@ def latest_build_from_versions(channel)
   puts " * Getting latest build from #{versions_url}"
   versions_json = JSON.parse(open(versions_url).read)
   build = versions_json.last
-  raise "Invalid build '#{build}' found for channel '#{channel}'" unless build =~ /^\d+$/
+  raise "Invalid build '#{build}' found for channel '#{channel}'" unless build =~ /^(\d+\.)?(\d+\.)?(\*|\d+)$/
   return build
 end
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Changed regex pattern in `ec2/Vagrantfile` to match build version of channels.
Also changed the owner of automate directory cloned on ec2 instance from `root` to `ubuntu`. Initially ubuntu user didn't had write permission in automate directory on newly created ec2 instance.

### :chains: Related Resources

### :+1: Definition of Done
One should able to create automate workspace in a new ec2 instance using Vagrant.

### :athletic_shoe: How to Build and Test the Change
Go to automate/ec2 and run "vagrant destroy -f; VERSION='dev' vagrant up; vagrant ssh" after following steps from README.md file.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
