### PR TITLE
Add reset user key under the server users tab

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -240,6 +240,11 @@
         </form>
       </section>
       <section class="page-body" *ngIf="tabValue === 'users'">
+        <app-reset-user-key
+          [openEvent]="openNotificationModal"
+          [serverId]="server?.id"
+          [name]="username">
+        </app-reset-user-key>
         <div id="user-table-container" *ngIf="isUserListLoaded">
           <chef-table>
             <chef-thead>
@@ -249,13 +254,13 @@
                 <chef-th class="three-dot-column no-border"></chef-th>
               </chef-tr>
             </chef-thead>
-            <chef-tbody *ngFor = "let users of users.users">
+            <chef-tbody *ngFor = "let user of users.users">
               <chef-tr>
-                <chef-td class="userName-column">{{users.infra_server_username}}</chef-td>
-                <chef-td class="automate-column">{{users.automate_user_id}}</chef-td>
+                <chef-td class="userName-column">{{user.infra_server_username}}</chef-td>
+                <chef-td class="automate-column">{{user.automate_user_id}}</chef-td>
                 <chef-td class="three-dot-column">
                     <mat-select panelClass="chef-control-menu">
-                    <mat-option data-cy="delete-org">Fetch PEM Key</mat-option>
+                      <mat-option data-cy="resetPUserEMKey" (onSelectionChange)="resetUserPEMKey(user.infra_server_username)">Reset User Key</mat-option>
                     </mat-select>
                 </chef-td>
               </chef-tr>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.html
@@ -260,7 +260,7 @@
                 <chef-td class="automate-column">{{user.automate_user_id}}</chef-td>
                 <chef-td class="three-dot-column">
                     <mat-select panelClass="chef-control-menu">
-                      <mat-option data-cy="resetPUserEMKey" (onSelectionChange)="resetUserPEMKey(user.infra_server_username)">Reset User Key</mat-option>
+                      <mat-option data-cy="resetUserPEMKey" (onSelectionChange)="resetUserPEMKey(user.infra_server_username)">Reset User Key</mat-option>
                     </mat-select>
                 </chef-td>
               </chef-tr>

--- a/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/chef-server-details/chef-server-details.component.ts
@@ -152,6 +152,11 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
 
   @ViewChild('upload', { static: false }) upload: SyncOrgUsersSliderComponent;
 
+  // reset user pem key
+  public openNotificationModal = new EventEmitter<void>();
+  public username: string;
+
+
   constructor(
     private fb: FormBuilder,
     private store: Store<NgrxStateAtom>,
@@ -672,5 +677,11 @@ export class ChefServerDetailsComponent implements OnInit, OnDestroy {
 
         this.migrationLoading = false;
       });
+  }
+
+  resetUserPEMKey(username: string) {
+    console.log('resetPEM', username);
+    this.username = username;
+    this.openNotificationModal.emit();
   }
 }

--- a/components/automate-ui/src/app/modules/infra-proxy/org-users/org-users.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-users/org-users.component.ts
@@ -45,8 +45,8 @@ export class OrgUsersComponent implements OnInit, OnDestroy {
 
     this.getOrgUsersData();
 
-    const abc = JSON.parse(localStorage.getItem('chef-automate-user'));
-    this.userName = abc['username'];
+    const getUsername = JSON.parse(localStorage.getItem('chef-automate-user'));
+    this.userName = getUsername['username'];
 
     combineLatest([
       this.store.select(getAllStatus),
@@ -88,7 +88,7 @@ export class OrgUsersComponent implements OnInit, OnDestroy {
     this.loading = true;
   }
 
-  resetPEMKey(name) {
+  resetPEMKey(name: string) {
     console.log('resetPEM', name);
     this.name = name;
     this.openNotificationModal.emit();


### PR DESCRIPTION
Signed-off-by: Vinay Sharma <vsharma@chef.io>

### :nut_and_bolt: Description: What code changed, and why?
As an automate user,  I can reset the user key under the server users tab.

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-122
### :+1: Definition of Done
I have added changes to reset the user key under the server user tab.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
