### PR TITLE
Added Organization in Breadcrumb Nav Bar

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
@@ -5,7 +5,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{orgId}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{orgId}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Clients
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
@@ -42,7 +42,6 @@
       </app-reset-client-key>
 
       <section class="page-body" *ngIf="tabValue === 'details'">
-        <!-- <chef-loading-spinner *ngIf="clientDetailsLoading" size="50" fixed></chef-loading-spinner> -->
         <div *ngIf="!clientDetailsLoading" class="key-tab">
           <div class="empty-section" *ngIf="!client?.client_key.public_key">
             <img alt="No preview" src="/assets/img/no_preview.gif" />

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
@@ -1,14 +1,20 @@
 <div class="content-container">
   <div class="container">
     <main>
+      <chef-loading-spinner *ngIf="clientTabLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Orgs</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Clients</chef-breadcrumb>
-         {{client?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{orgId}}
+        </chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Clients
+        </chef-breadcrumb>
+        {{client?.name}}
       </chef-breadcrumbs>
       <chef-page-header>
-        <chef-heading>{{client?.name}} <chef-badge no-data warning *ngIf="client?.validator">Validation Client</chef-badge></chef-heading>
+        <chef-heading>{{client?.name}} <chef-badge no-data warning *ngIf="client?.validator">Validation Client
+          </chef-badge>
+        </chef-heading>
         <table>
           <thead>
             <tr class="detail-row">
@@ -32,14 +38,11 @@
         </chef-tab-selector>
       </chef-page-header>
 
-      <app-reset-client-key
-        [openEvent]="openNotificationModal"
-        [serverId]="serverId"
-        [orgId]="orgId"
-        [name]="name"></app-reset-client-key>
+      <app-reset-client-key [openEvent]="openNotificationModal" [serverId]="serverId" [orgId]="orgId" [name]="name">
+      </app-reset-client-key>
 
       <section class="page-body" *ngIf="tabValue === 'details'">
-        <chef-loading-spinner *ngIf="clientDetailsLoading" size="50"></chef-loading-spinner>
+        <!-- <chef-loading-spinner *ngIf="clientDetailsLoading" size="50" fixed></chef-loading-spinner> -->
         <div *ngIf="!clientDetailsLoading" class="key-tab">
           <div class="empty-section" *ngIf="!client?.client_key.public_key">
             <img alt="No preview" src="/assets/img/no_preview.gif" />

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.scss
@@ -83,6 +83,7 @@ chef-table {
 chef-loading-spinner {
   z-index: 199;
 }
+
 .empty-section {
   margin-top: 130px;
   text-align: center;

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.scss
@@ -74,13 +74,15 @@ chef-table {
   }
 }
 
+// chef-loading-spinner {
+//   display: block;
+//   margin: 100px auto;
+//   width: 100px;
+//   z-index: 199;
+// }
 chef-loading-spinner {
-  display: block;
-  margin: 100px auto;
-  width: 100px;
   z-index: 199;
 }
-
 .empty-section {
   margin-top: 130px;
   text-align: center;

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
@@ -56,8 +56,7 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
       this.name = name;
       this.store.dispatch(new GetClient({
         server_id: server_id, org_id: org_id, name: name
-      })); 
-      
+      }));   
     });
 
     this.store.select(clientFromRoute).pipe(
@@ -69,7 +68,6 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
       this.clientDetailsLoading = false;  
       this.clientTabLoading = false;
     });
-
   }
 
   onSelectedTab(event: { target: { value: ClientTabName } }) {

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
@@ -56,7 +56,7 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
       this.name = name;
       this.store.dispatch(new GetClient({
         server_id: server_id, org_id: org_id, name: name
-      }));   
+      }));
     });
 
     this.store.select(clientFromRoute).pipe(
@@ -65,7 +65,7 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(client => {
       this.show = true;
       this.client = client;
-      this.clientDetailsLoading = false;  
+      this.clientDetailsLoading = false;
       this.clientTabLoading = false;
     });
   }

--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.ts
@@ -10,7 +10,7 @@ import { identity } from 'lodash/fp';
 import { clientFromRoute } from 'app/entities/clients/client-details.selectors';
 import { GetClient } from 'app/entities/clients/client.action';
 import { Client } from 'app/entities/clients/client.model';
-
+import { Org } from 'app/entities/orgs/org.model';
 export type ClientTabName = 'details';
 
 @Component({
@@ -20,6 +20,7 @@ export type ClientTabName = 'details';
 })
 
 export class ClientDetailsComponent implements OnInit, OnDestroy {
+  public org: Org;
   public client: Client;
   public tabValue: ClientTabName = 'details';
   public url: string;
@@ -29,8 +30,9 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
   public orgId: string;
   public name: string;
   public show = false;
+  public clientTabLoading = true;
   private isDestroyed = new Subject<boolean>();
-  clientDetailsLoading = true;
+  public clientDetailsLoading = true;
   public openNotificationModal = new EventEmitter<void>();
 
   constructor(
@@ -54,7 +56,8 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
       this.name = name;
       this.store.dispatch(new GetClient({
         server_id: server_id, org_id: org_id, name: name
-      }));
+      })); 
+      
     });
 
     this.store.select(clientFromRoute).pipe(
@@ -63,8 +66,10 @@ export class ClientDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(client => {
       this.show = true;
       this.client = client;
-      this.clientDetailsLoading = false;
+      this.clientDetailsLoading = false;  
+      this.clientTabLoading = false;
     });
+
   }
 
   onSelectedTab(event: { target: { value: ClientTabName } }) {

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -5,6 +5,8 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Cookbooks
         </chef-breadcrumb>
         {{ cookbookName }}
@@ -28,15 +30,14 @@
           <div class="item-column">
             <ul class="list" *ngIf="menuList.length">
               <li *ngFor="let item of menuList; let i = index;">
-                <span (click)="listClickEvent($event)" 
-                [ngClass]="{'extend-list': i === menuIndex}">
-                  {{ item.menu | titlecase  }} ({{ item.subMenu.length }})
+                <span (click)="listClickEvent($event)" [ngClass]="{'extend-list': i === menuIndex}">
+                  {{ item.menu | titlecase }} ({{ item.subMenu.length }})
                 </span>
                 <ul class="sub-list" [ngClass]="{'show': i === menuIndex}">
-                  <li *ngFor="let content of item.subMenu; let j = index;" 
-                  [ngClass]="{'active-sub-list': j === 0 && i === 0}" 
-                  (click)="subListClickEvent($event, content)">
-                    {{ content.name }}<chef-icon>fiber_manual_record</chef-icon></li>
+                  <li *ngFor="let content of item.subMenu; let j = index;"
+                    [ngClass]="{'active-sub-list': j === 0 && i === 0}" (click)="subListClickEvent($event, content)">
+                    {{ content.name }}<chef-icon>fiber_manual_record</chef-icon>
+                  </li>
                 </ul>
               </li>
             </ul>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -5,7 +5,7 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">{{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Cookbooks
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -88,7 +88,6 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
         const [, fragment] = url.split('#');
         this.tabValue = (fragment === 'details') ? 'details' : 'content';
       });
-  
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.ts
@@ -88,7 +88,6 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
         const [, fragment] = url.split('#');
         this.tabValue = (fragment === 'details') ? 'details' : 'content';
       });
