### PR TITLE
adding queries for asset count api

### DIFF
--- a/components/compliance-service/reporting/constants.go
+++ b/components/compliance-service/reporting/constants.go
@@ -1,3 +1,8 @@
 package reporting
 
 const ESize = 999999
+
+// These are filter types where we use ElasticSearch Term Queries
+var FilterType = []string{"environment", "organization", "chef_server", "chef_tags",
+	"policy_group", "policy_name", "status", "node_name", "platform", "platform_with_version",
+	"role", "recipe", "inspec_version", "ipaddress", "profile_id", "resource_type", "node_id"}

--- a/components/compliance-service/reporting/relaxting/assets.go
+++ b/components/compliance-service/reporting/relaxting/assets.go
@@ -1,0 +1,174 @@
+package relaxting
+
+import (
+	"context"
+	"github.com/chef/automate/components/compliance-service/ingest/ingestic/mappings"
+	"github.com/chef/automate/components/compliance-service/utils"
+	"github.com/olivere/elastic/v7"
+	"github.com/sirupsen/logrus"
+	"strings"
+	"time"
+)
+
+//getTotalAssets Get Total Number of documents from the comp-*-run-info
+func (backend ES2Backend) getAssets(ctx context.Context, boolQuery *elastic.BoolQuery) (int32, error) {
+	myIndex := mappings.ComplianceRunInfo.Index
+
+	client, err := backend.ES2Client()
+	if err != nil {
+		logrus.Errorf("Cannot connect to ElasticSearch: %v", err)
+		return 0, err
+	}
+
+	countService := elastic.NewCountService(client)
+
+	count, err := countService.Query(boolQuery).Index(myIndex).Do(ctx)
+	if err != nil {
+		logrus.Errorf("Cannot create client for count assets with error %v", err)
+		return 0, err
+	}
+
+	return int32(count), nil
+}
+
+//getFiltersQueryForAssetFilters Get Filteres query for the assets
+func (backend ES2Backend) getFiltersQueryForAssetFilters(filters map[string][]string) *elastic.BoolQuery {
+	utils.DeDupFilters(filters)
+	boolQuery := elastic.NewBoolQuery()
+
+	// These are filter types where we use ElasticSearch Term Queries
+	filterTypes := []string{"environment", "organization", "chef_server", "chef_tags",
+		"policy_group", "policy_name", "status", "node_name", "platform", "platform_with_version",
+		"role", "recipe", "inspec_version", "ipaddress", "control", "profile_id", "resource_type", "node_id"}
+
+	for _, filterType := range filterTypes {
+		if len(filters[filterType]) > 0 {
+			ESFieldName := getESFieldNameAsset(filterType)
+			termQuery := newTermQueryFromFilter(ESFieldName, filters[filterType])
+			boolQuery = boolQuery.Must(termQuery)
+		}
+	}
+
+	// Going through all filters to find the ones prefixed with 'control_tag', e.g. 'control_tag:nist'
+	for filterType := range filters {
+		if strings.HasPrefix(filterType, "control_tag:") {
+			_, tagKey := leftSplit(filterType, ":")
+			termQuery := newNestedQueryForControlStringTagAssets(tagKey, filters[filterType])
+			boolQuery = boolQuery.Must(termQuery)
+		}
+	}
+
+	return boolQuery
+}
+
+// Returns an ElasticSearch nested query to filter reports by control tags for assets
+func newNestedQueryForControlStringTagAssets(tagKey string, tagValues []string) *elastic.NestedQuery {
+	refinedValues := make([]string, 0, 0)
+	ESFieldPath := "control_tag"
+	ESFieldTagKey := "control_tag.key.lower"
+	ESFieldTagValues := "control_tag.values.lower"
+
+	// Add ElasticSearch query filter for the control tag key
+	tagKey = strings.ToLower(tagKey)
+	boolQuery := elastic.NewBoolQuery()
+	if containsWildcardChar(tagKey) {
+		boolQuery.Must(elastic.NewWildcardQuery(ESFieldTagKey, tagKey))
+	} else {
+		boolQuery.Must(elastic.NewTermsQuery(ESFieldTagKey, tagKey))
+	}
+
+	// Add ElasticSearch query filters for the control tag value(s)
+	insideBoolQuery := elastic.NewBoolQuery()
+	insideBool := false
+	emptyValuesRequested := false
+	for _, tagValue := range tagValues {
+		tagValue = strings.ToLower(tagValue)
+		if containsWildcardChar(tagValue) {
+			insideBoolQuery.Should(elastic.NewWildcardQuery(ESFieldTagValues, tagValue))
+			insideBool = true
+		} else if tagValue == "" {
+			emptyValuesRequested = true
+		} else {
+			refinedValues = append(refinedValues, tagValue)
+		}
+	}
+	// Here we handle control tag value(s) without wildcard characters
+	if len(refinedValues) > 0 {
+		termQuery := elastic.NewTermsQuery(ESFieldTagValues, stringArrayToInterfaceArray(refinedValues)...)
+		insideBoolQuery.Should(termQuery)
+		insideBool = true
+	}
+	// Here we handle the case where we want a tag key with NO values
+	if emptyValuesRequested {
+		existsQuery := elastic.NewExistsQuery(ESFieldTagValues)
+		insideBoolQuery.Should(elastic.NewBoolQuery().MustNot(existsQuery))
+		insideBool = true
+	}
+	if insideBool {
+		boolQuery.Must(insideBoolQuery)
+	}
+
+	nestedQuery := elastic.NewNestedQuery(ESFieldPath, boolQuery)
+	return nestedQuery
+}
+
+//getESFieldName get the getESFieldNameAsset for assets
+func getESFieldNameAsset(filterType string) string {
+	ESFieldName := filterType
+	switch filterType {
+	case "chef_server":
+		ESFieldName = "chef_server"
+	case "inspec_version":
+		ESFieldName = "inspec_version"
+	case "organization":
+		ESFieldName = "organization"
+	case "platform":
+		ESFieldName = "platform"
+	case "platform_with_version":
+		ESFieldName = "platform_with_version"
+	case "recipe":
+		ESFieldName = "recipe"
+	case "role":
+		ESFieldName = "role"
+	case "environment":
+		ESFieldName = "environment"
+	case "chef_tags":
+		ESFieldName = "chef_tags"
+	case "node_id":
+		ESFieldName = "node_id"
+	case "policy_group":
+		ESFieldName = "policy_group"
+	case "policy_name":
+		ESFieldName = "policy_name"
+	case "control":
+		ESFieldName = "control_id"
+	case "profile_id":
+		ESFieldName = "profile_id"
+	}
+
+	return ESFieldName
+}
+
+//getStartTimeAndEndTimeRangeForAsset gets the range query for date range and config as well
+func getStartTimeAndEndTimeRangeForAsset(filters map[string][]string, unreachableConfig int) *elastic.RangeQuery {
+
+	if unreachableConfig > 0 {
+		timeRangeQuery := elastic.NewRangeQuery("last_run")
+		timeRangeQuery.Gt(time.Now().Add(-24 * time.Hour * time.Duration(unreachableConfig)).UTC().Format(time.RFC3339))
+		return timeRangeQuery
+	}
+
+	endTime := firstOrEmpty(filters["end_time"])
+	startTime := firstOrEmpty(filters["start_time"])
+
+	timeRangeQuery := elastic.NewRangeQuery("last_run")
+	if len(startTime) > 0 {
+		timeRangeQuery.Gte(startTime)
+	}
+	if len(endTime) > 0 {
+		timeRangeQuery.Lte(endTime)
+	}
+
+	return timeRangeQuery
+
+}

