### PR TITLE
updated docs for s3 backup

### DIFF
--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -76,8 +76,7 @@ To store backups in an existing AWS S3 bucket, use the supported S3-related sett
   name = "<bucket name>"
 
   # endpoint (required): The endpoint for the region the bucket lives in.
-  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-  endpoint = "https://<region endpoint>"
+  endpoint = "https://s3.amazonaws.com"
 
   # base_path (optional):  The path within the bucket where backups should be stored
   # If base_path is not set, backups will be stored at the root of the bucket.

--- a/components/docs-chef-io/content/automate/ha_backup_restore.md
+++ b/components/docs-chef-io/content/automate/ha_backup_restore.md
@@ -159,8 +159,6 @@ Ensure you perform the backup configuration before deploying the Chef Automate H
 
     # endpoint (required): The endpoint for the region the bucket lives in.
 
-    # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-
     endpoint = "https://s3.amazonaws.com"
 
     # base_path (optional):  The path within the bucket where backups should be stored

--- a/components/docs-chef-io/content/automate/ha_backup_restore_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_backup_restore_prerequisites.md
@@ -105,7 +105,6 @@ Refer to the content for the `automate.toml` file below:
     name = "bucket-name"
 
     # endpoint (required): The endpoint for the region the bucket lives in.
-    # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
     endpoint = "https://s3.amazonaws.com"
 
     # base_path (optional):  The path within the bucket where backups should be stored

--- a/components/docs-chef-io/content/automate/managed_services.md
+++ b/components/docs-chef-io/content/automate/managed_services.md
@@ -458,8 +458,7 @@ To store backups in an existing AWS S3 bucket, add the following to your `config
   name = "<bucket name>"
 
   # endpoint (required): The endpoint for the region the bucket lives in.
-  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-  endpoint = "https://<region endpoint>"
+  endpoint = "https://s3.amazonaws.com"
 
   # base_path (optional):  The path within the bucket where backups should be stored
   # If base_path is not set, backups will be stored at the root of the bucket.

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -178,7 +178,6 @@
   name = "<%= overrides[:bucket_name] %>"
 
   # endpoint (required): The endpoint for the region the bucket lives in.
-  # See https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
   endpoint = "<%= overrides[:s3_endpoint] %>"
 
   # base_path (optional):  The path within the bucket where backups should be stored


### PR DESCRIPTION
Signed-off-by: Vivek Shankar <vshankar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
S3 uploads during backup does not support `s3.<region>.amazonaws.com` anymore now the format should be `s3.amazonaws.com`. The region is not required anymore.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