-
   
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
@@ -100,7 +99,6 @@ export class CookbookDetailsComponent implements OnInit, OnDestroy {
       this.serverId = server_id;
       this.orgId = org_id;
       this.cookbookName = cookbook_name;
-      
       this.store.dispatch(new GetCookbookVersions({
         server_id: server_id,
         org_id: org_id,

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
@@ -1,18 +1,17 @@
 <div class="content-container dataBagItems">
   <div class="container">
     <main>
-      <app-delete-infra-object-modal
-        [visible]="deleteModalVisible"
-        objectNoun="data bag item"
-        [objectName]="dataBagItemToDelete?.name"
-        (close)="closeDeleteModal()"
-        (deleteClicked)="deleteDataBagItem()"
+      <chef-loading-spinner *ngIf="dataBagsTabLoading" size="50" fixed></chef-loading-spinner>
+      <app-delete-infra-object-modal [visible]="deleteModalVisible" objectNoun="data bag item"
+        [objectName]="dataBagItemToDelete?.name" (close)="closeDeleteModal()" (deleteClicked)="deleteDataBagItem()"
         objectAction="Delete">
       </app-delete-infra-object-modal>
       <chef-loading-spinner class="spinner" *ngIf="dataBagsDetailsLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Data Bags
         </chef-breadcrumb>
         {{ dataBagName }}
@@ -35,36 +34,31 @@
         </chef-tab-selector>
       </chef-page-header>
 
-      <app-create-databag-item-modal
-          [openEvent]="openDataBagItemModal"
-          [server_Id]="serverId"
-          [org_Id]="orgId"
-          [name]="dataBagName"
-          [currentPage]="current_page">
+      <app-create-databag-item-modal [openEvent]="openDataBagItemModal" [server_Id]="serverId" [org_Id]="orgId"
+        [name]="dataBagName" [currentPage]="current_page">
       </app-create-databag-item-modal>
 
       <section class="page-body" *ngIf="tabValue === 'details'">
         <div class="search-create-container">
-          <app-infra-search-bar (searchButtonClick)="searchDataBagItems($event)" placeHolder="data bag items by name...">
+          <app-infra-search-bar (searchButtonClick)="searchDataBagItems($event)"
+            placeHolder="data bag items by name...">
           </app-infra-search-bar>
-          <app-paginator *ngIf="dataBagItems"
-            [length]= "total"
-            [pageSize]= "per_page"
-            [pageIndex]= "current_page"
-            (changePage)= "onUpdatePage($event)"
-          ></app-paginator>
+          <app-paginator *ngIf="dataBagItems" [length]="total" [pageSize]="per_page" [pageIndex]="current_page"
+            (changePage)="onUpdatePage($event)"></app-paginator>
           <chef-button primary (click)="openDatabagItemModal()">Create Item</chef-button>
         </div>
         <div class="section-container" *ngIf="dataBagItems">
-          <chef-loading-spinner *ngIf="loading || deleting" size="50" fixed class="full-screen-spinner"></chef-loading-spinner>
+          <chef-loading-spinner *ngIf="loading || deleting" size="50" fixed class="full-screen-spinner">
+          </chef-loading-spinner>
           <div class="empty-section" *ngIf="!loading && !dataBagItems.length">
             <img alt="No preview" src="/assets/img/no_preview.gif" />
             <p *ngIf="searchValue === ''">No data bag items available</p>
             <p *ngIf="searchValue != ''">No results found for "{{searchValue}}".</p>
           </div>
           <div *ngIf="dataBagItems.length">
-            <ul id="accordion" class="accordion" >
-              <li *ngFor="let item of dataBagItems; let i = index" [class.active]="item.active" class="items" id="{{item.name}}">
+            <ul id="accordion" class="accordion">
+              <li *ngFor="let item of dataBagItems; let i = index" [class.active]="item.active" class="items"
+                id="{{item.name}}">
                 <div class="menu" (click)="handleItemSelected(item.name, i)">
                   <div class="data-bag-name">
                     {{ item.name }}
@@ -73,7 +67,8 @@
                 </div>
                 <div class="submenu" [ngClass]="item.active ? activeClassName : ''">
                   <div class="item-details">
-                    <chef-loading-spinner *ngIf="item.active && dataBagsItemDetailsLoading" size="50" fixed></chef-loading-spinner>
+                    <chef-loading-spinner *ngIf="item.active && dataBagsItemDetailsLoading" size="50" fixed>
+                    </chef-loading-spinner>
                     <div *ngIf="!dataBagsItemDetailsLoading && selectedItemDetails">
                       <div class="expand-collapse edited">
                         <chef-button tertiary class="action" (click)="tree.expand()">
@@ -88,39 +83,27 @@
                           <chef-icon class="material-icons">delete</chef-icon>
                           <span>Delete</span>
                         </chef-button>
-                        <chef-button
-                          tertiary
-                          class="action right-button-box"
-                          (click)="startUpdateDataBagItem(item, selectedItemDetails)"
-                          [disabled]="editDisable">
+                        <chef-button tertiary class="action right-button-box"
+                          (click)="startUpdateDataBagItem(item, selectedItemDetails)" [disabled]="editDisable">
                           <chef-icon class="material-icons">mode_edit</chef-icon>
                           <span>Edit</span>
                         </chef-button>
                       </div>
 
-                      <app-json-tree-table class="json-tree-container" #tree [json]="selectedItemDetails"></app-json-tree-table>
+                      <app-json-tree-table class="json-tree-container" #tree [json]="selectedItemDetails">
+                      </app-json-tree-table>
                     </div>
                   </div>
                 </div>
               </li>
             </ul>
           </div>
-          <app-edit-data-bag-item-modal
-            [openEvent]="openEditDataBagItemModal"
-            [serverId]="serverId"
-            [orgId]="orgId"
-            [dataBagName]="dataBagName"
-            [dataBagItemName]="dataBagItemName"
-            [itemDataJson]="itemDataJson"
+          <app-edit-data-bag-item-modal [openEvent]="openEditDataBagItemModal" [serverId]="serverId" [orgId]="orgId"
+            [dataBagName]="dataBagName" [dataBagItemName]="dataBagItemName" [itemDataJson]="itemDataJson"
             (refreshData)="refreshData($event)">
           </app-edit-data-bag-item-modal>
-          <app-page-picker
-            *ngIf="!loading"
-            class="item-list-paging"
-            [total]="total"
-            [perPage]="per_page"
-            [page]="current_page"
-            (pageChanged)="onPageChange($event)">
+          <app-page-picker *ngIf="!loading" class="item-list-paging" [total]="total" [perPage]="per_page"
+            [page]="current_page" (pageChanged)="onPageChange($event)">
           </app-page-picker>
         </div>
       </section>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
@@ -10,7 +10,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Data Bags
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.scss
@@ -6,12 +6,6 @@ chef-page-header {
   padding-bottom: 0;
 }
 
-// chef-loading-spinner {
-//   margin-top: 188px;
-//   z-index: 199;
-//   background-color: $chef-white;
-//   opacity: 0.7;
-// }
 chef-loading-spinner {
   z-index: 199;
   opacity: 0.7;

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.scss
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.scss
@@ -6,10 +6,14 @@ chef-page-header {
   padding-bottom: 0;
 }
 
+// chef-loading-spinner {
+//   margin-top: 188px;
+//   z-index: 199;
+//   background-color: $chef-white;
+//   opacity: 0.7;
+// }
 chef-loading-spinner {
-  margin-top: 188px;
   z-index: 199;
-  background-color: $chef-white;
   opacity: 0.7;
 }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -157,7 +157,7 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
             }
           }
         }
-        this.dataBagsItemDetailsLoading = false; 
+        this.dataBagsItemDetailsLoading = false;
       });
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.ts
@@ -157,8 +157,7 @@ export class DataBagsDetailsComponent implements OnInit, OnDestroy {
             }
           }
         }
