### PR TITLE
Synced infra server deletion issue fix

### DIFF
--- a/components/infra-proxy-service/storage/postgres/migration/sql/06_user_management.up.sql
+++ b/components/infra-proxy-service/storage/postgres/migration/sql/06_user_management.up.sql
@@ -5,7 +5,7 @@ ALTER TABLE servers ADD COLUMN credential_id TEXT NOT NULL DEFAULT '';
 -- create table users
 CREATE TABLE IF NOT EXISTS users (
   id                        SERIAL PRIMARY KEY,
-  server_id                 TEXT NOT NULL references servers(id) ON DELETE RESTRICT,
+  server_id                 TEXT NOT NULL references servers(id) ON DELETE CASCADE,
   infra_server_username     TEXT NOT NULL DEFAULT '',
   connector                 TEXT NOT NULL DEFAULT 'local',
   automate_user_id          TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
Signed-off-by: sonali wale <sonali.wale@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Fixes for the synced infra server deletion issue.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-96
### :+1: Definition of Done
I have added the script changes in the users table for infra server deletion issue.
### :athletic_shoe: How to Build and Test the Change
```rebuild components/infra-proxy-service/```
After deleting all the orgs from server, the server should be deleted.
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