--- a/components/compliance-service/reporting/relaxting/assets.go
+++ b/components/compliance-service/reporting/relaxting/assets.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-//getTotalAssets Get Total Number of documents from the comp-*-run-info
+//getAssets Get Total Number of documents from the comp-*-run-info
 func (backend ES2Backend) getAssets(ctx context.Context, boolQuery *elastic.BoolQuery) (int32, error) {
 	myIndex := mappings.ComplianceRunInfo.Index
 

--- a/components/compliance-service/reporting/relaxting/assets_test.go
+++ b/components/compliance-service/reporting/relaxting/assets_test.go
@@ -3,6 +3,7 @@ package relaxting
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -165,17 +166,56 @@ func TestStartTimeAndEndTimeFilters(t *testing.T) {
 		unreachableConfig int
 		esr               ES2Backend
 	}{
-		{name: "Test for 0 unreachable config",
-			startTime:         startTime,
-			endTime:           endTime,
-			unreachableConfig: 0,
-			expectedQuery:     `{"range":{"last_run":{"from":"2022-07-17T00:00:00Z","include_lower":true,"include_upper":true,"to":"2022-07-18T23:59:59Z"}}}`,
-			esr:               esr,
+		{name: "Test for 15 days unreachable config",
+			endTime:       endTime,
+			expectedQuery: fmt.Sprintf(`{"range":{"last_run":{"from":"%s","include_lower":false,"include_upper":true,"to":null}}}`, startTime),
+			esr:           esr,
 		},
+	}
+	for _, test := range tests {
+		filters := make(map[string][]string)
+		filters["start_time"] = []string{test.startTime}
+		filters["end_time"] = []string{test.endTime}
+
+		if test.unreachableConfig > 0 {
+			startTimeBefore := time.Now().Add(-24 * time.Hour * time.Duration(test.unreachableConfig)).UTC().Format(time.RFC3339)
+			test.expectedQuery = fmt.Sprintf(`{"range":{"last_run":{"from":"%s","include_lower":false,"include_upper":true,"to":null}}}`, startTimeBefore)
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			got := getStartTimeAndEndTimeRangeForAsset(filters)
+			query, _ := got.Source()
+			data, _ := json.Marshal(query)
+			actualQuery := string(data)
+			assert.Equal(t, test.expectedQuery, actualQuery)
+
+		})
+
+	}
+
+}
+
+func TestReachableAssetFilters(t *testing.T) {
+	startTime := "2022-07-17T00:00:00Z"
+	endTime := "2022-07-18T23:59:59Z"
+	tests := []struct {
+		name              string
+		startTime         string
+		endTime           string
+		expectedQuery     string
+		unreachableConfig int
+		esr               ES2Backend
+	}{
 		{name: "Test for 15 days unreachable config",
 			endTime:           endTime,
 			unreachableConfig: 15,
 			expectedQuery:     fmt.Sprintf(`{"range":{"last_run":{"from":"%s","include_lower":false,"include_upper":true,"to":null}}}`, startTime),
+			esr:               esr,
+		},
+		{name: "Test for 0 days unreachable config",
+			endTime:           endTime,
+			unreachableConfig: 0,
+			expectedQuery:     "",
 			esr:               esr,
 		},
 	}
@@ -190,14 +230,95 @@ func TestStartTimeAndEndTimeFilters(t *testing.T) {
 		}
 
 		t.Run(test.name, func(t *testing.T) {
-			got := getStartTimeAndEndTimeRangeForAsset(filters, test.unreachableConfig)
-			query, _ := got.Source()
-			data, _ := json.Marshal(query)
-			actualQuery := string(data)
+			got := getReachableAssetTimeRangeQuery(test.unreachableConfig)
+			actualQuery := ""
+			if got != nil {
+				query, _ := got.Source()
+				data, _ := json.Marshal(query)
+				actualQuery = string(data)
+			}
+
 			assert.Equal(t, test.expectedQuery, actualQuery)
 
 		})
 
+	}
+
+}
+
+func TestGetResultAssetSummary(t *testing.T) {
+	assetSummary := AssetSummary{
+		Passed:  0,
+		Failed:  10,
+		Waived:  16,
+		Skipped: 20,
+	}
+
+	contentPassed := []byte(`{"doc_count": 0}`)
+	contentFailed := []byte(`{"doc_count": 10}`)
+	contentWaived := []byte(`{"doc_count": 16}`)
+	contentSkipped := []byte(`{"doc_count": 20}`)
+
+	aggregations := make(map[string]json.RawMessage)
+	aggregations["failed"] = contentFailed
+	aggregations["passed"] = contentPassed
+	aggregations["waived"] = contentWaived
+	aggregations["skipped"] = contentSkipped
+
+	searchResult := &elastic.SearchResult{
+		Aggregations: aggregations,
+	}
+
+	assetSummaryActual := getSummaryAssetAggResult(searchResult)
+
+	assert.Equal(t, assetSummary.Passed, assetSummaryActual.Passed)
+	assert.Equal(t, assetSummary.Failed, assetSummaryActual.Failed)
+	assert.Equal(t, assetSummary.Skipped, assetSummaryActual.Skipped)
+	assert.Equal(t, assetSummary.Waived, assetSummaryActual.Waived)
+
+}
+
+func TestGetAggsForAssets(t *testing.T) {
+
+	tests := []struct {
+		Name          string
+		expectedQuery string
+		aggsType      string
+	}{
+		{
+			Name:          "Test Failed Aggregation",
+			expectedQuery: `{"filter":{"term":{"status":"failed"}}}`,
+			aggsType:      "failed",
+		},
+		{
+			Name:          "Test Passed Aggregation",
+			expectedQuery: `{"filter":{"term":{"status":"passed"}}}`,
+			aggsType:      "passed",
+		},
+		{
+			Name:          "Test Waived Aggregation",
+			expectedQuery: `{"filter":{"term":{"status":"waived"}}}`,
+			aggsType:      "waived",
+		},
+		{
+			Name:          "Test Waived Aggregation",
+			expectedQuery: `{"filter":{"term":{"status":"skipped"}}}`,
+			aggsType:      "skipped",
+		},
+	}
+
+	for _, test := range tests {
+		aggsMap := getSummaryAssetAggregation()
+
+		failedAggs, found := aggsMap[test.aggsType]
+		actualQuery := ""
+		if found {
+
+			source, _ := failedAggs.Source()
+			data, _ := json.Marshal(source)
+			actualQuery = string(data)
+		}
+		assert.Equal(t, test.expectedQuery, actualQuery)
 	}
 
 }