-        this.dataBagsItemDetailsLoading = false;
-        
+        this.dataBagsItemDetailsLoading = false; 
       });
   }
 

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -5,7 +5,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Environments
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -5,8 +5,11 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Environments</chef-breadcrumb>
-         {{environment?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Environments
+        </chef-breadcrumb>
+        {{environment?.name}}
       </chef-breadcrumbs>
       <chef-page-header>
         <chef-heading>{{environment?.name}}</chef-heading>
@@ -15,19 +18,10 @@
           <chef-option value='attributes' data-cy="attributes-tab">Attributes</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      <app-edit-environment-attribute-modal
-        [jsonText]="jsonText"
-        [openEvent]="openEnvironmentModal"
-        [serverId]="serverId"
-        [orgId]="orgId"
-        [name]="name"
-        [environment]="environment"
-        [label]="label"
-        [cookbookConstraints]="cookbookConstraints"
-        [cookbookVersions]="cookbookVersions"
-        [constraintKeys]="constraintKeys"
-        [nameKeys]="nameKeys"
-        [name_id]="name_id">
+      <app-edit-environment-attribute-modal [jsonText]="jsonText" [openEvent]="openEnvironmentModal"
+        [serverId]="serverId" [orgId]="orgId" [name]="name" [environment]="environment" [label]="label"
+        [cookbookConstraints]="cookbookConstraints" [cookbookVersions]="cookbookVersions"
+        [constraintKeys]="constraintKeys" [nameKeys]="nameKeys" [name_id]="name_id">
       </app-edit-environment-attribute-modal>
       <section class="page-body" *ngIf="tabValue === 'cookbookConstraints'">
         <div *ngIf="show">
@@ -54,7 +48,7 @@
                     </chef-tr>
                   </chef-thead>
                   <chef-tbody>
-                    <chef-tr *ngFor= "let version of cookbookVersions" class="row-gap">
+                    <chef-tr *ngFor="let version of cookbookVersions" class="row-gap">
                       <chef-td class="no-border-th">{{ version.name }}</chef-td>
                       <chef-td class="no-border-th">{{ version.operator }}</chef-td>
                       <chef-td class="no-border-th">{{ version.versionNumber }}</chef-td>
@@ -76,21 +70,15 @@
         </label>
         <div class="attr">
           <div class="expand-collapse">
-            <chef-button tertiary class="action"
-              [disabled]= !hasDefaultJson
-              (click)="tree.expand()">
+            <chef-button tertiary class="action" [disabled]=!hasDefaultJson (click)="tree.expand()">
               <chef-icon>add_circle</chef-icon>
               <span>Expand All</span>
             </chef-button>
-            <chef-button tertiary class="action"
-              [disabled]= !hasDefaultJson
-              (click)="tree.collapse()">
+            <chef-button tertiary class="action" [disabled]=!hasDefaultJson (click)="tree.collapse()">
               <chef-icon>remove_circle</chef-icon>
               <span>Collapse All</span>
             </chef-button>
-            <chef-button
-              tertiary
-              class="right-button-box"
+            <chef-button tertiary class="right-button-box"
               (click)="openEditAttributeModal(environment?.default_attributes, 'Default')">
               <span class="material-icons edit-item">mode_edit</span>
               <span class="edit-text">Edit</span>
@@ -99,10 +87,7 @@
           <hr class="divider-constraints" />
           <div class="json-container">
             <div class="scroll">
-              <app-json-tree-table
-                class="json-tree-container"
-                [hidden]="hasDefaultJson? false : true"
-                #tree
+              <app-json-tree-table class="json-tree-container" [hidden]="hasDefaultJson? false : true" #tree
                 [json]="selectedAttrs?.default_attributes">
               </app-json-tree-table>
               <div *ngIf="!hasDefaultJson" class="img-section">
@@ -117,21 +102,15 @@
         </label>
         <div class="attr">
           <div class="expand-collapse">
-            <chef-button tertiary class="action"
-              [disabled]= !hasOverrideJson
-              (click)="override.expand()">
+            <chef-button tertiary class="action" [disabled]=!hasOverrideJson (click)="override.expand()">
               <chef-icon>add_circle</chef-icon>
               <span>Expand All</span>
             </chef-button>
-            <chef-button tertiary class="action"
-              [disabled]= !hasOverrideJson
-              (click)="override.collapse()">
+            <chef-button tertiary class="action" [disabled]=!hasOverrideJson (click)="override.collapse()">
               <chef-icon>remove_circle</chef-icon>
               <span>Collapse All</span>
             </chef-button>
-            <chef-button
-              tertiary
-              class="right-button-box"
+            <chef-button tertiary class="right-button-box"
               (click)="openEditAttributeModal(environment?.override_attributes, 'Override')">
               <span class="material-icons edit-item">mode_edit</span>
               <span class="edit-text">Edit</span>
@@ -140,10 +119,7 @@
           <hr class="divider-constraints" />
           <div class="json-container">
             <div class="scroll">
-              <app-json-tree-table
-                class="json-tree-container"
-                [hidden]="hasOverrideJson? false : true"
-                #override
+              <app-json-tree-table class="json-tree-container" [hidden]="hasOverrideJson? false : true" #override
                 [json]="selectedAttrs?.override_attributes">
               </app-json-tree-table>
               <div *ngIf="!hasOverrideJson" class="img-section">

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -122,8 +122,8 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
-    });
-      
+    });  
+    
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -102,27 +102,27 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
         this.tabValue = (fragment === 'attributes') ? 'attributes' : 'cookbookConstraints';
       });
 
-      combineLatest([
-        this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-        this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))
-      ]).pipe(
-        takeUntil(this.isDestroyed)
-      ).subscribe(([server_id, org_id]: string[]) => {
-        this.serverId = server_id;
-        this.orgId = org_id;
-        this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
-      });
-  
-      combineLatest([
-        this.store.select(gtStatus),
-        this.store.select(orgFromRoute)
-      ]).pipe(
-        filter(([getOrgSt, orgState]) => getOrgSt ===
-          EntityStatus.loadingSuccess && !isNil(orgState)),
-        takeUntil(this.isDestroyed)
-      ).subscribe(([_getOrgSt, orgState]) => {
-        this.org = { ...orgState };
-      });
+    combineLatest([
+      this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([server_id, org_id]: string[]) => {
+      this.serverId = server_id;
+      this.orgId = org_id;
+      this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
+    });
+
+    combineLatest([
+      this.store.select(gtStatus),
+      this.store.select(orgFromRoute)
+    ]).pipe(
+      filter(([getOrgSt, orgState]) => getOrgSt ===
+        EntityStatus.loadingSuccess && !isNil(orgState)),
+      takeUntil(this.isDestroyed)
+    ).subscribe(([_getOrgSt, orgState]) => {
+      this.org = { ...orgState };
+    });
       
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
@@ -169,7 +169,6 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
       setTimeout(() => this.filter(this.selected_level), 10);
       this.environmentDetailsLoading = false;
     });
-
   }
 
 

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -122,7 +122,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
       takeUntil(this.isDestroyed)
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
-    });  
+    });
 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.ts
