### PR TITLE
Adding Asychronous function for new control-index

### DIFF
--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -104,12 +104,11 @@ func init() {
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.CertPath, "cert", "", "Service certificate")
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.KeyPath, "key", "", "Service certificate key")
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.RootCACertPath, "root-cert", "", "Root CA Cert to use to verify clients")
-	runCmd.Flags().BoolVar(&conf.Service.EnableLargeReporting, "enable-large-reporting", false, "upgrade to support large reporting")
-	runCmd.Flags().IntVar(&conf.Service.LcrOpenSearchRequests, "lcr-open-search-requests", conf.Service.LcrOpenSearchRequests, "number of concurrent requests to communicate with open search for large compliance reporting")
-
 	runCmd.Flags().Int32Var(&conf.DataRetention.ComplianceReportDays, "reports-retention-days", 60, "Number of days to keep compliance reports")
 	runCmd.Flags().StringVar(&conf.Service.ConfigFilePath, "config", "", "config file")
 	runCmd.Flags().IntVar(&conf.Service.MessageBufferSize, "message-buffer-size", 100, "Number of ingest messages allowed to buffer")
+	runCmd.Flags().BoolVar(&conf.Service.EnableLargeReporting, "enable-large-reporting", false, "upgrade to support large reporting")
+	runCmd.Flags().IntVar(&conf.Service.LcrOpenSearchRequests, "lcr-open-search-requests", conf.Service.LcrOpenSearchRequests, "number of concurrent requests to communicate with open search for large compliance reporting")
 
 	// Postgres Config Flags
 	runCmd.Flags().StringVar(&conf.Postgres.ConnectionString, "postgres-uri", conf.Postgres.ConnectionString, "PostgreSQL connection string to use")
@@ -168,5 +167,4 @@ func init() {
 
 	// Report Manager Flags
 	runCmd.Flags().StringVar(&conf.ReportConfig.Endpoint, "report-manager-endpoint", conf.ReportConfig.Endpoint, "Report Manager Service Endpoint")
-
 }

--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -104,6 +104,9 @@ func init() {
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.CertPath, "cert", "", "Service certificate")
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.KeyPath, "key", "", "Service certificate key")
 	runCmd.Flags().StringVar(&conf.Service.TLSConfig.RootCACertPath, "root-cert", "", "Root CA Cert to use to verify clients")
+	runCmd.Flags().BoolVar(&conf.Service.EnableLargeReporting, "enable-large-reporting", false, "upgrade to support large reporting")
+	runCmd.Flags().IntVar(&conf.Service.LcrOpenSearchRequests, "lcr-open-search-requests", conf.Service.LcrOpenSearchRequests, "number of concurrent requests to communicate with open search for large compliance reporting")
+
 	runCmd.Flags().Int32Var(&conf.DataRetention.ComplianceReportDays, "reports-retention-days", 60, "Number of days to keep compliance reports")
 	runCmd.Flags().StringVar(&conf.Service.ConfigFilePath, "config", "", "config file")
 	runCmd.Flags().IntVar(&conf.Service.MessageBufferSize, "message-buffer-size", 100, "Number of ingest messages allowed to buffer")
@@ -162,4 +165,8 @@ func init() {
 
 	// Cereal Service Flags
 	runCmd.Flags().StringVar(&conf.CerealConfig.Endpoint, "cereal-endpoint", conf.CerealConfig.Endpoint, "Cereal Service Endpoint")
+
+	// Report Manager Flags
+	runCmd.Flags().StringVar(&conf.ReportConfig.Endpoint, "report-manager-endpoint", conf.ReportConfig.Endpoint, "Report Manager Service Endpoint")
+
 }

--- a/components/compliance-service/cmd/compliance-service/cmd/run.go
+++ b/components/compliance-service/cmd/compliance-service/cmd/run.go
@@ -63,6 +63,9 @@ var conf = config.Compliance{
 	ReportConfig: config.ReportConfig{
 		Endpoint: "127.0.0.1:10152",
 	},
+	CerealConfig: config.CerealConfig{
+		Workers: 2,
+	},
 }
 
 // runCmd represents the run command
