### PR TITLE
control report with date range logic update

### DIFF
--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -2254,6 +2254,28 @@ func validateFiltersTimeRange(endTime string, startTime string) error {
 	return nil
 }
 
+func isDateRange(endTime string, startTime string) (bool, error) {
+	if len(endTime) == 0 || len(startTime) == 0 {
+		return false, nil
+	}
+	eTime, err := time.Parse(layout, endTime)
+	if err != nil {
+		return false, errors.Errorf("cannot parse the time")
+	}
+	sTime, err := time.Parse(layout, startTime)
+	if err != nil {
+		return false, errors.Errorf("cannot parse the time")
+	}
+	diff := int(eTime.Sub(sTime).Hours() / 24)
+
+	if diff > 1 {
+		return true, nil
+	} else if diff < 0 {
+		return false, errors.Errorf("Start time should not be greater than end time")
+	}
+	return false, nil
+}
+
 func getStartDateFromEndDate(endTime string, startTime string, isEnhancedReportingEnabled bool) ([]string, error) {
 	if len(endTime) == 0 {
 		return nil, nil

--- a/components/compliance-service/reporting/relaxting/reports.go
+++ b/components/compliance-service/reporting/relaxting/reports.go
@@ -2260,11 +2260,11 @@ func isDateRange(endTime string, startTime string) (bool, error) {
 	}
 	eTime, err := time.Parse(layout, endTime)
 	if err != nil {
-		return false, errors.Errorf("cannot parse the time")
+		return false, errors.Errorf("cannot parse the end time")
 	}
 	sTime, err := time.Parse(layout, startTime)
 	if err != nil {
-		return false, errors.Errorf("cannot parse the time")
+		return false, errors.Errorf("cannot parse the start time")
 	}
 	diff := int(eTime.Sub(sTime).Hours() / 24)
 

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -120,9 +120,9 @@ func (backend ES2Backend) GetStatsSummaryNodes(filters map[string][]string) (*st
 	return depth.getStatsSummaryNodesResult(searchResult), nil
 }
 
-//GetStatsSummaryControls - Gets summary stats, control centric, aggregate data for the given set of filters
-func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (*stats.ControlsSummary, error) {
-	myName := "GetStatsSummaryControls"
+//GetStatsSummaryControlsRange - Gets summary stats, control centric, aggregate data for the given set of filters with date range
+func (backend ES2Backend) GetStatsSummaryControlsRange(filters map[string][]string) (*stats.ControlsSummary, error) {
+	myName := "GetStatsSummaryControlsRange"
 
 	filters["start_time"], err = getStartDateFromEndDate(firstOrEmpty(filters["end_time"]), firstOrEmpty(filters["start_time"]),
 		backend.IsEnhancedReportingEnabled)
@@ -133,6 +133,9 @@ func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (
 	latestOnly := FetchLatestDataOrNot(filters)
 
 	client, err := backend.ES2Client()
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to connect to es-client")
+	}
 
 	esIndex, err := getControlIndex(filters)
 	if err != nil {
@@ -170,6 +173,63 @@ func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (
 	LogQueryPartMin(esIndex, searchResult.Aggregations, fmt.Sprintf("%s searchResult aggs", myName))
 
 	return backend.getStatsSummaryControlsResult(searchResult), nil
+}
+
+//GetStatsSummaryControls - Gets summary stats, control centric, aggregate data for the given set of filters
+func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (*stats.ControlsSummary, error) {
+	myName := "GetStatsSummaryControls"
+
+	// Check for range and if enhanced_control_reporting is enabled?
+	isValidDateRange, err := isDateRange(firstOrEmpty(filters["end_time"]), firstOrEmpty(filters["start_time"]))
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("%s ", myName))
+	}
+	if isValidDateRange {
+		return backend.GetStatsSummaryControlsRange(filters)
+	}
+
+	// Only end_time matters for this call
+	filters["start_time"] = []string{}
+
+	latestOnly := FetchLatestDataOrNot(filters)
+
+	depth, err := backend.NewDepth(filters, latestOnly)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("%s unable to get depth level for report", myName))
+	}
+
+	queryInfo := depth.getQueryInfo()
+
+	searchSource := elastic.NewSearchSource().
+		Query(queryInfo.filtQuery).
+		Size(0)
+
+	for aggName, agg := range depth.getStatsSummaryControlsAggs() {
+		searchSource.Aggregation(aggName, agg)
+	}
+
+	source, err := searchSource.Source()
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("%s unable to get Source", myName))
+	}
+
+	LogQueryPartMin(queryInfo.esIndex, source, fmt.Sprintf("%s query", myName))
+	b, _ := json.Marshal(source)
+	logrus.Info(string(b))
+	searchResult, err := queryInfo.client.Search().
+		SearchSource(searchSource).
+		Index(queryInfo.esIndex).
+		Size(0).
+		Do(context.Background())
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+	logrus.Info(searchResult)
+
+	LogQueryPartMin(queryInfo.esIndex, searchResult.Aggregations, fmt.Sprintf("%s searchResult aggs", myName))
+
+	return depth.getStatsSummaryControlsResult(searchResult), nil
 }
 
 //GetStatsFailures - Gets top failures, aggregate data for the given set of filters


### PR DESCRIPTION
Signed-off-by: Abdul-Az <aazeez@progress.com>
https://chefio.atlassian.net/browse/KINETICS-237

### :nut_and_bolt: Description: What code changed, and why?
If date range filter is passed GetStatsSummaryControls will extract the data from control index else it will behave like old way.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
rebuild components/compliance-service

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1323" alt="Screenshot 2022-10-19 at 12 20 15 PM" src="https://user-images.githubusercontent.com/38317160/196618317-d8bafea6-5168-4df5-97dd-84eddce186e7.png">
<img width="1343" alt="Screenshot 2022-10-19 at 12 20 56 PM" src="https://user-images.githubusercontent.com/38317160/196618326-b7cdcc6a-1cf6-48e0-bb7c-872f036adab0.png">
<img width="1365" alt="Screenshot 2022-10-19 at 12 21 16 PM" src="https://user-images.githubusercontent.com/38317160/196618328-1dfed3a1-9e1f-4aca-b9c9-1a56111e27ef.png">
