### PR TITLE
Update airgap bundle expiry days

### DIFF
--- a/components/docs-chef-io/content/automate/airgapped_installation.md
+++ b/components/docs-chef-io/content/automate/airgapped_installation.md
@@ -45,7 +45,7 @@ Download the bundle of a specific version using:
 curl https://packages.chef.io/airgap_bundle/current/automate/<version>.aib -o </path/to/airgap-install-bundle>
 ```
 
-{{< note >}} Chef Automate bundles are available for 60 days from the release of a version.  
+{{< note >}} Chef Automate bundles are available for 365 days from the release of a version.  
 However, the milestone release bundles are available for download forever.{{< /note >}}
 
 ## Create an Airgap Installation Bundle

--- a/components/docs-chef-io/content/automate/airgapped_installation.md
+++ b/components/docs-chef-io/content/automate/airgapped_installation.md
@@ -45,8 +45,7 @@ Download the bundle of a specific version using:
 curl https://packages.chef.io/airgap_bundle/current/automate/<version>.aib -o </path/to/airgap-install-bundle>
 ```
 
-{{< note >}} Chef Automate bundles are available for 365 days from the release of a version.  
-However, the milestone release bundles are available for download forever.{{< /note >}}
+{{< note >}} Chef Automate bundles are available for 365 days from the release of a version. However, the milestone release bundles are available for download forever.{{< /note >}}
 
 ## Create an Airgap Installation Bundle
 

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -66,7 +66,7 @@ Run the following steps on Bastion Host Machine:
    ```
 
    {{< note >}} 
-   Chef Automate bundles are available for 60 days from the release of a version. However, the milestone release bundles are available for download forever.
+   Chef Automate bundles are available for 365 days from the release of a version. However, the milestone release bundles are available for download forever.
    {{< /note >}}
 
 2. Update Config with relevant data. Click [here](/automate/ha_aws_deploy_steps/#sample-config) for sample config

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -67,7 +67,7 @@ Follow the steps below to deploy Chef Automate High Availability (HA) on AWS (Am
    ```
 
    {{< note >}} 
-   Chef Automate bundles are available for 60 days from the release of a version. However, the milestone release bundles are available for download forever.
+   Chef Automate bundles are available for 365 days from the release of a version. However, the milestone release bundles are available for download forever.
    {{< /note >}}
 
 2. Update Config with relevant data

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -72,7 +72,7 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
    ```
 
    {{< note >}} 
-   Chef Automate bundles are available for 60 days from the release of a version. However, the milestone release bundles are available for download forever.
+   Chef Automate bundles are available for 365 days from the release of a version. However, the milestone release bundles are available for download forever.
    {{< /note >}}
 
    Note: If Airgapped Bastion machine is different, then transfer Bundle file (`latest.aib`) and Chef Automate CLI binary (`chef-automate`) to the Airgapped Bastion Machine using `scp` command. \

--- a/components/docs-chef-io/content/automate/ha_upgrade_introduction.md
+++ b/components/docs-chef-io/content/automate/ha_upgrade_introduction.md
@@ -34,7 +34,7 @@ Steps to upgrade the Chef Automate HA are as shown below:
   ```
 
   {{< note >}} 
-  Chef Automate bundles are available for 60 days from the release of a version. However, the milestone release bundles are available for download forever.
+  Chef Automate bundles are available for 365 days from the release of a version. However, the milestone release bundles are available for download forever.
   {{< /note >}}
 
 - If we want to only upgrade FrontEnd Services i.e. Chef Automate and Chef Infra Server.


### PR DESCRIPTION
Signed-off-by: Kallol Roy <kallol.roy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Update the airgap bundle notice to read 
`Chef Automate bundles are available for 365 days from the release of a version.
However, the milestone release bundles are available for download forever.`

### :chains: Related Resources

### :+1: Definition of Done
- The netlify preview link should show the expiry date to be 365 days instead of 60 days

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
