### PR TITLE
Documentation: More clarity in Claims and  Login URL discussion for Azure AD

### DIFF
--- a/components/docs-chef-io/content/automate/saml.md
+++ b/components/docs-chef-io/content/automate/saml.md
@@ -80,11 +80,19 @@ In Azure AD, add Chef Automate as a `non-gallery application`, and then configur
 Enter `https://{{< example_fqdn "automate" >}}/dex/callback` as the value for both _Identifier (Entity ID)_ and _Reply URL (Assertion Consumer Service URL)_.
 
 You may use the default claims provided by Azure AD.
-Remember to edit the Chef Automate configuration in `config.toml` to reflect this claims information.
+Remember to edit the Chef Automate configuration in `config.toml` to reflect this claims information. 
 
-Download the _Certificate (Base64)_ in Azure AD and take note of the _Login URL_ of use in the Chef Automate configuration.
+{{< note >}}
+If your claims look like a long URL as shown in the example below, those are exactly the values you would need to use in the Chef Automate configuration.
+{{< /note >}}
 
-After configuring Azure AD, edit your Chef Automate `config.toml` configuration file to reflect the values entered in the Azure AD interface.
+Download the Certificate (Base64) used to sign SAML responses from Azure AD and take note of the _Login URL_. These items will be used in the next step.
+
+{{< note >}}
+Chef Automate cannot use an _idP URL_. For clarity, a _Login URL_ begins with "login.", not "myapps".
+{{< /note >}}
+
+After configuring Azure AD, edit your Chef Automate `config.toml` configuration file to reflect the values found in the Azure AD interface.
 
 The minimal configuration snippet in `config.toml` will looks like:
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

* Add detail about claims.

* Customers were confused about which Azure AD URL value should be used to configure Automate's `sso_url`
  * It is only the Login URL.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) No code
- [X] Docs added/updated? (all customer-facing changes)
