### PR TITLE
Postgres Cert Rotate Command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -15,11 +15,13 @@ import (
 var certFlags = struct {
 	privateCert string
 	publicCert  string
+	rootCA      string
 }{}
 
 var sshFlag = struct {
 	automate   bool
 	chefserver bool
+	postgres   bool
 }{}
 
 var certRotateCmd = &cobra.Command{
@@ -36,9 +38,12 @@ func init() {
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.automate, "a2", false, "Automate Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.chefserver, "chefserver", false, "Chef Infra Server Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.chefserver, "cs", false, "Chef Infra Server Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.postgres, "postgres", false, "Postgres Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.postgres, "pg", false, "Postgres Certificate Rotation")
 
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.privateCert, "private-cert", "", "Private certificate")
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.publicCert, "public-cert", "", "Public certificate")
+	certRotateCmd.PersistentFlags().StringVar(&certFlags.rootCA, "root-ca", "", "RootCA certificate")
 }
 
 const (
@@ -49,17 +54,52 @@ const (
 	[[global.v1.frontend_tls]]
 		cert = """%v"""
 		key = """%v"""`
+
+	POSTGRES_CONFIG = `
+	[ssl]
+		enable = true
+		ssl_key = """%v"""
+		ssl_cert = """%v"""
+		issuer_cert = """%v"""`
+
+	POSTGRES_FRONTEND_CONFIG = `
+	[global.v1.external.postgresql.ssl]
+		enable = true
+		root_cert = """%v"""`
+
+	GET_USER_CONFIG = `
+	sudo cat /hab/user/automate-ha-%s/config/user.toml`
+
+	COPY_USER_CONFIG = `
+	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml`
 )
 
 func certRotate(cmd *cobra.Command, args []string) error {
 	privateCertPath := certFlags.privateCert
 	publicCertPath := certFlags.publicCert
+	rootCaPath := certFlags.rootCA
 	fileName := "cert-rotate.toml"
 	timestamp := time.Now().Format("20060102150405")
 
 	if privateCertPath == "" || publicCertPath == "" {
 		return errors.New("Please provide public and private cert paths")
 	}
+	var rootCA []byte
+	var err error
+	if sshFlag.postgres {
+		if rootCaPath == "" {
+			return errors.New("Please provide rootCA path")
+		}
+		rootCA, err = ioutil.ReadFile(rootCaPath) // nosemgrep
+		if err != nil {
+			return status.Wrap(
+				err,
+				status.FileAccessError,
+				fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			)
+		}
+	}
+
 	privateCert, err := ioutil.ReadFile(privateCertPath) // nosemgrep
 	if err != nil {
 		return status.Wrap(
@@ -129,6 +169,69 @@ func certRotate(cmd *cobra.Command, args []string) error {
 				writer.Printf(output)
 			}
 
+		} else if sshFlag.postgres {
+			config := fmt.Sprintf(POSTGRES_CONFIG, string(privateCert), string(publicCert), string(rootCA))
+			_, err = f.Write([]byte(config))
+			if err != nil {
+				log.Fatal(err)
+			}
+			f.Close()
+
+			remoteService := "postgresql"
+			file := []string{fileName}
+			tomlFilePath, err := getMergerTOMLPath(file, infra, timestamp, remoteService, GET_USER_CONFIG)
+			if err != nil {
+				return err
+			}
+			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
+			postgresIps := infra.Outputs.PostgresqlPrivateIps.Value
+			for i := 0; i < len(postgresIps); i++ {
+				err := copyFileToRemote(sskKeyFile, tomlFilePath, sshUser, postgresIps[i], remoteService+timestamp, false)
+				if err != nil {
+					writer.Errorf("%v", err)
+					return err
+				}
+				output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, postgresIps[i], scriptCommands)
+				if err != nil {
+					writer.Errorf("%v", err)
+					return err
+				}
+				writer.Printf(output)
+			}
+
+			// Patching root-ca to frontend-nodes
+			filename_fe := "pg_fe.toml"
+			config_fe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, string(rootCA))
+			fe, err := os.Create(filename_fe)
+			if err != nil {
+				log.Fatal(err)
+			}
+			_, err = fe.Write([]byte(config_fe))
+			if err != nil {
+				log.Fatal(err)
+			}
+			fe.Close()
+
+			frontendIps := append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
+			if len(frontendIps) == 0 {
+				return errors.New("No frontend IPs are found")
+			}
+			remoteService = "frontend"
+
+			scriptCommands = fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
+			for i := 0; i < len(frontendIps); i++ {
+				err := copyFileToRemote(sskKeyFile, filename_fe, sshUser, frontendIps[i], remoteService+timestamp, false)
+				if err != nil {
+					writer.Errorf("%v", err)
+					return err
+				}
+				output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, frontendIps[i], scriptCommands)
+				if err != nil {
+					writer.Errorf("%v", err)
+					return err
+				}
+				writer.Printf(output)
+			}
 		}
 	}
 	return nil

--- a/components/automate-cli/cmd/chef-automate/configTemplate.go
+++ b/components/automate-cli/cmd/chef-automate/configTemplate.go
@@ -145,48 +145,48 @@ type OpensearchConfig struct {
 }
 
 type PostgresqlConfig struct {
-	CheckpointCompletionTarget float64 `protobuf:"bytes,,opt,name=checkpoint_completion_target,proto3" toml:"checkpoint_completion_target,omitempty" json:"checkpoint_completion_target,omitempty" mapstructure:"checkpoint_completion_target,omitempty"`
+	CheckpointCompletionTarget float64 `protobuf:"bytes,,opt,name=checkpoint_completion_target,proto3" toml:"checkpoint_completion_target,omitzero" json:"checkpoint_completion_target,omitzero" mapstructure:"checkpoint_completion_target,omitzero"`
 	CheckpointTimeout          string  `protobuf:"bytes,,opt,name=checkpoint_timeout,proto3" toml:"checkpoint_timeout,omitempty" json:"checkpoint_timeout,omitempty" mapstructure:"checkpoint_timeout,omitempty"`
 	Host                       string  `protobuf:"bytes,,opt,name=host,proto3" toml:"host,omitempty" json:"host,omitempty" mapstructure:"host,omitempty"`
 	LogLevel                   string  `protobuf:"bytes,,opt,name=log_level,proto3" toml:"log_level,omitempty" json:"log_level,omitempty" mapstructure:"log_level,omitempty"`
 	LogLinePrefix              string  `protobuf:"bytes,,opt,name=log_line_prefix,proto3" toml:"log_line_prefix,omitempty" json:"log_line_prefix,omitempty" mapstructure:"log_line_prefix,omitempty"`
 	LoggingCollector           string  `protobuf:"bytes,,opt,name=logging_collector,proto3" toml:"logging_collector,omitempty" json:"logging_collector,omitempty" mapstructure:"logging_collector,omitempty"`
-	MaxConnections             int     `protobuf:"bytes,,opt,name=max_connections,proto3" toml:"max_connections,omitempty" json:"max_connections,omitempty" mapstructure:"max_connections,omitempty"`
-	MaxLocksPerTransaction     int     `protobuf:"bytes,,opt,name=max_locks_per_transaction,proto3" toml:"max_locks_per_transaction,omitempty" json:"max_locks_per_transaction,omitempty" mapstructure:"max_locks_per_transaction,omitempty"`
+	MaxConnections             int     `protobuf:"bytes,,opt,name=max_connections,proto3" toml:"max_connections,omitzero" json:"max_connections,omitzero" mapstructure:"max_connections,omitzero"`
+	MaxLocksPerTransaction     int     `protobuf:"bytes,,opt,name=max_locks_per_transaction,proto3" toml:"max_locks_per_transaction,omitzero" json:"max_locks_per_transaction,omitzero" mapstructure:"max_locks_per_transaction,omitzero"`
 	MaxWalSize                 string  `protobuf:"bytes,,opt,name=max_wal_size,proto3" toml:"max_wal_size,omitempty" json:"max_wal_size,omitempty" mapstructure:"max_wal_size,omitempty"`
 	MinWalSize                 string  `protobuf:"bytes,,opt,name=min_wal_size,proto3" toml:"min_wal_size,omitempty" json:"min_wal_size,omitempty" mapstructure:"min_wal_size,omitempty"`
-	Port                       int     `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitempty" json:"port,omitempty" mapstructure:"port,omitempty"`
+	Port                       int     `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitzero" json:"port,omitzero" mapstructure:"port,omitzero"`
 	PrintDbStatistics          bool    `protobuf:"bytes,,opt,name=print_db_statistics,proto3" toml:"print_db_statistics,omitempty" json:"print_db_statistics,omitempty" mapstructure:"print_db_statistics,omitempty"`
-	WalKeepSize                int     `protobuf:"bytes,,opt,name=wal_keep_size,proto3" toml:"wal_keep_size,omitempty" json:"wal_keep_size,omitempty" mapstructure:"wal_keep_size,omitempty"`
-	PgDump                     struct {
+	WalKeepSize                int     `protobuf:"bytes,,opt,name=wal_keep_size,proto3" toml:"wal_keep_size,omitzero" json:"wal_keep_size,omitzero" mapstructure:"wal_keep_size,omitzero"`
+	PgDump                     *struct {
 		Enable bool   `protobuf:"bytes,,opt,name=enable,proto3" toml:"enable,omitempty" json:"enable,omitempty" mapstructure:"enable,omitempty"`
 		Path   string `protobuf:"bytes,,opt,name=path,proto3" toml:"path,omitempty" json:"path,omitempty" mapstructure:"path,omitempty"`
 	} `protobuf:"bytes,,opt,name=pg_dump,proto3" toml:"pg_dump,omitempty" json:"pg_dump,omitempty" mapstructure:"pg_dump,omitempty"`
-	Replication struct {
-		LagHealthThreshold         int    `protobuf:"bytes,,opt,name=lag_health_threshold,proto3" toml:"lag_health_threshold,omitempty" json:"lag_health_threshold,omitempty" mapstructure:"lag_health_threshold,omitempty"`
-		MaxReplayLagBeforeRestartS int    `protobuf:"bytes,,opt,name=max_replay_lag_before_restart_s,proto3" toml:"max_replay_lag_before_restart_s,omitempty" json:"max_replay_lag_before_restart_s,omitempty" mapstructure:"max_replay_lag_before_restart_s,omitempty"`
+	Replication *struct {
+		LagHealthThreshold         int    `protobuf:"bytes,,opt,name=lag_health_threshold,proto3" toml:"lag_health_threshold,omitzero" json:"lag_health_threshold,omitzero" mapstructure:"lag_health_threshold,omitzero"`
+		MaxReplayLagBeforeRestartS int    `protobuf:"bytes,,opt,name=max_replay_lag_before_restart_s,proto3" toml:"max_replay_lag_before_restart_s,omitzero" json:"max_replay_lag_before_restart_s,omitzero" mapstructure:"max_replay_lag_before_restart_s,omitzero"`
 		Name                       string `protobuf:"bytes,,opt,name=name,proto3" toml:"name,omitempty" json:"name,omitempty" mapstructure:"name,omitempty"`
 		Password                   string `protobuf:"bytes,,opt,name=password,proto3" toml:"password,omitempty" json:"password,omitempty" mapstructure:"password,omitempty"`
 	} `protobuf:"bytes,,opt,name=replication,proto3" toml:"replication,omitempty" json:"replication,omitempty" mapstructure:"replication,omitempty"`
-	S3 struct {
+	S3 *struct {
 		Client struct {
 			Default struct {
 				ReadTimeout string `protobuf:"bytes,,opt,name=read_timeout,proto3" toml:"read_timeout,omitempty" json:"read_timeout,omitempty" mapstructure:"read_timeout,omitempty"`
 			} `protobuf:"bytes,,opt,name=default,proto3" toml:"default,omitempty" json:"default,omitempty" mapstructure:"default,omitempty"`
 		} `protobuf:"bytes,,opt,name=client,proto3" toml:"client,omitempty" json:"client,omitempty" mapstructure:"client,omitempty"`
 	} `protobuf:"bytes,,opt,name=s3,proto3" toml:"s3,omitempty" json:"s3,omitempty" mapstructure:"s3,omitempty"`
-	Ssl struct {
+	Ssl *struct {
 		Enable     bool   `protobuf:"bytes,,opt,name=enable,proto3" toml:"enable,omitempty" json:"enable,omitempty" mapstructure:"enable,omitempty"`
 		IssuerCert string `protobuf:"bytes,,opt,name=issuer_cert,proto3" toml:"issuer_cert,omitempty" json:"issuer_cert,omitempty" mapstructure:"issuer_cert,omitempty"`
 		SslCert    string `protobuf:"bytes,,opt,name=ssl_cert,proto3" toml:"ssl_cert,omitempty" json:"ssl_cert,omitempty" mapstructure:"ssl_cert,omitempty"`
 		SslKey     string `protobuf:"bytes,,opt,name=ssl_key,proto3" toml:"ssl_key,omitempty" json:"ssl_key,omitempty" mapstructure:"ssl_key,omitempty"`
 		TLSCiphers string `protobuf:"bytes,,opt,name=tls_ciphers,proto3" toml:"tls_ciphers,omitempty" json:"tls_ciphers,omitempty" mapstructure:"tls_ciphers,omitempty"`
 	} `protobuf:"bytes,,opt,name=ssl,proto3" toml:"ssl,omitempty" json:"ssl,omitempty" mapstructure:"ssl,omitempty"`
-	Superuser struct {
+	Superuser *struct {
 		Name     string `protobuf:"bytes,,opt,name=name,proto3" toml:"name,omitempty" json:"name,omitempty" mapstructure:"name,omitempty"`
 		Password string `protobuf:"bytes,,opt,name=password,proto3" toml:"password,omitempty" json:"password,omitempty" mapstructure:"password,omitempty"`
 	} `protobuf:"bytes,,opt,name=superuser,proto3" toml:"superuser,omitempty" json:"superuser,omitempty" mapstructure:"superuser,omitempty"`
-	WalArchive struct {
+	WalArchive *struct {
 		Enable bool   `protobuf:"bytes,,opt,name=enable,proto3" toml:"enable,omitempty" json:"enable,omitempty" mapstructure:"enable,omitempty"`
 		Path   string `protobuf:"bytes,,opt,name=path,proto3" toml:"path,omitempty" json:"path,omitempty" mapstructure:"path,omitempty"`
 	} `protobuf:"bytes,,opt,name=wal_archive,proto3" toml:"wal_archive,omitempty" json:"wal_archive,omitempty" mapstructure:"wal_archive,omitempty"`


### PR DESCRIPTION
Signed-off-by: “SanjuPal01” <sanju.sanju@progress.com>
"Sahiba3108" <sgoyal@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Added the cert rotate command for HA service. Now user has to pass the certificate paths to cert-rotate cmd and it will rotate the certificates of all postgres nodes.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-235

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Add this package in your manifest while deploying HA:
sahiba3108/automate-ha-deployment/0.1.0/20221028084038

Install this cli in your bastion host:
ssanju/automate-cli/0.1.0/20221102131051

Run the below command in bastion:
`chef-automate cert-rotate --public-cert client.pem --private-cert client-key.pem --root-ca root-ca.pem --pg`
(You can also use --postgres flag instead of pg)
This will rotate the public, private and root cert of all pg nodes.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1345" alt="Screenshot 2022-11-02 at 7 01 07 PM" src="https://user-images.githubusercontent.com/108404805/199502462-a47ed28a-b06c-491a-8fb7-56e7566477fb.png">
