### PR TITLE
adding the new control index mapping

### DIFF
--- a/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
@@ -1,0 +1,199 @@
+package mappings
+
+var ComplianceControlRepData = Mapping{
+	Index:      IndexNameControl,
+	Timeseries: true,
+	Mapping: `
+{
+    "index_patterns": ["` + IndexNameControl + `-20*"],
+    "settings": {
+      "analysis": {
+        "analyzer": {
+        "autocomplete": {
+          "filter": [
+            "lowercase"
+          ],
+          "tokenizer": "autocomplete_tokenizer"
+        },
+        "autocomplete_version_numbers": {
+          "filter": [
+            "lowercase"
+          ],
+          "tokenizer": "autocomplete_version_number_tokenizer"
+        }
+      },
+      "tokenizer": {
+        "autocomplete_tokenizer": {
+          "max_gram": 20,
+          "min_gram": 2,
+          "token_chars": [
+            "letter",
+            "digit"
+          ],
+          "type": "edge_ngram"
+        },
+        "autocomplete_version_number_tokenizer": {
+          "max_gram": 20,
+          "min_gram": 2,
+          "token_chars": [
+            "letter",
+            "digit",
+            "punctuation"
+          ],
+          "type": "edge_ngram"
+        }
+      },
+      "normalizer": {
+        "case_insensitive": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        }
+      }
+    },
+    "index": {
+      "refresh_interval": "1s"
+    }
+  },
+  "mappings": {
+    "properties": {
+      "control_id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "keyword",
+        "fields": {
+          "engram": {
+            "type": "text",
+            "analyzer": "autocomplete"
+          },
+          "lower": {
+            "type": "keyword",
+            "normalizer": "case_insensitive"
+          }
+        }
+      },
+      "waived_str": {
+        "type": "keyword"
+      },
+      "waiver_data": {
+        "properties": {
+          "expiration_date": {
+            "type": "keyword"
+          },
+          "justification": {
+            "type": "keyword"
+          },
+          "message": {
+            "type": "keyword"
+          },
+          "run": {
+            "type": "boolean"
+          },
+          "skipped_due_to_waiver": {
+            "type": "boolean"
+          }
+        }
+      },
+      "impact": {
+        "type": "double"
+      },
+      "string_tags": {
+        "type": "nested",
+        "properties": {
+          "key": {
+            "type": "keyword",
+            "fields": {
+              "engram": {
+                "type": "text",
+                "analyzer": "autocomplete"
+              },
+              "lower": {
+                "type": "keyword",
+                "normalizer": "case_insensitive"
+              }
+            }
+          },
+          "values": {
+            "type": "keyword",
+            "fields": {
+              "engram": {
+                "type": "text",
+                "analyzer": "autocomplete"
+              },
+              "lower": {
+                "type": "keyword",
+                "normalizer": "case_insensitive"
+              }
+            }
+          }
+        }
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "daily_latest": {
+        "type": "boolean"
+      },
+      "day_latest": {
+        "type": "boolean"
+      },
+      "latest": {
+        "type": "boolean"
+      },
+      "end_time": {
+        "type": "date"
+      },
+      "nodes": {
+        "properties": {
+          "node_uuid": {
+            "type": "keyword"
+          },
+          "end_time": {
+            "type": "date"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "latest": {
+            "type": "boolean"
+          },
+          "node_name": {
+            "type": "keyword",
+            "fields": {
+              "engram": {
+                "type": "text",
+                "analyzer": "autocomplete"
+              },
+              "lower": {
+                "type": "keyword",
+                "normalizer": "case_insensitive"
+              }
+            }
+          },
+          "report_uuid": {
+            "type": "keyword"
+          }
+        },
+        "type": "nested"
+      },
+      "profile": {
+        "properties": {
+          "profile": {
+            "type": "keyword"
+          },
+          "sha256": {
+            "type": "keyword"
+          }
+        }
+      },
+      "report_uuid": {
+        "type": "keyword"
+      }
+    }
+  }
+}`,
+}

--- a/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
@@ -1,5 +1,6 @@
 package mappings
 
+// ComplianceControlRepData Compliance mapping used to create the `comp-<version>-control-<date>` index
 var ComplianceControlRepData = Mapping{
 	Index:      IndexNameControl,
 	Timeseries: true,

--- a/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
+++ b/components/compliance-service/ingest/ingestic/mappings/comp-control-rep-date.go
@@ -142,9 +142,6 @@ var ComplianceControlRepData = Mapping{
       "day_latest": {
         "type": "boolean"
       },
-      "latest": {
-        "type": "boolean"
-      },
       "end_time": {
         "type": "date"
       },
@@ -159,8 +156,11 @@ var ComplianceControlRepData = Mapping{
           "status": {
             "type": "keyword"
           },
-          "latest": {
-            "type": "boolean"
+           "daily_latest": {
+             "type": "boolean"
+          },
+         "day_latest": {
+           "type": "boolean"
           },
           "node_name": {
             "type": "keyword",

--- a/components/compliance-service/ingest/ingestic/mappings/mappings.go
+++ b/components/compliance-service/ingest/ingestic/mappings/mappings.go
@@ -19,6 +19,7 @@ var AllMappings = []Mapping{
 	ComplianceSumDate,
 	ComplianceProfiles,
 	ComplianceRunInfo,
+	ComplianceControlRepData,
 }
 
 const (
@@ -31,16 +32,20 @@ const (
 	//ComplianceCurrentProfilesIndicesVersion allows us to know, for any version of compliance, what level we are at with our profiles and profiles-mappings indices
 	ComplianceCurrentProfilesIndicesVersion = "3"
 	ComplianceCurrentRunInfoVersion         = "2"
+	ComplianceCurrentControlInfoVersion     = "1"
 
 	compAndVersionTimeSeries = "comp-" + ComplianceCurrentTimeSeriesIndicesVersion
 	compAndVersionProfiles   = "comp-" + ComplianceCurrentProfilesIndicesVersion
 	compAndVersionRunInfo    = "comp-" + ComplianceCurrentRunInfoVersion
+	compAndControlRunInfo    = "comp-" + ComplianceCurrentControlInfoVersion
 
 	IndexNameProf              = compAndVersionProfiles + "-profiles"
 	IndexNameComplianceRunInfo = compAndVersionRunInfo + "-run-info"
 
 	IndexNameRep = compAndVersionTimeSeries + "-r"
 	IndexNameSum = compAndVersionTimeSeries + "-s"
+
+	IndexNameControl = compAndControlRunInfo + "-control"
 )
 
 // Mapping type is the representation of an ES mapping, it contains


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Added the mapping for new control based index structure

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-163

### :+1: Definition of Done

Mapping has been added and as soon as we add data into the control structure it will be reflected.

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/compliance-service/

chef_load_compliance_scans
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
