### PR TITLE
Migration ID is missing on server details api response

### DIFF
--- a/components/infra-proxy-service/storage/postgres/migrations.go
+++ b/components/infra-proxy-service/storage/postgres/migrations.go
@@ -260,8 +260,8 @@ func (p *postgres) GetActiveMigration(ctx context.Context, serverId string) (sto
 			  from migration m 
 			  join migration_type t on m.type_id=t.id 
 			  join migration_status s on m.status_id=s.id 
+			  and m.type_id = (select type_id from migration where server_id=$1 order by updated_timestamp desc FETCH FIRST ROW ONLY)
 			
-			  and m.type_id<5000
 			  and m.server_id=$1 order by updated_timestamp desc FETCH FIRST ROW ONLY`
 	err := p.db.QueryRowContext(ctx,
 		query, serverId).

--- a/components/infra-proxy-service/storage/postgres/migrations.go
+++ b/components/infra-proxy-service/storage/postgres/migrations.go
@@ -260,7 +260,7 @@ func (p *postgres) GetActiveMigration(ctx context.Context, serverId string) (sto
 			  from migration m 
 			  join migration_type t on m.type_id=t.id 
 			  join migration_status s on m.status_id=s.id 
-			  and m.type_id = (select type_id from migration where server_id=$1 order by updated_timestamp desc FETCH FIRST ROW ONLY)
+			
 			  and m.type_id<5000
 			  and m.server_id=$1 order by updated_timestamp desc FETCH FIRST ROW ONLY`
 	err := p.db.QueryRowContext(ctx,


### PR DESCRIPTION
Signed-off-by: Pappu Kumar <pappu.kumar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
So as an automate user, if I confirm/cancel the migration then the last migration id should always be save/update for the server.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
- Migration Id should always be fetched
- Migration status should always be there available 

### :athletic_shoe: How to Build and Test the Change

- rebuild components/infra-proxy-service/
- Run the following commands:
curl 'https://a2-dev.test/api/v0/infra/servers/test'  H 'accept: application/json, text/plain, */*' \
-H 'authorization: Bearer <Token>

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
