### PR TITLE
Fix for Automate HA upgrade via adding the terrafrom module deps

### DIFF
--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -41,6 +41,14 @@ wait_for_install() {
     n=$((n+1))
     echo "Waiting for $1 cli to be installed.."
     sleep 30
+    pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )
+    pkg_name=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1)
+    echo "pkg_count:$pkg_count"
+    echo "pkg_name:$pkg_name"
+    if [ $pkg_count -eq 1 ]
+      then
+        hab pkg install $pkg_name -bf 
+    fi    
   done
   if [[ $n -ge $max ]]; then
     failure "Timed out waiting for $1 to be installed within $max iterations!"

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -41,7 +41,7 @@ wait_for_install() {
     n=$((n+1))
     echo "Waiting for $1 cli to be installed.."
     sleep 30
-    if [ $cmd == "automate-backend-ctl"]
+    if [ $cmd == "automate-backend-ctl" ]
       then
         echo "bin-linking automate-backend-ctl"
         pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -43,6 +43,7 @@ wait_for_install() {
     sleep 30
     if [ $cmd == "automate-backend-ctl"]
       then
+        echo "bin-linking automate-backend-ctl"
         pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )
         pkg_name=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1)
         echo "Installing the package $pkg_name"

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -41,14 +41,17 @@ wait_for_install() {
     n=$((n+1))
     echo "Waiting for $1 cli to be installed.."
     sleep 30
-    pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )
-    pkg_name=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1)
-    echo "Installing the package $pkg_name"
-    echo "pkg_count:$pkg_count"
-    echo "pkg_name:$pkg_name"
-    if [ $pkg_count -eq 1 ]
+    if [ $cmd == "automate-backend-ctl"]
       then
-        hab pkg install $pkg_name -bf 
+        pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )
+        pkg_name=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1)
+        echo "Installing the package $pkg_name"
+        echo "pkg_count:$pkg_count"
+        echo "pkg_name:$pkg_name"
+        if [ $pkg_count -eq 1 ]
+          then
+            hab pkg install $pkg_name -bf 
+        fi
     fi    
   done
   if [[ $n -ge $max ]]; then

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -43,6 +43,7 @@ wait_for_install() {
     sleep 30
     pkg_count=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1 | wc -l )
     pkg_name=$(ls -Art /hab/cache/artifacts/chef-automate-ha-ctl* | tail -n 1)
+    echo "Installing the package $pkg_name"
     echo "pkg_count:$pkg_count"
     echo "pkg_name:$pkg_name"
     if [ $pkg_count -eq 1 ]

--- a/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
@@ -166,7 +166,7 @@ module "habitat-opensearch" {
   sudo_cmd               = var.sudo_cmd
   habitat_uid_gid        = var.habitat_uid_gid
   depends_on = [
-    module.system-tuning-opensearch
+    module.airgap_bundle-opensearch
   ]
 }
 
@@ -196,7 +196,7 @@ module "habitat-postgresql" {
   sudo_cmd               = var.sudo_cmd
   habitat_uid_gid        = var.habitat_uid_gid
   depends_on = [
-    module.system-tuning-postgresql
+    module.airgap_bundle-postgresql
   ]
 }
 
@@ -222,7 +222,7 @@ module "habitat-automate" {
   sudo_cmd                        = var.sudo_cmd
   habitat_uid_gid                 = var.habitat_uid_gid
   depends_on = [
-    module.system-tuning-automate
+    module.airgap_bundle-automate
   ]
 }
 
@@ -248,7 +248,7 @@ module "habitat-chef_server" {
   sudo_cmd                        = var.sudo_cmd
   habitat_uid_gid                 = var.habitat_uid_gid
   depends_on = [
-    module.system-tuning-chef_server
+    module.airgap_bundle-chef_server
   ]
 }
 
@@ -277,7 +277,7 @@ module "opensearch" {
   sudo_cmd                        = var.sudo_cmd
   backup_config_efs               = var.backup_config_efs
   depends_on = [
-    module.system-tuning-opensearch
+    module.habitat-opensearch
   ]
 }
 