--- a/components/compliance-service/reporting/relaxting/assets_test.go
+++ b/components/compliance-service/reporting/relaxting/assets_test.go
@@ -1,0 +1,203 @@
+package relaxting
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+var esr = ES2Backend{
+	ESUrl:             "",
+	Enterprise:        "",
+	ChefDeliveryUser:  "",
+	ChefDeliveryToken: "",
+}
+
+func TestFiltersForAssetIndex(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		filtersKey    string
+		filtersValue  []string
+		expectedQuery string
+		esr           ES2Backend
+	}{
+		{
+			name:          "Test for Environment",
+			filtersKey:    "environment",
+			filtersValue:  []string{"Test ENV"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"environment":["Test ENV"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Organisation",
+			filtersKey:    "organization",
+			filtersValue:  []string{"Test Org"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"organization":["Test Org"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for chef_server",
+			filtersKey:    "chef_server",
+			filtersValue:  []string{"fqdn"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"chef_server":["fqdn"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Policy group",
+			filtersKey:    "policy_group",
+			filtersValue:  []string{"Policy"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"policy_group":["Policy"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Policy Name",
+			filtersKey:    "policy_name",
+			filtersValue:  []string{"name"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"policy_name":["name"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Inspec Version",
+			filtersKey:    "inspec_version",
+			filtersValue:  []string{"1"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"inspec_version":["1"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for platform with version",
+			filtersKey:    "platform_with_version",
+			filtersValue:  []string{"1"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"platform_with_version":["1"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for recipe",
+			filtersKey:    "recipe",
+			filtersValue:  []string{"testrecipe"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"recipe":["testrecipe"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Role",
+			filtersKey:    "role",
+			filtersValue:  []string{"testrole"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"role":["testrole"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Platform",
+			filtersKey:    "platform",
+			filtersValue:  []string{"Test Plat"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"platform":["Test Plat"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Profile ID",
+			filtersKey:    "profile_id",
+			filtersValue:  []string{"Profile"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"profile_id":["Profile"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Control ID",
+			filtersKey:    "control",
+			filtersValue:  []string{"Control"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"control_id":["Control"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Node Id",
+			filtersKey:    "node_id",
+			filtersValue:  []string{"NodeUUId"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"node_id":["NodeUUId"]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Control tags",
+			filtersKey:    "control_tag:focus_area",
+			filtersValue:  []string{""},
+			expectedQuery: `{"bool":{"must":{"nested":{"path":"control_tag","query":{"bool":{"must":[{"terms":{"control_tag.key.lower":["focus_area"]}},{"bool":{"should":{"bool":{"must_not":{"exists":{"field":"control_tag.values.lower"}}}}}}]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for Control tags and Values",
+			filtersKey:    "control_tag:focus_area",
+			filtersValue:  []string{"test"},
+			expectedQuery: `{"bool":{"must":{"nested":{"path":"control_tag","query":{"bool":{"must":[{"terms":{"control_tag.key.lower":["focus_area"]}},{"bool":{"should":{"terms":{"control_tag.values.lower":["test"]}}}}]}}}}}}`,
+			esr:           esr,
+		},
+		{
+			name:          "Test for chef tags",
+			filtersKey:    "chef_tags",
+			filtersValue:  []string{"tags"},
+			expectedQuery: `{"bool":{"must":{"bool":{"should":{"terms":{"chef_tags":["tags"]}}}}}}`,
+			esr:           esr,
+		},
+	}
+
+	for _, test := range tests {
+		filters := make(map[string][]string)
+		filters[test.filtersKey] = test.filtersValue
+		t.Run(test.name, func(t *testing.T) {
+			got := esr.getFiltersQueryForAssetFilters(filters)
+			query, _ := got.Source()
+			data, _ := json.Marshal(query)
+			actualQuery := string(data)
+			assert.Equal(t, test.expectedQuery, actualQuery)
+
+		})
+
+	}
+
+}
+
+func TestStartTimeAndEndTimeFilters(t *testing.T) {
+	startTime := "2022-07-17T00:00:00Z"
+	endTime := "2022-07-18T23:59:59Z"
+	tests := []struct {
+		name              string
+		startTime         string
+		endTime           string
+		expectedQuery     string
+		unreachableConfig int
+		esr               ES2Backend
+	}{
+		{name: "Test for 0 unreachable config",
+			startTime:         startTime,
+			endTime:           endTime,
+			unreachableConfig: 0,
+			expectedQuery:     `{"range":{"last_run":{"from":"2022-07-17T00:00:00Z","include_lower":true,"include_upper":true,"to":"2022-07-18T23:59:59Z"}}}`,
+			esr:               esr,
+		},
+		{name: "Test for 15 days unreachable config",
+			endTime:           endTime,
+			unreachableConfig: 15,
+			expectedQuery:     fmt.Sprintf(`{"range":{"last_run":{"from":"%s","include_lower":false,"include_upper":true,"to":null}}}`, startTime),
+			esr:               esr,
+		},
+	}
+	for _, test := range tests {
+		filters := make(map[string][]string)
+		filters["start_time"] = []string{test.startTime}
+		filters["end_time"] = []string{test.endTime}
+
+		if test.unreachableConfig > 0 {
+			startTimeBefore := time.Now().Add(-24 * time.Hour * time.Duration(test.unreachableConfig)).UTC().Format(time.RFC3339)
+			test.expectedQuery = fmt.Sprintf(`{"range":{"last_run":{"from":"%s","include_lower":false,"include_upper":true,"to":null}}}`, startTimeBefore)
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			got := getStartTimeAndEndTimeRangeForAsset(filters, test.unreachableConfig)
+			query, _ := got.Source()
+			data, _ := json.Marshal(query)
+			actualQuery := string(data)
+			assert.Equal(t, test.expectedQuery, actualQuery)
+
+		})
+
+	}
+
+}

--- a/components/compliance-service/reporting/relaxting/es_types.go
+++ b/components/compliance-service/reporting/relaxting/es_types.go
@@ -305,3 +305,10 @@ type ESMigrationInfo struct {
 type EndTimeSource struct {
 	EndTime time.Time `json:"end_time"`
 }
+
+type AssetSummary struct {
+	Passed  int32 `json:"passed"`
+	Skipped int32 `json:"skipped"`
+	Failed  int32 `json:"failed"`
+	Waived  int32 `json:"waived"`
+}


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Added queries for open search which will get the total asset count with filters

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-180

### :+1: Definition of Done

The query is fetching from comp-run-info index.

### :athletic_shoe: How to Build and Test the Change
```
rebuild components/compliance-service/
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
