### PR TITLE
Add backup config with deployment for AWS

### DIFF
--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -148,10 +148,6 @@
   # base_path (optional):  The path within the bucket where backups should be stored
   # If base_path is not set, backups will be stored at the root of the bucket.
   base_path = "automate"
-
-[global.v1.backups.s3.credentials]
-  # access_key = ""
-  # secret_key = ""
 <% end %>
 
 <% if overrides[:backup_config_efs] == "true" -%>

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -95,6 +95,67 @@
   port = <%= overrides[:teams_port] %>
 <% end %>
 
+<% if overrides[:backup_config_s3] == "true" -%>
+[global.v1.external.elasticsearch.backup]
+    enable = true
+    location = "s3>"
+
+[global.v1.external.elasticsearch.backup.s3]
+
+    # bucket (required): The name of the bucket
+  bucket = "<%= overrides[:bucket_name] %>"
+
+  # base_path (optional):  The path within the bucket where backups should be stored
+  # If base_path is not set, backups will be stored at the root of the bucket.
+  base_path = "elasticsearch"
+
+  # name of an s3 client configuration you create in your elasticsearch.yml
+  # see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
+  # for full documentation on how to configure client settings on your
+  # Elasticsearch nodes
+  client = "default"
+
+[global.v1.external.elasticsearch.backup.s3.settings]
+  ## The meaning of these settings is documented in the S3 Repository Plugin
+  ## documentation. See the following links:
+  ## https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
+
+  ## Backup repo settings
+  # compress = false
+  # server_side_encryption = false
+  # buffer_size = "100mb"
+  # canned_acl = "private"
+  # storage_class = "standard"
+  ## Snapshot settings
+  # max_snapshot_bytes_per_sec = "40mb"
+  # max_restore_bytes_per_sec = "40mb"
+  # chunk_size = "null"
+  ## S3 client settings
+  # read_timeout = "50s"
+  # max_retries = 3
+  # use_throttle_retries = true
+  # protocol = "https"
+[global.v1.backups]
+  location = "s3"
+[global.v1.backups.s3.bucket]
+  # name (required): The name of the bucket
+  name = "<%= overrides[:bucket_name] %>"
+
+  # endpoint (required): The endpoint for the region the bucket lives in.
+  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+  endpoint = "<%= overrides[:s3_endpoint] %>"
+
+  # base_path (optional):  The path within the bucket where backups should be stored
+  # If base_path is not set, backups will be stored at the root of the bucket.
+  base_path = "automate"
+
+[global.v1.backups.s3.credentials]
+  # access_key = ""
+  # secret_key = ""
+<% elseif overrides[:backup_config_efs] == "true" -%>
+  # dns = "<%= overrides[:dns] %>" 
+<% end %>
+
 <% if overrides[:automate_config_file] %>
 <%= File.read(overrides[:automate_config_file]) %>
 <% end %>

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -48,14 +48,14 @@
 
 <% if overrides[:automate_role] == "chef_api" -%>
   [global.v1.external.automate]
-  enable = true
-  node = "https://<%= overrides[:automate_fqdn] %>"
+    enable = true
+    node = "https://<%= overrides[:automate_fqdn] %>"
 
   [global.v1.external.automate.auth]
-  token = "<%= overrides[:automate_dc_token] %>"
+    token = "<%= overrides[:automate_dc_token] %>"
 <% else %>
-[auth_n.v1.sys.service]
-  a1_data_collector_token = "<%= overrides[:automate_dc_token] %>"
+  [auth_n.v1.sys.service]
+    a1_data_collector_token = "<%= overrides[:automate_dc_token] %>"
 <% end %>
 
 # Deployment service configuration.
@@ -96,75 +96,76 @@
 <% end %>
 
 <% if overrides[:backup_config_s3] == "true" -%>
-[global.v1.external.elasticsearch.backup]
+  [global.v1.external.elasticsearch.backup]
     enable = true
-    location = "s3>"
+    location = "s3"
 
