### PR TITLE
Sahiba/customer bug kinetics187

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -224,7 +224,7 @@
                 <chef-loading-spinner *ngIf="control.controlDetailsLoading" size="50"></chef-loading-spinner>
                 <div *ngIf="!control.controlDetailsLoading">
                   <p *ngIf="control.desc">{{ control.desc }}</p>
-                  <chef-toggle [value]='openControls[control.id+" "+control.profile_id]?.pane'
+                  <chef-toggle [value]='openControls[toggleKey(control)]?.pane'
                     (change)="showControlPane(control, $event.target.value)">
                     <chef-option value='results'>Results</chef-option>
                     <chef-option value='source'>Source</chef-option>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -224,7 +224,7 @@
                 <chef-loading-spinner *ngIf="control.controlDetailsLoading" size="50"></chef-loading-spinner>
                 <div *ngIf="!control.controlDetailsLoading">
                   <p *ngIf="control.desc">{{ control.desc }}</p>
-                  <chef-toggle [value]="openControls[control.id]?.pane"
+                  <chef-toggle [value]='openControls[control.id+" "+control.profile_id]?.pane'
                     (change)="showControlPane(control, $event.target.value)">
                     <chef-option value='results'>Results</chef-option>
                     <chef-option value='source'>Source</chef-option>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -186,15 +186,15 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     return this.activeStatusFilter === status;
   }
 