@@ -313,7 +313,7 @@ module "postgresql" {
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd
   depends_on = [
-    module.system-tuning-postgresql
+    module.habitat-postgresql
   ]
 }
 
@@ -367,7 +367,7 @@ module "bootstrap_automate" {
   s3_endpoint                        = var.s3_endpoint
   bucket_name                        = var.bucket_name
   depends_on = [
-    module.system-tuning-automate
+    module.airgap_bundle-automate
   ]
 }
 
@@ -425,7 +425,7 @@ module "automate" {
   s3_endpoint            = var.s3_endpoint
   bucket_name            = var.bucket_name
   depends_on = [
-    module.system-tuning-automate
+    module.bootstrap_automate
   ]
 }
 
@@ -479,6 +479,6 @@ module "chef_server" {
   s3_endpoint                        = var.s3_endpoint
   bucket_name                        = var.bucket_name
   depends_on = [
-    module.system-tuning-chef_server
+    module.bootstrap_automate
   ]
 }

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -98,7 +98,7 @@ module "habitat-backend" {
     var.existing_opensearch_private_ips,
     var.existing_postgresql_private_ips
   )
-  depends_on = [module.system-tuning-backend]
+  depends_on = [module.airgap_bundle-backend]
 }
 
 module "habitat-frontend" {
@@ -122,7 +122,7 @@ module "habitat-frontend" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   habitat_uid_gid                 = var.habitat_uid_gid
-  depends_on = [module.system-tuning-frontend]
+  depends_on = [module.airgap_bundle-frontend]
 }
 
 module "opensearch" {
@@ -147,7 +147,7 @@ module "opensearch" {
   ssh_port                     = var.ssh_port
   ssh_user_sudo_password       = local.be_sudo_password
   sudo_cmd                     = var.sudo_cmd
-  depends_on = [module.system-tuning-backend]
+  depends_on = [module.airgap_bundle-backend]
 }
 
 module "postgresql" {
@@ -180,7 +180,7 @@ module "postgresql" {
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd
-  depends_on = [module.system-tuning-backend]
+  depends_on = [module.airgap_bundle-backend]
 }
 
 module "bootstrap_automate" {
@@ -213,7 +213,7 @@ module "bootstrap_automate" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
-  depends_on = [module.system-tuning-frontend]
+  depends_on = [module.airgap_bundle-frontend]
 }
 
 module "automate" {
@@ -250,7 +250,7 @@ module "automate" {
   ssh_user_sudo_password = local.fe_sudo_password
   sudo_cmd               = var.sudo_cmd
   teams_port             = var.teams_port
-  depends_on = [module.system-tuning-frontend]
+  depends_on = [module.bootstrap_automate]
 }
 
 module "chef_server" {
@@ -283,5 +283,5 @@ module "chef_server" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
-  depends_on = [module.system-tuning-frontend]
+  depends_on = [module.bootstrap_automate]
 }

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -147,7 +147,7 @@ module "opensearch" {
   ssh_port                     = var.ssh_port
   ssh_user_sudo_password       = local.be_sudo_password
   sudo_cmd                     = var.sudo_cmd
-  depends_on = [module.airgap_bundle-backend]
+  depends_on = [module.airgap_bundle-backend,module.habitat-backend]
 }
 
 module "postgresql" {
@@ -180,7 +180,7 @@ module "postgresql" {
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd
-  depends_on = [module.airgap_bundle-backend]
+  depends_on = [module.airgap_bundle-backend,module.habitat-backend]
 }
 
 module "bootstrap_automate" {
@@ -213,7 +213,7 @@ module "bootstrap_automate" {
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
   teams_port                      = var.teams_port
-  depends_on = [module.airgap_bundle-frontend]
+  depends_on = [module.airgap_bundle-frontend,module.habitat-frontend]
 }
 
 module "automate" {


### PR DESCRIPTION
Signed-off-by: punitmundra <punitmundra2008@gmail.com>

Need to add the  dependency between the terraform module. As of today they are running async, will cause an upgrade failure. 

How to test the changes 
build the package : 
rebuild components/automate-backend-deployment/
push the package to the your origin and create a bundle via customer manifest.json
Do the deployment with custom package.


### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
