### PR TITLE
[WIP]On destroying infra Storage bucket have to persist - AWS Infra

### DIFF
--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -11,10 +11,12 @@ If you are running chef-automate provision-infra and in between anything occure 
 If you have successfully done provision-infra and after that if you want to destroy infra then run below command in below order.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
 
-# SCENARIO 3 
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;cp -r ../../.tf_arch .;cp -r ../../../a2ha.rb ..;terraform apply -var="destroy_bucket=true";cd $i;done`(This line will destroy storage bucket while clean up. Use this only if you want remove storage bucket)
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
+
+# SCENARIO 3
 
 If you've completed `chef-automate deploy` and want to destroy deploy part then run below command. Remember destroy of deployment will not remove any kind of configuration from remote server but it will do terraform taint so that next time all the configuration things will be started again.
 
@@ -25,5 +27,7 @@ If you've completed `chef-automate deploy` and want to destroy deploy part then 
 If you have finished deployment and want destroy all the instances of whole infra then run below commnd.
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
- 
-`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done` 
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;cp -r ../../.tf_arch .;cp -r ../../../a2ha.rb ..;terraform apply -var="destroy_bucket=true";cd $i;done`(This line will destroy storage bucket while clean up. Use this only if you want remove storage bucket)
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`

--- a/terraform/a2ha-terraform/destroy/aws/main.tf
+++ b/terraform/a2ha-terraform/destroy/aws/main.tf
@@ -84,6 +84,7 @@ module "s3" {
   aws_s3_bucketName = var.aws_s3_bucketName
   random_id         = module.aws.random_id
   tags              = var.tag_name
+  destroy_bucket    = var.destroy_bucket
 }
 
 module "aws-output" {

--- a/terraform/a2ha-terraform/modules/s3/inputs.tf
+++ b/terraform/a2ha-terraform/modules/s3/inputs.tf
@@ -2,6 +2,10 @@ variable "aws_s3_bucketName" {
   default = "chef-automate-ha"
 }
 
+variable "destroy_bucket" {
+  default = false
+}
+
 variable "name" {
   default = "chef-automate-ha"
 }

--- a/terraform/a2ha-terraform/modules/s3/main.tf
+++ b/terraform/a2ha-terraform/modules/s3/main.tf
@@ -48,7 +48,7 @@ locals {
 
 resource "aws_s3_bucket" "createS3bucket" {
   bucket        = local.log_bucket
-  force_destroy = true
+  force_destroy = var.destroy_bucket
 }
 
 resource "aws_s3_bucket_acl" "elb_bucket_acl" {

--- a/terraform/a2ha-terraform/reference_architectures/aws/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/main.tf
@@ -88,6 +88,7 @@ module "s3" {
   aws_s3_bucketName = var.aws_s3_bucketName
   random_id         = module.aws.random_id
   tags              = var.tag_name
+  destroy_bucket    = var.destroy_bucket
 }
 
 module "aws-output" {

--- a/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/aws/variables.tf
@@ -97,6 +97,10 @@ variable "chef_server_lb_certificate_arn" {
   default = "arn:aws:acm:us-west-2:446539779517:certificate/e98235a7-ba3d-4900-9c55-4b35bb8b56c7"
 }
 
+variable "destroy_bucket" {
+  default = false
+}
+
 variable "managed_opensearch_certificate" {
   default = ""
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Automate HA as a product, when users have to destroy the infra by running destroy command, this should not delete the storage bucket. 

Observation:
<div data-cke-filler-webkit="start" data-cke-temp="1" style="display: block; width: 0px; height: 0px; padding: 0px; border: 0px; margin: 0px; position: absolute; top: 0px; left: -9999px; opacity: 0; overflow: hidden;">&nbsp;</div>

S3 Scenario | Output | Behaviour 
-- | -- | -- 
When bucket is empty | Bucket will be destroyed | Expected 
When Bucket is not empty (and not changing terraform status) | Bucket will persist | Expected 
When Bucket is not empty (and changing terraform status) | Bucket will be destroyed | Expected 

<br data-cke-eol="1">

### :chains: Related Resources
https://chefio.atlassian.net/browse/MADROX-235

### :+1: Definition of Done
S3 - It's done and tested
EFS - Work in progress 

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