-  isOpenControl({ id, profile }) {
-    let key = id + " " + profile
+  isOpenControl({ id, profile_id }) {
+    let key = id + " " + profile_id
     return this.openControls[key] && this.openControls[key].open;
   }
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
     this.index = i;
-    let key = control.id + " " + control.profile
+    let key = control.id + " " + control.profile_id
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
     const state = this.openControls[key];
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
@@ -216,8 +216,9 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
         this.allControlList.forEach((data) => {
           data.profiles.forEach(p => {
+            console.log(p, "test1")
             p.controls.forEach(c => {
-              if (c.id === control.id && p.name === control.profile) {
+              if (c.id === control.id && p.sha256 === control.profile_id) {
                 this.controlList.control_elements[this.index].controlDetailsLoading = false;
                 this.controlDetails = data;
                 const res = this.controlDetails['profiles'][0].controls[0].results;
@@ -226,6 +227,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
                 this.controlList.control_elements[this.index].result = res;
                 this.controlList.control_elements[this.index].code = code;
                 this.controlList.control_elements[this.index].desc = desc;
+                console.log("Sahiba")
               }
             });
           });
@@ -236,13 +238,13 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     }
   }
 
-  openControlPane(control: { id: string | number, profile: string; }) {
-    let key = control.id + " " + control.profile
+  openControlPane(control: { id: string | number, profile_id: string; }) {
+    let key = control.id + " " + control.profile_id
     return this.openControls[key].pane;
   }
 
-  showControlPane(control: { id: string | number, profile: string; }, pane: any,) {
-    let key = control.id + " " + control.profile
+  showControlPane(control: { id: string | number, profile_id: string; }, pane: any,) {
+    let key = control.id + " " + control.profile_id
     this.openControls[key].pane = pane;
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -186,15 +186,15 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     return this.activeStatusFilter === status;
   }
 
-  isOpenControl({ id, profile_id }) {
-    const key = id + ' ' + profile_id;
+  isOpenControl(control: { id: string | number, profile_id: string; }) {
+    const key = this.toggleKey(control);
     return this.openControls[key] && this.openControls[key].open;
   }
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
     this.index = i;
-    const key = control.id + ' ' + control.profile_id;
+    const key = this.toggleKey(control);
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
     const state = this.openControls[key];
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
@@ -236,13 +236,18 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     }
   }
 
-  openControlPane(control: { id: string | number, profile_id: string; }) {
+  toggleKey(control: any) {
     const key = control.id + ' ' + control.profile_id;
+    return key;
+  }
+
+  openControlPane(control: { id: string | number, profile_id: string; }) {
+    const key = this.toggleKey(control);
     return this.openControls[key].pane;
   }
 
   showControlPane(control: { id: string | number, profile_id: string; }, pane: any ) {
-    const key = control.id + ' ' + control.profile_id;
+    const key = this.toggleKey(control);
     this.openControls[key].pane = pane;
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -186,21 +186,22 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     return this.activeStatusFilter === status;
   }
 
-  isOpenControl({ id }) {
-    return this.openControls[id] && this.openControls[id].open;
+  isOpenControl({ id, profile }) {
+    let key = id + " " + profile
+    return this.openControls[key] && this.openControls[key].open;
   }
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
     this.index = i;
+    let key = control.id + " " + control.profile
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
-    const state = this.openControls[control.id];
+    const state = this.openControls[key];
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
-    this.openControls[control.id] = toggled;
-
+    this.openControls[key] = toggled;
     if (toggled.open === true) {
-      if (!this.reportIdArray.includes(control.id)) {
-        this.reportIdArray.push(control.id);
+      if (!this.reportIdArray.includes(key)) {
+        this.reportIdArray.push(key);
         const payload = {
           report_id : this.activeReport.id,
           filters : [
@@ -216,7 +217,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
         this.allControlList.forEach((data) => {
           data.profiles.forEach(p => {
             p.controls.forEach(c => {
-              if (c.id === control.id) {
+              if (c.id === control.id && p.name === control.profile) {
                 this.controlList.control_elements[this.index].controlDetailsLoading = false;
                 this.controlDetails = data;
                 const res = this.controlDetails['profiles'][0].controls[0].results;
@@ -235,12 +236,14 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     }
   }
 
-  openControlPane(control: { id: string | number; }) {
-    return this.openControls[control.id].pane;
+  openControlPane(control: { id: string | number, profile: string; }) {
+    let key = control.id + " " + control.profile
+    return this.openControls[key].pane;
   }
 
-  showControlPane(control: { id: string | number; }, pane: any) {
-    this.openControls[control.id].pane = pane;
+  showControlPane(control: { id: string | number, profile: string; }, pane: any,) {
+    let key = control.id + " " + control.profile
+    this.openControls[key].pane = pane;
   }
 
   statusIcon(status: any) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -187,14 +187,14 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   }
 
   isOpenControl({ id, profile_id }) {
-    let key = id + " " + profile_id
+    const key = id + ' ' + profile_id;
     return this.openControls[key] && this.openControls[key].open;
   }
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
     this.index = i;
-    let key = control.id + " " + control.profile_id
+    const key = control.id + ' ' + control.profile_id;
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
     const state = this.openControls[key];
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
@@ -237,12 +237,12 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   }
 
   openControlPane(control: { id: string | number, profile_id: string; }) {
-    let key = control.id + " " + control.profile_id
+    const key = control.id + ' ' + control.profile_id;
     return this.openControls[key].pane;
   }
 
-  showControlPane(control: { id: string | number, profile_id: string; }, pane: any,) {
-    let key = control.id + " " + control.profile_id
+  showControlPane(control: { id: string | number, profile_id: string; }, pane: any ) {
+    const key = control.id + ' ' + control.profile_id;
     this.openControls[key].pane = pane;
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -216,7 +216,6 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
         this.allControlList.forEach((data) => {
           data.profiles.forEach(p => {
-            console.log(p, "test1")
             p.controls.forEach(c => {
               if (c.id === control.id && p.sha256 === control.profile_id) {
                 this.controlList.control_elements[this.index].controlDetailsLoading = false;
@@ -227,7 +226,6 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
                 this.controlList.control_elements[this.index].result = res;
                 this.controlList.control_elements[this.index].code = code;
                 this.controlList.control_elements[this.index].desc = desc;
-                console.log("Sahiba")
               }
             });
           });

--- a/components/compliance-service/chef-load-data/samples/c5-full.json
+++ b/components/compliance-service/chef-load-data/samples/c5-full.json
@@ -7,19 +7,15 @@
     {
       "name": "mylinux-success",
       "version": "1.8.9",
-      "sha256": "1de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae27",
-      "title": "My Demo Linux successful profile",
+      "sha256": "0de944869a847da87d3774feaacb41829935a2f46b558f7fc34b4da21586ae21",
+      "title": "A Demo Linux success profile",
       "maintainer": "Chef Software, Inc.",
       "summary": "Demonstrates the use of InSpec Compliance Profile",
       "license": "Apache 2 license",
       "copyright": "Chef Software, Inc.",
       "copyright_email": "support@chef.io",
-      "supports": [
-
-      ],
-      "attributes": [
-
-      ],
+      "supports": [],
+      "attributes": [],
       "groups": [
         {
           "id": "controls/success.rb",
@@ -35,11 +31,8 @@
           "title": "Checking for /etc/passwd",
           "desc": "Checking for /etc/passwd desc",
           "impact": 0.6,
-          "refs": [
-
-          ],
-          "tags": {
-          },
+          "refs": [],
+          "tags": {},
           "code": "control '/etc/passwd must exist' do\n  title 'Checking for /etc/passwd'\n  desc 'Checking for /etc/passwd desc'\n  impact 0.6\n  describe file('/etc/passwd') do\n    it { should be_file }\n  end\nend\n",
           "source_location": {
             "line": 2,
@@ -59,11 +52,8 @@
           "title": "Checking for /etc/group",
           "desc": "Checking for /etc/group desc",
           "impact": 0.3,
-          "refs": [
-
-          ],
-          "tags": {
-          },
+          "refs": [],
+          "tags": {},
           "code": "control '/etc/group must exist' do\n  title 'Checking for /etc/group'\n  desc 'Checking for /etc/group desc'\n  impact 0.3\n  describe file('/etc/group') do\n    it { should be_file }\n  end\nend\n",
           "source_location": {
             "line": 11,
@@ -75,6 +65,268 @@
               "code_desc": "File /etc/group should be file",
               "run_time": 0.049345,
               "start_time": "2018-06-27T15:02:13+01:00"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "mylinux-failure-waived",
+      "version": "5.4.2",
+      "sha256": "0b7ecfb4f08d2ecdc8f08351d2e5ea93456c127aa751b2741b86f1e5f47614f2",
+      "title": "A Demo Linux failing profile waived",
+      "maintainer": "Chef Software, Inc.",
+      "summary": "Demonstrates the use of InSpec Compliance Profile",
+      "license": "Apache 2 license",
+      "copyright": "Chef Software, Inc.",
+      "copyright_email": "support@chef.io",
+      "supports": [
+        {
+          "os-family": "unix"
+        }
+      ],
+      "attributes": [],
+      "groups": [
+        {
+          "id": "controls/failure.rb",
+          "controls": [
+            "Checking /etc/missing5.rb"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "Checking /etc/missing5.rb",
+          "title": "Check /etc/missing5.rb",
+          "desc": "File test in failure.rb desc",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {},
+          "code": "control 'Checking /etc/missing5.rb' do\n  impact 0.5\n  title \"Check /etc/missing5.rb\"\n  desc \"File test in failure.rb desc\"\n  describe file('/etc/missing5.rb') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/failure.rb"
+          },
+          "waiver_data": {
+            "justification": "Sound reasoning",
+            "run": true,
+            "skipped_due_to_waiver": false,
+            "message": ""
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "File /etc/missing5.rb should be file",
+              "run_time": 0.00557,
+              "start_time": "2018-06-27T15:02:21+01:00",
+              "message": "expected `File /etc/missing5.rb.file?` to return true, got false"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "mylinux-failure",
+      "version": "5.4.4",
+      "sha256": "0b7ecfb4f08d2ecdc8f08351d2e5ea93456c127aa751b2741b86f1e5f47614f3",
+      "title": "A Demo Linux failing profile",
+      "maintainer": "Chef Software, Inc.",
+      "summary": "Demonstrates the use of InSpec Compliance Profile",
+      "license": "Apache 2 license",
+      "copyright": "Chef Software, Inc.",
+      "copyright_email": "support@chef.io",
+      "supports": [
+        {
+          "os-family": "unix"
+        }
+      ],
+      "attributes": [],
+      "groups": [
+        {
+          "id": "controls/failure.rb",
+          "controls": [
+            "Checking /etc/missing5.rb"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "failing control",
+          "title": "Log Suspicious Packets",
+          "desc": "When enabled, this feature logs packets with un-routable source addresses to the kernel log.\n\nRationale: Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server.",
+          "impact": 1.0,
+          "refs": [],
+          "tags": {},
+          "code": "control \"xccdf_org.cisecurity.benchmarks_rule_4.2.4_Log_Suspicious_Packets\" do\n  title \"Log Suspicious Packets\"\n  desc  \"\n    When enabled, this feature logs packets with un-routable source addresses to the kernel log.\n    \n    Rationale: Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server.\n  \"\n  impact 1.0\n  describe kernel_parameter(\"net.ipv4.conf.all.log_martians\") do\n    its(\"value\") { should_not be_nil }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.all.log_martians\") do\n    its(\"value\") { should eq 1 }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.default.log_martians\") do\n    its(\"value\") { should_not be_nil }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.default.log_martians\") do\n    its(\"value\") { should eq 1 }\n  end\nend\n",
+          "source_location": {
+            "line": 1010,
+            "ref": "controls/translated-controls.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.all.log_martians value should not be nil",
+              "run_time": 0.005221,
+              "start_time": "2018-06-27T15:02:16+01:00"
+            },
+            {
+              "status": "failed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.all.log_martians value should eq 1",
+              "run_time": 0.005416,
+              "start_time": "2018-06-27T15:02:16+01:00",
+              "message": "\nexpected: 1\n     got: 0\n\n(compared using ==)\n"
+            },
+            {
+              "status": "passed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.default.log_martians value should not be nil",
+              "run_time": 0.00562,
+              "start_time": "2018-06-27T15:02:16+01:00"
+            },
+            {
+              "status": "failed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.default.log_martians value should eq 1",
+              "run_time": 0.00532,
+              "start_time": "2018-06-27T15:02:16+01:00",
+              "message": "\nexpected: 1\n     got: 0\n\n(compared using ==)\n"
+            }
+          ]
+        },
+        {
+          "id": "Checking /etc/missing5.rb",
+          "title": "Check /etc/missing5.rb",
+          "desc": "File test in failure.rb desc",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {},
+          "code": "control 'Checking /etc/missing5.rb' do\n  impact 0.5\n  title \"Check /etc/missing5.rb\"\n  desc \"File test in failure.rb desc\"\n  describe file('/etc/missing5.rb') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/failure.rb"
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "File /etc/missing5.rb should be file",
+              "run_time": 0.00557,
+              "start_time": "2018-06-27T15:02:21+01:00",
+              "message": "expected `File /etc/missing5.rb.file?` to return true, got false"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "mylinux-failure-pass-waived",
+      "version": "5.4.6",
+      "sha256": "0b7ecfb4f08d2ecdc8f08351d2e5ea93456c127aa751b2741b86f1e5f47614f4",
+      "title": "A Demo Linux with major failing one passing and one waived",
+      "maintainer": "Chef Software, Inc.",
+      "summary": "Demonstrates the use of InSpec Compliance Profile",
+      "license": "Apache 2 license",
+      "copyright": "Chef Software, Inc.",
+      "copyright_email": "support@chef.io",
+      "supports": [
+        {
+          "os-family": "unix"
+        }
+      ],
+      "attributes": [],
+      "groups": [
+        {
+          "id": "controls/failure.rb",
+          "controls": [
+            "Checking /etc/missing5.rb"
+          ]
+        }
+      ],
+      "controls": [
+        {
+          "id": "failing control",
+          "title": "failing Log Suspicious Packets",
+          "desc": "When enabled, this feature logs packets with un-routable source addresses to the kernel log.\n\nRationale: Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server.",
+          "impact": 1.0,
+          "refs": [],
+          "tags": {},
+          "code": "control \"xccdf_org.cisecurity.benchmarks_rule_4.2.4_Log_Suspicious_Packets\" do\n  title \"Log Suspicious Packets\"\n  desc  \"\n    When enabled, this feature logs packets with un-routable source addresses to the kernel log.\n    \n    Rationale: Enabling this feature and logging these packets allows an administrator to investigate the possibility that an attacker is sending spoofed packets to their server.\n  \"\n  impact 1.0\n  describe kernel_parameter(\"net.ipv4.conf.all.log_martians\") do\n    its(\"value\") { should_not be_nil }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.all.log_martians\") do\n    its(\"value\") { should eq 1 }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.default.log_martians\") do\n    its(\"value\") { should_not be_nil }\n  end\n  describe kernel_parameter(\"net.ipv4.conf.default.log_martians\") do\n    its(\"value\") { should eq 1 }\n  end\nend\n",
+          "source_location": {
+            "line": 1010,
+            "ref": "controls/translated-controls.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.all.log_martians value should not be nil",
+              "run_time": 0.005221,
+              "start_time": "2018-06-27T15:02:16+01:00"
+            },
+            {
+              "status": "failed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.all.log_martians value should eq 1",
+              "run_time": 0.005416,
+              "start_time": "2018-06-27T15:02:16+01:00",
+              "message": "\nexpected: 1\n     got: 0\n\n(compared using ==)\n"
+            },
+            {
+              "status": "passed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.default.log_martians value should not be nil",
+              "run_time": 0.00562,
+              "start_time": "2018-06-27T15:02:16+01:00"
+            },
+            {
+              "status": "failed",
+              "code_desc": "Kernel Parameter net.ipv4.conf.default.log_martians value should eq 1",
+              "run_time": 0.00532,
+              "start_time": "2018-06-27T15:02:16+01:00",
+              "message": "\nexpected: 1\n     got: 0\n\n(compared using ==)\n"
+            }
+          ]
+        },
+        {
+          "id": "passing control",
+          "title": "passing Check /etc/missing5.rb",
+          "desc": "File test in failure.rb desc",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {},
+          "code": "control 'Checking /etc/missing5.rb' do\n  impact 0.5\n  title \"Check /etc/missing5.rb\"\n  desc \"File test in failure.rb desc\"\n  describe file('/etc/missing5.rb') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/failure.rb"
+          },
+          "results": [
+            {
+              "status": "passed",
+              "code_desc": "File /etc/missing5.rb should be file",
+              "run_time": 0.00557,
+              "start_time": "2018-06-27T15:02:21+01:00"
+            }
+          ]
+        },
+        {
+          "id": "waived failing control",
+          "title": "waived Check /etc/missing5.rb",
+          "desc": "File test in failure.rb desc",
+          "impact": 0.5,
+          "refs": [],
+          "tags": {},
+          "code": "control 'Checking /etc/missing5.rb' do\n  impact 0.5\n  title \"Check /etc/missing5.rb\"\n  desc \"File test in failure.rb desc\"\n  describe file('/etc/missing5.rb') do\n    it { should be_file }\n  end\nend\n",
+          "source_location": {
+            "line": 2,
+            "ref": "controls/failure.rb"
+          },
+          "waiver_data": {
+            "justification": "Sound reasoning",
+            "run": true,
+            "skipped_due_to_waiver": false,
+            "message": ""
+          },
+          "results": [
+            {
+              "status": "failed",
+              "code_desc": "File /etc/missing5.rb should be file",
+              "run_time": 0.00557,
+              "start_time": "2018-06-27T15:02:21+01:00",
+              "message": "expected `File /etc/missing5.rb.file?` to return true, got false"
             }
           ]
         }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The controls having the same name from different profiles are linked with each other. if we click on one control to see the results or Source, then the other control having the same name will also show its results and source.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-187
### :+1: Definition of Done
I am done some changes to make sure that whenever we expand any control, it will open that control only, not change the other control having same name.
### :athletic_shoe: How to Build and Test the Change

- hab studio enter
- build components/automate-ui-devproxy/
- start_automate_ui_background
- start_all_services
- hab pkg install chef/chef-load
- hab pkg binlink chef/chef-load chef-load
- vi chef-load.toml (Copy the below content in this file. Change the token)
`data_collector_url = "[http://a2-dev.test/api/v0/events/data-collector"](http://a2-dev.test/api/v0/events/data-collector%22)data_collector_token = "7gIQtE4uzImKGvCNqA02QpD_Nro="
#converge_status_json_file = "./sample-data/example-converge-status.json"
#ohai_json_file = "sample-data/ohai-data.json"
#log_file = "/tmp/chef-load.log"
#compliance_sample_reports_dir = "sample-data/inspec-reports"
#compliance_status_json_file = "sample-data/example-compliance-status.json"
#We use the generate command from chef-load, we don't have to set these options
#inside the config file since we will pass them through the command line
#num_nodes = 100
#num_actions = 10
#interval = 30
node_name_prefix = "sahiba"
random_data = true
converge_status_json_file = "./components/ingest-service/examples/converge-success-report.json"
ohai_json_file = "./components/ingest-service/chef-load-data/ohai-data.json"
log_file = "/tmp/chef-load.log"
compliance_sample_reports_dir = "./components/compliance-service/chef-load-data/samples"
compliance_status_json_file = "./components/compliance-service/chef-load-data/compliance-status.json"`
- rebuild components/compliance-service/
- Now try to generate random data using this command: **chef-load generate --config chef-load.toml -N1 -D1 -M2 -T2** (you have to run this cmd few times till you get any node with having exactly 3 control failures)
- Now open that particular node, click on failed controls, try to expand the control of same names. 

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
