### PR TITLE
Setting day_latest to false

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -344,7 +344,6 @@ func (backend *ESClient) setYesterdayLatestToFalse(ctx context.Context, nodeId s
 	script := elastic.NewScript("ctx._source.day_latest = false")
 
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
-	indexOneDayAgo := mapping.IndexTimeseriesFmt(oneDayAgo)
 
 	time90daysAgo := time.Now().Add(-24 * time.Hour * 90)
 
@@ -355,15 +354,7 @@ func (backend *ESClient) setYesterdayLatestToFalse(ctx context.Context, nodeId s
 	esIndexs, err := relaxting.GetEsIndex(filters, false)
 	if err != nil {
 		logrus.Errorf("Cannot get indexes: %+v", err)
-	}
-
-	// Avoid making an unnecessary update that will overlap with the update from the 'setLatestsToFalse' function
-	// Overlapping ES updates with Refresh(false) on same indices lead to inconsistent results
-	if index == indexOneDayAgo {
-		logrus.Debug("setYesterdayLatestToFalse: day_latest not required when the report end_time is on yesterday's UTC day")
-		return nil
-	} else {
-		logrus.Debugf("setYesterdayLatestToFalse: updating day_latest=false on %s", indexOneDayAgo)
+		return err
 	}
 
 	// Updating in all the Indices

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -290,6 +290,7 @@ func (backend *ESClient) InsertInspecReport(ctx context.Context, id string, endT
 	}
 	data.DailyLatest = true
 	data.ReportID = id
+
 	// Add the report document to the compliance timeseries index using the specified report id as document id
 	_, err := backend.client.Index().
 		Index(index).
@@ -351,7 +352,7 @@ func (backend *ESClient) setYesterdayLatestToFalse(ctx context.Context, nodeId s
 	filters := map[string][]string{"start_time": {time90daysAgo.Format(time.RFC3339)}, "end_time": {oneDayAgo.Format(time.RFC3339)}}
 
 	// Getting all the indices
-	esIndexs, err := relaxting.GetEsIndex(filters, true)
+	esIndexs, err := relaxting.GetEsIndex(filters, false)
 	if err != nil {
 		logrus.Errorf("Cannot get indexes: %+v", err)
 	}

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -366,7 +366,7 @@ func (backend *ESClient) setYesterdayLatestToFalse(ctx context.Context, nodeId s
 	for _, ind := range indexes {
 		if ind != indexToday {
 			_, err = elastic.NewUpdateByQueryService(backend.client).
-				Index("comp-7-r-" + "*"). // Needs to be removed the hardcoded "comp-7-r-"
+				Index(ind + "*").
 				Query(boolQueryDayLatestThisNodeNotThisReport).
 				Script(script).
 				Refresh("false").

--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -272,7 +272,7 @@ func (backend *ESClient) InsertInspecSummary(ctx context.Context, id string, end
 	}
 
 	if data.DayLatest {
-		err = backend.setYesterdayLatestToFalse(ctx, data.NodeID, id, index, mapping)
+		err = backend.UpdateDayLatestToFalse(ctx, data.NodeID, id, index, mapping)
 		if err != nil {
 			return err
 		}
@@ -303,7 +303,7 @@ func (backend *ESClient) InsertInspecReport(ctx context.Context, id string, endT
 	}
 
 	if data.DayLatest {
-		err = backend.setYesterdayLatestToFalse(ctx, data.NodeID, id, index, mapping)
+		err = backend.UpdateDayLatestToFalse(ctx, data.NodeID, id, index, mapping)
 		if err != nil {
 			return err
 		}
@@ -329,9 +329,8 @@ func (backend *ESClient) InsertComplianceRunInfo(ctx context.Context, nodeId str
 	return err
 }
 
-// Sets the 'day_latest' field to 'false' for all reports (except <reportId>) of node <nodeId> in yesterday's UTC index.
-// This way, the last 24 hours is covered.
-func (backend *ESClient) setYesterdayLatestToFalse(ctx context.Context, nodeId string, reportId string, index string, mapping mappings.Mapping) error {
+// Sets the 'day_latest' field to 'false' for all reports (except <reportId>) of node <nodeId> from yesterday upto 90 days UTC index.
+func (backend *ESClient) UpdateDayLatestToFalse(ctx context.Context, nodeId string, reportId string, index string, mapping mappings.Mapping) error {
 	termQueryDayLatestTrue := elastic.NewTermQuery("day_latest", true)
 	termQueryThisNode := elastic.NewTermsQuery("node_uuid", nodeId)
 	termQueryNotThisReport := elastic.NewTermsQuery("_id", reportId)

--- a/components/compliance-service/integration_lcr_test/suite_test.go
+++ b/components/compliance-service/integration_lcr_test/suite_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/chef/automate/components/compliance-service/ingest/pipeline/processor"
-	"github.com/chef/automate/lib/cereal"
-	"github.com/chef/automate/lib/cereal/postgres"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/chef/automate/components/compliance-service/ingest/pipeline/processor"
+	"github.com/chef/automate/lib/cereal"
+	"github.com/chef/automate/lib/cereal/postgres"
 
 	"github.com/chef/automate/api/interservice/authz"
 	"github.com/chef/automate/api/interservice/compliance/ingest/events/compliance"
@@ -22,6 +23,7 @@ import (
 	"github.com/chef/automate/components/compliance-service/ingest/server"
 	"github.com/chef/automate/components/compliance-service/reporting/relaxting"
 	notifications "github.com/chef/automate/components/notifications-client/api"
+
 	"github.com/chef/automate/lib/grpc/auth_context"
 
 	"github.com/golang/mock/gomock"
@@ -46,6 +48,7 @@ type Suite struct {
 	NotifierMock            *NotifierMock
 	EventServiceClientMock  *event.MockEventServiceClient
 	ReportServiceClientMock *report_manager.MockReportManagerServiceClient
+	CerealManagerMock       *cereal.Manager
 }
 
 // Initialize the test suite


### PR DESCRIPTION
Signed-off-by: Pappu Kumar <pappu.kumar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
We had to make the code changes to set all the datLatest flag to false for all the indices before 24 hours.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
- Test upgrade scenario from older version
- Only the latest report should have day_latest flag  true
- This is applicable for new data as well as old data after upgrade
- All Exceptions are Handled Properly
- Ensure information are logged and should not have unnecessary data.
- Test coverage for the new feature is done to at least 70%
- Smoke Test done.
- PR has 2 approvers.
- All Code Review Comments are Resolved.

### :athletic_shoe: How to Build and Test the Change
Run the following command :
./automate-load-test -url https://a2-dev.test/api/v0/events/data-collector -token <token> -numberOfElement=200 -concurrency=20 -data=compliance -status=failure

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
