### PR TITLE
Opensearch post-run hook for update number_of_replica while patching config

### DIFF
--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,7 +83,7 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in ${templates[@]};do
 echo -e " snapshot status for $template\n"
-export current_index = $(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template/?pretty -u 'admin:admin' --insecure)
+export current_index=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template/?pretty -u 'admin:admin' --insecure)
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
     "index_patterns" : [
        '"\"$template\""'

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,7 +83,7 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in ${templates[@]};do
 echo -e " snapshot status for $template\n"
-export index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
+export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
     "index_patterns" :'$index_patterns',
     "settings" : {

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -56,17 +56,47 @@ if [[ $(wait_until_healthy 5) -ne 0 ]]; then
 fi
 
 echo "Configuring index settings"
-curl \
-  -s \
-  -i \
-  -H 'Content-Type: application/json'\
-  -X PUT "https://${HOST}:{{cfg.network.port}}/_all/_settings?preserve_existing=true" \
-  -k \
-  -u admin:admin \
+
+# Getting all indices 
+export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+echo -e "list of indices\n$indices"
+
+# Looping over each index individually and patching "number_of_replica" from config (toml)
+for index in ${indices[@]};do
+echo -e " snapshot status for $index\n"
+curl -X PUT \
+  "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
+  -k -u admin:admin \
+  -H 'content-type: application/json' \
   -d '{
-    "index.number_of_replicas": "{{cfg.index.number_of_replicas}}",
-    "index.refresh_interval": "{{cfg.index.refresh_interval}}"
-  }'
+      "index" : {
+        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
+        "refresh_interval": "{{cfg.index.refresh_interval}}"
+      }
+    }'
+done
+
+# Getting all templates
+export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+echo -e "list of templates\n$templates"
+
+# Looping over each template individually and patching "number_of_replica" from config (toml)
+for template in ${templates[@]};do
+echo -e " snapshot status for $template\n"
+export current_index = $(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template/?pretty -u 'admin:admin' --insecure)
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
+    "index_patterns" : [
+       '"\"$template\""'
+    ],
+    "settings" : {
+      "index" : {
+        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
+        "refresh_interval" : "{{cfg.index.refresh_interval}}"
+      }
+    }
+}'
+
+done
 
 # The health-check hook will return an error unless we touch sentinel file to
 # signal to the health check that this hook has completed successfully.

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,16 +83,16 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in ${templates[@]};do
 echo -e " snapshot status for $template\n"
-export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
-    "index_patterns" :'$index_patterns',
-    "settings" : {
-      "index" : {
-        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
-        "refresh_interval" : "{{cfg.index.refresh_interval}}"
+export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
+    \"index_patterns\" : $index_patterns,
+    \"settings\" : {
+      \"index\" : {
+        \"number_of_replicas\" : \"{{cfg.index.number_of_replicas}}\",
+        \"refresh_interval\" : \"{{cfg.index.refresh_interval}}\"
       }
     }
-}'
+}"
 
 done
 

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,11 +83,9 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in ${templates[@]};do
 echo -e " snapshot status for $template\n"
-export current_index=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template/?pretty -u 'admin:admin' --insecure)
+export index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
-    "index_patterns" : [
-       '"\"$template\""'
-    ],
+    "index_patterns" :'$index_patterns',
     "settings" : {
       "index" : {
         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -62,7 +62,7 @@ export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
-for index in ${indices[@]};do
+for index in $indices;do
 echo -e " snapshot status for $index\n"
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
@@ -81,7 +81,7 @@ export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/template
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)
-for template in ${templates[@]};do
+for template in $templates;do
 echo -e " snapshot status for $template\n"
 export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -1,3 +1,5 @@
+#shellcheck disable=SC2155
+#shellcheck disable=SC2086
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 exec 2>&1

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -58,12 +58,14 @@ fi
 echo "Configuring index settings"
 
 # Getting all indices 
-export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+export indices
+indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
-for index in ${indices[@]};do
+for index in "${indices[@]}";do
 echo -e " snapshot status for $index\n"
+" snapshot status for $index\n" >> logs.txt
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
   -k -u admin:admin \
@@ -77,13 +79,15 @@ curl -X PUT \
 done
 
 # Getting all templates
-export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+export templates
+templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)
-for template in ${templates[@]};do
+for template in "${templates[@]}";do
 echo -e " snapshot status for $template\n"
