### PR TITLE
Validate all indexes are of version 6 before upgrade of Elasticsearch in major upgrade to 4.x

### DIFF
--- a/components/automate-deployment/pkg/majorupgradechecklist/v4_test.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4_test.go
@@ -24,6 +24,12 @@ func TestGetMajorVersion(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, int64(-1), majorVersion)
 	assert.Equal(t, "", version)
+
+	versionData = []byte(`{"comp-2-run-info":{"settings":{"index":{"creation_date_string":"2022-06-06T10:50:55.477Z","refresh_interval":"1s","number_of_shards":"5","provided_name":"comp-2-run-info","creation_date":"1654512655477","number_of_replicas":"1","uuid":"cYlQeyHNRn2mnsvIRZ1-rg"}}}}`)
+	majorVersion, version, err = getMajorVersion(versionData, "comp-2-run-info")
+	assert.Error(t, err)
+	assert.Equal(t, int64(-1), majorVersion)
+	assert.Equal(t, "", version)
 }
 
 func TestFormErrorMsg(t *testing.T) {

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4_test.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4_test.go
@@ -1,0 +1,38 @@
+package majorupgradechecklist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMajorVersion(t *testing.T) {
+	versionData := []byte(`{"comp-2-run-info":{"settings":{"index":{"creation_date_string":"2022-06-06T10:50:55.477Z","refresh_interval":"1s","number_of_shards":"5","provided_name":"comp-2-run-info","creation_date":"1654512655477","number_of_replicas":"1","uuid":"cYlQeyHNRn2mnsvIRZ1-rg","version":{"created_string":"1.2.4","created":"135238227"}}}}}`)
+	majorVersion, version, err := getMajorVersion(versionData, "comp-2-run-info")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), majorVersion)
+	assert.Equal(t, "1.2.4", version)
+
+	versionData = []byte(`{"comp-2-run-info":{"settings":{"index":{"creation_date_string":"2022-06-06T10:50:55.477Z","refresh_interval":"1s","number_of_shards":"5","provided_name":"comp-2-run-info","creation_date":"1654512655477","number_of_replicas":"1","uuid":"cYlQeyHNRn2mnsvIRZ1-rg","version":{"created_string":"7.2.4","created":"135238227"}}}}}`)
+	majorVersion, version, err = getMajorVersion(versionData, "comp-2-run-info")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(7), majorVersion)
+	assert.Equal(t, "7.2.4", version)
+
+	versionData = []byte(`{"comp-2-run-info":{"settings":{"index":{"creation_date_string":"2022-06-06T10:50:55.477Z","refresh_interval":"1s","number_of_shards":"5","provided_name":"comp-2-run-info","creation_date":"1654512655477","number_of_replicas":"1","uuid":"cYlQeyHNRn2mnsvIRZ1-rg","version":{"created":"135238227"}}}}}`)
+	majorVersion, version, err = getMajorVersion(versionData, "comp-2-run-info")
+	assert.Error(t, err)
+	assert.Equal(t, int64(-1), majorVersion)
+	assert.Equal(t, "", version)
+}
+
+func TestFormErrorMsg(t *testing.T) {
+	IndexDetailsArray := []indexDetails{
+		{Name: "abc", Version: "5.6.4"},
+		{Name: "def", Version: "4.3.1"},
+		{Name: "abc", Version: "5.6.2"},
+	}
+	errMsg := formErrorMsg(IndexDetailsArray)
+	assert.Error(t, errMsg)
+	assert.Equal(t, "\nUnsupported index versions. To continue with the upgrade, please reindex the indices shown below to version 6.\n- Index Name: abc, Version: 5.6.4 \n- Index Name: def, Version: 4.3.1 \n- Index Name: abc, Version: 5.6.2 \n\nFollow the guide below to learn more about reindexing:\nhttps://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-reindex.html", errMsg.Error())
+}

--- a/components/automate-es-gateway/habitat/hooks/run
+++ b/components/automate-es-gateway/habitat/hooks/run
@@ -9,4 +9,6 @@ export GODEBUG=x509ignoreCN=0
 # path. Attempt to clean up those log files if they exist:
 rm -f /hab/pkgs/core/nginx/1.15.6/20181212185120/chef /hab/pkgs/core/nginx/1.15.6/20190115154053/chef
 
+echo {{cfg.service.host}}:{{cfg.service.port}} > {{pkg.svc_config_path}}/URL
+
 exec nginx -c {{pkg.svc_config_path}}/nginx.conf


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Automate should check if indexes below version 6 are present before upgrading to automate v4. If they are present we should throw an error.

### :chains: Related Resources

https://chefio.atlassian.net/jira/software/c/projects/SHIELD/boards/365?modal=detail&selectedIssue=SHIELD-55

### :+1: Definition of Done
Before upgrading to automate 4.x, we should check and throw an error if elasticsearch index are below version 6.
### :athletic_shoe: How to Build and Test the Change
- `rebuild components/automate-cli`
- install automate `3.0.49` on a instance
- Create an es5 instance, create some indices, disable sharding using curl command(refer elastic docs)and copy the index data to `/hab/svc/automate-elasticsearch/data`
  Disable Sharding:
  `curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": "primaries"
  }
}
'
`
- `chown -R hab:hab /hab/svc/automate-elasticsearch/data/nodes`
- add the config `xpack.security.enabled: false` to `/hab/pkgs/chef/automate-elasticsearch/config/elasticsearch.yml`
- Enable Sharding:
`curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "cluster.routing.allocation.enable": null
  }
}
'
`
- Copy the chef-automate binary from `/bin/chef-automate` to the new instance
- Now run `./chef-automate upgrade run —major` command
- if there are es5 indices in automate elasticsearch upgrade should fail with error 

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1792" alt="Screenshot 2022-06-08 at 12 55 50 PM" src="https://user-images.githubusercontent.com/59958706/172557096-043e30b6-36ee-4958-9dd4-5ead0ae23201.png">