@@ -104,8 +107,6 @@ func init() {
 	runCmd.Flags().Int32Var(&conf.DataRetention.ComplianceReportDays, "reports-retention-days", 60, "Number of days to keep compliance reports")
 	runCmd.Flags().StringVar(&conf.Service.ConfigFilePath, "config", "", "config file")
 	runCmd.Flags().IntVar(&conf.Service.MessageBufferSize, "message-buffer-size", 100, "Number of ingest messages allowed to buffer")
-	runCmd.Flags().BoolVar(&conf.Service.EnableLargeReporting, "enable-large-reporting", false, "upgrade to support large reporting")
-	runCmd.Flags().IntVar(&conf.Service.LcrOpenSearchRequests, "lcr-open-search-requests", conf.Service.LcrOpenSearchRequests, "number of concurrent requests to communicate with open search for large compliance reporting")
 
 	// Postgres Config Flags
 	runCmd.Flags().StringVar(&conf.Postgres.ConnectionString, "postgres-uri", conf.Postgres.ConnectionString, "PostgreSQL connection string to use")
@@ -161,7 +162,4 @@ func init() {
 
 	// Cereal Service Flags
 	runCmd.Flags().StringVar(&conf.CerealConfig.Endpoint, "cereal-endpoint", conf.CerealConfig.Endpoint, "Cereal Service Endpoint")
-
-	// Report Manager Flags
-	runCmd.Flags().StringVar(&conf.ReportConfig.Endpoint, "report-manager-endpoint", conf.ReportConfig.Endpoint, "Report Manager Service Endpoint")
 }

--- a/components/compliance-service/compliance.go
+++ b/components/compliance-service/compliance.go
@@ -3,6 +3,8 @@ package compliance
 import (
 	"context"
 	"fmt"
+	"github.com/chef/automate/components/compliance-service/ingest/pipeline/processor"
+	"github.com/chef/automate/components/compliance-service/inspec-agent/resolver"
 	"io"
 	"net"
 	"net/http"
@@ -41,7 +43,6 @@ import (
 	ingestserver "github.com/chef/automate/components/compliance-service/ingest/server"
 	"github.com/chef/automate/components/compliance-service/inspec"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/remote"
-	"github.com/chef/automate/components/compliance-service/inspec-agent/resolver"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/runner"
 	"github.com/chef/automate/components/compliance-service/inspec-agent/scheduler"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
@@ -202,11 +203,16 @@ func serveGrpc(ctx context.Context, db *pgdb.DB, connFactory *secureconn.Factory
 		}
 	}
 
+	err = processor.InitCerealManager(cerealManager, 2, ingesticESClient)
+	if err != nil {
+		logrus.Fatalf("failed to initiate cereal manager: %v", err)
+	}
+
 	// needs to be the first one, since it creates the es indices
 	ingest.RegisterComplianceIngesterServiceServer(s,
 		ingestserver.NewComplianceIngestServer(ingesticESClient, nodeManagerServiceClient,
 			reportmanagerClient, conf.InspecAgent.AutomateFQDN, notifier, authzProjectsClient,
-			conf.Service.MessageBufferSize, conf.Service.EnableLargeReporting))
+			conf.Service.MessageBufferSize, conf.Service.EnableLargeReporting,cerealManager))
 
 	jobs.RegisterJobsServiceServer(s, jobsserver.New(db, connFactory, eventClient,
 		conf.Manager.Endpoint, cerealManager))
@@ -648,13 +654,6 @@ func Serve(conf config.Compliance, grpcBinding string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		err := cerealManager.Stop()
-		if err != nil {
-			logrus.WithError(err).Error("could not stop cereal manager")
-		}
-	}()
-
 	go serveGrpc(ctx, db, connFactory, esr, conf, grpcBinding, statusSrv, cerealManager) // nolint: errcheck
 
 	cfg := NewServiceConfig(&conf, connFactory)