-[global.v1.external.elasticsearch.backup.s3]
+  [global.v1.external.elasticsearch.backup.s3]
 
     # bucket (required): The name of the bucket
-  bucket = "<%= overrides[:bucket_name] %>"
+    bucket = "<%= overrides[:bucket_name] %>"
 
-  # base_path (optional):  The path within the bucket where backups should be stored
-  # If base_path is not set, backups will be stored at the root of the bucket.
-  base_path = "elasticsearch"
+    # base_path (optional):  The path within the bucket where backups should be stored
+    # If base_path is not set, backups will be stored at the root of the bucket.
+    base_path = "elasticsearch"
 
-  # name of an s3 client configuration you create in your elasticsearch.yml
-  # see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
-  # for full documentation on how to configure client settings on your
-  # Elasticsearch nodes
-  client = "default"
+    # name of an s3 client configuration you create in your elasticsearch.yml
+    # see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
+    # for full documentation on how to configure client settings on your
+    # Elasticsearch nodes
+    client = "default"
 
-[global.v1.external.elasticsearch.backup.s3.settings]
-  ## The meaning of these settings is documented in the S3 Repository Plugin
-  ## documentation. See the following links:
-  ## https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
+  [global.v1.external.elasticsearch.backup.s3.settings]
+    ## The meaning of these settings is documented in the S3 Repository Plugin
+    ## documentation. See the following links:
+    ## https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
 
-  ## Backup repo settings
-  # compress = false
-  # server_side_encryption = false
-  # buffer_size = "100mb"
-  # canned_acl = "private"
-  # storage_class = "standard"
-  ## Snapshot settings
-  # max_snapshot_bytes_per_sec = "40mb"
-  # max_restore_bytes_per_sec = "40mb"
-  # chunk_size = "null"
-  ## S3 client settings
-  # read_timeout = "50s"
-  # max_retries = 3
-  # use_throttle_retries = true
-  # protocol = "https"
-[global.v1.backups]
-  location = "s3"
-[global.v1.backups.s3.bucket]
-  # name (required): The name of the bucket
-  name = "<%= overrides[:bucket_name] %>"
+    ## Backup repo settings
+    # compress = false
+    # server_side_encryption = false
+    # buffer_size = "100mb"
+    # canned_acl = "private"
+    # storage_class = "standard"
+    ## Snapshot settings
+    # max_snapshot_bytes_per_sec = "40mb"
+    # max_restore_bytes_per_sec = "40mb"
+    # chunk_size = "null"
+    ## S3 client settings
+    # read_timeout = "50s"
+    # max_retries = 3
+    # use_throttle_retries = true
+    # protocol = "https"
+  [global.v1.backups]
+    location = "s3"
+  [global.v1.backups.s3.bucket]
+    # name (required): The name of the bucket
+    name = "<%= overrides[:bucket_name] %>"
 
-  # endpoint (required): The endpoint for the region the bucket lives in.
-  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-  endpoint = "<%= overrides[:s3_endpoint] %>"
+    # endpoint (required): The endpoint for the region the bucket lives in.
+    # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+    endpoint = "<%= overrides[:s3_endpoint] %>"
 
-  # base_path (optional):  The path within the bucket where backups should be stored
-  # If base_path is not set, backups will be stored at the root of the bucket.
-  base_path = "automate"
+    # base_path (optional):  The path within the bucket where backups should be stored
+    # If base_path is not set, backups will be stored at the root of the bucket.
+    base_path = "automate"
 
-[global.v1.backups.s3.credentials]
-  # access_key = ""
-  # secret_key = ""
-<% elseif overrides[:backup_config_efs] == "true" -%>
-  # dns = "<%= overrides[:dns] %>" 
+  [global.v1.backups.s3.credentials]
+    # access_key = ""
+    # secret_key = ""
+<% end %>
+
+<% if overrides[:backup_config_efs] == "true" -%>
   [global.v1.external.elasticsearch.backup]
-  enable = true
-  location = "fs"
+    enable = true
+    location = "fs"
 
   [global.v1.external.elasticsearch.backup.fs]
