### PR TITLE
sahithi/STALWART-203

### DIFF
--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -72,6 +72,27 @@ Otherwise, you may need to run "chef-automate dev start-converge".
 `
 
 func runUpgradeCmd(cmd *cobra.Command, args []string) error {
+	ci, err := majorupgradechecklist.NewChecklistManager(writer, "4")
+	if err != nil {
+		return status.Wrap(
+			err,
+			status.DeploymentServiceCallError,
+			"Request to start upgrade failed",
+		)
+	}
+
+	flags := majorupgradechecklist.ChecklistUpgradeFlags{
+		SkipStorageCheck: upgradeRunCmdFlags.skipStorageCheck,
+		OsDestDataDir:    upgradeRunCmdFlags.osDestDataDir,
+	}
+	err = ci.RunChecklist(configCmdFlags.timeout, flags)
+	if err != nil {
+		return status.Wrap(
+			err,
+			status.DeploymentServiceCallError,
+			"Request to start upgrade failed",
+		)
+	}
 	a1IsRunning, err := isA1Running()
 	if err != nil {
 		return status.Annotate(err, status.FileAccessError)

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -72,27 +72,6 @@ Otherwise, you may need to run "chef-automate dev start-converge".
 `
 
 func runUpgradeCmd(cmd *cobra.Command, args []string) error {
-	ci, err := majorupgradechecklist.NewChecklistManager(writer, "4")
-	if err != nil {
-		return status.Wrap(
-			err,
-			status.DeploymentServiceCallError,
-			"Request to start upgrade failed",
-		)
-	}
-
-	flags := majorupgradechecklist.ChecklistUpgradeFlags{
-		SkipStorageCheck: upgradeRunCmdFlags.skipStorageCheck,
-		OsDestDataDir:    upgradeRunCmdFlags.osDestDataDir,
-	}
-	err = ci.RunChecklist(configCmdFlags.timeout, flags)
-	if err != nil {
-		return status.Wrap(
-			err,
-			status.DeploymentServiceCallError,
-			"Request to start upgrade failed",
-		)
-	}
 	a1IsRunning, err := isA1Running()
 	if err != nil {
 		return status.Annotate(err, status.FileAccessError)

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -512,7 +512,7 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 	re := regexp.MustCompile(s3regex)
 
 	if re.MatchString(endpoint) {
-		resp, err := h.Writer.Confirm("Your Backup AWS S3 Endpoint will be changed from \"" + endpoint + "\" to \"https://s3.amazonaws.com\". This is changed due to changes from AWS side. Do you want to continue?")
+		resp, err := h.Writer.Confirm("Your Backup AWS S3 Endpoint will be changed from \"" + endpoint + "\" to \"https://s3.amazonaws.com\". This is changed due to changes from AWS side.For more details check the the blog url https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/. Do you want to Upgrade?")
 
 		if err != nil {
 			h.Writer.Error(err.Error())

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -512,16 +512,6 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 	re := regexp.MustCompile(s3regex)
 
 	if re.MatchString(endpoint) {
-		resp, err := h.Writer.Confirm("Your Backup AWS S3 Endpoint will be changed from \"" + endpoint + "\" to \"https://s3.amazonaws.com\". This is changed due to changes from AWS side.For more details check the the blog url https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/. Do you want to Upgrade?")
-
-		if err != nil {
-			h.Writer.Error(err.Error())
-			return status.Errorf(status.InvalidCommandArgsError, err.Error())
-		}
-
-		if !resp {
-			return nil
-		}
 
 		file, err := ioutil.TempFile("", filename) // nosemgrep
 		if err != nil {
@@ -538,8 +528,6 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 			h.Writer.Errorln("error in running automate patch command")
 			return nil
 		}
-
-		//h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))
 	}
 
 	return nil

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -542,7 +542,7 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 			return nil
 		}
 
-		// h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))
+		h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))
 	}
 
 	return nil

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type indexVersion struct {
@@ -207,9 +206,8 @@ func (ci *V4ChecklistManager) RunChecklist(timeout int64, flags ChecklistUpgrade
 	} else {
 		dbType = "Embedded"
 		postcheck = postChecklistV4Embedded
-		//checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
-		//	disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
-		checklists = append(checklists, []Checklist{replaceS3Url()}...)
+		checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
+			disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
 	}
 	checklists = append(checklists, showPostChecklist(&postcheck), promptUpgradeContinueV4(!ci.isExternalES))
 
@@ -505,7 +503,6 @@ func getHabRootPath(habrootcmd string) string {
 }
 
 func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
-	logrus.Infof("started replacing ...........")
 	res, err := client.GetAutomateConfig(int64(client.DefaultClientTimeout))
 	if err != nil {
 		h.Writer.Errorln("failed to get backup s3 url configuration: " + err.Error())
@@ -542,7 +539,7 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 			return nil
 		}
 
-		h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))
+		//h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))
 	}
 
 	return nil

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -18,6 +18,7 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type indexVersion struct {
@@ -206,8 +207,9 @@ func (ci *V4ChecklistManager) RunChecklist(timeout int64, flags ChecklistUpgrade
 	} else {
 		dbType = "Embedded"
 		postcheck = postChecklistV4Embedded
-		checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
-			disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
+		//checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
+		//	disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
+		checklists = append(checklists, []Checklist{replaceS3Url()}...)
 	}
 	checklists = append(checklists, showPostChecklist(&postcheck), promptUpgradeContinueV4(!ci.isExternalES))
 
@@ -503,6 +505,7 @@ func getHabRootPath(habrootcmd string) string {
 }
 
 func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
+	logrus.Infof("started replacing ...........")
 	res, err := client.GetAutomateConfig(int64(client.DefaultClientTimeout))
 	if err != nil {
 		h.Writer.Errorln("failed to get backup s3 url configuration: " + err.Error())

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -512,6 +512,17 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 	re := regexp.MustCompile(s3regex)
 
 	if re.MatchString(endpoint) {
+		resp, err := h.Writer.Confirm("Your Backup AWS S3 Endpoint will be changed from \"" + endpoint + "\" to \"https://s3.amazonaws.com\". This is changed due to changes from AWS side. Do you want to continue?")
+
+		if err != nil {
+			h.Writer.Error(err.Error())
+			return status.Errorf(status.InvalidCommandArgsError, err.Error())
+		}
+
+		if !resp {
+			return nil
+		}
+
 		file, err := ioutil.TempFile("", filename) // nosemgrep
 		if err != nil {
 			h.Writer.Errorln("could not create temp file" + err.Error())
@@ -526,18 +537,6 @@ func replaceAndPatchS3backupUrl(h ChecklistHelper) error {
 		if !strings.Contains(string(out), "Configuration patched") || err != nil {
 			h.Writer.Errorln("error in running automate patch command")
 			return nil
-		}
-
-		resp, err := h.Writer.Confirm("Your Backup AWS S3 Endpoint will be changed from \"" + endpoint + "\" to \"https://s3.amazonaws.com\". This is changed due to changes from AWS side. Do you want to continue?")
-
-		if err != nil {
-			h.Writer.Error(err.Error())
-			return status.Errorf(status.InvalidCommandArgsError, err.Error())
-		}
-
-		if !resp {
-			h.Writer.Error(s3UrlError)
-			return status.New(status.InvalidCommandArgsError, s3UrlError)
 		}
 
 		// h.Writer.Println(fmt.Sprintf(urlChangeMessage, endpoint))


### PR DESCRIPTION
Signed-off-by: SahithiMy <sahithi.mylangam@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Removed the CLI message when we use backup on S3.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-203

### :+1: Definition of Done

Removed the code for prompt when s3 url has been changed when we use backup on s3. 

### :athletic_shoe: How to Build and Test the Change
chef-automate upgrade run
chef-automate config show

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*
### :camera: Screenshots, if applicable



https://user-images.githubusercontent.com/98326242/190564658-9eb11940-06b5-43cf-a743-49940f69bc14.mp4


