### PR TITLE
docs migration A2HA to automate HA equivalent command addition

### DIFF
--- a/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
@@ -156,16 +156,12 @@ In Automate HA there are equivalent command which had been used in A2HA
 
 | Commands                   	| A2HA                                                          	|  Automate HA                                                                                                                  	|
 |----------------------------	|---------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|
-| init config aws            	| ```bash automate-cluster-ctl config init -a aws ```           	| ```bash chef-automate init-config-ha aws ```                                                                                  	|
 | init config existing infra 	| ```bash automate-cluster-ctl config init -a existing_nodes``` 	| ```bash chef-automate init-config-ha existing_infra ```                                                                       	|
-| provision                  	| ```bash automate-cluster-ctl provision ```                    	| ```bash chef-automate provision config.toml ```                                                                               	|
 | deploy                     	| ```bash automate-cluster-ctl deploy ```                       	| ```bash chef-automate deploy config.toml ```                                                                                  	|
 | info                       	| ```bash automate-cluster-ctl info ```                         	| ```bash chef-automate info ```                                                                                                	|
 | status                     	| ```bash chef-automate status ```                              	| ```bash chef-automate status ```                                                                                              	|
 | ssh                        	| ```bash automate-cluster-ctl ssh <name> ```                   	| ```bash chef-automate ssh --hostname <name> ```                                                                               	|
 | test                       	| ```bash automate-cluster-ctl test ```                         	| ```bash chef-automate test ```                                                                                                	|
-| patch                      	|                                                               	| To patch config in Automate HA, create a patch config.toml file, and run command  ```bash chef-automate patch config.toml ``` 	|
-| secret                     	| ```bash automate-cluster-clt secret init ```                  	| ```bash chef-automate secrets init ```                                                                                        	|
 | gather logs                	| ```bash automate-cluster-clt gather-logs ```                  	| ```bash chef-automate gather-logs ```                                                                                         	|
 | workspace                  	| ```bash automate-cluster-clt workspace ```                    	| ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```                                                            	|
 

--- a/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
@@ -154,22 +154,21 @@ This page explains migrating the existing A2HA data to the newly deployed Chef A
 ## Equivalent Commands
 In Automate HA there are equivalent command which had been used in A2HA
 
-| Commands                   	| A2HA                                                          	|  Automate HA                                                                                                                  	|   	|   	|
-|----------------------------	|---------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|---	|---	|
-| init config aws            	| ```bash automate-cluster-ctl config init -a aws ```           	| ```bash chef-automate init-config-ha aws ```                                                                                  	|   	|   	|
-| init config existing infra 	| ```bash automate-cluster-ctl config init -a existing_nodes``` 	| ```bash chef-automate init-config-ha existing_infra ```                                                                       	|   	|   	|
-| provision                  	| ```bash automate-cluster-ctl provision ```                    	| ```bash chef-automate provision config.toml ```                                                                               	|   	|   	|
-| deploy                     	| ```bash automate-cluster-ctl deploy ```                       	| ```bash chef-automate deploy config.toml ```                                                                                  	|   	|   	|
-| info                       	| ```bash automate-cluster-ctl info ```                         	| ```bash chef-automate info ```                                                                                                	|   	|   	|
-| status                     	| ```bash chef-automate status ```                              	| ```bash chef-automate status ```                                                                                              	|   	|   	|
-| ssh                        	| ```bash automate-cluster-ctl ssh <name> ```                   	| ```bash chef-automate ssh --hostname <name> ```                                                                               	|   	|   	|
-| test                       	| ```bash automate-cluster-ctl test ```                         	| ```bash chef-automate test ```                                                                                                	|   	|   	|
-| patch                      	|                                                               	| To patch config in Automate HA, create a patch config.toml file, and run command  ```bash chef-automate patch config.toml ``` 	|   	|   	|
-| secret                     	| ```bash automate-cluster-clt secret init ```                  	| ```bash chef-automate secrets init ```                                                                                        	|   	|   	|
-| gather logs                	| ```bash automate-cluster-clt gather-logs ```                  	| ```bash chef-automate gather-logs ```                                                                                         	|   	|   	|
-| workspace                  	| ```bash automate-cluster-clt workspace ```                    	| ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```                                                            	|   	|   	|
-|                            	|                                                               	|                                                                                                                               	|   	|   	|
-|                            	|                                                               	|                                                                                                                               	|   	|   	|
+| Commands                   	| A2HA                                                          	|  Automate HA                                                                                                                  	|
+|----------------------------	|---------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|
+| init config aws            	| ```bash automate-cluster-ctl config init -a aws ```           	| ```bash chef-automate init-config-ha aws ```                                                                                  	|
+| init config existing infra 	| ```bash automate-cluster-ctl config init -a existing_nodes``` 	| ```bash chef-automate init-config-ha existing_infra ```                                                                       	|
+| provision                  	| ```bash automate-cluster-ctl provision ```                    	| ```bash chef-automate provision config.toml ```                                                                               	|
+| deploy                     	| ```bash automate-cluster-ctl deploy ```                       	| ```bash chef-automate deploy config.toml ```                                                                                  	|
+| info                       	| ```bash automate-cluster-ctl info ```                         	| ```bash chef-automate info ```                                                                                                	|
+| status                     	| ```bash chef-automate status ```                              	| ```bash chef-automate status ```                                                                                              	|
+| ssh                        	| ```bash automate-cluster-ctl ssh <name> ```                   	| ```bash chef-automate ssh --hostname <name> ```                                                                               	|
+| test                       	| ```bash automate-cluster-ctl test ```                         	| ```bash chef-automate test ```                                                                                                	|
+| patch                      	|                                                               	| To patch config in Automate HA, create a patch config.toml file, and run command  ```bash chef-automate patch config.toml ``` 	|
+| secret                     	| ```bash automate-cluster-clt secret init ```                  	| ```bash chef-automate secrets init ```                                                                                        	|
+| gather logs                	| ```bash automate-cluster-clt gather-logs ```                  	| ```bash chef-automate gather-logs ```                                                                                         	|
+| workspace                  	| ```bash automate-cluster-clt workspace ```                    	| ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```                                                            	|
+
 
 ## Troubleshooting
 

--- a/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
@@ -151,6 +151,45 @@ This page explains migrating the existing A2HA data to the newly deployed Chef A
 
 {{< /warning >}}
 
+## Equivalent Commands
+In Automate HA there are equivalent command which had been used in A2HA
+
+Init Config Command
+```bash automate-cluster-ctl config init -a aws ``` will be ```bash chef-automate init-config-ha aws ```
+
+```bash automate-cluster-ctl config init -a ``` will be ```bash chef-automate init-config-ha existing_infra ```
+
+Provision Command
+```bash automate-cluster-ctl provision ``` will be ```bash chef-automate provision config.toml ```
+
+Deploy Command
+```bash automate-cluster-ctl deploy ``` will be ```bash chef-automate deploy config.toml ```
+
+Info Command
+```bash automate-cluster-ctl status ``` will be ```bash chef-automate status ```
+
+Info Command
+```bash automate-cluster-ctl ssh <name> ``` will be ```bash chef-automate ssh --hostname <name> ```
+
+Info Command
+```bash automate-cluster-ctl test ``` will be ```bash chef-automate test ```
+
+Patch Command
+To patch config in Automate HA, create a patch config.toml file, and run command 
+```bash chef-automate patch config.toml ```
+
+Secret Command
+```bash automate-cluster-clt secret init ``` will be ```bash chef-automate secrets init ```
+
+Gather logs Command
+```bash automate-cluster-clt gather-logs ``` will be ```bash chef-automate gather-logs ```
+
+Workspace Command
+```bash automate-cluster-clt workspace ``` will be ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```
+
+
+
+
 
 ## Troubleshooting
 

