### PR TITLE
Delete Client on Node Deletion of Infra Server View

### DIFF
--- a/components/infra-proxy-service/server/nodes.go
+++ b/components/infra-proxy-service/server/nodes.go
@@ -131,6 +131,11 @@ func (s *Server) DeleteNode(ctx context.Context, req *request.Node) (*response.D
 		return nil, err
 	}
 
+	err = c.client.Clients.Delete(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	return &response.DeleteNode{
 		Name: req.Name,
 	}, nil

--- a/components/infra-proxy-service/server/nodes.go
+++ b/components/infra-proxy-service/server/nodes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	chef "github.com/go-chef/chef"
 	"google.golang.org/grpc/codes"
@@ -133,7 +134,7 @@ func (s *Server) DeleteNode(ctx context.Context, req *request.Node) (*response.D
 
 	err = c.client.Clients.Delete(req.Name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Node is deleted but client deletion failed: %s", err)
 	}
 
 	return &response.DeleteNode{


### PR DESCRIPTION
Infra Server Node deletion was not deleting clients. The message on node deletion although claims to delete the corresponding client too.

### :chains: Related Resources

https://chefio.atlassian.net/browse/STALWART-196

### :+1: Definition of Done

- Connect Infra Server to Infra Server View
- Search for a node under Nodes tab
- Search for the same name in the Clients tab. You should find the client in the client tab.
- Delete the node from the Nodes tab
- After deletion, the clients tab should not return the client name

### :athletic_shoe: How to Build and Test the Change
- rebuild components/infra-proxy-service
- start_all_services
- Use server ec2-18-223-220-58.us-east-2.compute.amazonaws.com
- admin kallol

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable