### PR TITLE
not create a project if the project already exists during migration

### DIFF
--- a/components/authz-service/storage/postgres/project.go
+++ b/components/authz-service/storage/postgres/project.go
@@ -46,17 +46,6 @@ func (p *pg) CreateProject(ctx context.Context, project *storage.Project, skipPo
 		return nil, storage.ErrProjectInGraveyard
 	}
 
-	// Don't insert if the project is already in the DB.
-	var ifExists bool
-	row = tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM iam_projects WHERE id=$1 OR name=$2)", project.ID, project.Name)
-	if err := row.Scan(&ifExists); err != nil {
-		err = p.processError(err)
-		// failed with an unexpected error
-		if err != storage.ErrNotFound {
-			return nil, err
-		}
-	}
-
 	if err := p.insertProjectWithQuerier(ctx, project, tx); err != nil {
 		return nil, p.processError(err)
 	}

--- a/components/authz-service/storage/postgres/project.go
+++ b/components/authz-service/storage/postgres/project.go
@@ -46,6 +46,17 @@ func (p *pg) CreateProject(ctx context.Context, project *storage.Project, skipPo
 		return nil, storage.ErrProjectInGraveyard
 	}
 
+	// Don't insert if the project is already in the DB.
+	var ifExists bool
+	row = tx.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM iam_projects WHERE id=$1 OR name=$2)", project.ID, project.Name)
+	if err := row.Scan(&ifExists); err != nil {
+		err = p.processError(err)
+		// failed with an unexpected error
+		if err != storage.ErrNotFound {
+			return nil, err
+		}
+	}
+
 	if err := p.insertProjectWithQuerier(ctx, project, tx); err != nil {
 		return nil, p.processError(err)
 	}

--- a/components/infra-proxy-service/migrations/pipeline/utility.go
+++ b/components/infra-proxy-service/migrations/pipeline/utility.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/chef/automate/api/interservice/authz"
@@ -70,6 +71,18 @@ func createProjectFromOrgIdAndServerID(ctx context.Context, serverId string, org
 		Name:         serverId + "_" + orgId,
 		Id:           serverId + "_" + orgId,
 		SkipPolicies: false,
+	}
+
+	existingProject := &authz.GetProjectReq{
+		Id: serverId + "_" + orgId,
+	}
+
+	projResp, err := authzProjectClient.GetProject(ctx, existingProject)
+	if err != nil {
+		log.Error("cannot get the project with the id: ", existingProject.Id)
+	}
+	if projResp != nil {
+		return nil, errors.New("the project with this id is already created!")
 	}
 
 	projectID, err := authzProjectClient.CreateProject(ctx, newProject)

--- a/components/infra-proxy-service/migrations/pipeline/utility.go
+++ b/components/infra-proxy-service/migrations/pipeline/utility.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/chef/automate/api/interservice/authz"
@@ -82,7 +81,7 @@ func createProjectFromOrgIdAndServerID(ctx context.Context, serverId string, org
 		log.Error("cannot get the project with the id: ", existingProject.Id)
 	}
 	if projResp != nil {
-		return nil, errors.New("the project with this id is already created!")
+		return []string{projResp.Project.Name}, nil
 	}
 
 	projectID, err := authzProjectClient.CreateProject(ctx, newProject)

--- a/components/infra-proxy-service/migrations/pipeline/utility.go
+++ b/components/infra-proxy-service/migrations/pipeline/utility.go
@@ -65,6 +65,7 @@ func StoreOrg(ctx context.Context, st storage.Storage, org pipeline.Org, serverI
 
 //function to create a new iam project for each client
 func createProjectFromOrgIdAndServerID(ctx context.Context, serverId string, orgId string, authzProjectClient authz.ProjectsServiceClient) ([]string, error) {
+	var projectID *authz.CreateProjectResp
 
 	newProject := &authz.CreateProjectReq{
 		Name:         serverId + "_" + orgId,
@@ -80,13 +81,11 @@ func createProjectFromOrgIdAndServerID(ctx context.Context, serverId string, org
 	if err != nil {
 		log.Error("cannot get the project with the id: ", existingProject.Id)
 	}
-	if projResp != nil {
-		return []string{projResp.Project.Name}, nil
-	}
-
-	projectID, err := authzProjectClient.CreateProject(ctx, newProject)
-	if err != nil {
-		return nil, err
+	if projResp == nil {
+		projectID, err = authzProjectClient.CreateProject(ctx, newProject)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return []string{projectID.Project.Name}, nil


### PR DESCRIPTION
Signed-off-by: Pappu Kumar <pappu.kumar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
During migration a project shouldn't be created if it already exists in the db.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
During migration a project shouldn't be created if it already exists in the db.

### :athletic_shoe: How to Build and Test the Change
Run the migration pipeline when the project is already created.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
