### PR TITLE
read the hab path in case of /hab mount 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -394,6 +394,7 @@ func preRequisteForESDataMigration() (bool, error) {
 	return existDir, nil
 }
 
+/*
 const script = `
 mv /hab/svc/automate-opensearch/data /hab/svc/automate-opensearch/data.os;
 mv /hab/svc/automate-opensearch/var /hab/svc/automate-opensearch/var.os;
@@ -402,6 +403,16 @@ cp -r /hab/svc/automate-elasticsearch/var /hab/svc/automate-opensearch/;
 chown -RL hab:hab /hab/svc/automate-opensearch/data;
 chown -RL hab:hab /hab/svc/automate-opensearch/var;
 `
+*/
+const habrootcmd = "HAB_LICENSE=accept-no-persist hab pkg path chef/deployment-service"
+
+const fscript = `
+mv %[1]vsvc/automate-opensearch/data %[1]vsvc/automate-opensearch/data.os; 
+mv %[1]vsvc/automate-opensearch/var %[1]vsvc/automate-opensearch/var.os; 
+cp -r %[1]vsvc/automate-elasticsearch/data %[1]vsvc/automate-opensearch/; 
+cp -r %[1]vsvc/automate-elasticsearch/var %[1]vsvc/automate-opensearch/; 
+chown -RL hab:hab %[1]vsvc/automate-opensearch/data; 
+chown -RL hab:hab %[1]vsvc/automate-opensearch/var;`
 
 // esMigrateExecutor
 func esMigrateExecutor(ci *majorupgradechecklist.PostChecklistManager) error {
@@ -441,8 +452,10 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager) error {
 			writer.Fail(err.Error())
 		}
 	}()
-
+	habRoot := getHabRootPath(habrootcmd)
+	script := fmt.Sprintf(fscript, habRoot)
 	command := exec.Command("/bin/sh", "-c", script)
+
 	err := command.Run()
 	if err != nil {
 		writer.Fail(err.Error())
@@ -454,6 +467,19 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager) error {
 	}
 	writer.Title("Done with Migration \n Please wait for some time to reindex the data")
 	return nil
+}
+
+func getHabRootPath(habrootcmd string) string {
+	out, err := exec.Command(habrootcmd).Output()
+	if err != nil {
+		writer.Fail(err.Error())
+		return ""
+	}
+	pkgPath := string(out)
+	writer.Title("HAB Root Path " + pkgPath)
+	habIndex := strings.Index(string(pkgPath), "hab")
+	rootHab := pkgPath[0 : habIndex+4] // this will give <>/<>/hab/
+	return rootHab
 }
 
 func getLatestPgPath() {
@@ -540,11 +566,20 @@ func cleanUp() error {
 	return nil
 }
 
+/*
 const cleanUpScript = `
 rm -rf /hab/svc/automate-opensearch/data.os;
 rm -rf /hab/svc/automate-opensearch/var.os;
 rm -rf /hab/svc/automate-elasticsearch/data;
 rm -rf /hab/svc/automate-elasticsearch/var;
+`
+*/
+
+const fcleanUpScript = `
+rm -rf %[1]vsvc/automate-opensearch/data.os;
+rm -rf %[1]vsvc/automate-opensearch/var.os;
+rm -rf %[1]vsvc/automate-elasticsearch/data;
+rm -rf %[1]vsvc/automate-elasticsearch/var;
 `
 
 func cleanUpes() error {
@@ -558,6 +593,8 @@ func cleanUpes() error {
 			return err
 		}
 	}
+	habRoot := getHabRootPath(habrootcmd)
+	cleanUpScript := fmt.Sprintf(fcleanUpScript, habRoot)
 
 	command := exec.Command("/bin/sh", "-c", cleanUpScript)
 	err := command.Run()

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -475,16 +475,17 @@ func getHabRootPath(habrootcmd string) string {
 		writer.Fail(err.Error())
 		return ""
 	}
-	pkgPath := string(out)
+	pkgPath := string(out) // /a/b/c/hab    /hab/svc
 	writer.Title("HAB Root Path " + pkgPath)
 	habIndex := strings.Index(string(pkgPath), "hab")
 	rootHab := pkgPath[0 : habIndex+4] // this will give <>/<>/hab/
 	return rootHab
 }
 
