### PR TITLE
A2HA users should wait for Automate HA

### DIFF
--- a/components/docs-chef-io/content/automate/major_upgrade.md
+++ b/components/docs-chef-io/content/automate/major_upgrade.md
@@ -12,7 +12,7 @@ gh_repo = "automate"
     weight = 20
 +++
 
-{{< warning >}} Existing A2 HA customers should NOT upgrade to 3.x now. Please wait for Chef Automate HA release. {{< /warning >}}
+{{< warning >}} Existing A2 HA customers, DO NOT UPGRADE until further notice. Stay on the version you are using currently. The last supported release is https://docs.chef.io/release_notes_automate/#20220310123121 Please wait for Chef Automate HA release. {{< /warning >}}
 
 Chef Automate provides an entire suite of enterprise capabilities for node visibility and compliance. Chef Automate upgrades from one minor version to another automatically. However, Chef Automate will not automatically upgrade to a major version. See the instructions below for manually upgrading Chef Automate from date-based versions to Chef Automate 3.x.
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

A2HA users remain on 20220310123121 until Automate HA is supported.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests). Not test. Docs
- [X] Docs added/updated? (all customer-facing changes)