### PR TITLE
Automate ha deployment workspace upgrade

### DIFF
--- a/components/automate-backend-deployment/habitat/hooks/install
+++ b/components/automate-backend-deployment/habitat/hooks/install
@@ -87,5 +87,7 @@ if [ -L /hab/a2_deploy_workspace ]; then
   fi
 fi
 
+cp -r $OLD_WORKSPACE/terraform/destroy/aws/* $NEW_WORKSPACE/terraform/destroy/aws;
+
 # shellcheck disable=SC1083
 ln -nsf $NEW_WORKSPACE /hab/a2_deploy_workspace

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -33,7 +33,7 @@ func (a *awsDeployment) doDeployWork(args []string) error {
 
 func (a *awsDeployment) doProvisionJob(args []string) error {
 	writer.Print("AWS Provision")
-	err := bootstrapEnv(a)
+	err := bootstrapEnv(a, deployCmdFlags.airgap)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -20,7 +20,7 @@ func newExistingInfa(configPath string) *existingInfra {
 }
 
 func (e *existingInfra) doDeployWork(args []string) error {
-	var err = bootstrapEnv(e)
+	var err = bootstrapEnv(e, deployCmdFlags.airgap)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/airgap"
+	"github.com/chef/automate/components/automate-deployment/pkg/manifest/parser"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const habpkgcmd = "HAB_LICENSE=accept-no-persist hab pkg path chef/automate-ha-deployment"
+const pkgName = "automate-ha-deployment"
+
+const workspaceUpgradeHelpDocs = `
+This command will be used to upgrde Automate HA workspace version.
+Usage:
+    chef-automate workspace-upgrade <airgap-bundle>
+`
+
+func init() {
+	workspaceUpgrdeCmd.SetUsageTemplate(workspaceUpgradeHelpDocs)
+	RootCmd.AddCommand(workspaceUpgrdeCmd)
+}
+
+var workspaceUpgrdeCmd = &cobra.Command{
+	Use:   "workspace-upgrade",
+	Short: "upgrdeWorkspace",
+	Long:  "Upgrade Automate HA workspace version",
+	Annotations: map[string]string{
+		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
+	},
+	RunE: worspaceUpgradeCmdExecute,
+}
+
+func worspaceUpgradeCmdExecute(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return status.Wrap(errors.New("Incorrect command usage"), 0, workspaceUpgradeHelpDocs)
+	}
+	if isA2HARBFileExist() {
+		upgraded := upgradeWorspace(args[0])
+		if !upgraded {
+			return errors.New("No upgrade available in airgap bundle")
+		} else {
+			writer.Println("upgraded.")
+			return nil
+		}
+	}
+	return errors.New(AUTOMATE_HA_INVALID_BASTION)
+}
+
+func upgradeWorspace(bundle string) bool {
+	updateAvailabe, err := checkIfNewBundleHaveWorkspaceUpdate(bundle)
+	if err != nil {
+		writer.Println(err.Error())
+	}
+	if updateAvailabe {
+		upgradeAccepted := false
+		if !upgradeRunCmdFlags.upgradeHAWorkspace {
+			response, err := writer.Prompt("Automate HA workspace will get updated to latest version press y to agree, n to to disagree? [y/n]")
+			if err != nil {
+				upgradeAccepted = false
+			}
+			if !strings.Contains(response, "y") {
+				upgradeAccepted = false
+				writer.Println("Not update HA workspace to newer version.")
+			} else {
+				upgradeAccepted = true
+			}
+		} else {
+			upgradeAccepted = true
+		}
+		if upgradeAccepted {
+			writer.Println("Bootstraping for new version.")
+			err := doBootstrapEnv(bundle)
+			if err != nil {
+				writer.Println(err.Error())
+				return false
+			}
+			return true
+		}
+	}
+	return false
+}
+func checkIfNewBundleHaveWorkspaceUpdate(bundle string) (bool, error) {
+	currVerAndRel := getCurrentInstalledWorsapceVersion()
+	newVersion, err := getWorkspaceVersionFromBundle(bundle)
+	if err != nil {
+		return false, err
+	}
+	nv0 := semver.MustParse(newVersion[0])
+	cv0 := semver.MustParse(currVerAndRel[0])
+
+	nv1, _ := strconv.ParseInt(strings.TrimSpace(newVersion[1]), 10, 64)
+	cv1, _ := strconv.ParseInt(strings.TrimSpace(currVerAndRel[1]), 10, 64)
+	if nv0.GT(cv0) || nv1 > cv1 {
+		writer.Println("update for new verison of automate-ha-deployment available")
+		writer.Printf("Installed version %s, %s \n", currVerAndRel[0], currVerAndRel[1])
+		writer.Printf("Airgap bundled version %s, %s \n", newVersion[0], newVersion[1])
+		return true, nil
+	}
+	return false, nil
+}
+
+func getCurrentInstalledWorsapceVersion() []string {
+	out, err := exec.Command("/bin/sh", "-c", habpkgcmd).Output()
+	if err != nil {
+		writer.Fail(err.Error())
+		return nil
+	}
+	currentVersion := string(out)
+	cvTokens := strings.Split(currentVersion, "/")
+	currVerAndRel := cvTokens[len(cvTokens)-2:]
+	return currVerAndRel
+}
+
+func getWorkspaceVersionFromBundle(bundle string) ([]string, error) {
+	_, manifestBytes, err := airgap.GetMetadata(bundle)
+	if err != nil {
+		return nil, status.Annotate(err, status.AirgapUnpackInstallBundleError)
+	}
+
+	manifest, err := parser.ManifestFromBytes(manifestBytes)
+	if err != nil {
+		return nil, status.Annotate(err, status.AirgapUnpackInstallBundleError)
+	}
+
+	writer.Printf("  Version: %s\n", manifest.Build)
+	writer.Printf("Build SHA: %s\n", manifest.BuildSHA)
+	writer.Printf(" Packages:\n")
+	workspacePkgVersion := make([]string, 2)
+	for _, pkg := range manifest.Packages {
+		_pkgName := pkg.Name()
+		if strings.Contains(_pkgName, pkgName) {
+			pkg.Release()
+			workspacePkgVersion[0] = pkg.Version()
+			workspacePkgVersion[1] = pkg.Release()
+			//append(workspacePkgVersion, pkg.Version(), pkg.Release())
+			break
+		}
+	}
+	return workspacePkgVersion, nil
+}

--- a/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
@@ -34,7 +34,8 @@ var workspaceUpgrdeCmd = &cobra.Command{
 	Annotations: map[string]string{
 		NoCheckVersionAnnotation: NoCheckVersionAnnotation,
 	},
-	RunE: worspaceUpgradeCmdExecute,
+	RunE:   worspaceUpgradeCmdExecute,
+	Hidden: true,
 }
 
 func worspaceUpgradeCmdExecute(cmd *cobra.Command, args []string) error {

--- a/test/lib/credentials.rb
+++ b/test/lib/credentials.rb
@@ -177,13 +177,13 @@ module AutomateCluster
                   ssl_key = """#{certificates[:opensearch][:private][:value]}"""
                   admin_cert = """#{certificates[:opensearch_admin][:public][:value]}"""
                   admin_key = """#{certificates[:opensearch_admin][:private][:value]}"""
-                [plugins.security.authcz]
-                  admin_dn = [ "#{certificates[:opensearch_admin][:public][:full_cn_reversed]}" ]
-                [plugins.security.ssl.transport]
-                  enforce_hostname_verification = false
-                  resolve_hostname = false
-                [plugins.security]
-                  nodes_dn = [ "#{certificates[:opensearch][:public][:full_cn_reversed]}" ]
+                #[plugins.security.authcz]
+                #  admin_dn = [ "#{certificates[:opensearch_admin][:public][:full_cn_reversed]}" ]
+                #[plugins.security.ssl.transport]
+                #  enforce_hostname_verification = false
+                #  resolve_hostname = false
+                #[plugins.security]
+                #  nodes_dn = [ "#{certificates[:opensearch][:public][:full_cn_reversed]}" ]
               ENDHEREDOC
             else
               utils.backend_logger.error 'Opensearch Certificate values were not set properly - aborting!'
@@ -385,14 +385,14 @@ module AutomateCluster
             },
             opensearch_admin: {
               public: {
-                filename: "#{utils.top_level_dir}/certs/es_admin_ssl_public.pem",
+                filename: "#{utils.top_level_dir}/certs/oser_admin_ssl_public.pem",
                 value: nil,
                 full_cn_reversed: nil,
                 short_cn: nil,
                 extendedKeyUsage_client_server: true
               },
               private: {
-                filename: "#{utils.top_level_dir}/certs/es_admin_ssl_private.key",
+                filename: "#{utils.top_level_dir}/certs/oser_admin_ssl_private.key",
                 value: nil
               }
             },


### PR DESCRIPTION
While doing chef-automate upgrade we need to upgrade ha workspace in case airgap bundle have available updates for automate-ha-deployment package, we have included this feature in chef-automate upgrade run command,
also we have introduced a new command to manually upgrade workspace if needed, command will be chef-automate workspace-upgrade <automate-X.X.XX.aib>

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
