### PR TITLE
Printing success message after patching from bastion server

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -201,6 +201,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					return err
 				}
 				writer.Printf(output)
+
+				writer.Success("Cleanup is completed on " + remoteService + " node : " + frontendIps[i] + "\n")
 			}
 		}
 		if configCmdFlags.postgresql {
@@ -223,6 +225,7 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					return err
 				}
 				writer.Printf(output)
+				writer.Success("Cleanup is completed on " + remoteService + " node : " + remoteIp + "\n")
 			}
 		}
 		if configCmdFlags.opensearch {
@@ -245,6 +248,7 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					return err
 				}
 				writer.Printf(output)
+				writer.Success("Cleanup is completed on " + remoteService + " node : " + remoteIp + "\n")
 			}
 		}
 	} else {
@@ -258,7 +262,7 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	writer.Success("Configuration patched")
+	// writer.Success("Configuration patched")
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -200,9 +200,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					writer.Errorf("%v", err)
 					return err
 				}
-				writer.Printf(output)
-
-				writer.Success("Cleanup is completed on " + remoteService + " node : " + frontendIps[i] + "\n")
+				writer.Printf(output + "\n")
+				writer.Success("Patching is completed on " + remoteService + " node : " + frontendIps[i] + "\n")
 			}
 		}
 		if configCmdFlags.postgresql {
@@ -224,8 +223,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					writer.Errorf("%v", err)
 					return err
 				}
-				writer.Printf(output)
-				writer.Success("Cleanup is completed on " + remoteService + " node : " + remoteIp + "\n")
+				writer.Printf(output + "\n")
+				writer.Success("Patching is completed on " + remoteService + " node : " + remoteIp + "\n")
 			}
 		}
 		if configCmdFlags.opensearch {
@@ -247,8 +246,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 					writer.Errorf("%v", err)
 					return err
 				}
-				writer.Printf(output)
-				writer.Success("Cleanup is completed on " + remoteService + " node : " + remoteIp + "\n")
+				writer.Printf(output + "\n")
+				writer.Success("Patching is completed on " + remoteService + " node : " + remoteIp + "\n")
 			}
 		}
 	} else {


### PR DESCRIPTION
Signed-off-by: Arvinth C <arvinth.chandrasekaran@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
As an Automate HA user, after running `config patch` from the bastion server, the user needs to know to get success message with the mentioning of node IP after the patch output from remote node

### :chains: Related Resources
https://chefio.atlassian.net/browse/MADROX-321

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
