### PR TITLE
Adding steps to destroy infrastructure without destroying EFS

### DIFF
--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -193,7 +193,7 @@ To destroy infra after successfull provisioning, run below command in your basti
     for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform state rm "module.efs[0].aws_efs_file_system.backups";cd $i;done
     ```
 
-3. This command will destroy all resources created while provisioning (excluding S3).
+3. This command will destroy all resources created while provisioning (excluding EFS).
 
     ```bash
     for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -171,7 +171,29 @@ To destroy infra after successfull provisioning, run below command in your basti
     for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done
     ```
 
-2. This commond will destroy all resources created while provisioning (excluding S3).
+2. This command will destroy all resources created while provisioning (excluding S3).
+
+    ```bash
+    for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done
+    ```
+
+#### To destroy AWS infra created with EFS Bucket
+
+To destroy infra after successfull provisioning, run below command in your bastion host in same order.
+
+1. This command will initialise the terraform packages
+
+    ```bash
+    for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done
+    ```
+
+2. Following command will remove EFS from terraform state file, so that `destroy` command will not destroy EFS.
+
+    ```bash
+    for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform state rm "module.efs[0].aws_efs_file_system.backups";cd $i;done
+    ```
+
+3. This command will destroy all resources created while provisioning (excluding S3).
 
     ```bash
     for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done

--- a/terraform/a2ha-terraform/How-to-destroy-infra.md
+++ b/terraform/a2ha-terraform/How-to-destroy-infra.md
@@ -10,9 +10,19 @@ If you are running chef-automate provision-infra and in between anything occure 
 
 If you have successfully done provision-infra and after that if you want to destroy infra then run below command in below order.
 
+## SCENARIO 2.1 - S3 Bucket
+
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;cp -r ../../.tf_arch .;cp -r ../../../a2ha.rb ..;terraform apply -var="destroy_bucket=true";cd $i;done`(This line will destroy storage bucket while clean up. Use this only if you want remove storage bucket)
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
+
+## SCENARIO 2.2 - EFS Bucket
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done`
+
+`for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform state rm "module.efs[0].aws_efs_file_system.backups";cd $i;done`
 
 `for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy;cd $i;done`
 


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
In Automate HA, when destroy command is run from AWS-destroy architecture, it was also destroying EFS file system and the backup data is lost. In this PR, EFS state from .tfstate file is removed so that the same will not be destroyed when the infra is removed.

### :chains: Related Resources
https://chefio.atlassian.net/browse/MADROX-260

### :+1: Definition of Done
It's dev done that tested in AWS infrastructure

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
