### PR TITLE
Remove the users association with org while deleting orgs from automate

### DIFF
--- a/components/infra-proxy-service/server/orgs.go
+++ b/components/infra-proxy-service/server/orgs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chef/automate/components/infra-proxy-service/storage"
 	"github.com/chef/automate/components/infra-proxy-service/validation"
 	"github.com/gofrs/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // CreateOrg creates a new org
@@ -105,6 +106,13 @@ func (s *Server) DeleteOrg(ctx context.Context, req *request.DeleteOrg) (*respon
 	}).Validate()
 
 	if err != nil {
+		return nil, err
+	}
+
+	// Delete users asscoiation with org
+	err = s.service.Storage.DeleteAutomateInfraOrgUsers(ctx, req.ServerId, req.Id)
+	if err != nil {
+		log.Errorf("Failed to delete the org users ", err)
 		return nil, err
 	}
 

--- a/components/infra-proxy-service/server/orgs.go
+++ b/components/infra-proxy-service/server/orgs.go
@@ -112,7 +112,7 @@ func (s *Server) DeleteOrg(ctx context.Context, req *request.DeleteOrg) (*respon
 	// Delete users asscoiation with org
 	err = s.service.Storage.DeleteAutomateInfraOrgUsers(ctx, req.ServerId, req.Id)
 	if err != nil {
-		log.Errorf("Failed to delete the org users ", err)
+		log.Errorf("Failed to delete the org users %s", err.Error())
 		return nil, err
 	}
 

--- a/components/infra-proxy-service/storage/storage.go
+++ b/components/infra-proxy-service/storage/storage.go
@@ -32,6 +32,7 @@ type Storage interface {
 
 	GetAutomateInfraServerUsers(ctx context.Context, serverId string) ([]User, error)
 	GetAutomateInfraOrgUsers(ctx context.Context, serverId, orgId string) ([]OrgUser, error)
+	DeleteAutomateInfraOrgUsers(ctx context.Context, serverId, orgId string) error
 
 	StoreOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (OrgUser, error)
 	EditOrgUserAssociation(ctx context.Context, serverID, orgID, username string, isAdmin bool) (OrgUser, error)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Remove the users association with org while deleting orgs from automate

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-119

### :+1: Definition of Done
I have added changes in Delete org API to remove the users association with org
Removed the users entry from 'org_users' table for given org
Checked whether users exist for org or not, if exist then removed it

### :athletic_shoe: How to Build and Test the Change
Steps to build:
```
rebuild components/infra-proxy-service/
```
Steps to test:

Request

```curl -sSkH "api-token: $(get_admin_token)" 'https://a2-dev.test/apis/iam/v2/users/{USERNAME}'```

Response

```
{"org":{"id":"admin-org","name":"admin-org","admin_user":"","credential_id":"","server_id":"test","projects":["test_admin-org"]}}
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
