### PR TITLE
Enabling lifecycle and termination protection for AWS resources for HA provisioning

### DIFF
--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -14,6 +14,8 @@ If you have successfully done provision-infra and after that if you want to dest
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform apply -var "disable_api_termination=false";cd $i;done`
+
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
 
 # SCENARIO 3
@@ -27,5 +29,7 @@ If you've completed `chef-automate deploy` and want to destroy deploy part then 
 If you have finished deployment and want destroy all the instances of whole infra then run below commnd.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform apply -var "disable_api_termination=false";cd $i;done`
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`

--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -4,6 +4,8 @@
 
 If you are running chef-automate provision-infra and in between anything occure and provision get stopped then run below command to destroy that half part to start provision again.
 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/;terraform apply -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -var "disable_api_termination=false";cd $i;done`
+
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/;terraform destroy -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate;cd $i;done`
 
 # SCENARIO 2
@@ -11,10 +13,10 @@ If you are running chef-automate provision-infra and in between anything occure 
 If you have successfully done provision-infra and after that if you want to destroy infra then run below command in below order.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
 
-# SCENARIO 3 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
+
+# SCENARIO 3
 
 If you've completed `chef-automate deploy` and want to destroy deploy part then run below command. Remember destroy of deployment will not remove any kind of configuration from remote server but it will do terraform taint so that next time all the configuration things will be started again.
 
@@ -25,5 +27,5 @@ If you've completed `chef-automate deploy` and want to destroy deploy part then 
 If you have finished deployment and want destroy all the instances of whole infra then run below commnd.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`