--- a/components/compliance-service/config/types.go
+++ b/components/compliance-service/config/types.go
@@ -134,6 +134,7 @@ type EventConfig struct {
 
 type CerealConfig struct {
 	Endpoint string
+	Workers  int
 }
 
 type ReportConfig struct {

--- a/components/compliance-service/ingest/pipeline/compliance.go
+++ b/components/compliance-service/ingest/pipeline/compliance.go
@@ -3,8 +3,8 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"github.com/chef/automate/api/interservice/report_manager"
 	"github.com/chef/automate/lib/cereal"
-
 	"github.com/sirupsen/logrus"
 
 	"time"
@@ -27,16 +27,21 @@ type Compliance struct {
 
 func NewCompliancePipeline(client *ingestic.ESClient, authzClient authz.ProjectsServiceClient,
 	nodeMgrClient manager.NodeManagerServiceClient, reportMgrClient report_manager.ReportManagerServiceClient,
-	messageBufferSize int, notifierClient notifier.Notifier, automateURL string, enableLargeReporting bool,cerealService *cereal.Manager) Compliance {
+	messageBufferSize int, notifierClient notifier.Notifier, automateURL string, enableLargeReporting bool, cerealService *cereal.Manager) Compliance {
 	in := make(chan message.Compliance, messageBufferSize)
-	compliancePipeline(in,
+	pipes := []message.CompliancePipe{
 		processor.ComplianceProfile(client),
 		processor.ComplianceShared,
 		processor.ComplianceSummary,
 		processor.ComplianceReport(notifierClient, automateURL, enableLargeReporting),
 		processor.BundleReportProjectTagger(authzClient),
 		publisher.BuildNodeManagerPublisher(nodeMgrClient),
-		publisher.StoreCompliance(cerealService, client, 100))
+		publisher.StoreCompliance(cerealService, client, 100),
+	}
+	if enableLargeReporting {
+		pipes = append(pipes, publisher.ReportManagerPublisher(reportMgrClient))
+	}
+	compliancePipeline(in, pipes...)
 	return Compliance{in: in}
 }
 

--- a/components/compliance-service/ingest/pipeline/processor/control_worker.go
+++ b/components/compliance-service/ingest/pipeline/processor/control_worker.go
@@ -158,7 +158,6 @@ type GenerateControlParameters struct {
 
 func (t *GenerateControlTask) Run(ctx context.Context, task cereal.Task) (interface{}, error) {
 
-	logrus.Info("OnStartYashviTask inside")
 	var job GenerateControlParameters
 	if err := task.GetParameters(&job); err != nil {
 		err = errors.Wrap(err, "could not unmarshal GenerateReportParameters")

--- a/components/compliance-service/ingest/pipeline/processor/control_worker.go
+++ b/components/compliance-service/ingest/pipeline/processor/control_worker.go
@@ -1,0 +1,174 @@
+package processor
+
+import (
+	"context"
+	"github.com/chef/automate/components/compliance-service/ingest/ingestic"
+	"github.com/chef/automate/lib/cereal"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+var (
+	ReportWorkflowName = cereal.NewWorkflowName("control-workflow")
+	ReportTaskName     = cereal.NewTaskName("control-task")
+)
+
+const (
+	RunningStatus string = "running"
+	FailedStatus  string = "failed"
+	SuccessStatus string = "success"
+)
+
+func InitCerealManager(cerealManager *cereal.Manager, workerCount int, client *ingestic.ESClient) error {
+	logrus.Info("Successfully starting control-workflow")
+	err := cerealManager.RegisterWorkflowExecutor(ReportWorkflowName, &ControlWorkflow{})
+	if err != nil {
+		logrus.Info("Found error control-workflow")
+		logrus.Info(err)
+		return err
+	}
+
+	logrus.Info("Successfully registered control-workflow")
+	return cerealManager.RegisterTaskExecutor(ReportTaskName, &GenerateControlTask{
+		ESClient: client,
+	}, cereal.TaskExecutorOpts{Workers: workerCount})
+
+}
+
+type ControlWorkflow struct {
+}
+
+type ControlWorkflowParameters struct {
+	ReportUuid string
+	Retries    int
+}
+
+type ControlWorkflowPayload struct {
+	ReportUuid  string
+	RetriesLeft int
+	Status      string
+	StartTime   *time.Time
+}
+
+func (s *ControlWorkflow) OnStart(w cereal.WorkflowInstance,
+	ev cereal.StartEvent) cereal.Decision {
+
+	logrus.Info("In control-workflow start method")
+
+	startTime := time.Now()
+	workflowPayload := ControlWorkflowPayload{
+		StartTime: &startTime,
+	}
+
+	workflowParams := ControlWorkflowParameters{}
+	err := w.GetParameters(&workflowParams)
+	if err != nil {
+		err = errors.Wrap(err, "failed to unmarshal control-workflow parameters")
+		logrus.WithError(err).Error()
+		return w.Fail(err)
+	}
+
+	logrus.Infof("In On Start Method %s", workflowParams.ReportUuid)
+
+	workflowPayload.ReportUuid = workflowParams.ReportUuid
+	workflowPayload.RetriesLeft = workflowParams.Retries
+	workflowPayload.Status = RunningStatus
+
+	err = w.EnqueueTask(ReportTaskName, GenerateControlParameters{
+		ReportUuid: workflowParams.ReportUuid,
+	})
+	if err != nil {
+		err = errors.Wrap(err, "failed to enqueue the control-task")
+		logrus.WithError(err).Error()
+		return w.Fail(err)
+	}
+	return w.Continue(&workflowPayload)
+}
+
+func (s *ControlWorkflow) OnTaskComplete(w cereal.WorkflowInstance,
+	ev cereal.TaskCompleteEvent) cereal.Decision {
+
+	var payload ControlWorkflowPayload
+
+	if err := w.GetPayload(&payload); err != nil {
+		err = errors.Wrap(err, "failed to unmarshal control-workflow payload")
+		logrus.WithError(err).Error()
+		return w.Fail(err)
+	}
+
+	logrus.Infof("Entered ControlWorkflow > OnTaskComplete with payload %+v", payload)
+
+	if err := ev.Result.Err(); err != nil {
+		//received error, if the retries are available enqueue the task
+		if payload.RetriesLeft > 0 {
+			logrus.Debugf("retring control-task %s", payload.ReportUuid)
+
+			workflowParams := ControlWorkflowParameters{}
+			err := w.GetParameters(&workflowParams)
+			if err != nil {
+				err = errors.Wrap(err, "failed to unmarshal control-workflow parameters")
+				logrus.WithError(err).Error()
+				return w.Fail(err)
+			}
+
+			err = w.EnqueueTask(ReportTaskName, GenerateControlParameters{
+				ReportUuid: payload.ReportUuid,
+			})
+			if err != nil {
+				err = errors.Wrap(err, "failed to enqueue the control-task")
+				logrus.WithError(err).Error()
+				return w.Fail(err)
+			}
+
+			payload.RetriesLeft--
+			return w.Continue(&payload)
+		}
+		err = errors.Wrap(err, "failed to run control-task")
+		logrus.WithError(err).Error()
+		return w.Fail(err)
+	}
+
+	//get the results returned by task run
+	var controlResult GenerateControlParameters
+	err := ev.Result.Get(&controlResult)
+	if err != nil {
+		err = errors.Wrap(err, "failed to get the task run result in OnTaskComplete")
+		logrus.WithError(err).Error()
+		return w.Fail(err)
+	}
+	logrus.Infof("successfully completed the task %s", payload.ReportUuid)
+	return w.Complete()
+}
+
+func (s *ControlWorkflow) OnCancel(w cereal.WorkflowInstance, ev cereal.CancelEvent) cereal.Decision {
+	logrus.Debugf("ReportWorkflow got OnCancel")
+	return w.Complete()
+}
+
+type GenerateControlTask struct {
+	ESClient *ingestic.ESClient
+}
+
+type GenerateControlParameters struct {
+	ReportUuid string
+	StartTime  *time.Time
+	EndTime    *time.Time
+}
+
+func (t *GenerateControlTask) Run(ctx context.Context, task cereal.Task) (interface{}, error) {
+
+	logrus.Info("OnStartYashviTask inside")
+	var job GenerateControlParameters
+	if err := task.GetParameters(&job); err != nil {
+		err = errors.Wrap(err, "could not unmarshal GenerateReportParameters")
+		logrus.WithError(err).Error()
+		return nil, err
+	}
+
+	logrus.Infof("In TaskRun working on job %s", job.ReportUuid)
+
+	startTime := time.Now().UTC().Round(time.Second)
+	job.StartTime = &startTime
+	return &job, nil
+}

--- a/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
+++ b/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
@@ -363,7 +363,3 @@ func TestOnTaskComplete(t *testing.T) {
 		})
 	}
 }
-
-func setWorkflowParameters(isGetPayloadFailure bool, isRetriesLeft bool, isEnqueueFailure bool, isParameterFailure bool) {
-
-}

--- a/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
+++ b/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
@@ -1,0 +1,370 @@
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/chef/automate/lib/cereal"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOnStart(t *testing.T) {
+	tests := []struct {
+		name                  string
+		isGetParameterFailure bool
+		isEnqueueFailure      bool
+		isFailedExpected      bool
+		isContinueExpected    bool
+		expectedError         string
+	}{
+		{
+			name:                  "testOnStart_Success",
+			isGetParameterFailure: false,
+			isEnqueueFailure:      false,
+			isFailedExpected:      false,
+			isContinueExpected:    true,
+			expectedError:         "",
+		},
+		{
+			name:                  "testOnStart_GetParameter_Fail",
+			isGetParameterFailure: true,
+			isEnqueueFailure:      false,
+			isFailedExpected:      true,
+			isContinueExpected:    false,
+			expectedError:         "failed to unmarshal control-workflow parameters: error in fetching parameters",
+		},
+		{
+			name:                  "testOnStart_Enqueue_Fail",
+			isGetParameterFailure: false,
+			isEnqueueFailure:      true,
+			isFailedExpected:      true,
+			isContinueExpected:    false,
+			expectedError:         "failed to enqueue the control-task: error in enqueuing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			workFlow := ControlWorkflow{}
+
+			workflowInstance := &CerealWorkflow{
+				t: t,
+			}
+			if tc.isGetParameterFailure {
+				workflowInstance.failGetParameters = true
+			}
+			if tc.isEnqueueFailure {
+				workflowInstance.failEnqueueTask = true
+			}
+
+			result := workFlow.OnStart(workflowInstance, cereal.StartEvent{})
+			assert.Equal(t, tc.isFailedExpected, result.IsFailed())
+			assert.Equal(t, tc.isContinueExpected, result.IsContinuing())
+			if tc.isFailedExpected {
+				assert.Error(t, result.Err())
+				assert.Equal(t, tc.expectedError, result.Err().Error())
+			}
+		})
+	}
+}
+
+type CerealWorkflow struct {
+	t                 *testing.T
+	failGetParameters bool
+	failEnqueueTask   bool
+	failGetPayload    bool
+	isRetriesLeft     bool
+	isRetryTest       bool
+}
+
+func (c *CerealWorkflow) GetPayload(obj interface{}) error {
+	if c.failGetPayload {
+		return fmt.Errorf("Error in fetching payload")
+	}
+	var jsonString string
+	if c.isRetriesLeft {
+		jsonString = `{"ReportUuid":"test","Status":"running","RetriesLeft":5}`
+	} else {
+		jsonString = `{"ReportUuid":"test","Status":"running","RetriesLeft":0}`
+	}
+
+	jsonBytes := []byte(jsonString)
+	err := json.Unmarshal(jsonBytes, obj)
+	return err
+}
+
+func (c *CerealWorkflow) GetParameters(obj interface{}) error {
+	if c.failGetParameters {
+		return fmt.Errorf("error in fetching parameters")
+	}
+	jsonString := `{"ReportUuid":"test","Retries":2}`
+	jsonBytes := []byte(jsonString)
+	err := json.Unmarshal(jsonBytes, obj)
+	return err
+}
+
+func (c *CerealWorkflow) EnqueueTask(taskName cereal.TaskName, parameters interface{}, opts ...cereal.TaskEnqueueOpt) error {
+	if c.failEnqueueTask {
+		return fmt.Errorf("error in enqueuing")
+	}
+	assert.Equal(c.t, "control-task", taskName.String())
+	params := parameters.(GenerateControlParameters)
+	assert.Equal(c.t, "test", params.ReportUuid)
+	return nil
+}
+
+func (c *CerealWorkflow) Complete(opt ...cereal.CompleteOpt) cereal.Decision {
+	return cereal.NewCompleteDecision("")
+}
+
+func (c *CerealWorkflow) Continue(payload interface{}) cereal.Decision {
+	workflowPayload := payload.(*ControlWorkflowPayload)
+	assert.Equal(c.t, "test", workflowPayload.ReportUuid)
+	if c.isRetryTest {
+		assert.Equal(c.t, 4, workflowPayload.RetriesLeft)
+	} else {
+		assert.Equal(c.t, 2, workflowPayload.RetriesLeft)
+	}
+	assert.Equal(c.t, "running", workflowPayload.Status)
+	return cereal.NewContinueDecision(payload)
+}
+
+func (c *CerealWorkflow) Fail(err error) cereal.Decision {
+
+	return cereal.NewFailDecision(err)
+}
+
+func (c *CerealWorkflow) InstanceName() string {
+	return ""
+}
+
+func (c CerealWorkflow) TotalEnqueuedTasks() int {
+	return 1
+}
+
+func (c *CerealWorkflow) TotalCompletedTasks() int {
+	return 1
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name                   string
+		expectedError          string
+		isGetParametersFailure bool
+	}{
+		{
+			name:          "testRun_Success",
+			expectedError: "",
+		},
+		{
+			name:                   "testRun_ParametersFailure",
+			expectedError:          "could not unmarshal GenerateReportParameters: error in fetching parameters",
+			isGetParametersFailure: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			task := GenerateControlTask{}
+			result, err := task.Run(context.Background(), &CerealTask{
+				isParameterFailure: tc.isGetParametersFailure,
+			})
+
+			if tc.expectedError != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedError, err.Error())
+			}
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			}
+			if result != nil {
+				_ = result.(*GenerateControlParameters)
+
+			}
+		})
+	}
+}
+
+type CerealTask struct {
+	isParameterFailure bool
+}
+
+func (c CerealTask) GetParameters(obj interface{}) error {
+	if c.isParameterFailure {
+		return fmt.Errorf("error in fetching parameters")
+	}
+	jsonString := `{"ReportUuid":"test"}`
+	jsonBytes := []byte(jsonString)
+	err := json.Unmarshal(jsonBytes, obj)
+	return err
+}
+
+func (c CerealTask) GetMetadata() cereal.TaskMetadata {
+	return cereal.TaskMetadata{}
+}
+
+type TaskResult struct {
+	isError bool
+	failGet bool
+}
+
+func (t TaskResult) GetParameters(obj interface{}) error {
+	if t.failGet {
+		return fmt.Errorf("Error in fetching job results")
+	}
+	jsonString := `{"ReportUuid":"Test","Status":"complete"}`
+	jsonBytes := []byte(jsonString)
+	err := json.Unmarshal(jsonBytes, obj)
+	return err
+
+}
+
+func (t TaskResult) Get(obj interface{}) error {
+	return nil
+}
+
+func (t TaskResult) Err() error {
+	if t.isError {
+		return fmt.Errorf("error in task execution")
+	}
+	return nil
+}
+
+func TestOnTaskComplete(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		isGetPayloadFailure  bool
+		isEnqueueFailure     bool
+		isFailedExpected     bool
+		isContinueExpected   bool
+		isCompleteExpected   bool
+		isRetriesLeft        bool
+		isTaskError          bool
+		isRetryTest          bool
+		isParameterFailure   bool
+		expectedError        string
+		isFetchTaskResultErr bool
+	}{
+		{
+			name:                "testOnTaskComplete_Success",
+			isGetPayloadFailure: false,
+			isEnqueueFailure:    false,
+			isFailedExpected:    false,
+			isContinueExpected:  false,
+			isCompleteExpected:  true,
+			isRetriesLeft:       true,
+			expectedError:       "",
+		},
+		{
+			name:                "testOnTaskComplete_GetPayload_Fail",
+			isGetPayloadFailure: true,
+			isEnqueueFailure:    false,
+			isFailedExpected:    true,
+			isContinueExpected:  false,
+			isCompleteExpected:  false,
+			expectedError:       "failed to unmarshal control-workflow payload: Error in fetching payload",
+		},
+		{
+			name:                 "testOnTaskComplete_NoRetriesLeft_Fail",
+			isGetPayloadFailure:  false,
+			isEnqueueFailure:     false,
+			isFailedExpected:     true,
+			isContinueExpected:   false,
+			isCompleteExpected:   false,
+			isRetriesLeft:        false,
+			isTaskError:          true,
+			isFetchTaskResultErr: true,
+			expectedError:        "failed to run control-task: error in task execution",
+		},
+		{
+			name:                "testOnTaskComplete_RetriesLeft_Success",
+			isGetPayloadFailure: false,
+			isEnqueueFailure:    false,
+			isFailedExpected:    false,
+			isContinueExpected:  true,
+			isCompleteExpected:  false,
+			isRetriesLeft:       true,
+			isTaskError:         true,
+			isRetryTest:         true,
+			expectedError:       "",
+		},
+		{
+			name:                "testOnTaskComplete_RetriesLeft_GetParameter_Fail",
+			isGetPayloadFailure: false,
+			isEnqueueFailure:    false,
+			isFailedExpected:    true,
+			isContinueExpected:  false,
+			isCompleteExpected:  false,
+			isRetriesLeft:       true,
+			isTaskError:         true,
+			isRetryTest:         true,
+			isParameterFailure:  true,
+			expectedError:       "failed to unmarshal control-workflow parameters: error in fetching parameters",
+		},
+		{
+			name:                "testOnTaskComplete_RetriesLeft_GetParameter_Fail",
+			isGetPayloadFailure: false,
+			isEnqueueFailure:    false,
+			isFailedExpected:    true,
+			isContinueExpected:  false,
+			isCompleteExpected:  false,
+			isRetriesLeft:       true,
+			isTaskError:         true,
+			isRetryTest:         true,
+			isParameterFailure:  true,
+			expectedError:       "failed to unmarshal control-workflow parameters: error in fetching parameters",
+		},
+		{
+			name:                "testOnTaskComplete_RetriesLeft_EnqueueFail",
+			isGetPayloadFailure: false,
+			isEnqueueFailure:    true,
+			isFailedExpected:    true,
+			isContinueExpected:  false,
+			isCompleteExpected:  false,
+			isRetriesLeft:       true,
+			isTaskError:         true,
+			isRetryTest:         true,
+			expectedError:       "failed to enqueue the control-task: error in enqueuing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			workFlow := ControlWorkflow{}
+
+			workflowInstance := &CerealWorkflow{
+				t:           t,
+				isRetryTest: tc.isRetryTest,
+			}
+			if tc.isGetPayloadFailure {
+				workflowInstance.failGetPayload = true
+			}
+			if tc.isRetriesLeft {
+				workflowInstance.isRetriesLeft = true
+			}
+			if tc.isEnqueueFailure {
+				workflowInstance.failEnqueueTask = true
+			}
+			if tc.isParameterFailure {
+				workflowInstance.failGetParameters = true
+			}
+			result := workFlow.OnTaskComplete(workflowInstance, cereal.TaskCompleteEvent{
+				Result: &TaskResult{
+					isError: tc.isTaskError,
+					failGet: tc.isFetchTaskResultErr,
+				},
+			})
+			assert.Equal(t, tc.isFailedExpected, result.IsFailed())
+			assert.Equal(t, tc.isContinueExpected, result.IsContinuing())
+			assert.Equal(t, tc.isCompleteExpected, result.IsComplete())
+			if tc.isFailedExpected {
+				assert.Error(t, result.Err())
+				assert.Equal(t, tc.expectedError, result.Err().Error())
+			}
+		})
+	}
+}

