### PR TITLE
Added new security group for port 443 AND 80 and port 22 restrictions

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,4 +5,3 @@ This provides the `automate-backend-deployment` package.
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get avilable after installing this package.
-

--- a/components/automate-cluster-ctl/readme
+++ b/components/automate-cluster-ctl/readme
@@ -1,3 +1,2 @@
 automate-cluster-ctl
 
-

--- a/terraform/a2ha-terraform/destroy/aws/main.tf
+++ b/terraform/a2ha-terraform/destroy/aws/main.tf
@@ -1,3 +1,12 @@
+data "http" "getTodos" {
+  url = "http://169.254.169.254/latest/meta-data/local-ipv4"
+}
+
+locals {
+  json_data = "${join(".", [for i, s in split(".",data.http.getTodos.response_body) : (
+    i == 3 ? 0: s
+  )])}/26"
+}
 provider "aws" {
   region  = var.aws_region
   profile = var.aws_profile
@@ -47,6 +56,7 @@ module "aws" {
   lb_access_logs                  = var.lb_access_logs
   tags                            = var.aws_tags
   aws_instance_profile_name       = var.backup_config_s3 == "true" ? module.s3[0].instance_profile_name : null
+  json_data                          = local.json_data
 }
 
 module "efs" {

--- a/terraform/a2ha-terraform/destroy/aws/main.tf
+++ b/terraform/a2ha-terraform/destroy/aws/main.tf
@@ -1,9 +1,9 @@
-data "http" "getTodos" {
+data "http" "getEc2PrivateIP" {
   url = "http://169.254.169.254/latest/meta-data/local-ipv4"
 }
 
 locals {
-  json_data = "${join(".", [for i, s in split(".",data.http.getTodos.response_body) : (
+  json_data = "${join(".", [for i, s in split(".",data.http.getEc2PrivateIP.response_body) : (
     i == 3 ? 0: s
   )])}/26"
 }

--- a/terraform/a2ha-terraform/modules/aws/inputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/inputs.tf
@@ -93,6 +93,9 @@ variable "chef_server_instance_type" {
 variable "chef_server_lb_certificate_arn" {
 }
 
+variable "json_data" {
+}
+
 variable "kibana_listen_port" {
   default = 5601
 }

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -260,7 +260,7 @@ resource "aws_instance" "chef_automate" {
   instance_type               = var.automate_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
   subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
-  vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
+  vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id, aws_security_group.chef_automate_ui.id]
   associate_public_ip_address = false
   ebs_optimized               = true
   iam_instance_profile        = var.aws_instance_profile_name
@@ -291,7 +291,7 @@ resource "aws_instance" "chef_server" {
   instance_type               = var.chef_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
   subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
-  vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
+  vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id, aws_security_group.chef_automate_ui.id]
   associate_public_ip_address = false
   ebs_optimized               = true
   iam_instance_profile        = var.aws_instance_profile_name

--- a/terraform/a2ha-terraform/modules/aws/security.tf
+++ b/terraform/a2ha-terraform/modules/aws/security.tf
@@ -109,7 +109,6 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_80_tcp" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.chef_automate_ui.id
-  # source_security_group_id = aws_security_group.chef_automate.id
 }
 
 # HTTPS (nginx)
@@ -120,7 +119,6 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_443_tcp" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.chef_automate_ui.id
-  # source_security_group_id = aws_security_group.chef_automate.id
 }
 
 # Allow elasticsearch clients
@@ -132,16 +130,6 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_elasticsearch_tc
   security_group_id        = aws_security_group.chef_automate.id
   source_security_group_id = aws_security_group.chef_automate.id
 }
