### PR TITLE
update the automate-opensearch config

### DIFF
--- a/api/config/opensearch/config_request.go
+++ b/api/config/opensearch/config_request.go
@@ -193,7 +193,7 @@ const (
 	OSHeapMaxGB = 16
 	// ESHeapPortion is the proportion of system memory we
 	// recommend for ES Heap
-	OSHeapPortion = 0.25
+	OSHeapPortion = 0.5
 	// KBPerGB is the number of KB in a GB, used for conversions
 	KBPerGB = 1048576
 )

--- a/components/automate-opensearch/habitat/config/jvm.options
+++ b/components/automate-opensearch/habitat/config/jvm.options
@@ -45,7 +45,7 @@
 # 10-13:-XX:-UseCMSInitiatingOccupancyOnly
 14-:-XX:+UseG1GC
 14-:-XX:G1ReservePercent=25
-14-:-XX:InitiatingHeapOccupancyPercent=30
+14-:-XX:InitiatingHeapOccupancyPercent=15
 
 ## JVM temporary directory
 -Djava.io.tmpdir=${OPENSEARCH_TMPDIR}

--- a/components/automate-opensearch/habitat/default.toml
+++ b/components/automate-opensearch/habitat/default.toml
@@ -99,7 +99,7 @@
     #
     # Starting limit for overall parent breaker, defaults to 70% of JVM heap.
     #
-    total_limit =                    "70%"
+    total_limit =                    "95%"
     #
     # Limit for fielddata breaker, defaults to 60% of JVM heap.
     #


### PR DESCRIPTION
Signed-off-by: punitmundra <punitmundra2008@gmail.com>

Change the default value for the config 
OSHeapPortion: .5
InitiatingHeapOccupancyPercent : 15 %
indicies.breaker.total_limit : 95%

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