-export index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
+export index_patterns
+index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
     "index_patterns" :'$index_patterns',
     "settings" : {
@@ -93,7 +97,7 @@ curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$t
       }
     }
 }'
-
+" $template : \n" >> logs.txt
 done
 
 # The health-check hook will return an error unless we touch sentinel file to

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -58,14 +58,12 @@ fi
 echo "Configuring index settings"
 
 # Getting all indices 
-export indices
-indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
-for index in "${indices[@]}";do
+for index in ${indices[@]};do
 echo -e " snapshot status for $index\n"
-" snapshot status for $index\n" >> logs.txt
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
   -k -u admin:admin \
@@ -79,15 +77,13 @@ curl -X PUT \
 done
 
 # Getting all templates
-export templates
-templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)
-for template in "${templates[@]}";do
+for template in ${templates[@]};do
 echo -e " snapshot status for $template\n"
-export index_patterns
-index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
+export index_patterns=$(curl -XGET https://localhost:10168/_template/comp-7-s/?pretty -u 'admin:admin' --insecure | jq  '."'$templates'".index_patterns')
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
     "index_patterns" :'$index_patterns',
     "settings" : {
@@ -97,7 +93,7 @@ curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$t
       }
     }
 }'
-" $template : \n" >> logs.txt
+
 done
 
 # The health-check hook will return an error unless we touch sentinel file to

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,15 +83,18 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
-    \"index_patterns\" : [\"comp-7-s*\"],
-    \"settings\" : {
-      \"index\" : {
-        \"number_of_replicas\" : \"{{cfg.index.number_of_replicas}}\",
-        \"refresh_interval\" : \"{{cfg.index.refresh_interval}}\"
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+echo -e "Index Pattern: $index_patterns"
+echo -e " snapshot status for $template\n"
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
+    "index_patterns" : ["comp-7-s*"],
+    "settings" : {
+      "index" : {
+        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
+        "refresh_interval" : "{{cfg.index.refresh_interval}}"
       }
     }
-}"
+}'
 
 done
 

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,9 +83,8 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns")
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
-    \"index_patterns\" : $index_patterns,
+    \"index_patterns\" : [\"comp-7-s*\"],
     \"settings\" : {
       \"index\" : {
         \"number_of_replicas\" : \"{{cfg.index.number_of_replicas}}\",

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -85,17 +85,19 @@ for template in $templates;do
 echo -e " snapshot status for $template\n"
 index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns")
 echo -e "Index Pattern: $index_patterns"
-echo -e " snapshot status for $template\n"
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin \
--d '{
-    "settings" : {    
-      "index_patterns" : $index_patterns,
-      "index" : {
-        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
-        "refresh_interval" : "{{cfg.index.refresh_interval}}"
-      }
-    }
-}'
+echo -e " snapshot status for $template"
+JSON_STRING=$( jq -n \
+                  --arg ip "$index_patterns" \
+                  '{
+                    "index_patterns" : $ip,
+                    "settings" : {
+                      "index" : {
+                        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
+                        "refresh_interval" : "{{cfg.index.refresh_interval}}"
+                      }
+                    }}' )
+echo -e "JSON STRING: $JSON_STRING"
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin -d "${JSON_STRING}"
 
 done
 

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -1,5 +1,6 @@
 #shellcheck disable=SC2155
 #shellcheck disable=SC2086
+#shellcheck disable=SC1128
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 exec 2>&1

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,7 +83,7 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns")
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
     \"index_patterns\" : $index_patterns,
     \"settings\" : {

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -58,7 +58,7 @@ fi
 echo "Configuring index settings"
 
 # Getting all indices 
