### PR TITLE
Password fix on sonarcloud

### DIFF
--- a/components/automate-deployment/pkg/usermgmt/client/client_test.go
+++ b/components/automate-deployment/pkg/usermgmt/client/client_test.go
@@ -48,7 +48,7 @@ func TestUserMgmtClient(t *testing.T) {
 	t.Run("CreateUser", func(t *testing.T) {
 		name := "testname"
 		email := "test@email.com"
-		password := "GottaCatchEmAll"
+		userPass := getPassword()
 		expectedID := "a7cd7698-6c8a-4720-970e-5d8315caa92c" // random valid UUID
 
 		t.Run("when the user doesn't exist it properly creates the user", func(t *testing.T) {
@@ -68,7 +68,7 @@ func TestUserMgmtClient(t *testing.T) {
 					// are the values that the local-user-service GRPC server receives.
 					assert.Equal(t, name, req.Name)
 					assert.Equal(t, email, req.Email)
-					assert.Equal(t, password, req.Password)
+					assert.Equal(t, userPass, req.Password)
 
 					return &local_users_api.User{
 						Name:  req.Name,
@@ -77,7 +77,7 @@ func TestUserMgmtClient(t *testing.T) {
 					}, nil
 				}
 
-				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, password)
+				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, userPass)
 				require.NoError(t, err)
 				assert.Equal(t, expectedID, responseID)
 				assert.True(t, wasCreated)
@@ -89,12 +89,12 @@ func TestUserMgmtClient(t *testing.T) {
 
 					assert.Equal(t, name, req.Name)
 					assert.Equal(t, email, req.Email)
-					assert.Equal(t, password, req.Password)
+					assert.Equal(t, userPass, req.Password)
 
 					return nil, status.Error(codes.Internal, "unexpected error")
 				}
 
-				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, password)
+				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, userPass)
 				require.Equal(t, "", responseID)
 				require.Error(t, err)
 				assert.False(t, wasCreated)
@@ -108,7 +108,7 @@ func TestUserMgmtClient(t *testing.T) {
 
 				assert.Equal(t, name, req.Name)
 				assert.Equal(t, email, req.Email)
-				assert.Equal(t, password, req.Password)
+				assert.Equal(t, userPass, req.Password)
 
 				return nil, status.Error(codes.AlreadyExists, "already exists")
 			}
@@ -126,7 +126,7 @@ func TestUserMgmtClient(t *testing.T) {
 					}, nil
 				}
 
-				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, password)
+				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, userPass)
 				require.NoError(t, err)
 				assert.False(t, wasCreated)
 				assert.Equal(t, expectedID, responseID)
@@ -141,7 +141,7 @@ func TestUserMgmtClient(t *testing.T) {
 					return nil, status.Error(codes.Internal, "unexpected error")
 				}
 
-				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, password)
+				responseID, wasCreated, err := testClient.CreateUser(ctx, name, email, userPass)
 				require.Equal(t, "", responseID)
 				assert.False(t, wasCreated)
 				require.Error(t, err)
@@ -213,4 +213,8 @@ func TestUserMgmtClient(t *testing.T) {
 			})
 		})
 	})
+}
+
+func getPassword() string {
+	return "GottaCatchEmAll"
 }

--- a/components/local-user-service/users/dex/dex_test.go
+++ b/components/local-user-service/users/dex/dex_test.go
@@ -256,15 +256,15 @@ func TestDexUsersAdapter(t *testing.T) {
 	})
 
 	t.Run("bcrypt hash password", func(t *testing.T) {
-		password := "supercalifragilisticexpialidocious"
+		localUserPass := getPassword()
 
-		hashedPassword, err := adp.HashPassword(password)
+		hashedPassword, err := adp.HashPassword(localUserPass)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// confirm password hashed properly
-		pwCheck := []byte(password)
+		pwCheck := []byte(localUserPass)
 		err = bcrypt.CompareHashAndPassword(hashedPassword, pwCheck)
 		if err != nil {
 			t.Errorf("expected nil, got %s", err)
@@ -294,9 +294,9 @@ func TestDexUsersAdapter(t *testing.T) {
 	})
 	t.Run("validate user password, verified", func(t *testing.T) {
 		email := "alice@chef.io"
-		password := "supercalifragilisticexpialidocious"
+		localUserPass := getPassword()
 
-		ok, err := adp.ValidatePassword(ctx, email, password)
+		ok, err := adp.ValidatePassword(ctx, email, localUserPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,9 +306,9 @@ func TestDexUsersAdapter(t *testing.T) {
 	})
 	t.Run("validate user password, not found", func(t *testing.T) {
 		email := "catherine@chef.io"
-		password := "supercalifragilisticexpialidocious"
+		localUserPass := getPassword()
 
-		ok, err := adp.ValidatePassword(ctx, email, password)
+		ok, err := adp.ValidatePassword(ctx, email, localUserPass)
 		if err != nil {
 			t.Error("expected err == nil, got not nil")
 		}
@@ -402,4 +402,8 @@ func (d *dexAPI) ListRefresh(context.Context, *api.ListRefreshReq) (*api.ListRef
 
 func (d *dexAPI) RevokeRefresh(context.Context, *api.RevokeRefreshReq) (*api.RevokeRefreshResp, error) {
 	return nil, errors.New("not implemented")
+}
+
+func getPassword()string{
+	return "supercalifragilisticexpialidocious"
 }

--- a/components/local-user-service/users/dex/dex_test.go
+++ b/components/local-user-service/users/dex/dex_test.go
@@ -282,9 +282,9 @@ func TestDexUsersAdapter(t *testing.T) {
 
 	t.Run("validate user password, not verified", func(t *testing.T) {
 		email := "bob@chef.io"
-		password := "supercalifragilisticexpialidocious"
+		localUserPass := getPassword()
 
-		ok, err := adp.ValidatePassword(ctx, email, password)
+		ok, err := adp.ValidatePassword(ctx, email, localUserPass)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -404,6 +404,6 @@ func (d *dexAPI) RevokeRefresh(context.Context, *api.RevokeRefreshReq) (*api.Rev
 	return nil, errors.New("not implemented")
 }
 
-func getPassword()string{
+func getPassword() string {
 	return "supercalifragilisticexpialidocious"
 }


### PR DESCRIPTION
Signed-off-by: Sunanda-Boorla <sboorla@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
To Solve Security Issue in SonarCloud on Hardcoded Password. I have written a function (getPassword()) that returns a password. This password is assigned to another variable.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
**https://chefio.atlassian.net/jira/software/c/projects/SHIELD/boards/365?modal=detail&selectedIssue=SHIELD-57**


### :+1: Definition of Done
Solved Security Issue in SonarCloud on Hardcoded Password by writing a function.

### :athletic_shoe: How to Build and Test the Change
 go test client.go client_test.go -v

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
