### PR TITLE
Arvinth/termination protection tf

### DIFF
--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -4,6 +4,8 @@
 
 If you are running chef-automate provision-infra and in between anything occure and provision get stopped then run below command to destroy that half part to start provision again.
 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/;terraform apply -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -var "disable_api_termination=false";cd $i;done`
+
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/;terraform destroy -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate;cd $i;done`
 
 # SCENARIO 2
@@ -11,10 +13,10 @@ If you are running chef-automate provision-infra and in between anything occure 
 If you have successfully done provision-infra and after that if you want to destroy infra then run below command in below order.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
 
-# SCENARIO 3 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
+
+# SCENARIO 3
 
 If you've completed `chef-automate deploy` and want to destroy deploy part then run below command. Remember destroy of deployment will not remove any kind of configuration from remote server but it will do terraform taint so that next time all the configuration things will be started again.
 
@@ -25,5 +27,5 @@ If you've completed `chef-automate deploy` and want to destroy deploy part then 
 If you have finished deployment and want destroy all the instances of whole infra then run below commnd.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -180,3 +180,7 @@ variable "tags" {
 variable "tmp_path" {
   default = "/var/tmp"
 }
+
+variable "disable_api_termination" {
+  default = true
+}

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -45,6 +45,11 @@ resource "aws_alb" "automate_lb" {
     bucket           = aws_s3_bucket.elb_logs.bucket
     enabled          = var.lb_access_logs
   }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_alb_target_group" "automate_tg" {
@@ -100,6 +105,11 @@ resource "aws_alb" "chef_server_lb" {
   security_groups    = [aws_security_group.load_balancer.id]
   subnets            = aws_subnet.public.*.id
   tags               = var.tags
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_alb_target_group" "chef_server_tg" {

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "chef_automate_postgresql" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
-  disable_api_termination     = true
+  disable_api_termination     = var.disable_api_termination
 
   connection {
     host        = coalesce(self.private_ip)
@@ -148,6 +148,9 @@ resource "aws_instance" "chef_automate_postgresql" {
       )
     )
   )
+    lifecycle {
+    ignore_changes = [tags, root_block_device]
+  }
 
   provisioner "file" {
     content     = local.mount_nfs
@@ -173,7 +176,7 @@ resource "aws_instance" "chef_automate_elasticsearch" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = true
   ebs_optimized               = true
-  disable_api_termination     = true
+  disable_api_termination     = var.disable_api_termination
 
   connection {
     host        = coalesce(self.private_ip)
@@ -196,6 +199,9 @@ resource "aws_instance" "chef_automate_elasticsearch" {
       format("${var.tag_name}_${random_id.random.hex}_chef_automate_elasticsearch_%02d", count.index + 1)
     )
   )
+    lifecycle {
+    ignore_changes = [tags, root_block_device]
+  }
 
   provisioner "file" {
     content     = local.mount_nfs
@@ -229,7 +235,7 @@ resource "aws_instance" "chef_automate" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
-  disable_api_termination     = true
+  disable_api_termination     = var.disable_api_termination
 
   root_block_device {
     delete_on_termination = true
@@ -244,6 +250,10 @@ resource "aws_instance" "chef_automate" {
       format("${var.tag_name}_${random_id.random.hex}_chef_automate_%02d", count.index + 1)
     )
   )
+
+  lifecycle {
+    ignore_changes = [tags, root_block_device]
+  }
 
   provisioner "file" {
     content     = local.mount_nfs
@@ -277,7 +287,7 @@ resource "aws_instance" "chef_server" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
-  disable_api_termination     = true
+  disable_api_termination     = var.disable_api_termination
 
   root_block_device {
     delete_on_termination = true
@@ -292,6 +302,10 @@ resource "aws_instance" "chef_server" {
       format("${var.tag_name}_${random_id.random.hex}_chef_server_%02d", count.index + 1)
     )
   )
+
+  lifecycle {
+    ignore_changes = [tags, root_block_device]
+  }
 
   provisioner "file" {
     content     = local.mount_nfs

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -123,6 +123,7 @@ resource "aws_instance" "chef_automate_postgresql" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
+  disable_api_termination     = true
 
   connection {
     host        = coalesce(self.private_ip)
@@ -172,6 +173,7 @@ resource "aws_instance" "chef_automate_elasticsearch" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = true
   ebs_optimized               = true
+  disable_api_termination     = true
 
   connection {
     host        = coalesce(self.private_ip)
@@ -227,6 +229,7 @@ resource "aws_instance" "chef_automate" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
+  disable_api_termination     = true
 
   root_block_device {
     delete_on_termination = true
@@ -274,6 +277,7 @@ resource "aws_instance" "chef_server" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
+  disable_api_termination     = true
 
   root_block_device {
     delete_on_termination = true

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -41,6 +41,7 @@ module "aws" {
   source                             = "./modules/aws"
   lb_access_logs                     = var.lb_access_logs
   tags                               = var.aws_tags
+  disable_api_termination            = var.disable_api_termination
 }
 
 module "aws-output" {

--- a/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
@@ -163,3 +163,7 @@ variable "ssh_user" {
 variable "sudo_cmd" {
   default = "sudo"
 }
+
+variable "disable_api_termination" {
+  default = true
+}


### PR DESCRIPTION
### Description:

In Automate HA, when the user creates EC2 instances in AWS, it should by default create Instances with Termination Protection, ensuring the instances can't be terminated by mistake. As part of this story, when resources are created using the `provision-infra` command, `disable_api_termination` is set to true, which will enable Termination Protection.

Observations: 
- On creation, instances are created with Termination Protection enabled
- Not able to delete instances from AWS console(unless TP is disabled manually) and with the old clean up script (expected behavior)

Observations with the cleanup script:
Scenarios | Comment | Result
-- | -- | --
Provision failed in-between | Destroy script tries to add resources that are failed along with modifying Termination protection state | Working as expected
Provisioning completed |   | To be tested 




### :chains: Related Resources

Jira ticket: https://chefio.atlassian.net/browse/MADROX-176

### :+1: Definition of Done

Testing in progress

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