@@ -123,7 +123,7 @@ export class EnvironmentDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });  
-    
+
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
@@ -4,8 +4,11 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Nodes</chef-breadcrumb>
-          {{InfraNode?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Nodes
+        </chef-breadcrumb>
+        {{InfraNode?.name}}
       </chef-breadcrumbs>
       <chef-page-header>
         <chef-heading data-cy="infra-node-head">{{InfraNode?.name}}</chef-heading>
@@ -48,51 +51,33 @@
         </chef-tab-selector>
       </chef-page-header>
 
-      <app-edit-infra-node-modal
-        [label]="label"
-        [openEvent]="openEnvironmentModal"
-        [orgId]="orgId"
-        [availableType]="availableType"
-        [node]="InfraNode"
-        [serverId]="serverId"
-        [selected]="selected"
-        [runlistError]="conflictError"
-        (runlistUpdated)="updateRunlist()">
+      <app-edit-infra-node-modal [label]="label" [openEvent]="openEnvironmentModal" [orgId]="orgId"
+        [availableType]="availableType" [node]="InfraNode" [serverId]="serverId" [selected]="selected"
+        [runlistError]="conflictError" (runlistUpdated)="updateRunlist()">
       </app-edit-infra-node-modal>
 
-      <app-edit-infra-node-attribute-modal
-        [jsonText]="jsonText"
-        [openEvent]="openAttributeModal"
-        [orgId]="orgId" [node]="InfraNode"
-        [serverId]="serverId"
-        [attrParseError]="conflictError"
-        [isGetNode]="isGetNode">
+      <app-edit-infra-node-attribute-modal [jsonText]="jsonText" [openEvent]="openAttributeModal" [orgId]="orgId"
+        [node]="InfraNode" [serverId]="serverId" [attrParseError]="conflictError" [isGetNode]="isGetNode">
       </app-edit-infra-node-attribute-modal>
 
       <section class="page-body" *ngIf="tabValue === 'details'">
-        <chef-loading-spinner class="full-screen-spinner" *ngIf="nodeDetailsLoading" size="50"></chef-loading-spinner>
+        <chef-loading-spinner class="full-screen-spinner" *ngIf="nodeDetailsLoading" size="50" fixed>
+        </chef-loading-spinner>
         <div class="details-tab" *ngIf="!nodeDetailsLoading">
           <div class="spinner">
-            <chef-loading-spinner class="full-screen-spinner" *ngIf="nodeDetailsLoading" size="50" fixed></chef-loading-spinner>
-            <chef-loading-spinner class="full-screen-spinner" *ngIf="updatingTags" size="50" fixed></chef-loading-spinner>
+            <chef-loading-spinner class="full-screen-spinner" *ngIf="nodeDetailsLoading" size="50" fixed>
+            </chef-loading-spinner>
+            <chef-loading-spinner class="full-screen-spinner" *ngIf="updatingTags" size="50" fixed>
+            </chef-loading-spinner>
           </div>
           <ng-container *ngIf="!nodeDetailsLoading">
             <div class="node-details-section">
               <form [ngClass]="confirming === true ? 'auto-height' : ''" [formGroup]="updateNodeForm">
                 <chef-form-field>
                   <span class="label">Environment</span>
-                  <ng-select
-                    formControlName="environment"
-                    [items]="environmentsBuffer"
-                    [virtualScroll]="true"
-                    [loading]="loading"
-                    bindLabel="name"
-                    bindValue="name"
-                    appendTo="body"
-                    [searchable]="false"
-                    [clearable]="false"
-                    (scroll)="onScroll($event)"
-                    (change)="selectChangeHandler($event)"
+                  <ng-select formControlName="environment" [items]="environmentsBuffer" [virtualScroll]="true"
+                    [loading]="loading" bindLabel="name" bindValue="name" appendTo="body" [searchable]="false"
+                    [clearable]="false" (scroll)="onScroll($event)" (change)="selectChangeHandler($event)"
                     (scrollToEnd)="onScrollToEnd()">
                     <ng-template ng-option-tmp let-item="item" let-index="index">
                       {{item.name}}
@@ -102,17 +87,9 @@
                 <div *ngIf="confirming" class="changes-confirmation" data-cy="change-confirm">
                   <p class="change-node-text">Change Node Environment?</p>
                   <div id="button-env">
-                    <chef-button
-                      tertiary
-                      id="cancel"
-                      data-cy="cancel-button"
-                      [disabled]="saving"
+                    <chef-button tertiary id="cancel" data-cy="cancel-button" [disabled]="saving"
                       (click)="closeConfirmationBox()">Cancel</chef-button>
-                    <chef-button
-                      primary
-                      data-cy="save-button"
-                      id="save-btn"
-                      [disabled]="saving"
+                    <chef-button primary data-cy="save-button" id="save-btn" [disabled]="saving"
                       (click)="saveEnvironment()">
                       <chef-loading-spinner *ngIf="saving"></chef-loading-spinner>
                       <span *ngIf="!saving">Save</span>
@@ -123,32 +100,18 @@
               </form>
               <span class="label">Tags</span>
               <div class="node-tags-box">
-                <input
-                  chefInput
-                  type="text"
-                  id="tag-input"
-                  autocomplete="off"
-                  data-cy="add-tag"
-                  [ngClass]="saving ? 'disable' : ''"
-                  [(ngModel)]="inputTxt"/>
-                <button
-                  primary
-                  type="submit"
-                  class="primary"
-                  [disabled]= "(inputTxt === '') || saving"
-                  data-cy="add-tag-button"
-                  (click)="addTags()"> Add </button>
+                <input chefInput type="text" id="tag-input" autocomplete="off" data-cy="add-tag"
+                  [ngClass]="saving ? 'disable' : ''" [(ngModel)]="inputTxt" />
+                <button primary type="submit" class="primary" [disabled]="(inputTxt === '') || saving"
+                  data-cy="add-tag-button" (click)="addTags()"> Add </button>
               </div>
               <p class="tag-note">Note: Multiple Tags Should Be Comma-Separated. (Example: "Tag1, Tag2, Tag3")</p>
-              <div
-                *ngIf="nodeTags?.length"
-                class="display-node-tags"
-                [ngClass]="saving ? 'disable' : ''"
+              <div *ngIf="nodeTags?.length" class="display-node-tags" [ngClass]="saving ? 'disable' : ''"
                 data-cy="tag-box">
-              <span *ngFor="let tag of nodeTags" class="tag">
-                {{tag}}
-                <a class="removeTag" (click)="removeTag(tag)" data-cy="remove-tag"></a>
-              </span>
+                <span *ngFor="let tag of nodeTags" class="tag">
+                  {{tag}}
+                  <a class="removeTag" (click)="removeTag(tag)" data-cy="remove-tag"></a>
+                </span>
               </div>
             </div>
           </ng-container>
@@ -169,73 +132,49 @@
             </div>
             <div class="attr" *ngIf="!runListLoading">
               <div class="expand-collapse" *ngIf="!hasRun_List">
-                <chef-button
-                  tertiary
-                  class="action"
-                  (click)="''"
-                  [disabled]="true"
-                  data-cy="empty-expand-runlist">
+                <chef-button tertiary class="action" (click)="''" [disabled]="true" data-cy="empty-expand-runlist">
                   <chef-icon>add_circle</chef-icon>
                   <span>Expand All</span>
                 </chef-button>
-                <chef-button
-                  tertiary
-                  class="action"
-                  (click)="''"
-                  [disabled]="true"
-                  data-cy="empty-collapse-runlist">
+                <chef-button tertiary class="action" (click)="''" [disabled]="true" data-cy="empty-collapse-runlist">
                   <chef-icon>remove_circle</chef-icon>
                   <span>Collapse All</span>
                 </chef-button>
-                <chef-button
-                  tertiary
-                  class="float-right action"
-                  (click)="openEditModal('Run List')"
-                  [disabled]="runListLoading || conflictError"
-                  data-cy="node-edit-runlist">
+                <chef-button tertiary class="float-right action" (click)="openEditModal('Run List')"
+                  [disabled]="runListLoading || conflictError" data-cy="node-edit-runlist">
                   <span class="material-icons edit-item">mode_edit</span>
                   <span class="edit-text">Edit</span>
                 </chef-button>
               </div>
               <div *ngIf="hasRun_List">
                 <div class="expand-collapse">
-                  <chef-button
-                    tertiary
-                    class="action"
-                    (click)="trees ? trees.expand() : ''"
+                  <chef-button tertiary class="action" (click)="trees ? trees.expand() : ''"
                     data-cy="node-expand-runlist">
                     <chef-icon>add_circle</chef-icon>
                     <span>Expand All</span>
                   </chef-button>
-                  <chef-button
-                    tertiary
-                    class="action"
-                    (click)="trees ? trees.treeCollapsed() : ''"
+                  <chef-button tertiary class="action" (click)="trees ? trees.treeCollapsed() : ''"
                     data-cy="node-collapse-runlist">
                     <chef-icon>remove_circle</chef-icon>
                     <span>Collapse All</span>
                   </chef-button>
-                  <chef-button
-                    tertiary
-                    class="float-right action"
-                    (click)="openEditModal('Run List')"
+                  <chef-button tertiary class="float-right action" (click)="openEditModal('Run List')"
                     data-cy="node-edit-runlist">
                     <span class="material-icons edit-item">mode_edit</span>
                     <span class="edit-text">Edit</span>
                   </chef-button>
                 </div>
-                <app-tree-table
-                  [hidden]="hasRun_List ? false : true"
-                  [tree]="arrayOfNodesTree"
-                  #trees
+                <app-tree-table [hidden]="hasRun_List ? false : true" [tree]="arrayOfNodesTree" #trees
                   [options]="treeOptions">
                 </app-tree-table>
               </div>
-              <div data-cy="empty-runlist" *ngIf="!hasRun_List && !runListLoading && !conflictError" class="empty-section">
+              <div data-cy="empty-runlist" *ngIf="!hasRun_List && !runListLoading && !conflictError"
+                class="empty-section">
                 <img alt="No preview" src="/assets/img/no_preview.gif" />
                 <p>No run list is set for the node.</p>
               </div>
-              <div data-cy="error-runlist" *ngIf="!hasRun_List && !runListLoading && conflictError" class="empty-section">
+              <div data-cy="error-runlist" *ngIf="!hasRun_List && !runListLoading && conflictError"
+                class="empty-section">
                 <img alt="No preview" src="/assets/img/no_preview.gif" />
                 <p>Cannot load run_list!</p>
               </div>
@@ -256,21 +195,18 @@
               </label>
               <div class="attr">
                 <div class="expand-collapse">
-                  <chef-button tertiary class="action"
-                   (click)="tree.expand()" [disabled]=!hasattributes
+                  <chef-button tertiary class="action" (click)="tree.expand()" [disabled]=!hasattributes
                     data-cy="expand-attributes">
                     <chef-icon>add_circle</chef-icon>
                     <span>Expand All</span>
                   </chef-button>
-                  <chef-button tertiary class="action"
-                   (click)="tree.collapse()" [disabled]=!hasattributes
+                  <chef-button tertiary class="action" (click)="tree.collapse()" [disabled]=!hasattributes
                     data-cy="collapse-attributes">
                     <chef-icon>remove_circle</chef-icon>
                     <span>Collapse All</span>
                   </chef-button>
                   <chef-button tertiary class="right-button-box"
-                    (click)="openEditAttrModal(InfraNode.normal_attributes)"
-                    data-cy="node-edit-attributes">
+                    (click)="openEditAttrModal(InfraNode.normal_attributes)" data-cy="node-edit-attributes">
                     <span class="material-icons edit-item">mode_edit</span>
                     <span class="edit-text">Edit</span>
                   </chef-button>
@@ -278,10 +214,8 @@
                 <hr class="divider-constraints" />
                 <div class="json-container">
                   <div class="scroll">
-                    <app-json-tree-table class="json-tree-container"
-                    [hidden]="hasattributes? false : true"
-                    #tree
-                    [json]="attributes">
+                    <app-json-tree-table class="json-tree-container" [hidden]="hasattributes? false : true" #tree
+                      [json]="attributes">
                     </app-json-tree-table>
                     <div *ngIf="!hasattributes" class="img-section">
                       <img alt="No preview" src="/assets/img/no_preview.gif" />

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
@@ -4,7 +4,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Nodes
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.ts
@@ -177,7 +177,7 @@ export class InfraNodeDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
-    // load node details
+   // load node details
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.ts
@@ -177,7 +177,6 @@ export class InfraNodeDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
-
     // load node details
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
@@ -5,9 +5,11 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Roles
+        <chef-breadcrumb [routerLink]=" ['/infrastructure/chef-servers', serverId, 'organizations' , orgId]">Roles
         </chef-breadcrumb>
         {{role?.name}}
       </chef-breadcrumbs>

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
@@ -1,11 +1,15 @@
 <div class="content-container">
   <div class="container">
     <main>
+      <chef-loading-spinner *ngIf="infraRoleLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Roles</chef-breadcrumb>
-         {{role?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Roles
+        </chef-breadcrumb>
+        {{role?.name}}
       </chef-breadcrumbs>
       <chef-page-header>
         <chef-heading>{{role?.name}}</chef-heading>
@@ -28,29 +32,20 @@
           <chef-option value='attributes' data-cy="attributes-tab">Attributes</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      <app-edit-infra-role-modal
-        [jsonText]="jsonText"
-        [label]="label"
-        [openEvent]="openEnvironmentModal"
-        [orgId]="orgId"
-        [availableType]="availableType"
-        [role]="role"
-        [serverId]="serverId"
-        [selected]="selected"
+      <app-edit-infra-role-modal [jsonText]="jsonText" [label]="label" [openEvent]="openEnvironmentModal"
+        [orgId]="orgId" [availableType]="availableType" [role]="role" [serverId]="serverId" [selected]="selected"
         (runlistUpdated)="updateRunlist()">
       </app-edit-infra-role-modal>
       <section class="page-body" *ngIf="tabValue === 'runList'">
-        <chef-loading-spinner *ngIf="roleDetailsLoading" size="50"></chef-loading-spinner>
+        <chef-loading-spinner *ngIf="roleDetailsLoading && !infraRoleLoading" size="50"></chef-loading-spinner>
         <div *ngIf="show && !roleDetailsLoading">
           <div class="label-items">
             <label>
               <span class="label default">Run List</span>
             </label>
             <div class="version-dropdown">
-              <chef-select #li [value]="env_id" (change)="selectChangeHandler(li.value)" >
-                <chef-option
-                  *ngFor="let list of idList"
-                  [value]="list">
+              <chef-select #li [value]="env_id" (change)="selectChangeHandler(li.value)">
+                <chef-option *ngFor="let list of idList" [value]="list">
                   {{ list }}
                 </chef-option>
               </chef-select>
@@ -58,67 +53,44 @@
           </div>
           <div class="attr">
             <div class="expand-collapse" *ngIf="!hasRun_List">
-              <chef-button
-                tertiary
-                class="action"
-                (click)="''"
-                [disabled]="true">
+              <chef-button tertiary class="action" (click)="''" [disabled]="true">
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="action"
-                (click)="''"
-                [disabled]="true">
+              <chef-button tertiary class="action" (click)="''" [disabled]="true">
                 <chef-icon>remove_circle</chef-icon>
                 <span>Collapse All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="float-right action"
-                (click)="openEditModal(role?.default_attributes, 'Run List')"
-                [disabled]="editDisabled">
+              <chef-button tertiary class="float-right action"
+                (click)="openEditModal(role?.default_attributes, 'Run List')" [disabled]="editDisabled">
                 <span class="material-icons edit-item">mode_edit</span>
                 <span class="edit-text">Edit</span>
               </chef-button>
             </div>
             <div *ngIf="hasRun_List">
               <div class="expand-collapse">
-                <chef-button
-                  tertiary
-                  class="action"
-                  (click)="trees ? trees.expand() : ''"
-                  data-cy="expand-runlist">
+                <chef-button tertiary class="action" (click)="trees ? trees.expand() : ''" data-cy="expand-runlist">
                   <chef-icon>add_circle</chef-icon>
                   <span>Expand All</span>
                 </chef-button>
-                <chef-button
-                  tertiary
-                  class="action"
-                  (click)="trees ? trees.treeCollapsed() : ''"
+                <chef-button tertiary class="action" (click)="trees ? trees.treeCollapsed() : ''"
                   data-cy="collapse-runlist">
                   <chef-icon>remove_circle</chef-icon>
                   <span>Collapse All</span>
                 </chef-button>
-                <chef-button
-                  tertiary
-                  class="float-right action"
-                  (click)="openEditModal(role?.default_attributes, 'Run List')"
-                  data-cy="edit-runlist"
+                <chef-button tertiary class="float-right action"
+                  (click)="openEditModal(role?.default_attributes, 'Run List')" data-cy="edit-runlist"
                   [disabled]="editDisabled">
                   <span class="material-icons edit-item">mode_edit</span>
                   <span class="edit-text">Edit</span>
                 </chef-button>
               </div>
-              <app-tree-table
-                [hidden]="hasRun_List ? false : true"
-                [tree]="arrayOfNodesTree"
-                #trees
+              <app-tree-table [hidden]="hasRun_List ? false : true" [tree]="arrayOfNodesTree" #trees
                 [options]="treeOptions">
               </app-tree-table>
             </div>
-            <div data-cy="empty-runlist" *ngIf="!hasRun_List && !runListLoading && !conflictError" class="empty-section">
+            <div data-cy="empty-runlist" *ngIf="!hasRun_List && !runListLoading && !conflictError"
+              class="empty-section">
               <img alt="No preview" src="/assets/img/no_preview.gif" />
               <p>Run list details are not available for the <b>{{role?.name}}</b> role.</p>
             </div>
@@ -142,36 +114,23 @@
           </label>
           <div class="attr">
             <div class="expand-collapse">
-              <chef-button
-                tertiary
-                class="action"
-                (click)="tree ? tree.expand() : ''"
-                [disabled]="!hasDefaultJson"
+              <chef-button tertiary class="action" (click)="tree ? tree.expand() : ''" [disabled]="!hasDefaultJson"
                 data-cy="expand-default-attribute">
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="action"
-                (click)="tree ? tree.collapse() : ''"
-                [disabled]="!hasDefaultJson"
+              <chef-button tertiary class="action" (click)="tree ? tree.collapse() : ''" [disabled]="!hasDefaultJson"
                 data-cy="collapse-default-attribute">
                 <chef-icon>remove_circle</chef-icon>
                 <span>Collapse All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="float-right"
-                (click)="openEditModal(role?.default_attributes, 'Default')"
+              <chef-button tertiary class="float-right" (click)="openEditModal(role?.default_attributes, 'Default')"
                 data-cy="edit-default-attribute">
                 <span class="material-icons edit-item">mode_edit</span>
                 <span class="edit-text">Edit</span>
               </chef-button>
             </div>
-            <app-json-tree-table class="json-container"
-              [hidden]="hasDefaultJson ? false : true"
-              #tree
+            <app-json-tree-table class="json-container" [hidden]="hasDefaultJson ? false : true" #tree
               [json]="selectedAttrs?.default_attributes">
             </app-json-tree-table>
             <div data-cy="empty-default-attribute" *ngIf="!hasDefaultJson" class="img-section">
@@ -184,36 +143,23 @@
           </label>
           <div class="attr">
             <div class="expand-collapse">
-              <chef-button
-                tertiary
-                class="action"
-                (click)="override ? override.expand() : ''"
-                [disabled]="!hasOverrideJson"
-                data-cy="expand-override-attribute">
+              <chef-button tertiary class="action" (click)="override ? override.expand() : ''"
+                [disabled]="!hasOverrideJson" data-cy="expand-override-attribute">
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="action"
-                (click)="override ? override.collapse() : ''"
-                [disabled]="!hasOverrideJson"
-                data-cy="collapse-override-attribute">
+              <chef-button tertiary class="action" (click)="override ? override.collapse() : ''"
+                [disabled]="!hasOverrideJson" data-cy="collapse-override-attribute">
                 <chef-icon>remove_circle</chef-icon>
                 <span>Collapse All</span>
               </chef-button>
-              <chef-button
-                tertiary
-                class="float-right action"
-                (click)="openEditModal(role?.override_attributes, 'Override')"
-                data-cy="edit-override-attribute">
+              <chef-button tertiary class="float-right action"
+                (click)="openEditModal(role?.override_attributes, 'Override')" data-cy="edit-override-attribute">
                 <span class="material-icons edit-item">mode_edit</span>
                 <span class="edit-text">Edit</span>
               </chef-button>
             </div>
-            <app-json-tree-table class="json-container"
-              [hidden]="hasOverrideJson ? false : true"
-              #override
+            <app-json-tree-table class="json-container" [hidden]="hasOverrideJson ? false : true" #override
               [json]="selectedAttrs?.override_attributes">
             </app-json-tree-table>
             <div data-cy="empty-override-attribute" *ngIf="!hasOverrideJson" class="img-section">

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -115,27 +115,27 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
         this.tabValue = (fragment === 'attributes') ? 'attributes' : 'runList';
       });
 
-      combineLatest([
-        this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
-        this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))
-      ]).pipe(
-        takeUntil(this.isDestroyed)
-      ).subscribe(([server_id, org_id]: string[]) => {
-        this.serverId = server_id;
-        this.orgId = org_id;
-        this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
-      });
-  
-      combineLatest([
-        this.store.select(gtStatus),
-        this.store.select(orgFromRoute)
-      ]).pipe(
-        filter(([getOrgSt, orgState]) => getOrgSt ===
-          EntityStatus.loadingSuccess && !isNil(orgState)),
-        takeUntil(this.isDestroyed)
-      ).subscribe(([_getOrgSt, orgState]) => {
-        this.org = { ...orgState };
-      });
+    combineLatest([
+      this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
+      this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))
+    ]).pipe(
+      takeUntil(this.isDestroyed)
+    ).subscribe(([server_id, org_id]: string[]) => {
+      this.serverId = server_id;
+      this.orgId = org_id;
+      this.store.dispatch(new GetOrg({ server_id: server_id, id: org_id }));
+    });
+
+    combineLatest([
+      this.store.select(gtStatus),
+      this.store.select(orgFromRoute)
+    ]).pipe(
+      filter(([getOrgSt, orgState]) => getOrgSt ===
+        EntityStatus.loadingSuccess && !isNil(orgState)),
+      takeUntil(this.isDestroyed)
+    ).subscribe(([_getOrgSt, orgState]) => {
+      this.org = { ...orgState };
+    });
   
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
@@ -177,7 +177,6 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
         this.idList[0] = this.env_id;
       }
     });
