### PR TITLE
Handled duplicate empty key errors on report ingestion

### DIFF
--- a/components/compliance-service/ingest/server/compliance.go
+++ b/components/compliance-service/ingest/server/compliance.go
@@ -3,10 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"regexp"
 	"time"
 
 	"github.com/chef/automate/api/interservice/report_manager"
@@ -26,6 +24,7 @@ import (
 	ingest_api "github.com/chef/automate/api/interservice/compliance/ingest/ingest"
 	automate_event "github.com/chef/automate/api/interservice/event"
 	"github.com/chef/automate/api/interservice/nodemanager/manager"
+	"github.com/chef/automate/components/automate-gateway/gateway"
 	"github.com/chef/automate/components/compliance-service/ingest/ingestic"
 	"github.com/chef/automate/components/compliance-service/ingest/pipeline"
 	"github.com/chef/automate/components/notifications-client/notifier"
@@ -139,9 +138,9 @@ func (s *ComplianceIngestServer) ProcessComplianceReport(stream ingest_api.Compl
 		return err
 	}
 
-	// start1 := time.Now()
-	// gateway.ParseBytesToComplianceReport(jsonBytes)
-	// fmt.Println("::::::: old approach time taken", time.Since(start1))
+	start1 := time.Now()
+	in := gateway.ParseBytesToComplianceReport(jsonBytes)
+	fmt.Println("::::::: old approach time taken", time.Since(start1))
 
 	// in := &compliance.Report{}
 	// start2 := time.Now()
@@ -152,25 +151,25 @@ func (s *ComplianceIngestServer) ProcessComplianceReport(stream ingest_api.Compl
 	// }
 	// fmt.Println("received report ::::::::::::: 22222222222", in.GetProfiles()[0].GetAttributes()[0].Options.Fields["filesystem"], time.Since(start2))
 
-	in := &compliance.Report{}
-	re := regexp.MustCompile(`""\s*:`)
-	bb := bytes.Buffer{}
+	// in := &compliance.Report{}
+	// re := regexp.MustCompile(`""\s*:`)
+	// bb := bytes.Buffer{}
 
-	t := time.Now()
-	split := re.Split(string(jsonBytes), -1)
+	// t := time.Now()
+	// split := re.Split(string(jsonBytes), -1)
 
-	for i := range split {
-		if i < len(split)-1 {
-			bb.WriteString(split[i] + fmt.Sprintf(`"unknown-%d":`, i))
-		} else {
-			bb.WriteString(split[i])
-		}
-	}
-	err = json.Unmarshal(bb.Bytes(), &in)
-	if err != nil {
-		return fmt.Errorf("error in converting report bytes to compliance report struct: %w", err)
-	}
-	fmt.Println("::::::: new approach time taken", time.Since(t))
+	// for i := range split {
+	// 	if i < len(split)-1 {
+	// 		bb.WriteString(split[i] + fmt.Sprintf(`"unknown-%d":`, i))
+	// 	} else {
+	// 		bb.WriteString(split[i])
+	// 	}
+	// }
+	// err = json.Unmarshal(bb.Bytes(), &in)
+	// if err != nil {
+	// 	return fmt.Errorf("error in converting report bytes to compliance report struct: %w", err)
+	// }
+	// fmt.Println("::::::: new approach time taken", time.Since(t))
 
 	err = SendComplianceReport(context.Background(), in, s)
 	if err != nil {

--- a/components/compliance-service/ingest/server/compliance.go
+++ b/components/compliance-service/ingest/server/compliance.go
@@ -3,8 +3,10 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"github.com/chef/automate/api/interservice/report_manager"
@@ -24,7 +26,6 @@ import (
 	ingest_api "github.com/chef/automate/api/interservice/compliance/ingest/ingest"
 	automate_event "github.com/chef/automate/api/interservice/event"
 	"github.com/chef/automate/api/interservice/nodemanager/manager"
-	"github.com/chef/automate/components/automate-gateway/gateway"
 	"github.com/chef/automate/components/compliance-service/ingest/ingestic"
 	"github.com/chef/automate/components/compliance-service/ingest/pipeline"
 	"github.com/chef/automate/components/notifications-client/notifier"
@@ -138,9 +139,9 @@ func (s *ComplianceIngestServer) ProcessComplianceReport(stream ingest_api.Compl
 		return err
 	}
 
-	start1 := time.Now()
-	in := gateway.ParseBytesToComplianceReport(jsonBytes)
-	fmt.Println("::::::: old approach time taken", time.Since(start1))
+	// start1 := time.Now()
+	// gateway.ParseBytesToComplianceReport(jsonBytes)
+	// fmt.Println("::::::: old approach time taken", time.Since(start1))
 
 	// in := &compliance.Report{}
 	// start2 := time.Now()
@@ -151,25 +152,25 @@ func (s *ComplianceIngestServer) ProcessComplianceReport(stream ingest_api.Compl
 	// }
 	// fmt.Println("received report ::::::::::::: 22222222222", in.GetProfiles()[0].GetAttributes()[0].Options.Fields["filesystem"], time.Since(start2))
 
-	// in := &compliance.Report{}
-	// re := regexp.MustCompile(`""\s*:`)
-	// bb := bytes.Buffer{}
+	in := &compliance.Report{}
+	re := regexp.MustCompile(`""\s*:`)
+	bb := bytes.Buffer{}
 
-	// t := time.Now()
-	// split := re.Split(string(jsonBytes), -1)
+	t := time.Now()
+	split := re.Split(string(jsonBytes), -1)
 
-	// for i := range split {
-	// 	if i < len(split)-1 {
-	// 		bb.WriteString(split[i] + fmt.Sprintf(`"unknown-%d":`, i))
-	// 	} else {
-	// 		bb.WriteString(split[i])
-	// 	}
-	// }
-	// err = json.Unmarshal(bb.Bytes(), &in)
-	// if err != nil {
-	// 	return fmt.Errorf("error in converting report bytes to compliance report struct: %w", err)
-	// }
-	// fmt.Println("::::::: new approach time taken", time.Since(t))
+	for i := range split {
+		if i < len(split)-1 {
+			bb.WriteString(split[i] + fmt.Sprintf(`"unknown-%d":`, i))
+		} else {
+			bb.WriteString(split[i])
+		}
+	}
+	err = json.Unmarshal(bb.Bytes(), &in)
+	if err != nil {
+		return fmt.Errorf("error in converting report bytes to compliance report struct: %w", err)
+	}
+	fmt.Println("::::::: new approach time taken", time.Since(t))
 
 	err = SendComplianceReport(context.Background(), in, s)
 	if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Compliance report ingestions were getting failed when properties had duplicate empty values. 
https://chefio.atlassian.net/browse/IN-835

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
