### PR TITLE
chef-automate gather-logs for faulty nodes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -642,11 +642,18 @@ func gatherLogsForFaultyNodes(outfileOverride string, logLines uint64) error {
 		return runGatherLogsLocalCmd(outfileOverride, logLines)
 
 	}
-	cmd := exec.Command("hab", "svc", "status")
-	stdoutStderr, err := cmd.CombinedOutput()
+	cmd, err := exec.Command("hab", "svc", "status").CombinedOutput()
 	if err != nil {
-		return status.WithRecovery(errors.Wrap(err, string(stdoutStderr)), "hab-sup is not working")
+		return status.WithRecovery(errors.Wrapf(err, string(cmd)), "hab-sup is not working")
 	}
 
 	return gatherLogsFromServer(outfileOverride, logLines)
+}
+
+func gatherLogsForFaultyBackendNodes(outfileOverride string, logLines uint64) error {
+	cmd, err := exec.Command("hab", "svc", "status").CombinedOutput()
+	if err != nil {
+		return status.WithRecovery(errors.Wrapf(err, string(cmd)), "hab-sup is not working")
+	}
+	return runGatherLogsLocalCmd(outfileOverride, logLines)
 }

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -638,13 +638,14 @@ func init() {
 func gatherLogsForFaultyNodes(outfileOverride string, logLines uint64) error {
 	_, err := client.Connection(client.DefaultClientTimeout)
 
-	if status.ErrorType(err) == "DeploymentServiceCallError" || status.ErrorType(err) == "DeploymentServiceUnreachableError" {
-		return runGatherLogsLocalCmd(outfileOverride, logLines)
-
-	}
 	cmd, err := exec.Command("hab", "svc", "status").CombinedOutput()
 	if err != nil {
 		return status.WithRecovery(errors.Wrapf(err, string(cmd)), "hab-sup is not working")
+	}
+
+	if status.ErrorType(err) == "DeploymentServiceCallError" || status.ErrorType(err) == "DeploymentServiceUnreachableError" {
+		return runGatherLogsLocalCmd(outfileOverride, logLines)
+
 	}
 
 	return gatherLogsFromServer(outfileOverride, logLines)

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -638,7 +638,7 @@ func init() {
 //gatherLogsFromServerForFrontendNodes checks for hab svc status and for deployment service error
 //Gather the logs for all frontend nodes
 func gatherLogsFromServerForFrontendNodes(outfileOverride string, logLines uint64) error {
-	str := `
+	habSupErrorMsg := `
 	* * * chef-automate node services are down
 	* * * No gather-logs collected
 	`
@@ -646,7 +646,7 @@ func gatherLogsFromServerForFrontendNodes(outfileOverride string, logLines uint6
 	_, habSupError := exec.Command("hab", "svc", "status").CombinedOutput()
 
 	if habSupError != nil {
-		return status.WithRecovery(habSupError, str)
+		return status.WithRecovery(habSupError, habSupErrorMsg)
 	}
 	_, err := client.Connection(client.DefaultClientTimeout)
 	//check for deployment service error and if err return local gather-logs
@@ -660,7 +660,7 @@ func gatherLogsFromServerForFrontendNodes(outfileOverride string, logLines uint6
 //gatherLogsForBackendNodes checks for hab svc status
 // Gather the logs for all backend nodes
 func gatherLogsForBackendNodes(outfileOverride string, logLines uint64) error {
-	str := `
+	habSupErrorMsg := `
 	* * * Backend node services are down
 	* * * No gather-logs collected
 	`
@@ -668,7 +668,7 @@ func gatherLogsForBackendNodes(outfileOverride string, logLines uint64) error {
 	_, habSupError := exec.Command("hab", "svc", "status").CombinedOutput()
 
 	if habSupError != nil {
-		return status.WithRecovery(habSupError, str)
+		return status.WithRecovery(habSupError, habSupErrorMsg)
 	}
 	return runGatherLogsLocalCmd(outfileOverride, logLines)
 }

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -136,7 +136,7 @@ func runGatherLogsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if gatherLogsCmdFlags.localFallback {
-		return runGatherLogsLocalCmd(overridePath, gatherLogsCmdFlags.logLines)
+		return gatherLogsForFaultyBackendNodes(overridePath, gatherLogsCmdFlags.logLines)
 	}
 
 	return gatherLogsForFaultyNodes(overridePath, gatherLogsCmdFlags.logLines)

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -636,12 +636,11 @@ func init() {
 }
 
 func gatherLogsForFaultyNodes(outfileOverride string, logLines uint64) error {
-	_, err := client.Connection(client.DefaultClientTimeout)
-
 	cmd, err := exec.Command("hab", "svc", "status").CombinedOutput()
 	if err != nil {
 		return status.WithRecovery(errors.Wrapf(err, string(cmd)), "hab-sup is not working")
 	}
+	_, err = client.Connection(client.DefaultClientTimeout)
 
 	if status.ErrorType(err) == "DeploymentServiceCallError" || status.ErrorType(err) == "DeploymentServiceUnreachableError" {
 		return runGatherLogsLocalCmd(outfileOverride, logLines)

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -139,7 +139,7 @@ func runGatherLogsCmd(cmd *cobra.Command, args []string) error {
 		return runGatherLogsLocalCmd(overridePath, gatherLogsCmdFlags.logLines)
 	}
 
-	return gatherLogsRunning(overridePath, gatherLogsCmdFlags.logLines)
+	return gatherLogsForFaultyNodes(overridePath, gatherLogsCmdFlags.logLines)
 }
 
 const recoveryMsg = `
@@ -635,10 +635,10 @@ func init() {
 	RootCmd.AddCommand(newGatherLogsCmd())
 }
 
-func gatherLogsRunning(outfileOverride string, logLines uint64) error {
+func gatherLogsForFaultyNodes(outfileOverride string, logLines uint64) error {
 	_, err := client.Connection(client.DefaultClientTimeout)
 
-	if err != nil {
+	if status.ErrorType(err) == "DeploymentServiceCallError" || status.ErrorType(err) == "DeploymentServiceUnreachableError" {
 		return runGatherLogsLocalCmd(outfileOverride, logLines)
 
 	}


### PR DESCRIPTION
Signed-off-by: SahithiMy <sahithi.mylangam@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Changed the code for chef-automate gather-logs from sending gather-logs if there is any faulty/inactive nodes.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-228
### :+1: Definition of Done
chef-automate gather-logs for frontend and backend nodes
For Frontend nodes

- if hab is not installed returns error and continues with next node
- if hab-sup is not running it returns error and continues with next node
- if deployment-service is not running it will gather logs.
For backend nodes

- if hab is not installed returns error and continues with next node
- if hab-sup is not running it returns error and continues with next node

### :athletic_shoe: How to Build and Test the Change
Install this cli in your bastion host:
sahithimy/automate-cli/0.1.0/20221114080320

Run the below command in bastion:
chef-automate gather-logs
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/98326242/201635703-064d737e-4708-4122-a1ba-bfd1393fdf3a.mp4