+const habRootPathForPg = "HAB_LICENSE=accept-no-persist hab pkg path core/postgresql13"
+
 func getLatestPgPath() {
-	latestPgPath := "lsof -F n| grep /hab/pkgs/core/postgresql13 | awk '{print $0}' | awk -F \"/\" '/1/ {print $5\"/\"$6\"/\"$7}' | uniq"
-	cmd, err := exec.Command("/bin/sh", "-c", latestPgPath).Output()
+	cmd, err := exec.Command("/bin/sh", "-c", habRootPathForPg).Output()
 	if err != nil {
 		fmt.Printf("error %s", err)
 	}
@@ -497,7 +498,7 @@ func getLatestPgPath() {
 	}
 
 	if strings.Contains(strings.ToUpper(output), NEW_PG_VERSION) {
-		NEW_BIN_DIR = "/hab/pkgs/core/" + strings.TrimSpace(output) + "/bin"
+		NEW_BIN_DIR = strings.TrimSpace(output) + "/bin"
 	} else {
 		fmt.Printf("latest version %s not found", NEW_PG_VERSION)
 	}

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -476,10 +476,10 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager, habRoot stri
 }
 
 func getHabRootPath(habrootcmd string) string {
-	out, err := exec.Command(habrootcmd).Output()
+	out, err := exec.Command("/bin/sh", "-c", habrootcmd).Output()
 	if err != nil {
 		writer.Fail(err.Error())
-		return ""
+		return "/hab/"
 	}
 	pkgPath := string(out) // /a/b/c/hab    /hab/svc
 	writer.Title("HAB Root Path " + pkgPath)

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -491,7 +491,7 @@ func getLatestPgPath() {
 	}
 	output := string(cmd)
 
-	output = strings.Split(output, "\n")[0]
+	///output = strings.Split(output, "\n")[0]
 
 	if strings.TrimSpace(output) == "" {
 		return

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -453,7 +453,13 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager) error {
 		}
 	}()
 	habRoot := getHabRootPath(habrootcmd)
+	fmt.Println("---------------------habRoot-------------------")
+	fmt.Println(habRoot)
+
 	script := fmt.Sprintf(fscript, habRoot)
+	fmt.Println("---------------------scritp-------------------")
+	fmt.Println(script)
+
 	command := exec.Command("/bin/sh", "-c", script)
 
 	err := command.Run()
@@ -595,8 +601,12 @@ func cleanUpes() error {
 		}
 	}
 	habRoot := getHabRootPath(habrootcmd)
-	cleanUpScript := fmt.Sprintf(fcleanUpScript, habRoot)
+	fmt.Println("---------------------habRoot-------------------")
+	fmt.Println(habRoot)
 
+	cleanUpScript := fmt.Sprintf(fcleanUpScript, habRoot)
+	fmt.Println("----------------------------------------")
+	fmt.Println(cleanUpScript)
 	command := exec.Command("/bin/sh", "-c", cleanUpScript)
 	err := command.Run()
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -422,12 +422,15 @@ func esMigrateExecutor(ci *majorupgradechecklist.PostChecklistManager) error {
 		writer.Warn("Pre Requiste For ES DataMigration failed : " + err.Error())
 		return nil
 	}
+	habRoot := getHabRootPath(habrootcmd)
+	fmt.Println("---------------------habRoot-------------------")
+	fmt.Println(habRoot)
 
 	err = chefAutomateStop()
 	if err != nil {
 		return err
 	}
-	err = executeMigrate(ci)
+	err = executeMigrate(ci, habRoot)
 	if err != nil {
 		return err
 	}
@@ -435,7 +438,7 @@ func esMigrateExecutor(ci *majorupgradechecklist.PostChecklistManager) error {
 	return nil
 }
 
