### PR TITLE
Disabling a1-migration and airgap a1-migration pipelines

### DIFF
--- a/.expeditor/verify_private.pipeline.yml
+++ b/.expeditor/verify_private.pipeline.yml
@@ -576,25 +576,25 @@ steps:
         linux:
           privileged: true
 
-  - label: "a1migration"
-    command:
-      - integration/run_test integration/tests/a1migration.sh
-    timeout_in_minutes: 30
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
+#  - label: "a1migration"
+#    command:
+#      - integration/run_test integration/tests/a1migration.sh
+#    timeout_in_minutes: 30
+#    expeditor:
+#      executor:
+#        linux:
+#          single-use: true
+#          privileged: true
 
-  - label: "airgap a1migration"
-    command:
-      - integration/run_test integration/tests/airgap_a1migration.sh
-    timeout_in_minutes: 25
-    expeditor:
-      executor:
-        linux:
-          single-use: true
-          privileged: true
+#  - label: "airgap a1migration"
+#    command:
+#      - integration/run_test integration/tests/airgap_a1migration.sh
+#    timeout_in_minutes: 25
+#    expeditor:
+#      executor:
+#        linux:
+#          single-use: true
+#          privileged: true
 
   - label: "product"
     command:


### PR DESCRIPTION
Signed-off-by: jay vikram sharma <jsharma@progress.com>



**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
