### PR TITLE
Test response of chef-automate status when one service instance goes down

### DIFF
--- a/components/automate-cluster-ctl/libexec/cluster-status
+++ b/components/automate-cluster-ctl/libexec/cluster-status
@@ -108,8 +108,8 @@ class AutomateClusterStatus < AutomateCluster::Command
     state_entered = data.dig('process', 'state_entered')
     elapsed = state_entered.nil? ? 0 : elasped_time(Time.now.utc.to_i - state_entered)
     [
-      service, ip, data.dig('health_check', 'status'),
-      "#{data.dig('process', 'state') || 'Unknown' } (pid: #{data.dig('process', 'pid')})",
+      service, ip, data.dig('health_check', 'status') || 'Down',
+      data.dig('process', 'state') ? "#{data.dig('process', 'state') } (pid: #{data.dig('process', 'pid')})" : "Unknown",
       elapsed, data['role']
     ]
   end


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
In Automate HA, when one instance goes down, or hab supervisor is down, `chef-automate status` is showing error instead of status. This is fixed in this PR

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/MADROX-261

### :+1: Definition of Done
It's dev done and tested in On-Prem (with one of the instances in backend/frontend is down)

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
