### PR TITLE
Sahiba/customer bug kinetics 186

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -212,7 +212,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
         this.store.dispatch(new GetControlDetail(payload));
       } else {
         this.store.select(controlsList).subscribe(data => {
-          this.allControlList = data; 
+          this.allControlList = data;
         });
 
         this.allControlList.forEach((data) => {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -95,7 +95,6 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
       this.store.select(controlDetailList)
     ]).pipe(takeUntil(this.isDestroyed))
     .subscribe(([detailsStatusSt, detailsListState]) => {
-      console.log(this.controlList, 'test1');
       if (detailsStatusSt === EntityStatus.loadingSuccess && !isNil(detailsListState)
       && this.controlList && this.controlList.control_elements) {
         this.controlList.control_elements[this.index].controlDetailsLoading = false;

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -95,7 +95,8 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
       this.store.select(controlDetailList)
     ]).pipe(takeUntil(this.isDestroyed))
     .subscribe(([detailsStatusSt, detailsListState]) => {
-      if (detailsStatusSt === EntityStatus.loadingSuccess && !isNil(detailsListState)) {
+      if (detailsStatusSt === EntityStatus.loadingSuccess && !isNil(detailsListState)
+      && this.controlList.control_elements !== undefined) {
         this.controlList.control_elements[this.index].controlDetailsLoading = false;
         this.isError = false;
         this.controlDetails = detailsListState;
@@ -193,6 +194,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
+    console.log(control, "ctrl")
     this.index = i;
     const key = this.toggleKey(control);
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
@@ -209,9 +211,11 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
             {'type': 'control', 'values': [`${control.id}`]}]
         };
         this.store.dispatch(new GetControlDetail(payload));
+        console.log("first")
       } else {
+        console.log("second")
         this.store.select(controlsList).subscribe(data => {
-          this.allControlList = data;
+          this.allControlList = data; 
         });
 
         this.allControlList.forEach((data) => {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -194,7 +194,6 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
 
   toggleControl(i: number, ctrl: any) {
     const control = ctrl;
-    console.log(control, "ctrl")
     this.index = i;
     const key = this.toggleKey(control);
     this.controlList.control_elements[this.index].controlDetailsLoading = true;
@@ -211,9 +210,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
             {'type': 'control', 'values': [`${control.id}`]}]
         };
         this.store.dispatch(new GetControlDetail(payload));
-        console.log("first")
       } else {
-        console.log("second")
         this.store.select(controlsList).subscribe(data => {
           this.allControlList = data; 
         });

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -146,8 +146,8 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
   onFilterControlStatusClick(_event: any, status: string) {
     this.pageIndex = 1;
     this.activeStatusFilter = status;
-    this.getControlData(this.activeReport);
     this.openControls = {};
+    this.getControlData(this.activeReport);
   }
 
   onViewSourceClick(_event: any, control: { showMetaData: boolean; }) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -147,6 +147,7 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.pageIndex = 1;
     this.activeStatusFilter = status;
     this.getControlData(this.activeReport);
+    this.openControls = {};
   }
 
   onViewSourceClick(_event: any, control: { showMetaData: boolean; }) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -95,8 +95,9 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
       this.store.select(controlDetailList)
     ]).pipe(takeUntil(this.isDestroyed))
     .subscribe(([detailsStatusSt, detailsListState]) => {
+      console.log(this.controlList, 'test1');
       if (detailsStatusSt === EntityStatus.loadingSuccess && !isNil(detailsListState)
-      && this.controlList.control_elements !== undefined) {
+      && this.controlList && this.controlList.control_elements) {
         this.controlList.control_elements[this.index].controlDetailsLoading = false;
         this.isError = false;
         this.controlDetails = detailsListState;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
While expanding the control to see the results and/or source of control on the report details page, we were getting loader icon. So for fixing that, i have added some conditions.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-186
### :+1: Definition of Done
I have added some condition to fix that, now after expanding any control, we are getting proper data.
### :athletic_shoe: How to Build and Test the Change

- hab studio enter
- build components/automate-ui-devproxy/
- start_automate_ui_background
- start_all_services
- Add some data in compliance tab. 
- rebuild components/automate-ui/

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