-export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
@@ -77,13 +77,13 @@ curl -X PUT \
 done
 
 # Getting all templates
-export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
     \"index_patterns\" : $index_patterns,
     \"settings\" : {

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -62,14 +62,12 @@ fi
 echo "Configuring index settings"
 
 # Getting all indices 
-export indices
-indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
 for index in $indices;do
 echo -e " snapshot status for $index\n"
-" snapshot status for $index\n" >> logs.txt
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
   -k -u admin:admin \
@@ -83,8 +81,7 @@ curl -X PUT \
 done
 
 # Getting all templates
-export templates
-templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,13 +83,11 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns")
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns[]")
 echo -e "Index Pattern: $index_patterns"
 echo -e " snapshot status for $template"
-JSON_STRING=$( jq -n \
-                  --arg ip "$index_patterns" \
-                  '{
-                    "index_patterns" : $ip,
+JSON_STRING=$( jq -n --arg ip ${index_patterns} '{
+                    "index_patterns" : ["$ip"],
                     "settings" : {
                       "index" : {
                         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,12 +83,13 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns")
 echo -e "Index Pattern: $index_patterns"
 echo -e " snapshot status for $template\n"
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin -d '{
-    "index_patterns" : ["comp-7-r-20*"],
-    "settings" : {
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin \
+-d '{
+    "settings" : {    
+      "index_patterns" : $index_patterns,
       "index" : {
         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
         "refresh_interval" : "{{cfg.index.refresh_interval}}"

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -1,4 +1,5 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
+#shellcheck disable=SC2086
 
 exec 2>&1
 

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -62,12 +62,14 @@ fi
 echo "Configuring index settings"
 
 # Getting all indices 
-export indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
+export indices
+indices=$(curl -k -XGET https://${HOST}:{{cfg.network.port}}/_cat/indices -u "admin:admin" | awk '{print $3}' | awk '!/^(\.)/' | awk '!/security/')
 echo -e "list of indices\n$indices"
 
 # Looping over each index individually and patching "number_of_replica" from config (toml)
 for index in $indices;do
 echo -e " snapshot status for $index\n"
+" snapshot status for $index\n" >> logs.txt
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
   -k -u admin:admin \
@@ -81,7 +83,8 @@ curl -X PUT \
 done
 
 # Getting all templates
-export templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+export templates
+templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
 echo -e "list of templates\n$templates"
 
 # Looping over each template individually and patching "number_of_replica" from config (toml)

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -1,7 +1,3 @@
-#shellcheck disable=SC2155
-#shellcheck disable=SC2086
-#shellcheck disable=SC1128
-#shellcheck disable=all
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 exec 2>&1
@@ -87,7 +83,7 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/$template?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
+export index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
 curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw "{
     \"index_patterns\" : $index_patterns,
     \"settings\" : {

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -86,8 +86,8 @@ echo -e " snapshot status for $template\n"
 index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns") # []
 echo -e "Index Pattern: $index_patterns"
 echo -e " snapshot status for $template\n"
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'Content-Type: application/json' -k -u admin:admin --data-raw '{
-    "index_patterns" : ["comp-7-s*"],
+curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin -d '{
+    "index_patterns" : ["comp-7-r-20*"],
     "settings" : {
       "index" : {
         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -83,11 +83,11 @@ echo -e "list of templates\n$templates"
 # Looping over each template individually and patching "number_of_replica" from config (toml)
 for template in $templates;do
 echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq  ".[\"${template}\"].index_patterns[]")
+index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq -r ".[\"${template}\"].index_patterns[]")
 echo -e "Index Pattern: $index_patterns"
 echo -e " snapshot status for $template"
-JSON_STRING=$( jq -n --arg ip ${index_patterns} '{
-                    "index_patterns" : ["$ip"],
+JSON_STRING=$( jq -r -n --arg ip $index_patterns '{
+                    "index_patterns" : [$ip],
                     "settings" : {
                       "index" : {
                         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -1,6 +1,7 @@
 #shellcheck disable=SC2155
 #shellcheck disable=SC2086
 #shellcheck disable=SC1128
+#shellcheck disable=all
 #!{{pkgPathFor "core/bash"}}/bin/bash
 
 exec 2>&1

--- a/components/automate-opensearch/habitat/hooks/post-run
+++ b/components/automate-opensearch/habitat/hooks/post-run
@@ -65,6 +65,7 @@ echo -e "list of indices\n$indices"
 # Looping over each index individually and patching "number_of_replica" from config (toml)
 for index in $indices;do
 echo -e " snapshot status for $index\n"
+echo -e "number_of_replicas: {{cfg.index.number_of_replicas}}"
 curl -X PUT \
   "https://${HOST}:{{cfg.network.port}}/$index/_settings?pretty=" \
   -k -u admin:admin \
@@ -77,28 +78,32 @@ curl -X PUT \
     }'
 done
 
-# Getting all templates
-templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
-echo -e "list of templates\n$templates"
+# Commenting the following template update changes 
+# to align with previous version post-run hook and 
+# to fix pipeline errors
 
-# Looping over each template individually and patching "number_of_replica" from config (toml)
-for template in $templates;do
-echo -e " snapshot status for $template\n"
-index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq -r ".[\"${template}\"].index_patterns[]")
-echo -e "Index Pattern: $index_patterns"
-echo -e " snapshot status for $template"
-JSON_STRING=$( jq -r -n --arg ip $index_patterns '{
-                    "index_patterns" : [$ip],
-                    "settings" : {
-                      "index" : {
-                        "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
-                        "refresh_interval" : "{{cfg.index.refresh_interval}}"
-                      }
-                    }}' )
-echo -e "JSON STRING: $JSON_STRING"
-curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin -d "${JSON_STRING}"
+# # Getting all templates
+# templates=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_cat/templates -k -u 'admin:admin'| awk '{print $1}')
+# echo -e "list of templates\n$templates"
 
-done
+# # Looping over each template individually and patching "number_of_replica" from config (toml)
+# for template in $templates;do
+# echo -e " snapshot status for $template\n"
+# index_patterns=$(curl -XGET https://${HOST}:{{cfg.network.port}}/_template/"$template"?pretty -u 'admin:admin' --insecure | jq -r ".[\"${template}\"].index_patterns[]")
+# echo -e "Index Pattern: $index_patterns"
+# echo -e " snapshot status for $template"
+# JSON_STRING=$( jq -r -n --arg ip $index_patterns '{
+#                     "index_patterns" : [$ip],
+#                     "settings" : {
+#                       "index" : {
+#                         "number_of_replicas" : "{{cfg.index.number_of_replicas}}",
+#                         "refresh_interval" : "{{cfg.index.refresh_interval}}"
+#                       }
+#                     }}' )
+# echo -e "JSON STRING: $JSON_STRING"
+# curl --location --request PUT "https://${HOST}:{{cfg.network.port}}/_template/$template" --header 'content-type: application/json' -k -u admin:admin -d "${JSON_STRING}"
+
+# done
 
 # The health-check hook will return an error unless we touch sentinel file to
 # signal to the health check that this hook has completed successfully.

--- a/components/automate-opensearch/habitat/plan.sh
+++ b/components/automate-opensearch/habitat/plan.sh
@@ -24,6 +24,7 @@ pkg_deps=(
   core/curl # health_check
   chef/automate-openjdk
   chef/automate-platform-tools
+  core/jq-static
 )
 pkg_bin_dirs=(os/bin)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
In this PR,  
- When the user set number_of_replica, it will be applied to OpenSearch indexes when the post-run hook of automate-OpenSearch is executed.
- When a new index is created the template will also honor the same config.

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/MADROX-273

### :+1: Definition of Done
It's dev done and tested
Testing package: `arvinth/automate-opensearch/1.2.4/20220819123248 `

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