-  # The `path.repo` setting you've configured on your Elasticsearch nodes must be
-  # a parent directory of the setting you configure here:
-  path = "/mnt/automate_backups/elasticsearch"
+    # The `path.repo` setting you've configured on your Elasticsearch nodes must be
+    # a parent directory of the setting you configure here:
+    path = "/mnt/automate_backups/elasticsearch"
 
   [global.v1.backups.filesystem]
-  path = "/mnt/automate_backups/backups"
+    path = "/mnt/automate_backups/backups"
 <% end %>
 
 <% if overrides[:automate_config_file] %>

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -154,6 +154,17 @@
   # secret_key = ""
 <% elseif overrides[:backup_config_efs] == "true" -%>
   # dns = "<%= overrides[:dns] %>" 
+  [global.v1.external.elasticsearch.backup]
+  enable = true
+  location = "fs"
+
+  [global.v1.external.elasticsearch.backup.fs]
+  # The `path.repo` setting you've configured on your Elasticsearch nodes must be
+  # a parent directory of the setting you configure here:
+  path = "/mnt/automate_backups/elasticsearch"
+
+  [global.v1.backups.filesystem]
+  path = "/mnt/automate_backups/backups"
 <% end %>
 
 <% if overrides[:automate_config_file] %>

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -96,76 +96,76 @@
 <% end %>
 
 <% if overrides[:backup_config_s3] == "true" -%>
-  [global.v1.external.elasticsearch.backup]
-    enable = true
-    location = "s3"
+[global.v1.external.elasticsearch.backup]
+  enable = true
+  location = "s3"
 
-  [global.v1.external.elasticsearch.backup.s3]
+[global.v1.external.elasticsearch.backup.s3]
 
-    # bucket (required): The name of the bucket
-    bucket = "<%= overrides[:bucket_name] %>"
+  # bucket (required): The name of the bucket
+  bucket = "<%= overrides[:bucket_name] %>"
 
-    # base_path (optional):  The path within the bucket where backups should be stored
-    # If base_path is not set, backups will be stored at the root of the bucket.
-    base_path = "elasticsearch"
+  # base_path (optional):  The path within the bucket where backups should be stored
+  # If base_path is not set, backups will be stored at the root of the bucket.
+  base_path = "elasticsearch"
 
-    # name of an s3 client configuration you create in your elasticsearch.yml
-    # see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
-    # for full documentation on how to configure client settings on your
-    # Elasticsearch nodes
-    client = "default"
+  # name of an s3 client configuration you create in your elasticsearch.yml
+  # see https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
+  # for full documentation on how to configure client settings on your
+  # Elasticsearch nodes
+  client = "default"
 
-  [global.v1.external.elasticsearch.backup.s3.settings]
-    ## The meaning of these settings is documented in the S3 Repository Plugin
-    ## documentation. See the following links:
-    ## https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
+[global.v1.external.elasticsearch.backup.s3.settings]
+  ## The meaning of these settings is documented in the S3 Repository Plugin
+  ## documentation. See the following links:
+  ## https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
 
-    ## Backup repo settings
-    # compress = false
-    # server_side_encryption = false
-    # buffer_size = "100mb"
-    # canned_acl = "private"
-    # storage_class = "standard"
-    ## Snapshot settings
-    # max_snapshot_bytes_per_sec = "40mb"
-    # max_restore_bytes_per_sec = "40mb"
-    # chunk_size = "null"
-    ## S3 client settings
-    # read_timeout = "50s"
-    # max_retries = 3
-    # use_throttle_retries = true
-    # protocol = "https"
-  [global.v1.backups]
-    location = "s3"
-  [global.v1.backups.s3.bucket]
-    # name (required): The name of the bucket
-    name = "<%= overrides[:bucket_name] %>"
+  ## Backup repo settings
+  # compress = false
+  # server_side_encryption = false
+  # buffer_size = "100mb"
+  # canned_acl = "private"
+  # storage_class = "standard"
+  ## Snapshot settings
+  # max_snapshot_bytes_per_sec = "40mb"
+  # max_restore_bytes_per_sec = "40mb"
+  # chunk_size = "null"
+  ## S3 client settings
+  # read_timeout = "50s"
+  # max_retries = 3
+  # use_throttle_retries = true
+  # protocol = "https"
+[global.v1.backups]
+  location = "s3"
+[global.v1.backups.s3.bucket]
+  # name (required): The name of the bucket
+  name = "<%= overrides[:bucket_name] %>"
 