-func executeMigrate(ci *majorupgradechecklist.PostChecklistManager) error {
+func executeMigrate(ci *majorupgradechecklist.PostChecklistManager, habRoot string) error {
 	writer.Title(
 		"----------------------------------------------\n" +
 			"migration from es to os \n" +
@@ -452,9 +455,6 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager) error {
 			writer.Fail(err.Error())
 		}
 	}()
-	habRoot := getHabRootPath(habrootcmd)
-	fmt.Println("---------------------habRoot-------------------")
-	fmt.Println(habRoot)
 
 	script := fmt.Sprintf(fscript, habRoot)
 	fmt.Println("---------------------scritp-------------------")
@@ -485,6 +485,9 @@ func getHabRootPath(habrootcmd string) string {
 	writer.Title("HAB Root Path " + pkgPath)
 	habIndex := strings.Index(string(pkgPath), "hab")
 	rootHab := pkgPath[0 : habIndex+4] // this will give <>/<>/hab/
+	if rootHab == "" {
+		rootHab = "/hab/"
+	}
 	return rootHab
 }
 

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -577,12 +577,7 @@ func cleanUpes() error {
 		}
 	}
 	habRoot := getHabRootPath(habrootcmd)
-	fmt.Println("---------------------habRoot-------------------")
-	fmt.Println(habRoot)
-
 	cleanUpScript := fmt.Sprintf(fcleanUpScript, habRoot)
-	fmt.Println("----------------------------------------")
-	fmt.Println(cleanUpScript)
 	command := exec.Command("/bin/sh", "-c", cleanUpScript)
 	err := command.Run()
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -394,16 +394,6 @@ func preRequisteForESDataMigration() (bool, error) {
 	return existDir, nil
 }
 
-/*
-const script = `
-mv /hab/svc/automate-opensearch/data /hab/svc/automate-opensearch/data.os;
-mv /hab/svc/automate-opensearch/var /hab/svc/automate-opensearch/var.os;
-cp -r /hab/svc/automate-elasticsearch/data /hab/svc/automate-opensearch/;
-cp -r /hab/svc/automate-elasticsearch/var /hab/svc/automate-opensearch/;
-chown -RL hab:hab /hab/svc/automate-opensearch/data;
-chown -RL hab:hab /hab/svc/automate-opensearch/var;
-`
-*/
 const habrootcmd = "HAB_LICENSE=accept-no-persist hab pkg path chef/deployment-service"
 
 const fscript = `
@@ -423,9 +413,6 @@ func esMigrateExecutor(ci *majorupgradechecklist.PostChecklistManager) error {
 		return nil
 	}
 	habRoot := getHabRootPath(habrootcmd)
-	fmt.Println("---------------------habRoot-------------------")
-	fmt.Println(habRoot)
-
 	err = chefAutomateStop()
 	if err != nil {
 		return err
@@ -457,9 +444,6 @@ func executeMigrate(ci *majorupgradechecklist.PostChecklistManager, habRoot stri
 	}()
 
 	script := fmt.Sprintf(fscript, habRoot)
-	fmt.Println("---------------------scritp-------------------")
-	fmt.Println(script)
-
 	command := exec.Command("/bin/sh", "-c", script)
 
 	err := command.Run()
@@ -499,8 +483,6 @@ func getLatestPgPath() {
 		fmt.Printf("error %s", err)
 	}
 	output := string(cmd)
-
-	///output = strings.Split(output, "\n")[0]
 
 	if strings.TrimSpace(output) == "" {
 		return
@@ -575,15 +557,6 @@ func cleanUp() error {
 	}
 	return nil
 }
-
-/*
-const cleanUpScript = `
-rm -rf /hab/svc/automate-opensearch/data.os;
-rm -rf /hab/svc/automate-opensearch/var.os;
-rm -rf /hab/svc/automate-elasticsearch/data;
-rm -rf /hab/svc/automate-elasticsearch/var;
-`
-*/
 
 const fcleanUpScript = `
 rm -rf %[1]vsvc/automate-opensearch/data.os;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
need to read the /hab path in case of it mount to some other location
this changes tried to read the /hab path, either it return /hab OR /<>/hab 
SHIELD-45

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
