### PR TITLE
Changes for scaling the aws infra

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,3 +5,4 @@ This provides the `automate-backend-deployment` package.
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get avilable after installing this package.
+

--- a/terraform/a2ha-terraform/modules/aws_output/main.tf
+++ b/terraform/a2ha-terraform/modules/aws_output/main.tf
@@ -34,6 +34,10 @@ resource "local_file" "output" {
 #For starting deployment process after provisioning, we have to set deployment flag in tfvars and tf_arch file.
 resource "null_resource" "output" {
     count = 1
+
+    triggers = {
+      always_run = timestamp()
+    }
     
     provisioner "local-exec" {
         command = "mv ${path.root}/terraform.tfvars ${path.root}/aws.auto.tfvars;sed  -i 's/aws/deployment/' ${path.root}/.tf_arch;sed  -i 's/architecture \"aws\"/architecture \"deployment\"/' ${path.root}/../a2ha.rb"
@@ -44,6 +48,10 @@ resource "null_resource" "output" {
 
 resource "null_resource" "setup_destroy_directory" {
   for_each = toset(local.copy_terraform_files_for_destroy)
+
+  triggers = {
+    always_run = timestamp()
+  }
 
   provisioner "local-exec" {
     command = "cp ${each.value} ${local.destination_path}"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The PR contains the changes to scale the AWS infra after the setup is provisioned or deployed.
In order to properly scale the setup, we need to perform the following steps:
- Remove aws.auto.tfvars from /hab/a2_deploy_workspace/terraform and /hab/a2_deploy_workspace/terraform/destroy/aws/ 
- Modify /hab/a2_deploy_workspace/terraform/.tf_arch from "deployment" to "aws"
- Modify the instance count in config.toml
- Provision the setup (This will create or destroy the resources):
   chef-automate provision-infra config.toml
- Redeploy the cluster
   chef-automate deploy config.toml

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Below are the scenarios that have been tested on a simple HA setup (1 instance each for Automate and Server and 3 for opensearch and PG):
- Scale up the Automate instance count to 2
- Scale up the Server count to 2
- Add compliance and client run data and then scale OS and PG to 5 each
   - All 5 nodes were added to the OS cluster
   - chef-automate status displays all 10 instances in backend services
   - No data loss was seen after scale up. All the nodes and indices were  visible after scale up.
- Add orgs and users and then scale down OS and PG to 3 instances each
   - Data loss was observed. Node count for Client run was educed from 500 to 309
   - All the indices related to client-run and compliance run are in red state
   - Compliance service is stuck in Critical state therefore, hampering the deploy
- Scale down Automate and Server to 1 instance each
   - Make sure to backup all the user and org pem files from the Server instance if any.
   - No loss of data was observed in scale down.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
