### PR TITLE
"Bump minimist from 1.2.5 to 1.2.6 in /components/automate-ui"

### DIFF
--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -10680,9 +10680,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "3.1.3",

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -56,7 +56,7 @@
     "immutable": "^3.8.2",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
-    "minimist": "^1.2.6",
+    "minimist": "^1.2.5",
     "moment": "^2.29.1",
     "ngx-cookie": "^5.0.2",
     "ngx-infinite-scroll": "^10.0.1",


### PR DESCRIPTION
chef/automate#7068