-
-# Allow Kibana Login
-# resource "aws_security_group_rule" "ingress_chef_automate_allow_kibana_tcp" {
-#   type              = "ingress"
-#   from_port         = var.kibana_listen_port
-#   to_port           = var.kibana_listen_port
-#   protocol          = "tcp"
-#   cidr_blocks       = ["0.0.0.0/0"]
-#   security_group_id = aws_security_group.chef_automate.id
-# }
 
 # Allow postgresql connections
 resource "aws_security_group_rule" "ingress_chef_automate_allow_postgres_tcp" {
@@ -182,7 +170,6 @@ resource "aws_security_group_rule" "ingress_allow_80_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.load_balancer.id
-  # source_security_group_id = aws_security_group.load_balancer.id
 }
 
 resource "aws_security_group_rule" "ingress_allow_443_tcp_all" {
@@ -192,7 +179,6 @@ resource "aws_security_group_rule" "ingress_allow_443_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.load_balancer.id
-  # source_security_group_id = aws_security_group.load_balancer.id
 }
 
 resource "aws_security_group_rule" "load_balancer_egress_allow_0-65535_all" {
@@ -230,17 +216,7 @@ resource "aws_security_group_rule" "egress_allow_443_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.base_linux.id
-  # source_security_group_id = aws_security_group.base_linux.id
 }
-
-# resource "aws_security_group_rule" "egress_allow_5601_tcp_all" {
-#   type              = "egress"
-#   from_port         = 5601
-#   to_port           = 5601
-#   protocol          = "tcp"
-#   cidr_blocks       = ["0.0.0.0/0"]
-#   security_group_id = aws_security_group.base_linux.id
-# }
 
 resource "aws_security_group_rule" "egress_allow_6432_tcp_all" {
   type              = "egress"

--- a/terraform/a2ha-terraform/modules/aws/security.tf
+++ b/terraform/a2ha-terraform/modules/aws/security.tf
@@ -22,6 +22,14 @@ resource "aws_security_group" "chef_automate" {
   tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_automate_security_group"))
 }
 
+resource "aws_security_group" "chef_automate_ui" {
+  name        = "chef_automate_ui_${random_id.random.hex}"
+  description = "Chef Automate Server protocol"
+  vpc_id      = data.aws_vpc.default.id
+
+  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_automate_security_group"))
+}
+
 resource "aws_security_group" "efs_mount" {
   name        = "efs_${random_id.random.hex}"
   description = "NFS for EFS"
@@ -45,7 +53,7 @@ resource "aws_security_group_rule" "ingress_allow_22_tcp_all" {
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [var.json_data]
   security_group_id = aws_security_group.base_linux.id
 }
 
@@ -100,7 +108,8 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_80_tcp" {
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.chef_automate.id
+  security_group_id = aws_security_group.chef_automate_ui.id
+  # source_security_group_id = aws_security_group.chef_automate.id
 }
 
 # HTTPS (nginx)
@@ -110,7 +119,8 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_443_tcp" {
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.chef_automate.id
+  security_group_id = aws_security_group.chef_automate_ui.id
+  # source_security_group_id = aws_security_group.chef_automate.id
 }
 
 # Allow elasticsearch clients
@@ -124,14 +134,14 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_elasticsearch_tc
 }
 
 # Allow Kibana Login
-resource "aws_security_group_rule" "ingress_chef_automate_allow_kibana_tcp" {
-  type              = "ingress"
-  from_port         = var.kibana_listen_port
-  to_port           = var.kibana_listen_port
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.chef_automate.id
-}
+# resource "aws_security_group_rule" "ingress_chef_automate_allow_kibana_tcp" {
+#   type              = "ingress"
+#   from_port         = var.kibana_listen_port
+#   to_port           = var.kibana_listen_port
+#   protocol          = "tcp"
+#   cidr_blocks       = ["0.0.0.0/0"]
+#   security_group_id = aws_security_group.chef_automate.id
+# }
 
 # Allow postgresql connections
 resource "aws_security_group_rule" "ingress_chef_automate_allow_postgres_tcp" {
@@ -172,6 +182,7 @@ resource "aws_security_group_rule" "ingress_allow_80_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.load_balancer.id
+  # source_security_group_id = aws_security_group.load_balancer.id
 }
 
 resource "aws_security_group_rule" "ingress_allow_443_tcp_all" {
@@ -181,6 +192,7 @@ resource "aws_security_group_rule" "ingress_allow_443_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.load_balancer.id
+  # source_security_group_id = aws_security_group.load_balancer.id
 }
 
 resource "aws_security_group_rule" "load_balancer_egress_allow_0-65535_all" {
@@ -218,16 +230,17 @@ resource "aws_security_group_rule" "egress_allow_443_tcp_all" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.base_linux.id
+  # source_security_group_id = aws_security_group.base_linux.id
 }
 
