### PR TITLE
Changes in upgrade command for SaaS

### DIFF
--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -34,6 +34,7 @@ var upgradeRunCmdFlags = struct {
 	versionsPath         string
 	acceptMLSA           bool
 	upgradeHAWorkspace   string
+	saas                 bool
 }{}
 
 var upgradeRunCmd = &cobra.Command{
@@ -212,7 +213,7 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 	}
 
 	if offlineMode {
-		uperr, upgraded := upgradeWorspace(upgradeRunCmdFlags.airgap)
+		uperr, upgraded := upgradeWorspace(upgradeRunCmdFlags.airgap, upgradeRunCmdFlags.saas)
 		if uperr != nil {
 			return status.Annotate(uperr, status.UpgradeError)
 		}
@@ -445,10 +446,24 @@ func init() {
 		"Path to versions.json",
 	)
 
+	upgradeRunCmd.PersistentFlags().BoolVarP(
+		&upgradeRunCmdFlags.saas,
+		"saas",
+		"",
+		false,
+		"Flag for saas setup")
+
 	upgradeStatusCmd.PersistentFlags().StringVar(
 		&upgradeStatusCmdFlags.versionsPath, "versions-file", "",
 		"Path to versions.json",
 	)
+
+	upgradeRunCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		// Hide flag for this command
+		command.Flags().MarkHidden("saas")
+		// Call parent help func
+		command.Parent().HelpFunc()(command, strings)
+	})
 
 	if !isDevMode() {
 		err := upgradeStatusCmd.PersistentFlags().MarkHidden("versions-file")

--- a/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
@@ -45,7 +45,7 @@ func worspaceUpgradeCmdExecute(cmd *cobra.Command, args []string) error {
 		return status.Wrap(errors.New("Incorrect command usage"), 0, workspaceUpgradeHelpDocs)
 	}
 	if isA2HARBFileExist() {
-		err, upgraded := upgradeWorspace(args[0], false)
+		err, upgraded := upgradeWorspace(args[0], upgradeRunCmdFlags.saas)
 		if err != nil {
 			return status.Annotate(err, status.UpgradeError)
 		}

--- a/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
+++ b/components/automate-cli/cmd/chef-automate/workspaceUpgrade.go
@@ -14,7 +14,9 @@ import (
 )
 
 const habpkgcmd = "HAB_LICENSE=accept-no-persist hab pkg path chef/automate-ha-deployment"
+const saashabpkgcmd = "HAB_LICENSE=accept-no-persist hab pkg path chef/chef-saas-deployment"
 const pkgName = "automate-ha-deployment"
+const saaspkgName = "chef-saas-deployment"
 
 const workspaceUpgradeHelpDocs = `
 This command will be used to upgrde Automate HA workspace version.
@@ -43,7 +45,7 @@ func worspaceUpgradeCmdExecute(cmd *cobra.Command, args []string) error {
 		return status.Wrap(errors.New("Incorrect command usage"), 0, workspaceUpgradeHelpDocs)
 	}
 	if isA2HARBFileExist() {
-		err, upgraded := upgradeWorspace(args[0])
+		err, upgraded := upgradeWorspace(args[0], false)
 		if err != nil {
 			return status.Annotate(err, status.UpgradeError)
 		}
@@ -57,8 +59,8 @@ func worspaceUpgradeCmdExecute(cmd *cobra.Command, args []string) error {
 	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }
 
-func upgradeWorspace(bundle string) (error, bool) {
-	updateAvailabe, err := checkIfNewBundleHaveWorkspaceUpdate(bundle)
+func upgradeWorspace(bundle string, saas bool) (error, bool) {
+	updateAvailabe, err := checkIfNewBundleHaveWorkspaceUpdate(bundle, saas)
 	if err != nil {
 		writer.Println(err.Error())
 	}
@@ -84,7 +86,7 @@ func upgradeWorspace(bundle string) (error, bool) {
 		}
 		if upgradeAccepted {
 			writer.Println("Bootstraping for new version.")
-			err := doBootstrapEnv(bundle, false)
+			err := doBootstrapEnv(bundle, upgradeRunCmdFlags.saas)
 			if err != nil {
 				writer.Println(err.Error())
 				return nil, false
@@ -94,9 +96,9 @@ func upgradeWorspace(bundle string) (error, bool) {
 	}
 	return nil, false
 }
-func checkIfNewBundleHaveWorkspaceUpdate(bundle string) (bool, error) {
-	currVerAndRel := getCurrentInstalledWorsapceVersion()
-	newVersion, err := getWorkspaceVersionFromBundle(bundle)
+func checkIfNewBundleHaveWorkspaceUpdate(bundle string, saas bool) (bool, error) {
+	currVerAndRel := getCurrentInstalledWorsapceVersion(saas)
+	newVersion, err := getWorkspaceVersionFromBundle(bundle, saas)
 	if err != nil {
 		return false, err
 	}
@@ -114,8 +116,13 @@ func checkIfNewBundleHaveWorkspaceUpdate(bundle string) (bool, error) {
 	return false, nil
 }
 
-func getCurrentInstalledWorsapceVersion() []string {
-	out, err := exec.Command("/bin/sh", "-c", habpkgcmd).Output()
+func getCurrentInstalledWorsapceVersion(saas bool) []string {
+	pkgcmd := habpkgcmd
+	if saas {
+		pkgcmd = saashabpkgcmd
+	}
+
+	out, err := exec.Command("/bin/sh", "-c", pkgcmd).Output()
 	if err != nil {
 		writer.Fail(err.Error())
 		return nil
@@ -126,7 +133,7 @@ func getCurrentInstalledWorsapceVersion() []string {
 	return currVerAndRel
 }
 
-func getWorkspaceVersionFromBundle(bundle string) ([]string, error) {
+func getWorkspaceVersionFromBundle(bundle string, saas bool) ([]string, error) {
 	_, manifestBytes, err := airgap.GetMetadata(bundle)
 	if err != nil {
 		return nil, status.Annotate(err, status.AirgapUnpackInstallBundleError)
@@ -142,8 +149,12 @@ func getWorkspaceVersionFromBundle(bundle string) ([]string, error) {
 	writer.Printf(" Packages:\n")
 	workspacePkgVersion := make([]string, 2)
 	for _, pkg := range manifest.Packages {
+		habpkgname := pkgName
+		if saas {
+			habpkgname = saaspkgName
+		}
 		_pkgName := pkg.Name()
-		if strings.Contains(_pkgName, pkgName) {
+		if strings.Contains(_pkgName, habpkgname) {
 			pkg.Release()
 			workspacePkgVersion[0] = pkg.Version()
 			workspacePkgVersion[1] = pkg.Release()


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

The upgrades were failing for SaaS cluster because the deployment package name is different from HA and therefore it wasn't able to upgrade the workspace.
To resolve this, I have added a new hidden flag (--saas) in the upgrade command which will ensure that the correct package names are being used.

Upgrade command for HA: upgrade run --airgap-bundle automate-4.2.27.aib --upgrade-frontends

Upgrade command for SaaS: upgrade run --airgap-bundle automate-4.2.27.aib --upgrade-frontends --saas

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Have tested out the upgrades for SaaS

**Known issue**
- With workspace upgrade, the terraform.tfstate file is not copied properly due to which the terraform plan execution fails during the upgrade.
Temporary Solution: Copy the terraform.tfstate file from /hab/workspace_<>/terraform to /hab/a2_deploy_workspace/terraform and re-run upgrades

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
