### PR TITLE
Workspace upgrade copying Missing files

### DIFF
--- a/components/automate-backend-deployment/habitat/hooks/install
+++ b/components/automate-backend-deployment/habitat/hooks/install
@@ -55,7 +55,13 @@ if [ -L /hab/a2_deploy_workspace ]; then
   # copy over tfvars from old workspace if any exist
   find $OLD_WORKSPACE/terraform -name \*.tfvars -exec cp {} $NEW_WORKSPACE/terraform \;
   # copy over tfstate from old workspace if any exist
-  find $OLD_WORKSPACE/terraform -name \*.tfstate -exec cp {} $NEW_WORKSPACE/terraform \;
+  # find $OLD_WORKSPACE/terraform -name \*.tfstate -exec cp {} $NEW_WORKSPACE/terraform \;
+  if [[ -f $OLD_WORKSPACE/terraform/terraform.tfstate ]]; then
+    cp $OLD_WORKSPACE/terraform/*.tfstate $NEW_WORKSPACE/terraform \;
+  fi
+  if [[ -f $OLD_WORKSPACE/terraform/destroy/aws/terraform.tfstate ]]; then
+    cp -r $OLD_WORKSPACE/terraform/destroy/aws/* $NEW_WORKSPACE/terraform/destroy/aws/ \;
+  fi
   # copy .abb files from old workspace if any exist
   find $OLD_WORKSPACE/terraform -name \*.abb -exec cp {} $NEW_WORKSPACE/terraform \;
   # copy over configs from old workspace if any exist
@@ -111,6 +117,7 @@ EOF
     echo "Copying previous 'automate-cluster-ctl' config and secrets to new workspace"
     cp $OLD_WORKSPACE/a2ha.rb $NEW_WORKSPACE/a2ha.rb
     cp $OLD_WORKSPACE/secrets.json $NEW_WORKSPACE/secrets.json
+    cp $OLD_WORKSPACE/secrets.key $NEW_WORKSPACE/secrets.key
   else
     display_upgrade_help $(cat $OLD_WORKSPACE/terraform/.tf_arch)
   fi


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
In this PR, during AWS deployment, when the workspace is upgrading, tfstate file of AWS provisioning is copied into terraform folder instead of the deployment tfstate file. With this when the upgrade command is running, it destroys the infrastructure itself (destruction happens only when AWS_region is provided to terraform provider). To rectify it, some of the logic is altered so that it will copy the tfstate file appropriately from the old workspace to the new workspace. 

Changes:
- tfstate files are copied individually in all places
- secret.key is also copied into workspace

**Before fix:**
Scenario | Observation | Test
-- | -- | --
AWS - upgrade | tfstate file of both deployment and aws provision is copied in in terraform folder (later one is re-written by the former one) | - upgrade is failed due to AWS provide credential error(main.tf belongs to deployment, tfstate belong to AWS provision) |  
On_prem - upgrade |  tfstate file is copied in appropriate places(as there is no tfstate file for deployment) | _upgrade successful_  |  

**Post fix:**
Scenario | Observation | Test
-- | -- | --
AWS - upgrade | tfstate file is copied in appropriate places | Success |  
On_prem - upgrade | tfstate file is copied in appropriate places  | Success  |  

**Bundles that can be used to verify:**
automate-cli with support for 'arvinth' origin - `arvinth/automate-cli/0.1.0/20220722175552`

automate-backend-deplyoment packages - `arvinth/automate-ha-deployment/0.1.0/20220722144129`, `arvinth/automate-ha-deployment/0.1.0/20220722192918`


### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
