### PR TITLE
No profiles for SELinux and others

### DIFF
--- a/components/docs-chef-io/content/automate/system_requirements.md
+++ b/components/docs-chef-io/content/automate/system_requirements.md
@@ -31,6 +31,8 @@ Chef Automate requires
 * `useradd`
 * `curl` or `wget`
 * The shell that starts Automate should have a max open files setting of at least 65535
+* SELinux or other security modules should either be disabled, or running in a permissive mode.
+  For more detail, see [Security module details](https://docs.chef.io/server/install_server_pre/#security-modules)
 
 Commercial support for Chef Automate is available for platforms that satisfy these
 criteria.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

There is no support for SELinux in Chef server products including Automate.

For this reason, security modules should run in permissive mode or less.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :chains: Related Resources

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) . No code
- [X] Docs added/updated? (all customer-facing changes)