--- a/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
+++ b/components/compliance-service/ingest/pipeline/processor/control_worker_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+var expectedGenericError = "failed to unmarshal control-workflow parameters: error in fetching parameters"
+
 func TestOnStart(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -32,7 +34,7 @@ func TestOnStart(t *testing.T) {
 			isEnqueueFailure:      false,
 			isFailedExpected:      true,
 			isContinueExpected:    false,
-			expectedError:         "failed to unmarshal control-workflow parameters: error in fetching parameters",
+			expectedError:         expectedGenericError,
 		},
 		{
 			name:                  "testOnStart_Enqueue_Fail",
@@ -302,7 +304,7 @@ func TestOnTaskComplete(t *testing.T) {
 			isTaskError:         true,
 			isRetryTest:         true,
 			isParameterFailure:  true,
-			expectedError:       "failed to unmarshal control-workflow parameters: error in fetching parameters",
+			expectedError:       expectedGenericError,
 		},
 		{
 			name:                "testOnTaskComplete_RetriesLeft_GetParameter_Fail",
@@ -315,7 +317,7 @@ func TestOnTaskComplete(t *testing.T) {
 			isTaskError:         true,
 			isRetryTest:         true,
 			isParameterFailure:  true,
-			expectedError:       "failed to unmarshal control-workflow parameters: error in fetching parameters",
+			expectedError:       expectedGenericError,
 		},
 		{
 			name:                "testOnTaskComplete_RetriesLeft_EnqueueFail",
@@ -340,18 +342,11 @@ func TestOnTaskComplete(t *testing.T) {
 				t:           t,
 				isRetryTest: tc.isRetryTest,
 			}
-			if tc.isGetPayloadFailure {
-				workflowInstance.failGetPayload = true
-			}
-			if tc.isRetriesLeft {
-				workflowInstance.isRetriesLeft = true
-			}
-			if tc.isEnqueueFailure {
-				workflowInstance.failEnqueueTask = true
-			}
-			if tc.isParameterFailure {
-				workflowInstance.failGetParameters = true
-			}
+			workflowInstance.failGetPayload = tc.isGetPayloadFailure
+			workflowInstance.isRetriesLeft = tc.isRetriesLeft
+			workflowInstance.failEnqueueTask = tc.isEnqueueFailure
+			workflowInstance.failGetParameters = tc.isParameterFailure
+
 			result := workFlow.OnTaskComplete(workflowInstance, cereal.TaskCompleteEvent{
 				Result: &TaskResult{
 					isError: tc.isTaskError,
@@ -367,4 +362,8 @@ func TestOnTaskComplete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setWorkflowParameters(isGetPayloadFailure bool, isRetriesLeft bool, isEnqueueFailure bool, isParameterFailure bool) {
+
 }

--- a/components/compliance-service/ingest/server/compliance.go
+++ b/components/compliance-service/ingest/server/compliance.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/chef/automate/api/interservice/report_manager"
+	"github.com/chef/automate/lib/cereal"
 
 	"github.com/blang/semver"
 	"github.com/gofrs/uuid"
@@ -41,10 +42,10 @@ var MinimumSupportedInspecVersion = semver.MustParse("2.0.0")
 
 func NewComplianceIngestServer(esClient *ingestic.ESClient, mgrClient manager.NodeManagerServiceClient, reportMgrClient report_manager.ReportManagerServiceClient,
 	automateURL string, notifierClient notifier.Notifier, authzProjectsClient authz.ProjectsServiceClient,
-	messageBufferSize int, enableLargeReporting bool) *ComplianceIngestServer {
+	messageBufferSize int, enableLargeReporting bool,cerealManager *cereal.Manager) *ComplianceIngestServer {
 
 	compliancePipeline := pipeline.NewCompliancePipeline(esClient, authzProjectsClient, mgrClient,
-		reportMgrClient, messageBufferSize, notifierClient, automateURL, enableLargeReporting)
+		reportMgrClient, messageBufferSize, notifierClient, automateURL, enableLargeReporting,cerealManager)
 
 	return &ComplianceIngestServer{
 		compliancePipeline:   compliancePipeline,

--- a/components/compliance-service/integration_test/global_test.go
+++ b/components/compliance-service/integration_test/global_test.go
@@ -13,6 +13,8 @@ var (
 	// The opensearch URL is coming from the environment variable OPENSEARCH_URL
 	opensearchUrl = os.Getenv("OPENSEARCH_URL")
 
+	postgresUrl = os.Getenv("PG_URL")
+
 	// This suite variable will be available for every single test as long as they
 	// belong to the 'integration_test' package.
 	suite = NewGlobalSuite()


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Created a new asynchronous function which will get the report uuid at the time of inserting the report into the database and update the new index.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/STALWART-164

### :+1: Definition of Done

A connection with cereal manager is implemented which will have a new workflow now.

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/compliance-service/
chef_load_compliance_scans
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