--- a/terraform/a2ha-terraform/destroy/aws/main.tf
+++ b/terraform/a2ha-terraform/destroy/aws/main.tf
@@ -41,6 +41,7 @@ module "aws" {
   proxy_listen_port                  = var.proxy_listen_port
   source                             = "../../modules/aws"
   tags                               = var.aws_tags
+  disable_api_termination            = var.disable_api_termination
 }
 
 module "aws-output" {

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -184,3 +184,7 @@ variable "tags" {
 variable "tmp_path" {
   default = "/var/automate-ha"
 }
+
+variable "disable_api_termination" {
+  default = true
+}

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -1,7 +1,7 @@
 data "aws_elb_service_account" "main" {}
 
 resource "aws_s3_bucket" "elb_logs" {
-  bucket = "a2ha-elb-bucket-arvi"
+  bucket = "a2ha-elb-bucket"
   force_destroy = true
 }
 
@@ -23,7 +23,7 @@ resource "aws_s3_bucket_policy" "elb_logs_bucket_policy" {
       "Principal": {
         "AWS": "${data.aws_elb_service_account.main.arn}"
       },
-      "Resource": "arn:aws:s3:::a2ha-elb-bucket-arvi/AWSLogs/*",
+      "Resource": "arn:aws:s3:::a2ha-elb-bucket/AWSLogs/*",
       "Sid": "Stmt1446575236270"
     }
   ],

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -8,6 +8,15 @@ resource "aws_alb" "automate_lb" {
   security_groups    = [aws_security_group.load_balancer.id]
   subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : aws_subnet.public.*.id
   tags               = var.tags
+  access_logs {
+    bucket           = aws_s3_bucket.elb_logs.bucket
+    enabled          = var.lb_access_logs
+  }
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_alb_target_group" "automate_tg" {
@@ -63,6 +72,11 @@ resource "aws_alb" "chef_server_lb" {
   security_groups    = [aws_security_group.load_balancer.id]
   subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : aws_subnet.public.*.id
   tags               = var.tags
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
 }
 
 resource "aws_alb_target_group" "chef_server_tg" {

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -1,3 +1,36 @@
+data "aws_elb_service_account" "main" {}
+
+resource "aws_s3_bucket" "elb_logs" {
+  bucket = "a2ha-elb-bucket-arvi"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "elb_bucket_acl" {
+  bucket = aws_s3_bucket.elb_logs.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_policy" "elb_logs_bucket_policy" {
+  bucket = aws_s3_bucket.elb_logs.id
+
+  policy = <<EOF
+{
+  "Id": "Policy1446577137248",
+  "Statement": [
+    {
+      "Action": "s3:PutObject",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${data.aws_elb_service_account.main.arn}"
+      },
+      "Resource": "arn:aws:s3:::a2ha-elb-bucket-arvi/AWSLogs/*",
+      "Sid": "Stmt1446575236270"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+EOF
+}
 
 /////////////////////////
 // Automate Load Balancing

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -46,9 +46,7 @@ resource "aws_alb" "automate_lb" {
     enabled          = var.lb_access_logs
   }
   lifecycle {
-    ignore_changes = [
-      tags
-    ]
+    ignore_changes = [tags]
   }
 }
 
@@ -106,9 +104,7 @@ resource "aws_alb" "chef_server_lb" {
   subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : aws_subnet.public.*.id
   tags               = var.tags
   lifecycle {
-    ignore_changes = [
-      tags
-    ]
+    ignore_changes = [tags]
   }
 }
 

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -195,6 +195,7 @@ resource "aws_instance" "chef_automate_postgresql" {
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
+  disable_api_termination     = true
 
   connection {
     host        = coalesce(self.private_ip)
@@ -235,6 +236,14 @@ resource "aws_instance" "chef_automate_elasticsearch" {
   associate_public_ip_address = false //Changes to false as Dashboards are no longer enabled
   ebs_optimized               = true
   iam_instance_profile        = var.aws_instance_profile_name
+
+  connection {
+    host        = coalesce(self.private_ip)
+    type        = "ssh"
+    user        = var.aws_ssh_user
+    private_key = file(var.aws_ssh_key_file)
+    script_path = "${var.tmp_path}/tf_inline_script_aws.sh"
+  }
 
   root_block_device {
     delete_on_termination = true

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -221,7 +221,7 @@ resource "aws_instance" "chef_automate_postgresql" {
     )
   )
     lifecycle {
-    ignore_changes = [tags, root_block_device]
+    ignore_changes = [tags, root_block_device, ami]
   }
 
   depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
@@ -263,7 +263,7 @@ resource "aws_instance" "chef_automate_elasticsearch" {
     )
   )
     lifecycle {
-    ignore_changes = [tags, root_block_device]
+    ignore_changes = [tags, root_block_device, ami]
   }
 
   depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
@@ -300,7 +300,7 @@ resource "aws_instance" "chef_automate" {
   depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
   
   lifecycle {
-    ignore_changes = [tags, root_block_device]
+    ignore_changes = [tags, root_block_device, ami]
   }
 
   provisioner "file" {
@@ -346,7 +346,7 @@ resource "aws_instance" "chef_server" {
   depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
 
   lifecycle {
-    ignore_changes = [tags, root_block_device]
+    ignore_changes = [tags, root_block_device, ami]
   }
 
   provisioner "file" {

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -220,7 +220,7 @@ resource "aws_instance" "chef_automate_postgresql" {
       )
     )
   )
-    lifecycle {
+  lifecycle {
     ignore_changes = [tags, root_block_device, ami]
   }
 
@@ -262,7 +262,7 @@ resource "aws_instance" "chef_automate_elasticsearch" {
       format("${var.tag_name}_${random_id.random.hex}_chef_automate_elasticsearch_%02d", count.index + 1)
     )
   )
-    lifecycle {
+  lifecycle {
     ignore_changes = [tags, root_block_device, ami]
   }
 

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -47,6 +47,7 @@ module "aws" {
   lb_access_logs                     = var.lb_access_logs
   tags                               = var.aws_tags
   aws_instance_profile_name          = var.backup_config_s3 == "true" ? module.s3[0].instance_profile_name : null
+  disable_api_termination            = var.disable_api_termination
 }
 
 module "efs" {

--- a/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
@@ -193,3 +193,7 @@ variable "sudo_cmd" {
 variable "tag_name" {
   default = "A2"
 }
+
+variable "disable_api_termination" {
+  default = true
+}


### PR DESCRIPTION
### Description:

In Automate HA, when the user creates EC2 instances in AWS, it should by default create Instances with Termination Protection, ensuring the instances can't be terminated by mistake. As part of this story, when resources are created using the `provision-infra` command, `disable_api_termination` is set to true, which will enable Termination Protection.

Observations: 
- On creation, instances are created with Termination Protection enabled
- Not able to delete instances from AWS console(unless TP is disabled manually) and with the old clean up script (expected behavior)

Observations with the cleanup script:
Scenarios | Comment | Result
-- | -- | --
Provision failed in-between | Destroy script tries to add resources that are failed along with modifying Termination protection state | Working as expected
Provisioning completed |   | To be tested 




### :chains: Related Resources

Jira ticket: https://chefio.atlassian.net/browse/MADROX-176

### :+1: Definition of Done

Work in progress

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
