### PR TITLE
Disk space check moved to start of upgrade

### DIFF
--- a/components/automate-cli/cmd/chef-automate/migration_pg.go
+++ b/components/automate-cli/cmd/chef-automate/migration_pg.go
@@ -201,7 +201,7 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 }
 
 func checkSpaceAvailable(dataDir string) (bool, error) {
-	return majorupgradechecklist.CheckSpaceAvailable(true, dataDir, nil, "", false, "")
+	return majorupgradechecklist.CheckSpaceAvailable(true, dataDir, "", false, "")
 }
 
 func runMigrateDataCmd(cmd *cobra.Command, args []string) error {

--- a/components/automate-cli/pkg/status/error.go
+++ b/components/automate-cli/pkg/status/error.go
@@ -49,6 +49,10 @@ const (
 // When an invocation of the chef-automate CLI results in a Failure it exits with
 // one of the following codes that identifies the error types.
 const (
+	InsufficientSpaceError            = 122
+	CalDestDirSizeError               = 121
+	CalESDirSizeError                 = 120
+	AvailableSpaceError               = 119
 	InappropriateSettingError         = 118
 	RestartDeploymentServiceError     = 117
 	IAMResetV1DatabaseError           = 116
@@ -96,6 +100,10 @@ const (
 // an error code and its type and a description, but also as a way to generate
 // documentation.
 var ErrorMetadata = map[int][]string{
+	InsufficientSpaceError:            {"122", "InsufficientSpaceError", "Insufficient disk space"},
+	CalDestDirSizeError:               {"121", "CalDestDirSizeError", "Error in calculating Dest directory size"},
+	CalESDirSizeError:                 {"120", "CalESDirSizeError", "Error in calculating ES directory size"},
+	AvailableSpaceError:               {"119", "AvailableSpaceError", "Error in getting available space"},
 	InappropriateSettingError:         {"118", "InappropriateSettingError", "Settings are not appropriate"},
 	RestartDeploymentServiceError:     {"117", "DeploymentServiceError", "Failed to restart Deployment Service"},
 	IAMResetV1DatabaseError:           {"116", "UnknownError", "Failed to reset IAM state to v1"},

--- a/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
@@ -90,15 +90,6 @@ func CheckSpaceAvailable(isMigration bool, dbDataPath string, writer cli.FormatW
 		return false, status.Errorf(status.UnknownError, err.Error())
 	}
 
-	// If (/hab) dir size is less than 5GB, then throw error
-	// habSpaceAvailable, err := cm.CheckSpaceAvailability(habRootPath, MIN_DIRSIZE_GB)
-	// if err != nil || !habSpaceAvailable {
-	// 	if writer != nil {
-	// 		writer.Errorln(fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space", habRootPath, MIN_DIRSIZE_GB))
-	// 	}
-	// 	return false, status.New(status.UnknownError, fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space.", habRootPath, MIN_DIRSIZE_GB))
-	// }
-
 	if !isMigration {
 		version, _ = GetMajorVersion(version)
 		switch version {

--- a/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
@@ -15,6 +15,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	MIN_DIRSIZE_GB float64 = 5
+
+	DISKSPACE_CHECK_ERROR = `You do not have minimum space available to continue with this %s. 
+Please ensure you have %.2f GB free disk space.
+To skip this free disk space check please use --skip-storage-check flag.`
+)
+
 type Checklist struct {
 	Name        string
 	Description string

--- a/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
@@ -117,16 +117,6 @@ func CheckSpaceAvailable(isMigration bool, dbDataPath string, writer cli.FormatW
 		if osDestDataDir != "" {
 			destDir = osDestDataDir
 		}
-		if writer != nil {
-			resp, err := writer.Confirm(fmt.Sprintf("Ensure destination directory (%s) is having min. %.2f GB free space ?", destDir, minReqDiskSpace))
-			if err != nil {
-				writer.Error(err.Error())
-				return false, status.Errorf(status.UnknownError, err.Error())
-			}
-			if !resp {
-				return false, status.New(status.UnknownError, fmt.Sprintf(diskSpaceError, minReqDiskSpace))
-			}
-		}
 		diskSpaceErrorType = "upgrade"
 	}
 

--- a/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
@@ -91,13 +91,13 @@ func CheckSpaceAvailable(isMigration bool, dbDataPath string, writer cli.FormatW
 	}
 
 	// If (/hab) dir size is less than 5GB, then throw error
-	habSpaceAvailable, err := cm.CheckSpaceAvailability(habRootPath, MIN_DIRSIZE_GB)
-	if err != nil || !habSpaceAvailable {
-		if writer != nil {
-			writer.Errorln(fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space", habRootPath, MIN_DIRSIZE_GB))
-		}
-		return false, status.New(status.UnknownError, fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space.", habRootPath, MIN_DIRSIZE_GB))
-	}
+	// habSpaceAvailable, err := cm.CheckSpaceAvailability(habRootPath, MIN_DIRSIZE_GB)
+	// if err != nil || !habSpaceAvailable {
+	// 	if writer != nil {
+	// 		writer.Errorln(fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space", habRootPath, MIN_DIRSIZE_GB))
+	// 	}
+	// 	return false, status.New(status.UnknownError, fmt.Sprintf("Hab (%s) directory should have more than %.2fGB free space.", habRootPath, MIN_DIRSIZE_GB))
+	// }
 
 	if !isMigration {
 		version, _ = GetMajorVersion(version)

--- a/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/upgrade_utils.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
+	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
@@ -21,6 +21,10 @@ const (
 	DISKSPACE_CHECK_ERROR = `You do not have minimum space available to continue with this %s. 
 Please ensure you have %.2f GB free disk space.
 To skip this free disk space check please use --skip-storage-check flag.`
+	HAB_DIR                  = "/hab"
+	HAB_5GB_FREE_SPACE_ERROR = "\n  - /hab/ directory should have more than 5GB free space"
+	DIR_FREE_SPACE_ERROR     = "\n  - %s directory should have more than %.2fGB free space"
+	DEST_FLAG_INFO           = "%s\nDestination directory chosen to check free disk space: %s\nTo change destination directory please use --os-dest-data-dir flag"
 )
 
 type Checklist struct {
@@ -79,17 +83,12 @@ func IsExternalElasticSearch() bool {
 	return res.Config.GetGlobal().GetV1().GetExternal().GetElasticsearch().GetEnable().GetValue()
 }
 
-func CheckSpaceAvailable(isMigration bool, dbDataPath string, writer cli.FormatWriter, version string, skipStorageCheck bool, osDestDataDir string) (bool, error) {
-	habRootPath := getHabRootPath(habrootcmd)
-	habDirSize, err := cm.CalDirSizeInGB(habRootPath)
+func CheckSpaceAvailable(isMigration bool, dbDataPath string, version string, skipStorageCheck bool, osDestDataDir string) (bool, error) {
 
-	if err != nil {
-		if writer != nil {
-			writer.Error(err.Error())
-		}
-		return false, status.Errorf(status.UnknownError, err.Error())
+	if skipStorageCheck {
+		return true, nil
 	}
-
+	habRootPath := getHabRootPath(habrootcmd)
 	if !isMigration {
 		version, _ = GetMajorVersion(version)
 		switch version {
@@ -99,36 +98,41 @@ func CheckSpaceAvailable(isMigration bool, dbDataPath string, writer cli.FormatW
 			dbDataPath = habRootPath + "svc/automate-elasticsearch/data"
 		}
 	}
-
-	dbDataSize, err := cm.CalDirSizeInGB(dbDataPath)
+	habFreeSpace, err := cm.GetFreeSpaceinGB(habRootPath)
 	if err != nil {
-		if writer != nil {
-			writer.Error(err.Error())
-		}
-		return false, status.Errorf(status.UnknownError, err.Error())
+		return false, status.Errorf(status.AvailableSpaceError, err.Error())
 	}
-
-	minReqDiskSpace := math.Max(MIN_DIRSIZE_GB, math.Max(habDirSize, dbDataSize)) * 11 / 10
-
-	diskSpaceErrorType := "migration"
+	sizeESDir, err := cm.CalDirSizeInGB(dbDataPath)
+	if err != nil {
+		return false, status.Errorf(status.CalESDirSizeError, err.Error())
+	}
 	destDir := habRootPath
+	eSDirSizeWithBuffer := sizeESDir * 11 / 10
+	message := ""
+	isDestDirFlag := len(strings.TrimSpace(osDestDataDir)) > 0
 
-	if !isMigration {
-		if osDestDataDir != "" {
-			destDir = osDestDataDir
+	if isDestDirFlag && osDestDataDir != HAB_DIR {
+		destDir = osDestDataDir
+		sizeDestDir, err := cm.GetFreeSpaceinGB(osDestDataDir)
+		if err != nil {
+			return false, status.Errorf(status.CalDestDirSizeError, err.Error())
 		}
-		diskSpaceErrorType = "upgrade"
+		if habFreeSpace < MIN_DIRSIZE_GB {
+			message = HAB_5GB_FREE_SPACE_ERROR
+		}
+		if sizeDestDir < eSDirSizeWithBuffer {
+			message += fmt.Sprintf(DIR_FREE_SPACE_ERROR, osDestDataDir, eSDirSizeWithBuffer)
+		}
+	} else {
+		if habFreeSpace < MIN_DIRSIZE_GB+eSDirSizeWithBuffer {
+			message = fmt.Sprintf(DIR_FREE_SPACE_ERROR, habRootPath, MIN_DIRSIZE_GB+eSDirSizeWithBuffer)
+		}
 	}
-
-	if !skipStorageCheck {
-		if !isMigration && writer != nil {
-			writer.Printf("Destination directory chosen to check free disk space: %s\n", destDir)
-			writer.Println("To change destination directory please use --os-dest-data-dir flag")
+	if message != "" {
+		if !isMigration && isDestDirFlag {
+			message = fmt.Sprintf(DEST_FLAG_INFO, message, destDir)
 		}
-		spaceAvailable, err := cm.CheckSpaceAvailability(destDir, minReqDiskSpace)
-		if err != nil || !spaceAvailable {
-			return false, status.New(status.UnknownError, fmt.Sprintf(DISKSPACE_CHECK_ERROR, diskSpaceErrorType, minReqDiskSpace))
-		}
+		return false, status.Errorf(status.InsufficientSpaceError, message)
 	}
 	return true, nil
 }

--- a/components/automate-deployment/pkg/majorupgradechecklist/v3.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v3.go
@@ -167,7 +167,7 @@ func (ci *V3ChecklistManager) RunChecklist(timeout int64, flags ChecklistUpgrade
 	} else {
 		dbType = "Embedded"
 		postcheck = postChecklistEmbedded
-		checklists = append(checklists, []Checklist{downTimeCheck(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir), postChecklistIntimationCheck()}...)
+		checklists = append(checklists, []Checklist{diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir), downTimeCheck(), backupCheck(), replaceS3Url(), postChecklistIntimationCheck()}...)
 	}
 	checklists = append(checklists, showPostChecklist(&postcheck), promptUpgradeContinue())
 

--- a/components/automate-deployment/pkg/majorupgradechecklist/v3.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v3.go
@@ -59,11 +59,6 @@ Now, upgrade will start, Please confirm to continue...`
 Post Upgrade Steps:
 ===================
 `
-	MIN_DIRSIZE_GB float64 = 5
-
-	DISKSPACE_CHECK_ERROR = `You do not have minimum space available to continue with this %s. 
-Please ensure you have %.2f GB free disk space.
-To skip this free disk space check please use --skip-storage-check flag.`
 )
 
 var postChecklistEmbedded = []PostCheckListItem{

--- a/components/automate-deployment/pkg/majorupgradechecklist/v3.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v3.go
@@ -63,7 +63,7 @@ Post Upgrade Steps:
 
 	DISKSPACE_CHECK_ERROR = `You do not have minimum space available to continue with this %s. 
 Please ensure you have %.2f GB free disk space.
-To skip this free disk space check please use --skip-storage-check flag`
+To skip this free disk space check please use --skip-storage-check flag.`
 )
 
 var postChecklistEmbedded = []PostCheckListItem{

--- a/components/automate-deployment/pkg/majorupgradechecklist/v3.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v3.go
@@ -247,7 +247,7 @@ func diskSpaceCheck(version string, skipStorageCheck bool, osDestDataDir string)
 		Name:        "disk_space_acceptance",
 		Description: "confirmation check for disk space",
 		TestFunc: func(h ChecklistHelper) error {
-			_, err := CheckSpaceAvailable(false, "", h.Writer, version, skipStorageCheck, osDestDataDir)
+			_, err := CheckSpaceAvailable(false, "", version, skipStorageCheck, osDestDataDir)
 			return err
 		},
 	}

--- a/components/automate-deployment/pkg/majorupgradechecklist/v4.go
+++ b/components/automate-deployment/pkg/majorupgradechecklist/v4.go
@@ -203,7 +203,7 @@ func (ci *V4ChecklistManager) RunChecklist(timeout int64, flags ChecklistUpgrade
 	} else {
 		dbType = "Embedded"
 		postcheck = postChecklistV4Embedded
-		checklists = append(checklists, []Checklist{storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(), diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir),
+		checklists = append(checklists, []Checklist{diskSpaceCheck(ci.version, flags.SkipStorageCheck, flags.OsDestDataDir), storeSearchEngineSettings(), deleteA1Indexes(timeout), deleteStaleIndices(timeout), downTimeCheckV4(), backupCheck(), replaceS3Url(),
 			disableSharding(), postChecklistIntimationCheckV4(!ci.isExternalES)}...)
 	}
 	checklists = append(checklists, showPostChecklist(&postcheck), promptUpgradeContinueV4(!ci.isExternalES))

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -52,13 +52,20 @@ func CalDirSizeInGB(path string) (float64, error) {
 }
 
 func CheckSpaceAvailability(dir string, minSpace float64) (bool, error) {
-	v, err := sys.SpaceAvailForPath(dir)
+	dirSpaceInGB, err := GetFreeSpaceinGB(dir)
 	if err != nil {
 		return false, err
 	}
-	dirSpaceInGB := float64(v) / (1024 * 1024)
 	if minSpace <= dirSpaceInGB {
 		return true, nil
 	}
 	return false, nil
+}
+
+func GetFreeSpaceinGB(dir string) (float64, error) {
+	v, err := sys.SpaceAvailForPath(dir)
+	if err != nil {
+		return -1, err
+	}
+	return float64(v) / (1024 * 1024), nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
```
A= find free space in hab
B= find es dir size


if flag is given and dir != "hab", 
    C = find new flag dir free space;
    C should be greater than (B + 10% of B);
     and A should be greater than 5 GB

if no flag;
    A should be greater than 5+(B + 10% of B)GB
```
### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

<img width="1466" alt="Screenshot 2022-09-19 at 2 34 14 PM" src="https://user-images.githubusercontent.com/59958706/190985297-02f0728f-72cf-4597-bf37-53c474d671ee.png">

