### PR TITLE
Managed OS backup/restore fixes

### DIFF
--- a/api/config/esgateway/config_request.go
+++ b/api/config/esgateway/config_request.go
@@ -154,7 +154,7 @@ func (c *ConfigRequest) SetGlobalConfig(g *ac.GlobalConfig) {
 					auth.GetBasicAuth().GetPassword().GetValue(),
 				),
 			)))
-		case "aws_es":
+		case "aws_os":
 			// If we only have 1 AWS Opensearch Service endpoint specified, we can assume that
 			// the host header should be the name of that endpoint.
 			if c.V1.Sys.Ngx.Http.ProxySetHeaderHost.Value == "$http_host" && len(endpoints) == 1 {

--- a/api/config/esgateway/config_request_test.go
+++ b/api/config/esgateway/config_request_test.go
@@ -29,7 +29,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.False(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -59,7 +59,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.False(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -90,7 +90,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -118,7 +118,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.False(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -146,7 +146,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -173,7 +173,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.False(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -201,7 +201,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.False(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -229,7 +229,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -257,7 +257,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		assert.True(t,
 			c.GetV1().GetSys().GetExternal().GetSslUpstream().GetValue(),
@@ -276,7 +276,7 @@ func TestExternalOpensearch(t *testing.T) {
 		require.Equal(t, c.V1.Sys.Ngx.Main.Resolvers.NameserversString.GetValue(), "111.11.11.11:50", "does not match with the nameserver passed")
 	})
 
-	t.Run("aws elasticsearch", func(t *testing.T) {
+	t.Run("aws opensearch", func(t *testing.T) {
 		c := DefaultConfigRequest()
 		c.SetGlobalConfig(&ac.GlobalConfig{
 			V1: &ac.V1{
@@ -287,7 +287,7 @@ func TestExternalOpensearch(t *testing.T) {
 							w.String("https://server1"),
 						},
 						Auth: &ac.External_Opensearch_Authentication{
-							Scheme: w.String("aws_es"),
+							Scheme: w.String("aws_os"),
 							AwsOs: &ac.External_Opensearch_Authentication_AwsOpensearchAuth{
 								Username: w.String("testuser"),
 								Password: w.String("testpassword"),
@@ -300,7 +300,7 @@ func TestExternalOpensearch(t *testing.T) {
 
 		require.True(t,
 			c.GetV1().GetSys().GetExternal().GetEnable().GetValue(),
-			"expected external ES to be enabled")
+			"expected external OS to be enabled")
 
 		require.Equal(t, "server1", c.GetV1().GetSys().GetExternal().GetParsedEndpoints()[0].GetAddress().GetValue())
 		require.Equal(t, "443", c.GetV1().GetSys().GetExternal().GetParsedEndpoints()[0].GetPort().GetValue())

--- a/components/es-sidecar-service/habitat/config/config.toml
+++ b/components/es-sidecar-service/habitat/config/config.toml
@@ -62,42 +62,42 @@ elasticsearch_url = "http://127.0.0.1:{{gwmember.cfg.http-port}}"
   {{~#if cfg.backups.s3.base_path}}
   base_path = "{{cfg.backups.s3.base_path}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.compress}}
-  compress = {{cfg.backups.s3.es.compress}}
+  {{~#if cfg.backups.s3.os.compress}}
+  compress = {{cfg.backups.s3.os.compress}}
   {{~/if}}
-  {{~#if cfg.backups.s3.es.server_side_encryption}}
-  server_side_encryption = "{{cfg.backups.s3.es.server_side_encryption}}"
+  {{~#if cfg.backups.s3.os.server_side_encryption}}
+  server_side_encryption = "{{cfg.backups.s3.os.server_side_encryption}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.buffer_size}}
-  buffer_size = "{{cfg.backups.s3.es.buffer_size}}"
+  {{~#if cfg.backups.s3.os.buffer_size}}
+  buffer_size = "{{cfg.backups.s3.os.buffer_size}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.canned_acl}}
-  canned_acl = "{{cfg.backups.s3.es.canned_acl}}"
+  {{~#if cfg.backups.s3.os.canned_acl}}
+  canned_acl = "{{cfg.backups.s3.os.canned_acl}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.storage_class}}
-  storage_class = "{{cfg.backups.s3.es.storage_class}}"
+  {{~#if cfg.backups.s3.os.storage_class}}
+  storage_class = "{{cfg.backups.s3.os.storage_class}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.max_snapshot_bytes_per_sec}}
-  max_snapshot_bytes_per_sec = "{{cfg.backups.s3.es.max_snapshot_bytes_per_sec}}"
+  {{~#if cfg.backups.s3.os.max_snapshot_bytes_per_sec}}
+  max_snapshot_bytes_per_sec = "{{cfg.backups.s3.os.max_snapshot_bytes_per_sec}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.max_restore_bytes_per_sec}}
-  max_restore_bytes_per_sec = "{{cfg.backups.s3.es.max_restore_bytes_per_sec}}"
+  {{~#if cfg.backups.s3.os.max_restore_bytes_per_sec}}
+  max_restore_bytes_per_sec = "{{cfg.backups.s3.os.max_restore_bytes_per_sec}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.chunk_size}}
-  chunk_size = "{{cfg.backups.s3.es.chunk_size}}"
+  {{~#if cfg.backups.s3.os.chunk_size}}
+  chunk_size = "{{cfg.backups.s3.os.chunk_size}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.region}}
-  region = "{{cfg.backups.s3.es.region}}"
+  {{~#if cfg.backups.s3.os.region}}
+  region = "{{cfg.backups.s3.os.region}}"
   {{~/if}}
-  {{~#if cfg.backups.s3.es.role_arn}}
-  role_arn = "{{cfg.backups.s3.es.role_arn}}"
+  {{~#if cfg.backups.s3.os.role_arn}}
+  role_arn = "{{cfg.backups.s3.os.role_arn}}"
   {{~/if}}
 
   {{~#if cfg.backups.s3.enable_aws_auth}}
 [backups.s3.aws_auth]
 enable = true
-    {{~#if cfg.backups.s3.es.region}}
-region = "{{cfg.backups.s3.es.region}}"
+    {{~#if cfg.backups.s3.os.region}}
+region = "{{cfg.backups.s3.os.region}}"
     {{~/if}}
     {{~#if cfg.backups.s3.aws_auth.access_key}}
 access_key = "{{cfg.backups.s3.aws_auth.access_key}}"
@@ -105,8 +105,8 @@ access_key = "{{cfg.backups.s3.aws_auth.access_key}}"
     {{~#if cfg.backups.s3.aws_auth.secret_key}}
 secret_key = "{{cfg.backups.s3.aws_auth.secret_key}}"
     {{~/if}}
-    {{~#if cfg.backups.s3.es_url}}
-es_url = "{{cfg.backups.s3.es_url}}"
+    {{~#if cfg.backups.s3.os_url}}
+es_url = "{{cfg.backups.s3.os_url}}"
     {{~/if}}
 
   {{~/if}}

--- a/components/es-sidecar-service/pkg/elastic/snapshot.go
+++ b/components/es-sidecar-service/pkg/elastic/snapshot.go
@@ -618,6 +618,7 @@ func (es *Elastic) indicesAndShardsInSnapshot(ctx context.Context, repoName, sna
 	return indexesList, shardsToWaitFor, nil
 }
 
+
 func (es *Elastic) indicesSnapshotRecoveryStatus(ctx context.Context) (*indicesRecoveryStats, error) {
 	indicesRecoveryPath := "/_all/_recovery"
 

--- a/components/es-sidecar-service/pkg/elastic/snapshot.go
+++ b/components/es-sidecar-service/pkg/elastic/snapshot.go
@@ -619,7 +619,7 @@ func (es *Elastic) indicesAndShardsInSnapshot(ctx context.Context, repoName, sna
 }
 
 func (es *Elastic) indicesSnapshotRecoveryStatus(ctx context.Context) (*indicesRecoveryStats, error) {
-	indicesRecoveryPath := "/_recovery"
+	indicesRecoveryPath := "/_all/_recovery"
 
 	response, err := es.client.PerformRequest(ctx, elastic.PerformRequestOptions{
 		Method: "GET",


### PR DESCRIPTION
Signed-off-by: Vipin Yadav <vipin.yadav@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

- Variable changed from aws_es to aws_os in config/esgateway go file
- Also made changes in es-sidecar-service config.toml to use os settings.
- As AWS OpenSearch returns "Your request: '/_recovery' is not allowed." for "/_recovery"  api.
Modified api call from  "/_recovery" to "/_all/_recovery" to get snapshot recovery status during OpenSearch recovery operations 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
1. First build the following packages:-
   a. es-sidecar-service
   b. automate-deployment
   c. automate-gateway
   d.automate-cli
2. provide required info in config:-

[global.v1.external.opensearch]
enable = true
nodes = ["node_endpoint"]

[global.v1.external.opensearch.auth]
scheme = "aws_os"          
[global.v1.external.opensearch.auth.aws_os]
username = "username"
password = "password"
access_key = "access_key"
secret_key = "sercet_key"
[global.v1.external.opensearch.ssl]
root_cert = "certificate"
[global.v1.external.opensearch.backup]
enable = true
location = "s3"
[global.v1.external.opensearch.backup.s3]
bucket = "your_bucket_name"
[global.v1.external.opensearch.backup.s3.settings]
region   = "ap-south-1"
role_arn = "iam_role_with_required_permissions"

[global.v1.backups]
location = "s3"
[global.v1.backups.s3.bucket]
name = "bucket_name"
endpoint = "https://s3.amazonaws.com"
base_path = "your_base_path"

3. patch config 
4. now backup and restore should work


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