-    # endpoint (required): The endpoint for the region the bucket lives in.
-    # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-    endpoint = "<%= overrides[:s3_endpoint] %>"
+  # endpoint (required): The endpoint for the region the bucket lives in.
+  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+  endpoint = "<%= overrides[:s3_endpoint] %>"
 
-    # base_path (optional):  The path within the bucket where backups should be stored
-    # If base_path is not set, backups will be stored at the root of the bucket.
-    base_path = "automate"
+  # base_path (optional):  The path within the bucket where backups should be stored
+  # If base_path is not set, backups will be stored at the root of the bucket.
+  base_path = "automate"
 
-  [global.v1.backups.s3.credentials]
-    # access_key = ""
-    # secret_key = ""
+[global.v1.backups.s3.credentials]
+  # access_key = ""
+  # secret_key = ""
 <% end %>
 
 <% if overrides[:backup_config_efs] == "true" -%>
-  [global.v1.external.elasticsearch.backup]
-    enable = true
-    location = "fs"
+[global.v1.external.elasticsearch.backup]
+  enable = true
+  location = "fs"
 
-  [global.v1.external.elasticsearch.backup.fs]
-    # The `path.repo` setting you've configured on your Elasticsearch nodes must be
-    # a parent directory of the setting you configure here:
-    path = "/mnt/automate_backups/elasticsearch"
+[global.v1.external.elasticsearch.backup.fs]
+  # The `path.repo` setting you've configured on your Elasticsearch nodes must be
+  # a parent directory of the setting you configure here:
+  path = "/mnt/automate_backups/elasticsearch"
 
-  [global.v1.backups.filesystem]
-    path = "/mnt/automate_backups/backups"
+[global.v1.backups.filesystem]
+  path = "/mnt/automate_backups/backups"
 <% end %>
 
 <% if overrides[:automate_config_file] %>

