### PR TITLE
Fixing admin-dn and node-dn for openserarch cert rotations

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -6,3 +6,4 @@ This package will build a package using terraform/a2ha-terraform, inspecs, test,
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get avilable after installing this package.
 
+

--- a/components/automate-cluster-ctl/readme
+++ b/components/automate-cluster-ctl/readme
@@ -1,2 +1,3 @@
 automate-cluster-ctl
 
+

--- a/test/lib/credentials.rb
+++ b/test/lib/credentials.rb
@@ -177,13 +177,13 @@ module AutomateCluster
                   ssl_key = """#{certificates[:opensearch][:private][:value]}"""
                   admin_cert = """#{certificates[:opensearch_admin][:public][:value]}"""
                   admin_key = """#{certificates[:opensearch_admin][:private][:value]}"""
-                #[plugins.security.authcz]
-                #  admin_dn = [ "#{certificates[:opensearch_admin][:public][:full_cn_reversed]}" ]
-                #[plugins.security.ssl.transport]
-                #  enforce_hostname_verification = false
-                #  resolve_hostname = false
-                #[plugins.security]
-                #  nodes_dn = [ "#{certificates[:opensearch][:public][:full_cn_reversed]}" ]
+                [plugins.security.authcz]
+                  admin_dn = '- #{certificates[:opensearch_admin][:public][:full_cn_reversed]}'
+                [plugins.security.ssl.transport]
+                  enforce_hostname_verification = false
+                  resolve_hostname = false
+                [plugins.security]
+                  nodes_dn = '- #{certificates[:opensearch][:public][:full_cn_reversed]}'
               ENDHEREDOC
             else
               utils.backend_logger.error 'Opensearch Certificate values were not set properly - aborting!'


### PR DESCRIPTION
after cert rotation with admin-dn and node-dn es-sidecar was complaining for as it is not proper, This fix will will solve this problem.

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
