### PR TITLE
Moving deployment type under payload

### DIFF
--- a/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
+++ b/components/automate-ui/src/app/services/telemetry/telemetry.service.ts
@@ -430,7 +430,7 @@ export class TelemetryService {
     const nodeUsageStatsSubscription = this.emitToPipeline('track', {
       userId: this.anonymousId,
       event: eventName,
-      properties: { node_cnt: nodeUsageStats.node_cnt }
+      properties: { node_cnt: nodeUsageStats.node_cnt, deployment_type: this.deploymentType }
     }, true).subscribe(() => {
       if (nodeUsageStatsSubscription) {
         nodeUsageStatsSubscription.unsubscribe();
@@ -453,7 +453,10 @@ export class TelemetryService {
     const applicationUsageStatsSubscription = this.emitToPipeline('track', {
       userId: this.anonymousId,
       event: 'servicesCountsGlobal',
-      properties: { total_services: applicationUsageStats.total_services }
+      properties: {
+        total_services: applicationUsageStats.total_services,
+        deployment_type: this.deploymentType
+      }
     }, true).subscribe(() => {
       if (applicationUsageStatsSubscription) {
         applicationUsageStatsSubscription.unsubscribe();


### PR DESCRIPTION
Signed-off-by: Kallol Roy <kallol.roy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Move deployment_type under payload since the global field is not being set in the Redshift DB

### :chains: Related Resources

### :+1: Definition of Done
- Check the event in Segment
- 
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
