### PR TITLE
Enabling/Disabling maintenance flag while upgrade and post-upgrade 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -265,6 +265,15 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 	} else if strings.ToLower(migrateDataCmdFlags.data) == "es" {
 		var isAvailableSpace bool
 		var err error
+
+		//Disabling  of the maintenance mode when staring for migration
+		writer.Println("Disabling the Maintenance mode")
+		out, err := exec.Command("/bin/sh", "-c", "chef-automate maintenance off").Output()
+		if !strings.Contains(string(out), "Updating deployment configuration") || err != nil {
+			writer.Error("Failed to disable the maintenance mode : " + err.Error() +
+				"/n/n Please disable it manually post migration using chef-automate maintenance off")
+		}
+
 		if migrateDataCmdFlags.check {
 			writer.Title("--check flag is not required for es-migation. \nPlease run the command without --check flag")
 			return nil

--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -266,7 +266,7 @@ func runMigrateDataCmd(cmd *cobra.Command, args []string) error {
 		var isAvailableSpace bool
 		var err error
 
-		//Disabling  of the maintenance mode when staring for migration
+		//Disabling  of the maintenance mode when starting for migration post-upgrade
 		writer.Println("Disabling the Maintenance mode")
 		out, err := exec.Command("/bin/sh", "-c", "chef-automate maintenance off").Output()
 		if !strings.Contains(string(out), "Updating deployment configuration") || err != nil {

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -64,6 +65,8 @@ var upgradeStatusCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(0),
 }
 
+const disableMaintenanceModeCmd = `chef-automate maintenance off`
+const disableMaintenanceModeMsg = `Please disable the maintenance mode to allow ingestion by using ` + disableMaintenanceModeCmd
 const a1RunningMsg = "You have a running Chef Automate v1 installation. Did you mean to type `chef-automate upgrade-from-v1` (alias for: `chef-automate migrate-from-v1`)?"
 const convergeDisabledWarning = `Converge is disabled. This will prevent Automate from upgrading.
 
@@ -179,6 +182,7 @@ func runUpgradeCmd(cmd *cobra.Command, args []string) error {
 			}
 			err = ci.RunChecklist(configCmdFlags.timeout, flags)
 			if err != nil {
+				exec.Command("/bin/sh", "-c", disableMaintenanceModeCmd).Output()
 				return status.Wrap(
 					err,
 					status.DeploymentServiceCallError,
@@ -343,10 +347,11 @@ func statusUpgradeCmd(cmd *cobra.Command, args []string) error {
 		VersionsPath: upgradeStatusCmdFlags.versionsPath,
 	})
 	if err != nil {
+		writer.Warn(disableMaintenanceModeMsg)
 		return status.Wrap(
 			err,
 			status.DeploymentServiceCallError,
-			"Request to get upgrade status failed",
+			fmt.Sprintf("Request to get upgrade status failed"),
 		)
 	}
 
@@ -428,7 +433,7 @@ func statusUpgradeCmd(cmd *cobra.Command, args []string) error {
 		return status.Wrap(
 			err,
 			status.DeploymentServiceCallError,
-			"Upgrade state could not be determined!",
+			fmt.Sprintf("Upgrade state could not be determined! /n/n %s", disableMaintenanceModeMsg),
 		)
 	}
 

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -209,9 +209,8 @@ func (ci *V4ChecklistManager) RunChecklist(timeout int64, flags ChecklistUpgrade
 	} else {
 		dbType = "Embedded"
 		postcheck = postChecklistV4Embedded
-		/*checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
-		disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)*/
-		checklists = append(checklists, []Checklist{downTimeCheckV4()}...)
+		checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
+			disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
 	}
 	checklists = append(checklists, showPostChecklist(&postcheck), promptUpgradeContinueV4(!ci.isExternalES))
 


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

A prompt is giving to the user is they are ready to put automate in maintenance mode while starting the upgrade. 

When the user run 'post-upgrade migration' command we disable the maintenance mode.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/jira/software/c/projects/STALWART/boards/361?modal=detail&selectedIssue=STALWART-202

### :+1: Definition of Done

1. Enable the maintenance mode as a part of checklist
2. if some errors occurs while having checklist, if the user has already enabled the maintenance mode disable it
3. If some errors occurs while upgrading, a warning is shown to disable the mode.
4. At the time of starting post-upgrade step, disable the maintenance mode.

### :athletic_shoe: How to Build and Test the Change
1. Deploy chef-automate using new bin
2. Start the upgrade process
``` chef-automate config show ```
4. Run Post Upgrade step

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