--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -140,3 +140,19 @@ variable "teams_port" {
 variable "tmp_path" {
   default = "/var/tmp"
 }
+variable "backup_config_s3" {
+  default = "false"
+}
+
+variable "backup_config_efs" {
+  default = "false"
+}
+
+
+variable "s3_endpoint" {
+  default = "https://s3.amazonaws.com"
+}
+
+variable "bucket_name" {
+}
+

--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -38,6 +38,18 @@ variable "backend_aib_dest_file" {
 variable "backend_aib_local_file" {
 }
 
+variable "backup_config_efs" {
+  default = "false"
+}
+
+variable "backup_config_s3" {
+  default = "false"
+}
+
+variable "bucket_name" {
+  default = "chef-automate-ha"
+}
+
 variable "cluster_id" {
   default = ""
 }
@@ -120,6 +132,10 @@ variable "public_ips" {
   default = []
 }
 
+variable "s3_endpoint" {
+  default = "https://s3.amazonaws.com"
+}
+
 variable "ssh_key_file" {
 }
 
@@ -140,20 +156,3 @@ variable "teams_port" {
 variable "tmp_path" {
   default = "/var/tmp"
 }
-variable "backup_config_s3" {
-  default = "false"
-}
-
-variable "backup_config_efs" {
-  default = "false"
-}
-
-
-variable "s3_endpoint" {
-  default = "https://s3.amazonaws.com"
-}
-
-variable "bucket_name" {
-  default = "chef-automate-ha"
-}
-

--- a/terraform/a2ha-terraform/modules/automate/inputs.tf
+++ b/terraform/a2ha-terraform/modules/automate/inputs.tf
@@ -154,5 +154,6 @@ variable "s3_endpoint" {
 }
 
 variable "bucket_name" {
+  default = "chef-automate-ha"
 }
 

--- a/terraform/a2ha-terraform/modules/automate/main.tf
+++ b/terraform/a2ha-terraform/modules/automate/main.tf
@@ -38,16 +38,6 @@ locals {
 # the file resource is nice and will wait until the file appears
 resource "null_resource" "automate_pre" {
 
-  provisioner "remote-exec" {
-    inline = [ 
-      "echo 'automate_role: ' ${var.automate_role}\n/n", 
-      "echo 'tmp_path: ' ${var.tmp_path}\n/n", 
-      "echo 'backup_config_s3: ' ${var.backup_config_s3}\n/n",
-      "echo 'backup_config_efs: ' ${var.backup_config_efs}\n/n",
-      "echo 's3_endpoint: ' ${var.s3_endpoint}\n/n",
-      "echo 'bucket_name: ' ${var.bucket_name}\n/n"
-      ]
-  }
 
   count = var.automate_role != "bootstrap_automate" ? var.automate_instance_count : 0
 

--- a/terraform/a2ha-terraform/modules/automate/main.tf
+++ b/terraform/a2ha-terraform/modules/automate/main.tf
@@ -16,6 +16,10 @@ locals {
     proxy_listen_port         = var.proxy_listen_port,
     teams_port                = var.teams_port,
     tmp_path                  = var.tmp_path,
+    backup_config_s3          = var.backup_config_s3
+    backup_config_efs         = var.backup_config_efs
+    s3_endpoint               = var.s3_endpoint
+    bucket_name               = var.bucket_name
   })
 
   provision = templatefile("${path.module}/templates/provision.sh.tpl", {
@@ -33,6 +37,19 @@ locals {
 # special conditional resource if the server is a non-bootstrap
 # the file resource is nice and will wait until the file appears
 resource "null_resource" "automate_pre" {
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo 'Arvinth test'\n", 
+      "echo ${var.automate_role}\n/n", 
+      "echo ${var.tmp_path}\n/n", 
+      "echo ${var.backup_config_s3}\n/n",
+      "echo ${var.backup_config_efs}\n/n",
+      "echo ${var.s3_endpoint}\n/n",
+      "echo ${var.bucket_name}\n/n"
+      ]
+  }
+
   count = var.automate_role != "bootstrap_automate" ? var.automate_instance_count : 0
 
   connection {

--- a/terraform/a2ha-terraform/modules/automate/main.tf
+++ b/terraform/a2ha-terraform/modules/automate/main.tf
@@ -39,14 +39,13 @@ locals {
 resource "null_resource" "automate_pre" {
 
   provisioner "remote-exec" {
-    inline = [
-      "echo 'Arvinth test'\n", 
-      "echo ${var.automate_role}\n/n", 
-      "echo ${var.tmp_path}\n/n", 
-      "echo ${var.backup_config_s3}\n/n",
-      "echo ${var.backup_config_efs}\n/n",
-      "echo ${var.s3_endpoint}\n/n",
-      "echo ${var.bucket_name}\n/n"
+    inline = [ 
+      "echo 'automate_role: ' ${var.automate_role}\n/n", 
+      "echo 'tmp_path: ' ${var.tmp_path}\n/n", 
+      "echo 'backup_config_s3: ' ${var.backup_config_s3}\n/n",
+      "echo 'backup_config_efs: ' ${var.backup_config_efs}\n/n",
+      "echo 's3_endpoint: ' ${var.s3_endpoint}\n/n",
+      "echo 'bucket_name: ' ${var.bucket_name}\n/n"
       ]
   }
 

--- a/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
@@ -9,8 +9,8 @@
   channel = "current"
   upgrade_strategy = "none"
   teams_port = ${teams_port}
-  backup_config_s3 = ${backup_config_s3}
-  backup_config_efs = ${backup_config_efs}
+  backup_config_s3 = "${backup_config_s3}"
+  backup_config_efs = "${backup_config_efs}"
   bucket_name = "${bucket_name}"
   s3_endpoint = "${s3_endpoint}"
 

--- a/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
@@ -11,8 +11,8 @@
   teams_port = ${teams_port}
   backup_config_s3 = ${backup_config_s3}
   backup_config_efs = ${backup_config_efs}
-  bucket_name = ${bucket_name}
-  s3_endpoint = ${s3_endpoint}
+  bucket_name = "${bucket_name}"
+  s3_endpoint = "${s3_endpoint}"
 
 [services]
   [services.elasticsearch]

--- a/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/connector.toml.tpl
@@ -9,6 +9,10 @@
   channel = "current"
   upgrade_strategy = "none"
   teams_port = ${teams_port}
+  backup_config_s3 = ${backup_config_s3}
+  backup_config_efs = ${backup_config_efs}
+  bucket_name = ${bucket_name}
+  s3_endpoint = ${s3_endpoint}
 
 [services]
   [services.elasticsearch]

--- a/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
+++ b/terraform/a2ha-terraform/modules/elasticsearch/inputs.tf
@@ -7,6 +7,10 @@ variable "backend_aib_dest_file" {
 variable "backend_aib_local_file" {
 }
 
+variable "backup_config_efs" {
+  default = "false"
+}
+
 variable "curator_pkg_ident" {
 }
 

--- a/terraform/a2ha-terraform/modules/elasticsearch/main.tf
+++ b/terraform/a2ha-terraform/modules/elasticsearch/main.tf
@@ -132,3 +132,30 @@ resource "null_resource" "elasticsearch" {
     ]
   }
 }
+
+resource "null_resource" "backup_configuration" {
+  count = var.backup_config_efs == "true" ? 1 : 0
+
+  connection {
+    user        = var.ssh_user
+    private_key = file(var.ssh_key_file)
+    host        = var.private_ips[0]
+    script_path = "${var.tmp_path}/tf_inline_script_system_elasticsearch.sh"
+  }
+  
+  provisioner "file" {
+    destination = "${var.tmp_path}/efs_backup.sh"
+    source = "${path.module}/templates/efs_backup.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "chmod 0700 ${var.tmp_path}/efs_backup.sh",
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S ${var.tmp_path}/efs_backup.sh",
+    ]
+  }
+  
+  depends_on = [
+    null_resource.elasticsearch
+  ]
+}

--- a/terraform/a2ha-terraform/modules/elasticsearch/templates/efs_backup.sh
+++ b/terraform/a2ha-terraform/modules/elasticsearch/templates/efs_backup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source /hab/sup/default/SystemdEnvironmentFile.sh
+echo  " 
+[es_yaml.path]      
+  repo = /mnt/automate_backups/elasticsearch " > es_config.toml
+
+hab config apply automate-ha-elasticsearch.default es_config.toml

--- a/terraform/a2ha-terraform/modules/elasticsearch/templates/efs_backup.sh
+++ b/terraform/a2ha-terraform/modules/elasticsearch/templates/efs_backup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 source /hab/sup/default/SystemdEnvironmentFile.sh
-echo  " 
+echo  '
 [es_yaml.path]      
-  repo = /mnt/automate_backups/elasticsearch " > es_config.toml
+  repo = "/mnt/automate_backups/elasticsearch" ' > es_config.toml
 
-hab config apply automate-ha-elasticsearch.default es_config.toml
+hab config apply automate-ha-elasticsearch.default $(date '+%s') es_config.toml

--- a/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
@@ -231,6 +231,7 @@ module "elasticsearch" {
   ssh_user                     = var.ssh_user
   ssh_user_sudo_password       = local.be_sudo_password
   sudo_cmd                     = var.sudo_cmd
+  backup_config_efs            = var.backup_config_efs
 }
 
 module "postgresql" {

--- a/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
@@ -293,6 +293,10 @@ module "bootstrap_automate" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
+  backup_config_s3                = var.backup_config_s3
+  backup_config_efs               = var.backup_config_efs
+  s3_endpoint                     = var.s3_endpoint
+  bucket_name                       = var.bucket_name
 }
 
 module "automate" {
@@ -328,6 +332,10 @@ module "automate" {
   ssh_user_sudo_password = local.fe_sudo_password
   sudo_cmd               = var.sudo_cmd
   teams_port             = var.teams_port
+  backup_config_s3       = var.backup_config_s3
+  backup_config_efs      = var.backup_config_efs
+  s3_endpoint            = var.s3_endpoint
+  bucket_name            = var.bucket_name
 }
 
 module "chef_server" {
@@ -359,4 +367,8 @@ module "chef_server" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
+  backup_config_s3                = var.backup_config_s3
+  backup_config_efs               = var.backup_config_efs
+  s3_endpoint                     = var.s3_endpoint
+  bucket_name                       = var.bucket_name
 }

--- a/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
@@ -177,3 +177,19 @@ variable "ssh_user" {
 variable "sudo_cmd" {
   default = "sudo"
 }
+
+variable "backup_config_s3" {
+  default = "false"
+}
+
+variable "backup_config_efs" {
+  default = "false"
+}
+
+
+variable "s3_endpoint" {
+  default = "https://s3.amazonaws.com"
+}
+
+variable "bucket_name" {
+}

--- a/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
@@ -55,6 +55,17 @@ variable "aws_ssh_key_pair_name" {
 variable "aws_tags" {
 }
 
+variable "backup_config_efs" {
+  default = "false"
+}
+
+variable "backup_config_s3" {
+  default = "false"
+}
+
+variable "bucket_name" {
+}
+
 variable "chef_ebs_volume_iops" {
   default = 100
 }
@@ -163,6 +174,10 @@ variable "postgresql_server_instance_type" {
   default = "t3a.medium"
 }
 
+variable "s3_endpoint" {
+  default = "https://s3.amazonaws.com"
+}
+
 variable "setup_managed_services" {
   default = false
 }
@@ -176,20 +191,4 @@ variable "ssh_user" {
 
 variable "sudo_cmd" {
   default = "sudo"
-}
-
-variable "backup_config_s3" {
-  default = "false"
-}
-
-variable "backup_config_efs" {
-  default = "false"
-}
-
-
-variable "s3_endpoint" {
-  default = "https://s3.amazonaws.com"
-}
-
-variable "bucket_name" {
 }


### PR DESCRIPTION
Signed-off-by: Arvinth C <54614142+ArvinthC3000@users.noreply.github.com>

### Description: 

For Automate HA as a product, users want to configure automated backup with respect to the configuration in config.toml. 
When `backup_config` is set to `s3`, the s3 service will be mounted to the Elasticsearch node during deployment. Similarly when `backup_config` is set to `efs`, then efs will be mounted. This will be mounted during deployment itself and thus user no longer has to patch the backup config.

Note: 
- When s3 is selected for backup_config, `s3_bucketName` needs to be uncommented
- Value of `s3_bucketName` can be changed as the user desire. 
- After creation, s3_bucketName will also includes a random string for unique bucket name. (Eg: if `s3_bucketName = "chef-automate-ha"`, then bucket name could be `chef-automate-ha-8es***`)

**Observations:**
S3:
- On successful deployment, the s3 bucket has been created in AWS.
- On running `chef-automate backup create` in automate node, backup is created and stored in s3 (confirmed in AWS S3 console)

EFS:
- On successful deployment, efs is created and mounted in /mnt/automate-backup in all 3 ES nodes and automate node
- On running `chef-automate backup create` in the automate node, backup is created and stored. (Confirmation: New backup with timestamp is created in the mounted path)

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/MADROX-158

### :+1: Definition of Done
It's dev done and tested

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots
<img width="881" alt="Screenshot 2022-04-01 at 8 56 56 PM" src="https://user-images.githubusercontent.com/54614142/161294327-fbe83f25-6ba7-4a69-b969-bbc8bf129bc4.png">