-
   }
 
   ngOnDestroy(): void {

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -136,7 +136,7 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
-  
+ 
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -37,7 +37,6 @@ import { Node, Options } from '../tree-table/models';
 import { ListItem } from '../select-box/src/lib/list-item.domain';
 import { List, ExpandedChildList, Runlist } from 'app/entities/runlists/runlists.model';
 import { AvailableType } from '../infra-roles/infra-roles.component';
-
 export type InfraRoleTabName = 'runList' | 'attributes';
 
 @Component({
@@ -85,7 +84,6 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
   public label: string;
   public per_page = 9;
   public selectedAttrs: any;
-
   // precedence levels
   public default_attributes = 'default_attributes';
   public override_attributes = 'override_attributes';
@@ -114,7 +112,6 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
         const [, fragment] = url.split('#');
         this.tabValue = (fragment === 'attributes') ? 'attributes' : 'runList';
       });
-
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity))

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.ts
@@ -136,7 +136,7 @@ export class InfraRoleDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
- 
+
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),
       this.store.select(routeParams).pipe(pluck('org-id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -7,7 +7,7 @@
         {{ org?.name }}
       </chef-breadcrumbs>
       <chef-page-header>
-        <chef-heading>{{ org?.name }}</chef-heading>
+        <chef-heading>{{ org?.name }} </chef-heading>
         <table>
           <thead>
             <tr class="detail-row">
@@ -28,34 +28,43 @@
       <div class="main page-body">
         <app-tabs class="tabs-row" (tabChange)="tabChange($event)">
           <app-tab tabTitle="Cookbooks" #cookbooks_tab [active]="cookbooksTab">
-            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-cookbooks>
+            <app-cookbooks *ngIf="cookbooks_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-cookbooks>
           </app-tab>
-          <app-tab tabTitle="Roles" #roles_tab  [active]="rolesTab">
-            <app-infra-roles *ngIf="roles_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-infra-roles>
+          <app-tab tabTitle="Roles" #roles_tab [active]="rolesTab">
+            <app-infra-roles *ngIf="roles_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-infra-roles>
           </app-tab>
-          <app-tab tabTitle="Environments" #environments_tab  [active]="environmentsTab">
-            <app-environments *ngIf="environments_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-environments>
-          </app-tab>  
-          <app-tab tabTitle="Data Bags" #data_bags_tab  [active]="dataBagsTab">
-            <app-data-bags-list *ngIf="data_bags_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-data-bags-list>
+          <app-tab tabTitle="Environments" #environments_tab [active]="environmentsTab">
+            <app-environments *ngIf="environments_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-environments>
           </app-tab>
-          <app-tab tabTitle="Clients" #clients_tab  [active]="clientsTab">
-            <app-clients *ngIf="clients_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-clients>
+          <app-tab tabTitle="Data Bags" #data_bags_tab [active]="dataBagsTab">
+            <app-data-bags-list *ngIf="data_bags_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-data-bags-list>
           </app-tab>
-          <app-tab tabTitle="Nodes" #nodes_tab  [active]="nodesTab">
-            <app-infra-nodes *ngIf="nodes_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-infra-nodes>
+          <app-tab tabTitle="Clients" #clients_tab [active]="clientsTab">
+            <app-clients *ngIf="clients_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-clients>
           </app-tab>
-          <app-tab tabTitle="Policyfiles" #policyFiles_tab  [active]="policyFilesTab">
-            <app-policy-files *ngIf="policyFiles_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-policy-files>
+          <app-tab tabTitle="Nodes" #nodes_tab [active]="nodesTab">
+            <app-infra-nodes *ngIf="nodes_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-infra-nodes>
           </app-tab>
-          <app-tab tabTitle="Policy Groups" #policyGroups_tab  [active]="policyGroupsTab">
-            <app-policy-groups *ngIf="policyGroups_tab.active" [serverId]="serverId" [orgId]="orgId" (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-policy-groups>
+          <app-tab tabTitle="Policyfiles" #policyFiles_tab [active]="policyFilesTab">
+            <app-policy-files *ngIf="policyFiles_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-policy-files>
+          </app-tab>
+          <app-tab tabTitle="Policy Groups" #policyGroups_tab [active]="policyGroupsTab">
+            <app-policy-groups *ngIf="policyGroups_tab.active" [serverId]="serverId" [orgId]="orgId"
+              (resetKeyRedirection)="resetAdminKeyRedirection($event)"></app-policy-groups>
           </app-tab>
           <app-tab *ngIf="chefInfraViewsFeatureFlagOn" tabTitle="Details" #details_tab [active]="false">
-            <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit> 
+            <app-org-edit *ngIf="details_tab.active" [serverId]="serverId" [orgId]="orgId"></app-org-edit>
           </app-tab>
           <app-tab *ngIf="chefInfraViewsFeatureFlagOn" tabTitle="Reset Admin Key" #resetkey_tab [active]="resetKeyTab">
-            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId"></app-reset-admin-key>
+            <app-reset-admin-key *ngIf="resetkey_tab.active" [serverId]="serverId" [orgId]="orgId">
+            </app-reset-admin-key>
           </app-tab>
         </app-tabs>
         <chef-scroll-top></chef-scroll-top>

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Params} from '@angular/router';
+import { Params } from '@angular/router';
 import { Observable, Subject, combineLatest } from 'rxjs';
 import { filter, pluck, takeUntil } from 'rxjs/operators';
 import { identity, isNil } from 'lodash/fp';
@@ -94,7 +94,7 @@ export class OrgDetailsComponent implements OnInit, OnDestroy {
           this.policyGroupsTab = true;
         }
       });
