### PR TITLE
Chef-automate installation on Selinux status change

### DIFF
--- a/components/automate-deployment/pkg/preflight/checks.go
+++ b/components/automate-deployment/pkg/preflight/checks.go
@@ -56,7 +56,8 @@ func SELinuxPermissiveCheck() Check {
 				t.ReportFailure("Failed to determine if SELinux is enabled")
 				return nil
 			}
-			if strings.EqualFold(string(out), "disabled") || strings.EqualFold(string(out), "permissive") {
+			var outValue = strings.TrimSuffix(string(out), "\n")
+			if strings.EqualFold(outValue,"disabled") || strings.EqualFold(outValue , "permissive") {
 				t.ReportSuccess("SELinux is not enabled")
 				return nil
 			}

--- a/components/automate-deployment/pkg/preflight/checks.go
+++ b/components/automate-deployment/pkg/preflight/checks.go
@@ -57,7 +57,7 @@ func SELinuxPermissiveCheck() Check {
 				return nil
 			}
 			var outValue = strings.TrimSuffix(string(out), "\n")
-			if strings.EqualFold(outValue,"disabled") || strings.EqualFold(outValue , "permissive") {
+			if strings.EqualFold(outValue, "disabled") || strings.EqualFold(outValue, "permissive") {
 				t.ReportSuccess("SELinux is not enabled")
 				return nil
 			}
@@ -67,7 +67,6 @@ func SELinuxPermissiveCheck() Check {
 		},
 	}
 }
-
 
 const GB = 1 << 30
 

--- a/components/automate-deployment/pkg/preflight/preflight.go
+++ b/components/automate-deployment/pkg/preflight/preflight.go
@@ -65,6 +65,7 @@ func (c *DeployPreflightChecker) Run(probe TestProbe) error {
 	checks := []Check{
 		RootUserRequiredCheck(),
 		DefaultMinimumDiskCheck(c.automateConfig),
+		SELinuxPermissiveCheck(),
 		chefAutomateInBinCheck,
 		isA2DeployedCheck,
 		IsSystemdCheck(),

--- a/components/automate-deployment/pkg/preflight/preflight_test.go
+++ b/components/automate-deployment/pkg/preflight/preflight_test.go
@@ -51,10 +51,10 @@ type mockTestProbe struct {
 	lookupUser       map[string]userOrError
 	httpConnectivity map[string]bool
 	euid             int
-  selinux          []byte
-	successes []string
-	failures  []string
-	summaries []string
+	selinux          []byte
+	successes        []string
+	failures         []string
+	summaries        []string
 }
 
 func NewMockTestProbe(t *testing.T) *mockTestProbe {

--- a/components/automate-deployment/pkg/preflight/preflight_test.go
+++ b/components/automate-deployment/pkg/preflight/preflight_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/chef/automate/lib/user"
 )
 
+const check_has_correct_name = "check has correct name"
+
 type fileOrError struct {
 	data []byte
 	err  error
@@ -408,7 +410,7 @@ func TestCLIInBinCheck(t *testing.T) {
 func TestUseraddCheck(t *testing.T) {
 	check := preflight.HasUseraddCheck()
 
-	t.Run("check has correct name", func(t *testing.T) {
+	t.Run(check_has_correct_name, func(t *testing.T) {
 		assert.Equal(t, "has_cmd_useradd", check.Name)
 	})
 
@@ -432,7 +434,7 @@ func TestUseraddCheck(t *testing.T) {
 func TestNobodyCheck(t *testing.T) {
 	check := preflight.HasNobodyCheck()
 
-	t.Run("check has correct name", func(t *testing.T) {
+	t.Run(check_has_correct_name, func(t *testing.T) {
 		assert.Equal(t, "has_user_nobody", check.Name)
 	})
 
@@ -743,7 +745,7 @@ sl  local_address                         remote_address                        
 func TestSELinuxPermissiveCheck(t *testing.T) {
 	check := preflight.SELinuxPermissiveCheck()
 
-	t.Run("check has correct name", func(t *testing.T) {
+	t.Run(check_has_correct_name, func(t *testing.T) {
 		assert.Equal(t, "selinux_permissive_required", check.Name)
 	})
 

--- a/components/automate-deployment/pkg/preflight/test_probe.go
+++ b/components/automate-deployment/pkg/preflight/test_probe.go
@@ -32,6 +32,7 @@ type TestProbe interface {
 	LookupUser(username string) (*user.User, error)
 	LookPath(file string) (string, error)
 	HTTPConnectivity(url string) error
+	SELinuxStatus() ([]byte, error)
 }
 
 type ConsoleReporter struct {
@@ -124,6 +125,10 @@ func (*localTestProbe) IsSymlink(filePath string) (bool, error) {
 
 func (*localTestProbe) Euid() int {
 	return os.Geteuid()
+}
+
+func (*localTestProbe) SELinuxStatus() ([]byte, error) {
+	return exec.Command("getenforce").Output()
 }
 
 func (*localTestProbe) AvailableDiskSpace(path string) (uint64, error) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
SELinux is enabled by default on Centos and Redhat systems. When installing automate, there is no preflight check performed to see if SELinux is set to permissive or disabled which is a requirement for the install to success. What this leads to is a install which seems to succeed but actually the habitat supervisor fails to start properly. The leads to a weird state because you cannot run the deploy command again due to the `is_a2_deployed` check failing. The user must figure out the issue and restart the hab supervisor themselves.


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
#4719 
https://chefio.atlassian.net/browse/SHIELD-51

### :+1: Definition of Done
Automate installation needs to be successfull once SELinux is Disabled.

### :athletic_shoe: How to Build and Test the Change
1.Create centos 8.
2. Run rebuild components/automate-deployment and rebuild components/automate-cli services .
3. Create an airgap bundle my using binary generated by rebuilding  components/automate-cli and by using the hart file generated using rebuilding components/automate-deployment . 
4. Deploy this airgap bundle on centos 8.
Automate installing is successful when centos is disabled. And error appears in the preflight check when the centos is enabled.
(One can enable/disable centos by running  sudo vi /etc/selinux/config and using values SELinux=enforcing/permissive and by restarting the centos server. Use sestatus command to see the status.)
5. Run go test pkg/preflight/preflight_test.go to test if tests are passing.


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
