### PR TITLE
Align bundle name to its timestamp/build-version

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -271,13 +271,9 @@ func getFrontendBundleName(airgapPath string) string {
 	if strings.Contains(parts[0], "automate") {
 		parts[0] = strings.ReplaceAll(bundleName, "automate", "frontend")
 	}
-
 	versionExt := strings.Split(parts[1], ".")
-	//
-	// timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
-
-
 	version, err := getVersion(airgapPath)
+	fmt.Print("\n Version and err : ",version,  ",", err)
 	versionExt[0] = version
 	newVersionExt := strings.Join(versionExt, ".")
 	parts[1] = newVersionExt
@@ -520,23 +516,6 @@ func executeShellCommand(command string, args []string, workingDir string) error
 	err := c.Run()
 	writer.Printf("%s command execution done, exiting\n", command)
 	return err
-}
-
-func executeShellCommandAndGrepValue(command string, args []string, workingDir string) (string, error) {
-	writer.Printf("%s command execution started \n\n\n", command)
-	c := exec.Command(command, args...)
-	writer.Printf("%s :c output \n", c)
-	c.Stdin = os.Stdin
-	if len(workingDir) > 0 {
-		c.Dir = workingDir
-	}
-	c.Stdout = io.MultiWriter(os.Stdout)
-	c.Stderr = io.MultiWriter(os.Stderr)
-	out, err := c.Output()
-	writer.Printf("%s, %s :out, err \n", out, err)
-	writer.Printf("%s command execution done, exiting\n", command)
-	executeShellCommand("echo", []string{"timestamp: ", string(out)}, "")
-	return string(out), err
 }
 
 func extarctVersionAndRelease(filename string) (string, string) {

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -256,7 +256,7 @@ func getFrontendBundleName(airgapPath string) string {
 	if strings.Contains(bundleName, "automate") {
 		bundleName = strings.ReplaceAll(bundleName, "automate", "frontend")
 	}
-	timestamp, err := executeShellCommandAndGrepValue("chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
+	timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
 	if err != nil {
 		return bundleName
 	}
@@ -498,6 +498,7 @@ func executeShellCommand(command string, args []string, workingDir string) error
 func executeShellCommandAndGrepValue(command string, args []string, workingDir string) (string, error) {
 	writer.Printf("%s command execution started \n\n\n", command)
 	c := exec.Command(command, args...)
+	writer.Printf("%s :c output \n", c)
 	c.Stdin = os.Stdin
 	if len(workingDir) > 0 {
 		c.Dir = workingDir
@@ -505,6 +506,7 @@ func executeShellCommandAndGrepValue(command string, args []string, workingDir s
 	c.Stdout = io.MultiWriter(os.Stdout)
 	c.Stderr = io.MultiWriter(os.Stderr)
 	out, err := c.Output()
+	writer.Printf("%s, %s :out, err \n", out, err)
 	writer.Printf("%s command execution done, exiting\n", command)
 	executeShellCommand("echo", []string{"timestamp: ", string(out)}, "")
 	return string(out), err

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -281,7 +281,7 @@ func getFrontendBundleName(airgapPath string) string {
 		if err != nil {
 		return bundleName
 	}
-	executeShellCommand("echo", []string{version}, "")
+	executeShellCommand("echo", []string{bundleName + version}, "")
 	return bundleName + version
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -265,23 +265,11 @@ func moveAirgapBackendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetad
 	return nil
 }
 func getFrontendBundleName(airgapPath string) string {
-	var bundleName string = filepath.Base(airgapPath)
-	parts := strings.Split(bundleName, "-")
-	if strings.Contains(parts[0], "automate") {
-		parts[0] = strings.ReplaceAll(parts[0], "automate", "frontend")
-	}
-	versionExt := strings.Split(parts[1], ".")
 	version, err := getVersion(airgapPath)
-	versionExt[0] = version
-	newVersionExt := strings.Join(versionExt, ".")
-	parts[1] = newVersionExt
-	bundleName = strings.Join(parts, "-")
-	
 	if err != nil {
-		return bundleName
+		return "frontend"
 	}
-	// executeShellCommand("echo", []string{bundleName}, "")
-	return bundleName
+	return "frontend-"+ version
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
 	err := copyFileContents(airgapPath, (AIRGAP_HA_TRANS_DIR_PATH + bundleName))

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -256,7 +256,8 @@ func getFrontendBundleName(airgapPath string) string {
 	if strings.Contains(bundleName, "automate") {
 		bundleName = strings.ReplaceAll(bundleName, "automate", "frontend")
 	}
-	timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
+	// timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
+	timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath}, "")
 	if err != nil {
 		return bundleName
 	}

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -268,7 +268,7 @@ func getFrontendBundleName(airgapPath string) string {
 	var bundleName string = filepath.Base(airgapPath)
 	parts := strings.Split(bundleName, "-")
 	if strings.Contains(parts[0], "automate") {
-		parts[0] = strings.ReplaceAll(bundleName, "automate", "frontend")
+		parts[0] = strings.ReplaceAll(parts[0], "automate", "frontend")
 	}
 	versionExt := strings.Split(parts[1], ".")
 	version, err := getVersion(airgapPath)

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -209,8 +209,11 @@ we also need to have following files in /hab/a2_deploy_workspace/terraform dir
 */
 func moveFrontendBackendAirgapToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
 	if len(airgapBundle) > 0 {
-		bundleName := getFrontendBundleName(airgapBundle)
-		err := generateFrontendBundles(bundleName, airgapBundle)
+		bundleName, err := getFrontendBundleName(airgapBundle)
+		if err != nil {
+			return err
+		}
+		err = generateFrontendBundles(bundleName, airgapBundle)
 		if err != nil {
 			return err
 		}
@@ -228,8 +231,11 @@ func moveFrontendBackendAirgapToTransferDir(airgapMetadata airgap.UnpackMetadata
 }
 func moveAirgapFrontendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
 	if len(airgapBundle) > 0 {
-		bundleName := getFrontendBundleName(airgapBundle)
-		err := generateFrontendBundles(bundleName, airgapBundle)
+		bundleName, err := getFrontendBundleName(airgapBundle)
+		if err != nil {
+			return err
+		}
+		err = generateFrontendBundles(bundleName, airgapBundle)
 		if err != nil {
 			return err
 		}
@@ -251,8 +257,11 @@ func getVersion(airgapBundle string) (string, error) {
 
 func moveAirgapBackendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
 	if len(airgapBundle) > 0 {
-		bundleName := getFrontendBundleName(airgapBundle)
-		err := generateBackendBundles(bundleName, airgapBundle)
+		bundleName, err := getFrontendBundleName(airgapBundle)
+		if err != nil {
+			return err
+		}
+		err = generateBackendBundles(bundleName, airgapBundle)
 		if err != nil {
 			return err
 		}
@@ -264,12 +273,12 @@ func moveAirgapBackendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetad
 	}
 	return nil
 }
-func getFrontendBundleName(airgapPath string) string {
+func getFrontendBundleName(airgapPath string) (string, error) {
 	version, err := getVersion(airgapPath)
 	if err != nil {
-		return "frontend"
+		return "", err
 	}
-	return "frontend-" + version
+	return "frontend-" + version, nil
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
 	err := copyFileContents(airgapPath, (AIRGAP_HA_TRANS_DIR_PATH + bundleName))

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -267,22 +267,27 @@ func moveAirgapBackendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetad
 }
 func getFrontendBundleName(airgapPath string) string {
 	var bundleName string = filepath.Base(airgapPath)
-	if strings.Contains(bundleName, "automate") {
-		bundleName = strings.ReplaceAll(bundleName, "automate", "frontend")
+	parts := strings.Split(bundleName, "-")
+	if strings.Contains(parts[0], "automate") {
+		parts[0] = strings.ReplaceAll(bundleName, "automate", "frontend")
 	}
+
+	versionExt := strings.Split(parts[1], ".")
 	//
 	// timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
 
 
 	version, err := getVersion(airgapPath)
-	if err !=nil {
-		executeShellCommand("echo", []string{"Some error"}, "")
-	}
-		if err != nil {
+	versionExt[0] = version
+	newVersionExt := strings.Join(versionExt, ".")
+	parts[1] = newVersionExt
+	bundleName = strings.Join(parts, "-")
+	
+	if err != nil {
 		return bundleName
 	}
-	executeShellCommand("echo", []string{bundleName + version}, "")
-	return bundleName + version
+	executeShellCommand("echo", []string{bundleName}, "")
+	return bundleName
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
 	err := copyFileContents(airgapPath, (AIRGAP_HA_TRANS_DIR_PATH + bundleName))

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -275,16 +275,12 @@ func getFrontendBundleName(airgapPath string) string {
 	versionExt[0] = version
 	newVersionExt := strings.Join(versionExt, ".")
 	parts[1] = newVersionExt
-	fmt.Print("\n  ", versionExt[0])
-	fmt.Print("\n part[0] : ",parts[0])
-	fmt.Print("\n part[1] : ",parts[1])
 	bundleName = strings.Join(parts, "-")
-	fmt.Print("\n part : ",parts)
 	
 	if err != nil {
 		return bundleName
 	}
-	executeShellCommand("echo", []string{bundleName}, "")
+	// executeShellCommand("echo", []string{bundleName}, "")
 	return bundleName
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
@@ -507,7 +503,7 @@ func executeSecretsInitCommand(secretsKeyFilePath string) error {
 }
 
 func executeShellCommand(command string, args []string, workingDir string) error {
-	writer.Printf("%s command execution started \n\n\n", command)
+	writer.Printf("\n%s command execution started \n\n\n", command)
 	c := exec.Command(command, args...)
 	c.Stdin = os.Stdin
 	if len(workingDir) > 0 {

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -269,7 +269,7 @@ func getFrontendBundleName(airgapPath string) string {
 	if err != nil {
 		return "frontend"
 	}
-	return "frontend-"+ version
+	return "frontend-" + version
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
 	err := copyFileContents(airgapPath, (AIRGAP_HA_TRANS_DIR_PATH + bundleName))

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -228,11 +228,6 @@ func moveFrontendBackendAirgapToTransferDir(airgapMetadata airgap.UnpackMetadata
 	return nil
 }
 func moveAirgapFrontendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
-	version, err := getVersion(airgapBundle)
-	if err !=nil {
-		executeShellCommand("echo", []string{"Some error"}, "")
-	}
-	executeShellCommand("echo", []string{version}, "")
 	if len(airgapBundle) > 0 {
 		bundleName := getFrontendBundleName(airgapBundle)
 		err := generateFrontendBundles(bundleName, airgapBundle)
@@ -275,11 +270,19 @@ func getFrontendBundleName(airgapPath string) string {
 	if strings.Contains(bundleName, "automate") {
 		bundleName = strings.ReplaceAll(bundleName, "automate", "frontend")
 	}
-	timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
-	if err != nil {
+	//
+	// timestamp, err := executeShellCommandAndGrepValue("/usr/bin/chef-automate", []string{"airgap", "bundle", "info", airgapPath, "|", "grep", "-i", "version", "|", "awk", "'{print $2}'"}, "")
+
+
+	version, err := getVersion(airgapPath)
+	if err !=nil {
+		executeShellCommand("echo", []string{"Some error"}, "")
+	}
+		if err != nil {
 		return bundleName
 	}
-	return bundleName + timestamp
+	executeShellCommand("echo", []string{version}, "")
+	return bundleName + version
 }
 func generateFrontendBundles(bundleName string, airgapPath string) error {
 	err := copyFileContents(airgapPath, (AIRGAP_HA_TRANS_DIR_PATH + bundleName))

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -227,6 +227,7 @@ func moveFrontendBackendAirgapToTransferDir(airgapMetadata airgap.UnpackMetadata
 	return nil
 }
 func moveAirgapFrontendBundlesOnlyToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
+	executeShellCommand("echo", []string{airgapBundle}, "")
 	if len(airgapBundle) > 0 {
 		bundleName := getFrontendBundleName(airgapBundle)
 		err := generateFrontendBundles(bundleName, airgapBundle)

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -209,7 +209,6 @@ we also need to have following files in /hab/a2_deploy_workspace/terraform dir
 */
 func moveFrontendBackendAirgapToTransferDir(airgapMetadata airgap.UnpackMetadata, airgapBundle string) error {
 	if len(airgapBundle) > 0 {
-		writer.Printf("airgapBundle: %s", airgapBundle)
 		bundleName := getFrontendBundleName(airgapBundle)
 		err := generateFrontendBundles(bundleName, airgapBundle)
 		if err != nil {
@@ -273,11 +272,14 @@ func getFrontendBundleName(airgapPath string) string {
 	}
 	versionExt := strings.Split(parts[1], ".")
 	version, err := getVersion(airgapPath)
-	fmt.Print("\n Version and err : ",version,  ",", err)
 	versionExt[0] = version
 	newVersionExt := strings.Join(versionExt, ".")
 	parts[1] = newVersionExt
+	fmt.Print("\n  ", versionExt[0])
+	fmt.Print("\n part[0] : ",parts[0])
+	fmt.Print("\n part[1] : ",parts[1])
 	bundleName = strings.Join(parts, "-")
+	fmt.Print("\n part : ",parts)
 	
 	if err != nil {
 		return bundleName

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -88,7 +88,7 @@ airgap_bundle_create() {
   args+=("${original_aib_path}")
   # printf '%s\n' "Running: ${CHEF_AUTOMATE_BIN_PATH} ${args[*]}"
   if "${CHEF_AUTOMATE_BIN_PATH}" "${args[@]}" > /tmp/thelog.log; then
-    BUILD_VERSION=`"${CHEF_AUTOMATE_BIN_PATH}" airgap bundle info "${original_aib_path}" | grep Version | awk '{print $2}'`
+    BUILD_VERSION=`"${CHEF_AUTOMATE_BIN_PATH}" airgap bundle info "${original_aib_path}" | grep -i version | awk '{print $2}'`
     if [ "$BUNDLE_TYPE" == "upgradefrontends" ] || [ "$BUNDLE_TYPE" == "all" ]
     then
           frontend_aib="/hab/a2_deploy_workspace/terraform/transfer_files/frontend-${BUILD_VERSION}.aib"

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -97,7 +97,7 @@ airgap_bundle_create() {
           bname=$(basename "${outfile}")
           echo "frontend_aib_dest_file = \"/var/tmp/${bname}\""  > "${FRONTENDAIB_TFVARS}"
           echo "frontend_aib_local_file = \"${bname}\"" >> "${FRONTENDAIB_TFVARS}"
-	        $(hab pkg path core/coreutils)/bin/md5sum "${frontend_aib}" > "${frontend_aib}".md5
+	        "$(hab pkg path core/coreutils)/bin/md5sum" "${frontend_aib}" > "${frontend_aib}".md5
     fi
 
     if [ "$BUNDLE_TYPE" == "upgradebackends" ] || [ "$BUNDLE_TYPE" == "all" ]
@@ -113,7 +113,7 @@ airgap_bundle_create() {
           backend_name=$(basename "${outfile_backend}")
           echo "backend_aib_dest_file = \"/var/tmp/${backend_name}\"" > "${BACKENDAIB_TFVARS}" 
           echo "backend_aib_local_file = \"${backend_name}\"" >> "${BACKENDAIB_TFVARS}"
-	        $(hab pkg path core/coreutils)/bin/md5sum "${backend_aib}" > "${backend_aib}".md5
+	        "$(hab pkg path core/coreutils)/bin/md5sum" "${backend_aib}" > "${backend_aib}".md5
     fi
     rm -f "${original_aib_path}"
   else

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -97,7 +97,7 @@ airgap_bundle_create() {
           bname=$(basename "${outfile}")
           echo "frontend_aib_dest_file = \"/var/tmp/${bname}\""  > "${FRONTENDAIB_TFVARS}"
           echo "frontend_aib_local_file = \"${bname}\"" >> "${FRONTENDAIB_TFVARS}"
-	        $(hab pkg path core/coreutils)/bin/md5sum $(frontend_aib) > $(frontend_aib).md5 
+	        $(hab pkg path core/coreutils)/bin/md5sum "${frontend_aib}" > "${frontend_aib}".md5
     fi
 
     if [ "$BUNDLE_TYPE" == "upgradebackends" ] || [ "$BUNDLE_TYPE" == "all" ]
@@ -113,7 +113,7 @@ airgap_bundle_create() {
           backend_name=$(basename "${outfile_backend}")
           echo "backend_aib_dest_file = \"/var/tmp/${backend_name}\"" > "${BACKENDAIB_TFVARS}" 
           echo "backend_aib_local_file = \"${backend_name}\"" >> "${BACKENDAIB_TFVARS}"
-	        $(hab pkg path core/coreutils)/bin/md5sum $(backend_aib) > $(backend_aib).md5
+	        $(hab pkg path core/coreutils)/bin/md5sum "${backend_aib}" > "${backend_aib}".md5
     fi
     rm -f "${original_aib_path}"
   else

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -183,7 +183,7 @@ do_tasks() {
 if [ $# -eq 0 ]; then
   usage
 fi
-while getopts ":b:t:w:o:h:v:q:c:" opt; do
+while getopts ":t:w:h:v:q:c:" opt; do
   case "${opt}" in
     w)
       export WORKSPACE_PATH=${OPTARG}

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -88,7 +88,7 @@ airgap_bundle_create() {
   args+=("${original_aib_path}")
   # printf '%s\n' "Running: ${CHEF_AUTOMATE_BIN_PATH} ${args[*]}"
   if "${CHEF_AUTOMATE_BIN_PATH}" "${args[@]}" > /tmp/thelog.log; then
-    BUILD_VERSION=`"${CHEF_AUTOMATE_BIN_PATH}" airgap bundle info "${original_aib_path}" | grep -i version | awk '{print $2}'`
+    BUILD_VERSION=$("${CHEF_AUTOMATE_BIN_PATH}" airgap bundle info "${original_aib_path}" | grep -i version | awk '{print $2}')
     if [ "$BUNDLE_TYPE" == "upgradefrontends" ] || [ "$BUNDLE_TYPE" == "all" ]
     then
           frontend_aib="/hab/a2_deploy_workspace/terraform/transfer_files/frontend-${BUILD_VERSION}.aib"

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -97,7 +97,7 @@ airgap_bundle_create() {
           bname=$(basename "${outfile}")
           echo "frontend_aib_dest_file = \"/var/tmp/${bname}\""  > "${FRONTENDAIB_TFVARS}"
           echo "frontend_aib_local_file = \"${bname}\"" >> "${FRONTENDAIB_TFVARS}"
-	        "$(hab pkg path core/coreutils)/bin/md5sum" "${frontend_aib}" > "${frontend_aib}".md5
+	        $(hab pkg path core/coreutils)/bin/md5sum "${frontend_aib}" > "${frontend_aib}".md5
     fi
 
     if [ "$BUNDLE_TYPE" == "upgradebackends" ] || [ "$BUNDLE_TYPE" == "all" ]
@@ -113,7 +113,7 @@ airgap_bundle_create() {
           backend_name=$(basename "${outfile_backend}")
           echo "backend_aib_dest_file = \"/var/tmp/${backend_name}\"" > "${BACKENDAIB_TFVARS}" 
           echo "backend_aib_local_file = \"${backend_name}\"" >> "${BACKENDAIB_TFVARS}"
-	        "$(hab pkg path core/coreutils)/bin/md5sum" "${backend_aib}" > "${backend_aib}".md5
+	        $(hab pkg path core/coreutils)/bin/md5sum "${backend_aib}" > "${backend_aib}".md5
     fi
     rm -f "${original_aib_path}"
   else

--- a/scripts/bundle_creation.sh
+++ b/scripts/bundle_creation.sh
@@ -188,12 +188,6 @@ while getopts ":b:t:w:o:h:v:q:c:" opt; do
     w)
       export WORKSPACE_PATH=${OPTARG}
       ;;
-    o)
-      export TARBALL_PATH=${OPTARG}
-      ;;
-    b)
-      export BACKENDAIB=${OPTARG}
-      ;;  
     t)
       export BUNDLE_TYPE=${OPTARG}
       ;;

--- a/terraform/a2ha-terraform/Makefile
+++ b/terraform/a2ha-terraform/Makefile
@@ -6,10 +6,10 @@ SUP_KEY_SH = $(shell pwd)/../../scripts/sup-keys.sh
 TMPOUT = '/tmp/make.out'
 REPO_ROOT = $(shell pwd)
 DATESTAMP := $(shell date +"%Y%m%d%H%M%S")
-BUNDLEAIB = $(TERRAFORM_PATH)/transfer_files/bundle-$(DATESTAMP).aib
-BACKENDAIB = $(TERRAFORM_PATH)/transfer_files/backend-$(DATESTAMP).aib
+BUNDLEAIB = $(TERRAFORM_PATH)/transfer_files/bundle.aib
+BACKENDAIB = $(TERRAFORM_PATH)/transfer_files/backend.aib
 BACKENDAIB_TFVARS = $(shell pwd)/a2ha_aib_be.auto.tfvars
-FRONTENDAIB = $(TERRAFORM_PATH)/transfer_files/frontend-$(DATESTAMP).aib
+FRONTENDAIB = $(TERRAFORM_PATH)/transfer_files/frontend.aib
 FRONTENDAIB_TFVARS = $(shell pwd)/a2ha_aib_fe.auto.tfvars
 TMPFILE := $(shell mktemp)
 VARFILES := $(shell find $(TERRAFORM_PATH) -name variables.tf -o -name inputs.tf)
@@ -114,19 +114,15 @@ sort:
 
 $(BUNDLEAIB):
 	@echo "# Updating FE and BE component package versions" && \
-		$(AIRGAP_SH) -t all -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)  && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+		$(AIRGAP_SH) -t all -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
 
 $(FRONTENDAIB):
 	@echo "# Updating FE component package versions: $(FRONTENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS) && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 
+		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS) 
 
 $(BACKENDAIB):
 	@echo "# Updating BE component package versions: $(BACKENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradebackends -b $(BACKENDAIB) -q $(BACKENDAIB_TFVARS) && \
-	    $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+		$(AIRGAP_SH) -t upgradebackends -b $(BACKENDAIB) -q $(BACKENDAIB_TFVARS)
 
 $(HABITAT_TFVARS):
 	@echo -e "# Generating habitat encryption keys in $(HABITAT_TFVARS)" && \

--- a/terraform/a2ha-terraform/deployment-makefile/Makefile
+++ b/terraform/a2ha-terraform/deployment-makefile/Makefile
@@ -56,19 +56,19 @@ help:
 
 $(BUNDLEAIB):
 	@echo "# Updating FE and BE component package versions" && \
-		$(AIRGAP_SH) -t all -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
+		$(AIRGAP_SH) -t all -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
 
 $(BUNDLEAIBDEV):
 	@echo "# Updating FE and BE component package versions from dev channel " && \
-		$(AIRGAP_SH) -t all -c dev -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
+		$(AIRGAP_SH) -t all -c dev -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
 
 $(FRONTENDAIB):
 	@echo "# Updating FE component package versions: $(FRONTENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS)
+		$(AIRGAP_SH) -t upgradefrontends -v $(FRONTENDAIB_TFVARS)
 
 $(BACKENDAIB):
 	@echo "# Updating BE component package versions: $(BACKENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradebackends -b $(BACKENDAIB) -q $(BACKENDAIB_TFVARS)
+		$(AIRGAP_SH) -t upgradebackends -q $(BACKENDAIB_TFVARS)
 
 $(HABITAT_TFVARS):
 	@echo -e "# Generating habitat encryption keys in $(HABITAT_TFVARS)" && \

--- a/terraform/a2ha-terraform/deployment-makefile/Makefile
+++ b/terraform/a2ha-terraform/deployment-makefile/Makefile
@@ -6,11 +6,11 @@ SUP_KEY_SH = $(shell pwd)/scripts/sup-keys.sh
 TMPOUT = '/tmp/make.out'
 REPO_ROOT = $(shell pwd)
 DATESTAMP := $(shell date +"%Y%m%d%H%M%S")
-BUNDLEAIB = $(TERRAFORM_PATH)/transfer_files/bundle-$(DATESTAMP).aib
-BUNDLEAIBDEV = $(TERRAFORM_PATH)/transfer_files/bundle-dev-$(DATESTAMP).aib
-BACKENDAIB = $(TERRAFORM_PATH)/transfer_files/backend-$(DATESTAMP).aib
+BUNDLEAIB = $(TERRAFORM_PATH)/transfer_files/bundle.aib
+BUNDLEAIBDEV = $(TERRAFORM_PATH)/transfer_files/bundle-dev.aib
+BACKENDAIB = $(TERRAFORM_PATH)/transfer_files/backend.aib
 BACKENDAIB_TFVARS = $(shell pwd)/terraform/a2ha_aib_be.auto.tfvars
-FRONTENDAIB = $(TERRAFORM_PATH)/transfer_files/frontend-$(DATESTAMP).aib
+FRONTENDAIB = $(TERRAFORM_PATH)/transfer_files/frontend.aib
 FRONTENDAIB_TFVARS = $(shell pwd)/terraform/a2ha_aib_fe.auto.tfvars
 TMPFILE := $(shell mktemp)
 VARFILES := $(shell find $(TERRAFORM_PATH) -name variables.tf -o -name inputs.tf)
@@ -56,25 +56,19 @@ help:
 
 $(BUNDLEAIB):
 	@echo "# Updating FE and BE component package versions" && \
-		$(AIRGAP_SH) -t all -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)  && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+		$(AIRGAP_SH) -t all -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
 
 $(BUNDLEAIBDEV):
 	@echo "# Updating FE and BE component package versions from dev channel " && \
-		$(AIRGAP_SH) -t all -c dev -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)  && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+		$(AIRGAP_SH) -t all -c dev -o $(FRONTENDAIB) -b $(BACKENDAIB) -v $(FRONTENDAIB_TFVARS) -q $(BACKENDAIB_TFVARS)
 
 $(FRONTENDAIB):
 	@echo "# Updating FE component package versions: $(FRONTENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS) && \
-	  $$(hab pkg path core/coreutils)/bin/md5sum $(FRONTENDAIB) > $(FRONTENDAIB).md5 
+		$(AIRGAP_SH) -t upgradefrontends -o $(FRONTENDAIB) -v $(FRONTENDAIB_TFVARS)
 
 $(BACKENDAIB):
 	@echo "# Updating BE component package versions: $(BACKENDAIB_TFVARS)" && \
-		$(AIRGAP_SH) -t upgradebackends -b $(BACKENDAIB) -q $(BACKENDAIB_TFVARS) && \
-	    $$(hab pkg path core/coreutils)/bin/md5sum $(BACKENDAIB) > $(BACKENDAIB).md5
+		$(AIRGAP_SH) -t upgradebackends -b $(BACKENDAIB) -q $(BACKENDAIB_TFVARS)
 
 $(HABITAT_TFVARS):
 	@echo -e "# Generating habitat encryption keys in $(HABITAT_TFVARS)" && \


### PR DESCRIPTION
### Description: 

In Automate HA, the user who creates a bundle (including frontend and backend) wants to see the latest version timestamp in the bundle name. With the current change, when they create the bundle using the non-airgap method, the name will contain the timestamp (or build version) of the latest build instead of the downloaded time's timestamp.

Note: 
- Latest build version is obtained by the 'chef-automate info' command is used.
- Applicable but both internet and non-internet environments.

Observations:
- On running deploy/upgrade commands, the name of the bundles inside transfer_files are appended with the latest release version (timestamp)

Method | Result
-- | --
Airgap - Deploy | Working as expected
Airgap - Upgrade | Working as expected
Non-airgap - Deploy | Working as expected
Non-airgap - Upgrade | Working as expected

<br data-cke-eol="1">

### :chains: Related Resources

Link to Jira Ticket: https://chefio.atlassian.net/browse/MADROX-148

### :+1: Definition of Done
It's dev done and tested

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