-      if(this.redirect == 'cookbook') {
+      if (this.redirect === 'cookbook') {
         this.resetTabs();
         this.cookbooksTab = true;
       }

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -4,8 +4,11 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Policy files</chef-breadcrumb>
-          {{PolicyFile?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Policy files
+        </chef-breadcrumb>
+        {{PolicyFile?.name}}
       </chef-breadcrumbs>
       <chef-page-header>
         <div class="header">
@@ -60,18 +63,17 @@
         </chef-tab-selector>
       </chef-page-header>
       <section class="page-body" *ngIf="tabValue === 'details'">
-        <chef-loading-spinner class="top-spinner" *ngIf="policyFileDetailsLoading" size="50"></chef-loading-spinner>
+        <chef-loading-spinner *ngIf="policyFileDetailsLoading" size="50" fixed>
+        </chef-loading-spinner>
         <div class="cookbook-button" *ngIf="!policyFileDetailsLoading">
-          <chef-button
-            id="cookbook-dependencies"
-            primary
+          <chef-button id="cookbook-dependencies" primary
             (click)="cookbook.slidePanel(cookbookRuleList, cookbookDependencyList, cookbookList)"
             data-cy="cookbook-dependencies-button">
             Cookbook Dependencies
           </chef-button>
         </div>
         <div class="accordion-section" *ngIf="!policyFileDetailsLoading">
-          <ul id="included-policy-accordion" class="accordion" >
+          <ul id="included-policy-accordion" class="accordion">
             <li class="items" [class.active]="showIncludedPolicies">
               <div class="menu" (click)="handlePolicyFileSelected()">
                 <div class="data-bag-name" data-cy="included-policy">
@@ -85,7 +87,8 @@
                     <img alt="No preview" src="/assets/img/no_preview.gif" />
                     <p>No Included Policyfiles</p>
                   </div>
-                  <div id="included-policy-table-container" *ngIf="included_policy_locks.length" data-cy="included-policy-table-container">
+                  <div id="included-policy-table-container" *ngIf="included_policy_locks.length"
+                    data-cy="included-policy-table-container">
                     <chef-table>
                       <chef-thead>
                         <chef-tr class="no_border_tr">
@@ -98,8 +101,7 @@
                       <chef-tbody>
                         <chef-tr *ngFor="let included_policy_lock of included_policy_locks">
                           <chef-td>
-                            <a
-                              (click)="policyfile.slidePanel(included_policy_lock.name, included_policy_lock.revision_id)"
+                            <a (click)="policyfile.slidePanel(included_policy_lock.name, included_policy_lock.revision_id)"
                               class="details-link">
                               {{included_policy_lock.name}}
                             </a>
@@ -115,10 +117,10 @@
               </div>
             </li>
           </ul>
-          <ul id="run-list-accordion" class="accordion" >
+          <ul id="run-list-accordion" class="accordion">
             <li class="items" [class.active]="showRunList">
               <div class="menu" (click)="handleRunListSelected()">
-                <div class="data-bag-name"  data-cy="run-list">
+                <div class="data-bag-name" data-cy="run-list">
                   Run List
                 </div>
                 <chef-icon class="arrows">keyboard_arrow_down</chef-icon>
@@ -142,10 +144,9 @@
                       <chef-tbody>
                         <chef-tr *ngFor="let cookbook_lock of cookbook_locks">
                           <chef-td>
-                            <a
-                            (click)="cookbooksDetails.slidePanel(cookbook_lock.name, cookbook_lock.version)"
-                            class="details-link">
-                            {{cookbook_lock.name}}
+                            <a (click)="cookbooksDetails.slidePanel(cookbook_lock.name, cookbook_lock.version)"
+                              class="details-link">
+                              {{cookbook_lock.name}}
                             </a>
                           </chef-td>
                           <chef-td>{{cookbook_lock.version}}</chef-td>
@@ -170,16 +171,12 @@
           </label>
           <div class="attr">
             <div class="expand-collapse">
-              <chef-button tertiary class="action"
-                [disabled]= !hasDefaultattributes
-                (click)="tree.expand()"
+              <chef-button tertiary class="action" [disabled]=!hasDefaultattributes (click)="tree.expand()"
                 data-cy="expand-default-attribute">
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button tertiary class="action"
-                [disabled]= !hasDefaultattributes
-                (click)="tree.collapse()"
+              <chef-button tertiary class="action" [disabled]=!hasDefaultattributes (click)="tree.collapse()"
                 data-cy="collapse-default-attribute">
                 <chef-icon>remove_circle</chef-icon>
                 <span>Collapse All</span>
@@ -188,15 +185,10 @@
             <hr class="divider-constraints" />
             <div class="json-container">
               <div class="scroll">
-                <app-json-tree-table
-                  class="json-tree-container"
-                  [hidden]="hasDefaultattributes? false : true"
-                  #tree
+                <app-json-tree-table class="json-tree-container" [hidden]="hasDefaultattributes? false : true" #tree
                   [json]="defaultAttributes">
                 </app-json-tree-table>
-                <div
-                 *ngIf="!hasDefaultattributes"
-                  class="empty-section empty-default-attribute">
+                <div *ngIf="!hasDefaultattributes" class="empty-section empty-default-attribute">
                   <img alt="No preview" src="/assets/img/no_preview.gif" />
                   <p>There are no items to display.</p>
                 </div>
@@ -208,16 +200,12 @@
           </label>
           <div class="attr">
             <div class="expand-collapse">
-              <chef-button tertiary class="action"
-                [disabled]= !hasOverrideattributes
-                (click)="override.expand()"
+              <chef-button tertiary class="action" [disabled]=!hasOverrideattributes (click)="override.expand()"
                 data-cy="expand-override-attribute">
                 <chef-icon>add_circle</chef-icon>
                 <span>Expand All</span>
               </chef-button>
-              <chef-button tertiary class="action"
-                [disabled]= !hasOverrideattributes
-                (click)="override.collapse()"
+              <chef-button tertiary class="action" [disabled]=!hasOverrideattributes (click)="override.collapse()"
                 data-cy="collapse-override-attribute">
                 <chef-icon>remove_circle</chef-icon>
                 <span>Collapse All</span>
@@ -226,15 +214,10 @@
             <hr class="divider-constraints" />
             <div class="json-container">
               <div class="scroll">
-                <app-json-tree-table
-                  class="json-tree-container"
-                  [hidden]="hasOverrideattributes? false : true"
-                  #override
-                  [json]="overrideAttributes">
+                <app-json-tree-table class="json-tree-container" [hidden]="hasOverrideattributes? false : true"
+                  #override [json]="overrideAttributes">
                 </app-json-tree-table>
-                <div
-                 *ngIf="!hasOverrideattributes"
-                  class="empty-section empty-override-attribute">
+                <div *ngIf="!hasOverrideattributes" class="empty-section empty-override-attribute">
                   <img alt="No preview" src="/assets/img/no_preview.gif" />
                   <p>There are no items to display.</p>
                 </div>
@@ -243,25 +226,13 @@
           </div>
         </div>
       </section>
-      <app-revision-id
-        #slide
-        [serverId]="serverId"
-        [orgId]="orgId">
+      <app-revision-id #slide [serverId]="serverId" [orgId]="orgId">
       </app-revision-id>
-      <app-included-policies-details
-        #policyfile
-        [serverId]="serverId"
-        [orgId]="orgId">
+      <app-included-policies-details #policyfile [serverId]="serverId" [orgId]="orgId">
       </app-included-policies-details>
-      <app-cookbook-dependencies
-        #cookbook
-        [serverId]="serverId"
-        [orgId]="orgId">
+      <app-cookbook-dependencies #cookbook [serverId]="serverId" [orgId]="orgId">
       </app-cookbook-dependencies>
-      <app-cookbook-dependencies-details
-        #cookbooksDetails
-        [serverId]="serverId"
-        [orgId]="orgId">
+      <app-cookbook-dependencies-details #cookbooksDetails [serverId]="serverId" [orgId]="orgId">
       </app-cookbook-dependencies-details>
     </main>
   </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -4,7 +4,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Policy files
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.ts
@@ -120,7 +120,6 @@ export class PolicyFileDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
-
     // load policy file details
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
@@ -1,9 +1,12 @@
 <div class="content-container">
   <div class="container">
     <main>
+      <!-- <chef-loading-spinner *ngIf="cookbookVersionsLoading" size="50" fixed></chef-loading-spinner> -->
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Orgs</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Policy Groups
         </chef-breadcrumb>
         {{policyGroup?.name}}
@@ -41,12 +44,12 @@
           <chef-option value='nodes' data-cy="nodes-tab">Nodes</chef-option>
         </chef-tab-selector>
       </chef-page-header>
-      
+
       <section class="page-body" *ngIf="tabValue === 'policyfiles'">
+        <div class="spinner">
+          <chef-loading-spinner *ngIf="policyGroupDetailsLoading" size="50" fixed></chef-loading-spinner>
+        </div>
         <div class="policyfiles-tab" *ngIf="!policyGroupDetailsLoading">
-          <div class="spinner">
-            <chef-loading-spinner *ngIf="policyGroupDetailsLoading" size="50" fixed></chef-loading-spinner>
-          </div>
           <div data-cy="empty-list" class="empty-section" *ngIf="!isPolicyfileAvailable">
             <img alt="No preview" src="/assets/img/no_preview.gif" />
             <p>No policyfiles available</p>
@@ -111,11 +114,7 @@
                 </chef-tr>
               </chef-tbody>
             </chef-table>
-            <app-page-picker
-              class="nodes-list-paging"
-              [total]="total"
-              [perPage]="per_page"
-              [page]="current_page"
+            <app-page-picker class="nodes-list-paging" [total]="total" [perPage]="per_page" [page]="current_page"
               (pageChanged)="onPageChange($event)">
             </app-page-picker>
           </div>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
@@ -4,7 +4,9 @@
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
-        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{org?.name}}
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
+          [queryParams]="{ redirect: 'cookbook'}">
+          {{org?.name}}
         </chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">Policy Groups
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
@@ -1,7 +1,6 @@
 <div class="content-container">
   <div class="container">
     <main>
-      <!-- <chef-loading-spinner *ngIf="cookbookVersionsLoading" size="50" fixed></chef-loading-spinner> -->
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.ts
@@ -82,7 +82,6 @@ export class PolicyGroupDetailsComponent implements OnInit, OnDestroy {
     ).subscribe(([_getOrgSt, orgState]) => {
       this.org = { ...orgState };
     });
-    
     // load policy Group details
     combineLatest([
       this.store.select(routeParams).pipe(pluck('id'), filter(identity)),


### PR DESCRIPTION
Signed-off-by: Sahiba31 <sahibagoyal1999@gmail.com>

### :nut_and_bolt: Description: What code changed, and why?
When navigating in Automate under Infrastructure / Chef Infra Servers the Organization gets lost from the breadcrumb navigation. So I have added the code so that the Org should stay visible and clickable in the breadcrumbs.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-170
https://chefio.atlassian.net/browse/KINETICS-145
### :+1: Definition of Done
After changing the code, now Organization is visible and clickable in the breadcrumbs for all the required tabs and clicking the organisation in the breadcrumb in Chef Infra Server take the user to the cookbook tab.
### :athletic_shoe: How to Build and Test the Change
After going to my branch run these commands:

- hab studio enter
- build components/automate-ui-devproxy/
- start_automate_ui_background
- start_all_services
- rebuild components/automate-ui/
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
