### PR TITLE
Fix terraform deploy

### DIFF
--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -34,6 +34,8 @@ module "airgapped_single_local_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -35,7 +35,7 @@ module "airgapped_single_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_fresh_install.tf
@@ -35,7 +35,7 @@ module "airgapped_single_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "airgapped_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "airgapped_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/airgapped_single_local_inplace_upgrade.tf
@@ -34,6 +34,8 @@ module "airgapped_single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "chef_server_performance_test_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -34,6 +34,8 @@ module "chef_server_performance_test_single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/chef-server_performance_test_single_local_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "chef_server_performance_test_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/common.tf
+++ b/terraform/test-environments/scenarios/common.tf
@@ -11,6 +11,10 @@ module "cd_infrastructure" {
 provider "aws" {
   region  = "${module.cd_infrastructure.aws_region}"
   profile = "${module.cd_infrastructure.aws_profile}"
+
+  ignore_tags {
+    keys = ["CreatedBy", "X-CreatedBy", "CreatorPrincipalId"]
+  }
 }
 
 #

--- a/terraform/test-environments/scenarios/common.tf
+++ b/terraform/test-environments/scenarios/common.tf
@@ -11,10 +11,6 @@ module "cd_infrastructure" {
 provider "aws" {
   region  = "${module.cd_infrastructure.aws_region}"
   profile = "${module.cd_infrastructure.aws_profile}"
-
-  ignore_tags {
-    keys = ["CreatedBy", "X-CreatedBy", "CreatorPrincipalId"]
-  }
 }
 
 #

--- a/terraform/test-environments/scenarios/inspec_target_rhel7.tf
+++ b/terraform/test-environments/scenarios/inspec_target_rhel7.tf
@@ -27,8 +27,8 @@ module "inspec_target_rhel7" {
   tag_application = "a2"
 
   additional_tags = {
-    X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-LongRunning = "true"
+    X-Sleep       = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/inspec_target_rhel7.tf
+++ b/terraform/test-environments/scenarios/inspec_target_rhel7.tf
@@ -28,7 +28,7 @@ module "inspec_target_rhel7" {
 
   additional_tags = {
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/inspec_target_rhel7.tf
+++ b/terraform/test-environments/scenarios/inspec_target_rhel7.tf
@@ -25,6 +25,11 @@ module "inspec_target_rhel7" {
   tag_dept        = "CoreEng"
   tag_contact     = "${var.aws_tag_contact}"
   tag_application = "a2"
+
+  additional_tags = {
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+  }
 }
 
 module "inspec_target_rhel7_cd_base" {

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -35,6 +35,8 @@ module "performance_test_single_local_inplace_upgrade" {
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
     X-CI-Test          = "e2e"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -36,7 +36,7 @@ module "performance_test_single_local_inplace_upgrade" {
     X-SAML             = "saml"
     X-CI-Test          = "e2e"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/performance_test_single_local_inplace_upgrade.tf
@@ -36,7 +36,7 @@ module "performance_test_single_local_inplace_upgrade" {
     X-SAML             = "saml"
     X-CI-Test          = "e2e"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/s3_websites.tf
+++ b/terraform/test-environments/scenarios/s3_websites.tf
@@ -12,6 +12,11 @@ module "dashboard" {
   meta_description = "This is just a link to the channel-specific release dashboard site you are viewing right now...recursion FTW!"
 
   tag_contact = "${var.aws_tag_contact}"
+
+  additional_tags = {
+    X-LongRunning = "true"
+    X-Sleep       = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+  }
 }
 
 resource "null_resource" "dashboard_deploy" {
@@ -41,6 +46,11 @@ module "ui_library_website" {
 
   tag_contact = "${var.aws_tag_contact}"
   create      = "${var.environment == "union" ? "true" : "false"}"
+
+  additional_tags = {
+    X-LongRunning = "true"
+    X-Sleep       = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+  }
 }
 
 #########################################################################
@@ -58,4 +68,9 @@ module "a2_code_coverage_website" {
 
   tag_contact = "${var.aws_tag_contact}"
   create      = "${var.environment == "union" ? "true" : "false"}"
+
+  additional_tags = {
+    X-LongRunning = "true"
+    X-Sleep       = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+  }
 }

--- a/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_hardened_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_hardened_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_hardened_local_fresh_install.tf
@@ -35,6 +35,8 @@ module "single_hardened_local_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_all_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_all_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_all_fresh_install.tf
@@ -35,6 +35,8 @@ module "single_local_all_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "single_local_all_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
@@ -34,6 +34,8 @@ module "single_local_all_inplace_upgrade" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_all_inplace_upgrade.tf
@@ -35,7 +35,7 @@ module "single_local_all_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
@@ -35,6 +35,8 @@ module "single_local_desktop_fresh_install" {
     X-Topology         = "single"
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_desktop_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_desktop_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_desktop_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_fresh_install" {
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -36,7 +36,7 @@ module "single_local_fresh_install" {
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
     X-LongRunning      = "true"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_fresh_install.tf
+++ b/terraform/test-environments/scenarios/single_local_fresh_install.tf
@@ -35,6 +35,8 @@ module "single_local_fresh_install" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-CI-Test          = "e2e"
+    X-LongRunning      = "true"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
@@ -34,7 +34,7 @@ module "single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
-    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
     X-LongRunning      = "true"
   }
 }

--- a/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
@@ -34,6 +34,8 @@ module "single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
+    X-Sleep = "off=(M-F,23);on=(M-F,7);tz=Asia/Kolkata"
+    X-LongRunning      = "true"
   }
 }
 

--- a/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
+++ b/terraform/test-environments/scenarios/single_local_inplace_upgrade.tf
@@ -34,7 +34,7 @@ module "single_local_inplace_upgrade" {
     X-Deployment-Type  = "local"
     X-Channel          = "${var.channel}"
     X-SAML             = "saml"
-    X-Sleep = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
+    X-Sleep            = "off=(M-S,23);on=(M-S,7);tz=Asia/Kolkata"
     X-LongRunning      = "true"
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

With repeating policy on, the deployed environments need to have the tags for long running and sleep
The sleep is applied for Monday to Saturday from 11pm to 7am and Sunday full day

### :chains: Related Resources

### :+1: Definition of Done
- The deployed environments should have the tags

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
