### PR TITLE
enabling dot match regex

### DIFF
--- a/components/automate-ui/src/app/helpers/auth/regex.ts
+++ b/components/automate-ui/src/app/helpers/auth/regex.ts
@@ -19,6 +19,13 @@ export class Regex {
     // Allows no special characters except hyphen and underscore.
     NO_WILDCARD_ALLOW_HYPHEN: /^[0-9a-zA-Z-_]+$/,
 
+    // Only allows words or numbers or hyphen or underscore or dot also combined
+    // Note: the first character should not be dot(.).
+    // Legal Values: _, -, chef, _state, -chef, test-23-23.com-1.test.com etc.
+    // Illegal Values: .chef, *chef, ., c*h*e*f, **, * chef
+    // Allows no special characters except hyphen, underscore and dot(.).
+    NO_WILDCARD_ALLOW_HYPHEN_AND_DOT: /^[0-9a-zA-Z-_]+[0-9a-zA-Z-_.]*$/,
+
     // Only allows wildcard alone or words and numbers, but not combined
     // Legal Values: *, chef, _state, etc.
     // Illegal Values: abc*, *chef, c*h*e*f, **

--- a/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/clients/clients.component.ts
@@ -86,7 +86,8 @@ export class ClientsComponent implements OnInit, OnDestroy {
     this.current_page = 1;
     this.loading = true;
     this.searchValue = currentText;
-    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+    if ( currentText !== ''  &&
+      !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN_AND_DOT.test(currentText)) {
       this.loading = false;
       this.clients.length = 0;
       this.total = 0;

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.ts
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-nodes/infra-nodes.component.ts
@@ -135,7 +135,8 @@ export class InfraNodesComponent implements OnInit, OnDestroy {
     this.currentPage = 1;
     this.loading = true;
     this.searchValue = currentText;
-    if ( currentText !== ''  && !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN.test(currentText)) {
+    if ( currentText !== ''  &&
+      !Regex.patterns.NO_WILDCARD_ALLOW_HYPHEN_AND_DOT.test(currentText)) {
       this.loading = false;
       this.nodes.length = 0;
       this.total = 0;


### PR DESCRIPTION
Issue: https://chefio.atlassian.net/browse/KINETICS-214
### :nut_and_bolt: Description: What code changed, and why?
updated the regular expression to allow the search string that contains dot(.) while node and client search.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
The end user should be able to search for node names and client names with dot(.) combinations.  
ex: test-123-45.test-test.test.test.com

### :athletic_shoe: How to Build and Test the Change
rebuild components/automate-ui
start_all_services

From automate UI, link external infra server.
Goto Nodes tab under the organizations. 
Search for Node name with a string having a dot(.)
It should display the search results

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
