### PR TITLE
adding upgrade time for upgrade process

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -1222,9 +1222,6 @@ func (backend *ESClient) GetReportsDailyLatestTrue(ctx context.Context, upgradeT
 	boolQuery := elastic.NewBoolQuery().
 		Must(elastic.NewTermQuery("daily_latest", true)).Must(rangeQuery)
 
-	src, _ := boolQuery.Source()
-	logrus.Infof("Test Query For upgrade is noow : %v", src)
-
 	fsc := elastic.NewFetchSourceContext(true).Include(
 		"report_uuid",
 		"node_uuid",

--- a/components/compliance-service/migrations/cereal_interface.go
+++ b/components/compliance-service/migrations/cereal_interface.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/chef/automate/lib/cereal"
 	"github.com/pkg/errors"
@@ -10,7 +11,7 @@ import (
 )
 
 type cerealInterface interface {
-	EnqueueWorkflowUpgrade() error
+	EnqueueWorkflowUpgrade(updateDate time.Time) error
 }
 
 type cerealService struct {
@@ -18,14 +19,15 @@ type cerealService struct {
 }
 
 //EnqueueWorkflowUpgrade enqueue the work flow
-func (u *cerealService) EnqueueWorkflowUpgrade() error {
+func (u *cerealService) EnqueueWorkflowUpgrade(updateDate time.Time) error {
 	err := u.cerealManger.EnqueueWorkflow(context.TODO(), MigrationWorkflowName,
-		fmt.Sprintf("%s-%s", MigrationWorkflowName, UpgradeTaskName),
+		fmt.Sprintf("%s-%s-%s", MigrationWorkflowName, UpgradeTaskName, time.Now().Format(time.RFC3339)),
 		MigrationWorkflowParameters{
 			ControlIndexFlag: true,
+			UpgradeDate:      updateDate,
 		})
 	if err != nil {
-		logrus.Debugf("Unable to Enqueue Workflow for Daily Latest Task")
+		logrus.Errorf("Unable to Enqueue Workflow for Daily Latest Task %v", err)
 		return errors.Wrapf(err, "Unable to Enqueue Workflow for Daily Latest Task")
 	}
 	return nil

--- a/components/compliance-service/migrations/cererl_interface_test.go
+++ b/components/compliance-service/migrations/cererl_interface_test.go
@@ -1,13 +1,16 @@
 package migrations
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+	"time"
+)
 
 type CerealInterfaceTest struct {
 	NeedError           bool
 	NeedErrorForControl bool
 }
 
-func (c CerealInterfaceTest) EnqueueWorkflowUpgrade() error {
+func (c CerealInterfaceTest) EnqueueWorkflowUpgrade(update time.Time) error {
 	if c.NeedError {
 		return errors.New("Unable to enqueue workflow for day latest flag")
 	}

--- a/components/compliance-service/migrations/migration_workflow.go
+++ b/components/compliance-service/migrations/migration_workflow.go
@@ -128,9 +128,9 @@ func (t *UpgradeTask) Run(ctx context.Context, task cereal.Task) (interface{}, e
 		return nil, err
 	}
 
-	logrus.Info("Inside the upgrades flag flow")
 	logrus.Infof("Upgrade started at time %v", time.Now())
 	if job.ControlFlag {
+
 		logrus.Info("Inside the control flag")
 		if err := performActionForUpgrade(ctx, t.ESClient, job.UpgradeDate); err != nil {
 			logrus.WithError(err).Error("Unable to upgrade control index flag for latest record ")
@@ -159,7 +159,7 @@ type ControlIndexUpgradeTask struct {
 
 func performActionForUpgrade(ctx context.Context, esClient *ingestic.ESClient, upgradeTime time.Time) error {
 	mapping := mappings.ComplianceRepDate
-	if time.Now().Sub(upgradeTime)/24 > 90 {
+	if time.Now().Sub(upgradeTime).Hours()/24 > 90 {
 		upgradeTime = time.Now().Add(-24 * time.Hour * 90)
 	}
 	reportsMap, latestReportsMap, err := esClient.GetReportsDailyLatestTrue(ctx, upgradeTime)

--- a/components/compliance-service/migrations/upgrades.go
+++ b/components/compliance-service/migrations/upgrades.go
@@ -29,12 +29,13 @@ func (u *Upgrade) PollForUpgradeFlagDayLatest(upgradeDate time.Time) error {
 		return err
 	}
 	if controlFlag.Status {
-		err = u.cerealInterface.EnqueueWorkflowUpgrade()
+		err = u.cerealInterface.EnqueueWorkflowUpgrade(upgradeDate)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to enqueue the message in the flow for daily latest flag")
 		}
 		u.storage.UpdateControlFlagTimeStamp()
 	}
+
 	return nil
 }
 

--- a/components/compliance-service/migrations/upgrades.go
+++ b/components/compliance-service/migrations/upgrades.go
@@ -21,7 +21,6 @@ func NewService(pg *pgdb.UpgradesDB, cerealManger *cereal.Manager) *Upgrade {
 }
 
 //PollForUpgradeFlagDayLatest checks for the day latest flag value in upgrade flags
-//TODO:: run the upgrade from current date to upgradeDate
 func (u *Upgrade) PollForUpgradeFlagDayLatest(upgradeDate time.Time) error {
 	logrus.Infof("upgrade will run from %s to till now", upgradeDate.String())
 	controlFlag, err := u.getUpgradeFlag(pgdb.ControlIndexFlag)


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Added the upgrade time for upgrade process, now the reports will be picked where the flag was disabled.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/KINETICS-238

### :+1: Definition of Done

Now the report will be extracted from given time.

### :athletic_shoe: How to Build and Test the Change

rebuild components/compliance-service

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