--- a/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
@@ -154,88 +154,22 @@ This page explains migrating the existing A2HA data to the newly deployed Chef A
 ## Equivalent Commands
 In Automate HA there are equivalent command which had been used in A2HA
 
-Init Config Command
-
-```bash automate-cluster-ctl config init -a aws ``` 
-
-will be 
-
-```bash chef-automate init-config-ha aws ``` 
-
-```bash automate-cluster-ctl config init -a ``` 
-
-will be 
-
-```bash chef-automate init-config-ha existing_infra ```
-
-Provision Command
-
-```bash automate-cluster-ctl provision ``` 
-
-will be 
-
-```bash chef-automate provision config.toml ```
-
-Deploy Command
-
-```bash automate-cluster-ctl deploy ``` 
-
-will be 
-
-```bash chef-automate deploy config.toml ```
-
-Info Command
-
-```bash automate-cluster-ctl status ``` 
-
-will be 
-
-```bash chef-automate status ```
-
-Info Command
-
-```bash automate-cluster-ctl ssh <name> ```
-
- will be 
- 
- ```bash chef-automate ssh --hostname <name> ```
-
-Info Command
-
-```bash automate-cluster-ctl test ``` 
-
-will be 
-
-```bash chef-automate test ```
-
-Patch Command
-To patch config in Automate HA, create a patch config.toml file, and run command 
-```bash chef-automate patch config.toml ```
-
-Secret Command
-```bash automate-cluster-clt secret init ``` 
-
-will be 
-
-```bash chef-automate secrets init ```
-
-Gather logs Command
-```bash automate-cluster-clt gather-logs ``` 
-
-will be 
-
-```bash chef-automate gather-logs ```
-
-Workspace Command
-```bash automate-cluster-clt workspace ``` 
-
-will be 
-
-```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```
-
-
-
-
+| Commands                   	| A2HA                                                          	|  Automate HA                                                                                                                  	|   	|   	|
+|----------------------------	|---------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------	|---	|---	|
+| init config aws            	| ```bash automate-cluster-ctl config init -a aws ```           	| ```bash chef-automate init-config-ha aws ```                                                                                  	|   	|   	|
+| init config existing infra 	| ```bash automate-cluster-ctl config init -a existing_nodes``` 	| ```bash chef-automate init-config-ha existing_infra ```                                                                       	|   	|   	|
+| provision                  	| ```bash automate-cluster-ctl provision ```                    	| ```bash chef-automate provision config.toml ```                                                                               	|   	|   	|
+| deploy                     	| ```bash automate-cluster-ctl deploy ```                       	| ```bash chef-automate deploy config.toml ```                                                                                  	|   	|   	|
+| info                       	| ```bash automate-cluster-ctl info ```                         	| ```bash chef-automate info ```                                                                                                	|   	|   	|
+| status                     	| ```bash chef-automate status ```                              	| ```bash chef-automate status ```                                                                                              	|   	|   	|
+| ssh                        	| ```bash automate-cluster-ctl ssh <name> ```                   	| ```bash chef-automate ssh --hostname <name> ```                                                                               	|   	|   	|
+| test                       	| ```bash automate-cluster-ctl test ```                         	| ```bash chef-automate test ```                                                                                                	|   	|   	|
+| patch                      	|                                                               	| To patch config in Automate HA, create a patch config.toml file, and run command  ```bash chef-automate patch config.toml ``` 	|   	|   	|
+| secret                     	| ```bash automate-cluster-clt secret init ```                  	| ```bash chef-automate secrets init ```                                                                                        	|   	|   	|
+| gather logs                	| ```bash automate-cluster-clt gather-logs ```                  	| ```bash chef-automate gather-logs ```                                                                                         	|   	|   	|
+| workspace                  	| ```bash automate-cluster-clt workspace ```                    	| ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```                                                            	|   	|   	|
+|                            	|                                                               	|                                                                                                                               	|   	|   	|
+|                            	|                                                               	|                                                                                                                               	|   	|   	|
 
 ## Troubleshooting
 

--- a/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_existing_a2ha_to_automate_ha.md
@@ -155,37 +155,83 @@ This page explains migrating the existing A2HA data to the newly deployed Chef A
 In Automate HA there are equivalent command which had been used in A2HA
 
 Init Config Command
-```bash automate-cluster-ctl config init -a aws ``` will be ```bash chef-automate init-config-ha aws ```
 
-```bash automate-cluster-ctl config init -a ``` will be ```bash chef-automate init-config-ha existing_infra ```
+```bash automate-cluster-ctl config init -a aws ``` 
+
+will be 
+
+```bash chef-automate init-config-ha aws ``` 
+
+```bash automate-cluster-ctl config init -a ``` 
+
+will be 
+
+```bash chef-automate init-config-ha existing_infra ```
 
 Provision Command
-```bash automate-cluster-ctl provision ``` will be ```bash chef-automate provision config.toml ```
+
+```bash automate-cluster-ctl provision ``` 
+
+will be 
+
+```bash chef-automate provision config.toml ```
 
 Deploy Command
-```bash automate-cluster-ctl deploy ``` will be ```bash chef-automate deploy config.toml ```
+
+```bash automate-cluster-ctl deploy ``` 
+
+will be 
+
+```bash chef-automate deploy config.toml ```
 
 Info Command
-```bash automate-cluster-ctl status ``` will be ```bash chef-automate status ```
+
+```bash automate-cluster-ctl status ``` 
+
+will be 
+
+```bash chef-automate status ```
 
 Info Command
-```bash automate-cluster-ctl ssh <name> ``` will be ```bash chef-automate ssh --hostname <name> ```
+
+```bash automate-cluster-ctl ssh <name> ```
+
+ will be 
+ 
+ ```bash chef-automate ssh --hostname <name> ```
 
 Info Command
-```bash automate-cluster-ctl test ``` will be ```bash chef-automate test ```
+
+```bash automate-cluster-ctl test ``` 
+
+will be 
+
+```bash chef-automate test ```
 
 Patch Command
 To patch config in Automate HA, create a patch config.toml file, and run command 
 ```bash chef-automate patch config.toml ```
 
 Secret Command
-```bash automate-cluster-clt secret init ``` will be ```bash chef-automate secrets init ```
+```bash automate-cluster-clt secret init ``` 
+
+will be 
+
+```bash chef-automate secrets init ```
 
 Gather logs Command
-```bash automate-cluster-clt gather-logs ``` will be ```bash chef-automate gather-logs ```
+```bash automate-cluster-clt gather-logs ``` 
+
+will be 
+
+```bash chef-automate gather-logs ```
 
 Workspace Command
-```bash automate-cluster-clt workspace ``` will be ```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```
+```bash automate-cluster-clt workspace ``` 
+
+will be 
+
+```bash chef-automate workspace [OPTIONS] SUBCOMMAND [ARG] ... ```
 
 
 


### PR DESCRIPTION
Signed-off-by: jayvikramsharma <jsharma@progress.com>

### Description

As an automate user when we migrate from  A2HA to Automat HA then I should be able to find equivalent command of A2HA in automate HA docs.


### :chains: Related Resources

https://chefio.atlassian.net/browse/MADROX-301

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