-resource "aws_security_group_rule" "egress_allow_5601_tcp_all" {
-  type              = "egress"
-  from_port         = 5601
-  to_port           = 5601
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.base_linux.id
-}
+# resource "aws_security_group_rule" "egress_allow_5601_tcp_all" {
+#   type              = "egress"
+#   from_port         = 5601
+#   to_port           = 5601
+#   protocol          = "tcp"
+#   cidr_blocks       = ["0.0.0.0/0"]
+#   security_group_id = aws_security_group.base_linux.id
+# }
 
 resource "aws_security_group_rule" "egress_allow_6432_tcp_all" {
   type              = "egress"
@@ -315,7 +328,7 @@ resource "aws_security_group_rule" "egress_allow_22_tcp_all" {
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [var.json_data]
   security_group_id = aws_security_group.base_linux.id
 }
 //////////////////////////

--- a/terraform/a2ha-terraform/modules/aws/security.tf
+++ b/terraform/a2ha-terraform/modules/aws/security.tf
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "ingress_allow_22_tcp_all" {
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = [var.json_data]
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.base_linux.id
 }
 

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -1,3 +1,12 @@
+data "http" "getTodos" {
+  url = "http://169.254.169.254/latest/meta-data/local-ipv4"
+}
+
+locals {
+  json_data = "${join(".", [for i, s in split(".",data.http.getTodos.response_body) : (
+    i == 3 ? 0: s
+  )])}/26"
+}
 provider "aws" {
   region  = var.aws_region
   profile = var.aws_profile
@@ -53,6 +62,7 @@ module "aws" {
   lb_access_logs                     = var.lb_access_logs
   tags                               = var.aws_tags
   aws_instance_profile_name          = var.backup_config_s3 == "true" ? module.s3[0].instance_profile_name : null
+  json_data                          = local.json_data
 }
 
 module "efs" {

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -1,9 +1,9 @@
-data "http" "getTodos" {
+data "http" "getEc2PrivateIP" {
   url = "http://169.254.169.254/latest/meta-data/local-ipv4"
 }
 
 locals {
-  json_data = "${join(".", [for i, s in split(".", data.http.getTodos.response_body) : (
+  json_data = "${join(".", [for i, s in split(".", data.http.getEc2PrivateIP.response_body) : (
     i == 3 ? 0 : s
   )])}/26"
 }

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -3,8 +3,8 @@ data "http" "getTodos" {
 }
 
 locals {
-  json_data = "${join(".", [for i, s in split(".",data.http.getTodos.response_body) : (
-    i == 3 ? 0: s
+  json_data = "${join(".", [for i, s in split(".", data.http.getTodos.response_body) : (
+    i == 3 ? 0 : s
   )])}/26"
 }
 provider "aws" {


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description:
In this PR, following changes are made

- Port 443 and 80 are removed from existing security groups and a new security group is added with ports 443 and 80, and this SG is added only to all frontend nodes. (443 and 80 are not required for backend nodes)
- Port 22 accessibility is now restricted from 0.0.0.0/0. Only Bastion server can access it

### :chains: Related Resources
NA

### :+1: Definition of Done
It's dev done and tested

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
