### PR TITLE
Adding note for airgap bundle issue

### DIFF
--- a/components/docs-chef-io/content/automate/airgapped_installation.md
+++ b/components/docs-chef-io/content/automate/airgapped_installation.md
@@ -49,6 +49,21 @@ curl https://packages.chef.io/airgap_bundle/current/automate/<version>.aib -o </
 
 ## Create an Airgap Installation Bundle
 
+{{< note >}}
+In case,you are unable to create airgap bundle using 
+```shell
+./chef-automate airgap bundle create
+```
+you can create airgap bundle using 
+```shell
+./chef-automate airgap bundle create --version 3.0.49
+```
+or, you can download the airgap bundle directly using
+```shell
+curl https://packages.chef.io/airgap_bundle/current/automate/3.0.49.aib -o </path/to/airgap-install-bundle>
+```
+{{< /note >}}
+
 Download the Chef Automate command-line tool on an internet-connected host, and use it to prepare an Airgap Installation Bundle.
 
 ### Prepare Airgap Installation Bundle


### PR DESCRIPTION
Signed-off-by: Kallol Roy <kallol.roy@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Airgap bundle creation is failure at times so adding the note to warn user to use --version flag or download the bundle

### :chains: Related Resources

### :+1: Definition of Done
- Check the netlify preview link for the details

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
