### PR TITLE
Fix/improve docs make commands

### DIFF
--- a/components/docs-chef-io/Makefile
+++ b/components/docs-chef-io/Makefile
@@ -25,8 +25,10 @@ chef_web_docs:
 		git clone https://github.com/chef/chef-web-docs.git; \
 	fi
 
-clean_all: clean_swagger_files
-	pushd chef-web-docs && make clean_all && popd
+clean:
+	rm -rf chef-web-docs
+
+clean_all: clean_swagger_files clean
 
 clean_swagger_files:
 	rm -rf ./$(SWAGGER_DIR)/*

--- a/components/docs-chef-io/Makefile
+++ b/components/docs-chef-io/Makefile
@@ -61,9 +61,9 @@ spellcheck:
 	@pushd ../.. > /dev/null; \
 		cspell \
 			"api/external/**/*.proto" \
-			"components/docs-chef-io/**/*.md" \
+			--exclude "components/docs-chef-io/chef-web-docs/**/*" "components/docs-chef-io/**/*.md" \
 			"components/docs-chef-io/data/automate/api-static/**/*" \
-			"components/docs-chef-io/layouts/**/*.html" \
+			"components/docs-chef-io/layouts/**/*.{html,md}" \
 			"components/automate-gateway/**/*.proto" \
 		; EXIT_CODE=$$?; \
 		popd > /dev/null; \


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Fix the `make spellcheck` command in `components/docs-chef-io`.

This will: 
- add md files in `components/docs-chef-io/layouts/`
- exclude any files from `components/docs-chef-io/chef-web-docs` (which are just cloned from chef/chef-web-docs)

We'll have a better and more relevant spellcheck output.

Also:
- simplify the `make clean_all` and add a `make clean` command

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
