### PR TITLE
Addition of Default  Config applied for Opensearch after major Upgrade 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -503,28 +503,31 @@ func GetPendingPostChecklist(version string) ([]string, error) {
 	return []string{}, nil
 }
 
-func GetopenSearchConfig() error {
+func GetopenSearchConfig() {
 	res, err := client.GetAutomateConfig(configCmdFlags.timeout)
 	if err != nil {
-		return nil
+		return
 	}
 
 	con := res.Config.GetOpensearch()
-	opensearchV1 := &OpenSearch_v1{
-		V1: con.V1,
-	}
-	opensearchModel := &OpenSearchModel{
-		Opensearch: opensearchV1,
-	}
-	t, err := toml.Marshal(opensearchModel)
-	if err != nil {
-		return nil
+	if con != nil {
+		opensearchV1 := &OpenSearch_v1{
+			V1: con.V1,
+		}
+		opensearchModel := &OpenSearchModel{
+			Opensearch: opensearchV1,
+		}
+		t, err := toml.Marshal(opensearchModel)
+		if err != nil {
+			return
+		}
+
+		fmt.Println("This is your OpenSearch Config")
+		fmt.Println(string(t))
+
 	}
 
-	fmt.Println("This is your OpenSearch Config")
-	fmt.Println(string(t))
-
-	return nil
+	return
 }
 
 type OpenSearchModel struct {

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -24,7 +24,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 var upgradeRunCmdFlags = struct {
-	airgap               string
+	airgapsss            string
 	version              string
 	upgradefrontends     bool
 	upgradebackends      bool

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -510,13 +510,13 @@ func GetopenSearchConfig() error {
 	}
 
 	con := res.Config.GetOpensearch()
-	opensearch_v1 := &OpenSearch_v1{
+	opensearchV1 := &OpenSearch_v1{
 		V1: con.V1,
 	}
-	opensearch_model := &OpenSearchModel{
-		Opensearch: opensearch_v1,
+	opensearchModel := &OpenSearchModel{
+		Opensearch: opensearchV1,
 	}
-	t, err := toml.Marshal(opensearch_model)
+	t, err := toml.Marshal(opensearchModel)
 	if err != nil {
 		return nil
 	}

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -521,7 +521,7 @@ func GetopenSearchConfig() {
 			return
 		}
 
-		writer.Println("This is your current OpenSearch Config")
+		writer.Println("This is your OpenSearch Config")
 		writer.Println(string(t))
 
 	}

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -521,7 +521,7 @@ func GetopenSearchConfig() {
 			return
 		}
 
-		writer.Println("This is your OpenSearch Config")
+		writer.Println("This is your current OpenSearch Config")
 		writer.Println(string(t))
 
 	}

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -522,8 +521,8 @@ func GetopenSearchConfig() {
 			return
 		}
 
-		fmt.Println("This is your OpenSearch Config")
-		fmt.Println(string(t))
+		writer.Println("This is your OpenSearch Config")
+		writer.Println(string(t))
 
 	}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In this PR,

- When a user is on Automate 3.x with embedded Elastic Search, when upgraded to Automate 4.x with embedded Open Search, then in Post Upgrade steps the applied config of Open Search should be shown

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/MADROX-275

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="865" alt="Screenshot 2022-08-24 at 5 14 17 PM" src="https://user-images.githubusercontent.com/98522106/186410471-a6ff68f2-e8bb-4dda-b780-854408c4fdb5.png">



https://user-images.githubusercontent.com/98522106/186878507-a6045a80-3bef-423d-bafa-c085f6fecbcf.mp4




