### PR TITLE
cert rotate cmd for OS

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -107,167 +107,200 @@ const (
 
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func certRotate(cmd *cobra.Command, args []string) error {
-	fileName := "cert-rotate.toml"
-	timestamp := time.Now().Format("20060102150405")
-
 	rootCA, publicCert, privateCert, adminCert, adminKey, err := getCerts()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	f, err := os.Create(fileName)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	if isA2HARBFileExist() {
-
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
 		}
-		sshUser := infra.Outputs.SSHUser.Value
-		sskKeyFile := infra.Outputs.SSHKeyFile.Value
-		sshPort := infra.Outputs.SSHPort.Value
 
 		if sshFlag.automate || sshFlag.chefserver {
-			// Writing the required configurations in the toml file
-			config := fmt.Sprintf(FRONTEND_CONFIG, string(publicCert), string(privateCert), string(publicCert), string(privateCert))
-			_, err = f.Write([]byte(config))
+			err := certRotateFrontend(publicCert, privateCert, infra)
 			if err != nil {
 				log.Fatal(err)
 			}
-			f.Close()
-
-			var frontendIps []string
-			var remoteService string
-			if sshFlag.automate {
-				frontendIps = infra.Outputs.AutomatePrivateIps.Value
-				remoteService = "automate"
-			} else if sshFlag.chefserver {
-				frontendIps = infra.Outputs.ChefServerPrivateIps.Value
-				remoteService = "chefserver"
-			}
-			if len(frontendIps) == 0 {
-				return errors.New(fmt.Sprintf("No %s Ips found", remoteService))
-			}
-
-			// Defining set of commands which run on frontend nodes
-			scriptCommands := fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
-			err := copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
-			if err != nil {
-				log.Fatal(err)
-			}
-
 		} else if sshFlag.postgres {
-			// Writing the required configurations in the toml file
-			config := fmt.Sprintf(POSTGRES_CONFIG, string(privateCert), string(publicCert), string(rootCA))
-			_, err = f.Write([]byte(config))
+			err := certRotatePG(publicCert, privateCert, rootCA, infra)
 			if err != nil {
 				log.Fatal(err)
 			}
-			f.Close()
-
-			postgresIps := infra.Outputs.PostgresqlPrivateIps.Value
-			if len(postgresIps) == 0 {
-				return errors.New("No Postgres IPs are found")
-			}
-			remoteService := "postgresql"
-
-			// Defining set of commands which run on postgres nodes
-			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
-			err = copyAndExecute(postgresIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// Patching root-ca to frontend-nodes
-			filename_fe := "pg_fe.toml"
-			// Creating and Writing the required configurations in the toml file
-			config_fe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, string(rootCA))
-			fe, err := os.Create(filename_fe)
-			if err != nil {
-				log.Fatal(err)
-			}
-			_, err = fe.Write([]byte(config_fe))
-			if err != nil {
-				log.Fatal(err)
-			}
-			fe.Close()
-
-			frontendIps := append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
-			if len(frontendIps) == 0 {
-				return errors.New("No frontend IPs are found")
-			}
-			remoteService = "frontend"
-
-			// Defining set of commands which run on frontend nodes
-			scriptCommands = fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
-			err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, filename_fe, scriptCommands)
-			if err != nil {
-				log.Fatal(err)
-			}
-
 		} else if sshFlag.opensearch {
-			e := existingInfra{}
-			admin_dn, err := e.getDistinguishedNameFromKey(string(adminCert))
-			if err != nil {
-				return err
-			}
-			nodes_dn, err := e.getDistinguishedNameFromKey(string(publicCert))
-			if err != nil {
-				return err
-			}
-
-			// Writing the required configurations in the toml file
-			config := fmt.Sprintf(OPENSEARCH_CONFIG, string(rootCA), string(adminCert), string(adminKey), string(publicCert), string(privateCert), fmt.Sprintf("%v", admin_dn), fmt.Sprintf("%v", nodes_dn))
-			_, err = f.Write([]byte(config))
-			if err != nil {
-				log.Fatal(err)
-			}
-			f.Close()
-
-			opensearchIps := infra.Outputs.OpensearchPrivateIps.Value
-			if len(opensearchIps) == 0 {
-				return errors.New("No Opensearch IPs are found")
-			}
-			remoteService := "opensearch"
-
-			// Defining set of commands which run on opensearch nodes
-			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
-			err = copyAndExecute(opensearchIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			// Patching root-ca to frontend-nodes
-			cn := nodes_dn.CommonName
-			filename_fe := "os_fe.toml"
-			// Creating and Writing the required configurations in the toml file
-			config_fe := fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG, string(rootCA), cn)
-			fe, err := os.Create(filename_fe)
-			if err != nil {
-				log.Fatal(err)
-			}
-			_, err = fe.Write([]byte(config_fe))
-			if err != nil {
-				log.Fatal(err)
-			}
-			fe.Close()
-
-			frontendIps := append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
-			if len(frontendIps) == 0 {
-				return errors.New("No frontend IPs are found")
-			}
-			remoteService = "frontend"
-
-			// Defining set of commands which run on frontend nodes
-			scriptCommands = fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
-			err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, filename_fe, scriptCommands)
+			err := certRotateOS(publicCert, privateCert, rootCA, adminCert, adminKey, infra)
 			if err != nil {
 				log.Fatal(err)
 			}
 		}
+	}
+	return nil
+}
+
+func getSshDetails(infra *AutomteHAInfraDetails) (string, string, string) {
+	return infra.Outputs.SSHUser.Value, infra.Outputs.SSHKeyFile.Value, infra.Outputs.SSHPort.Value
+}
+
+// This function will rotate the certificates of Automate and Chef Infra Server,
+func certRotateFrontend(publicCert, privateCert string, infra *AutomteHAInfraDetails) error {
+	fileName := "cert-rotate-fe.toml"
+	timestamp := time.Now().Format("20060102150405")
+	sshUser, sskKeyFile, sshPort := getSshDetails(infra)
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Writing the required configurations in the toml file
+	config := fmt.Sprintf(FRONTEND_CONFIG, publicCert, privateCert, publicCert, privateCert)
+	_, err = f.Write([]byte(config))
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	var frontendIps []string
+	var remoteService string
+	if sshFlag.automate {
+		frontendIps = infra.Outputs.AutomatePrivateIps.Value
+		remoteService = "automate"
+	} else if sshFlag.chefserver {
+		frontendIps = infra.Outputs.ChefServerPrivateIps.Value
+		remoteService = "chefserver"
+	}
+	if len(frontendIps) == 0 {
+		return errors.New(fmt.Sprintf("No %s Ips found", remoteService))
+	}
+
+	// Defining set of commands which run on frontend nodes
+	scriptCommands := fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
+	err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+// This function will rotate the certificates of Postgres
+func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraDetails) error {
+	fileName := "cert-rotate-pg.toml"
+	timestamp := time.Now().Format("20060102150405")
+	sshUser, sskKeyFile, sshPort := getSshDetails(infra)
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Writing the required configurations in the toml file
+	config := fmt.Sprintf(POSTGRES_CONFIG, privateCert, publicCert, rootCA)
+	_, err = f.Write([]byte(config))
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	postgresIps := infra.Outputs.PostgresqlPrivateIps.Value
+	if len(postgresIps) == 0 {
+		return errors.New("No Postgres IPs are found")
+	}
+	remoteService := "postgresql"
+
+	// Defining set of commands which run on postgres nodes
+	scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
+	err = copyAndExecute(postgresIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Patching root-ca to frontend-nodes
+	filename_fe := "pg_fe.toml"
+	// Creating and Writing the required configurations in the toml file
+	config_fe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, rootCA)
+	err = patchRootCaToFrontend(config_fe, filename_fe, timestamp, infra)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+// This function will rotate the certificates of OpenSearch
+func certRotateOS(publicCert, privateCert, rootCA, adminCert, adminKey string, infra *AutomteHAInfraDetails) error {
+	fileName := "cert-rotate-os.toml"
+	timestamp := time.Now().Format("20060102150405")
+	sshUser, sskKeyFile, sshPort := getSshDetails(infra)
+
+	f, err := os.Create(fileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	e := existingInfra{}
+	admin_dn, err := e.getDistinguishedNameFromKey(adminCert)
+	if err != nil {
+		return err
+	}
+	nodes_dn, err := e.getDistinguishedNameFromKey(publicCert)
+	if err != nil {
+		return err
+	}
+
+	// Writing the required configurations in the toml file
+	config := fmt.Sprintf(OPENSEARCH_CONFIG, rootCA, adminCert, adminKey, publicCert, privateCert, fmt.Sprintf("%v", admin_dn), fmt.Sprintf("%v", nodes_dn))
+	_, err = f.Write([]byte(config))
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	opensearchIps := infra.Outputs.OpensearchPrivateIps.Value
+	if len(opensearchIps) == 0 {
+		return errors.New("No Opensearch IPs are found")
+	}
+	remoteService := "opensearch"
+
+	// Defining set of commands which run on opensearch nodes
+	scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
+	err = copyAndExecute(opensearchIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Patching root-ca to frontend-nodes
+	cn := nodes_dn.CommonName
+	filename_fe := "os_fe.toml"
+	// Creating and Writing the required configurations in the toml file
+	config_fe := fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG, rootCA, cn)
+	err = patchRootCaToFrontend(config_fe, filename_fe, timestamp, infra)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+// This function will patch the root-ca to frontend nodes to maintain the connection with backend nodes.
+func patchRootCaToFrontend(config_fe, filename_fe, timestamp string, infra *AutomteHAInfraDetails) error {
+	sshUser, sskKeyFile, sshPort := getSshDetails(infra)
+	remoteService := "frontend"
+	fe, err := os.Create(filename_fe)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = fe.Write([]byte(config_fe))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fe.Close()
+
+	frontendIps := append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
+	if len(frontendIps) == 0 {
+		return errors.New("No frontend IPs are found")
+	}
+
+	// Defining set of commands which run on frontend nodes
+	scriptCommands := fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
+	err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, filename_fe, scriptCommands)
+	if err != nil {
+		log.Fatal(err)
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -273,7 +273,7 @@ func copyAndExecute(ips []string, sshUser string, sshPort string, sskKeyFile str
 			return err
 		}
 
-		fmt.Printf("Started Applying the Configurations in %s node", remoteService)
+		fmt.Printf("Started Applying the Configurations in %s node: %s", remoteService, ips[i])
 		output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, ips[i], scriptCommands)
 		if err != nil {
 			writer.Errorf("%v", err)

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/toml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -16,12 +17,15 @@ var certFlags = struct {
 	privateCert string
 	publicCert  string
 	rootCA      string
+	adminCert   string
+	adminKey    string
 }{}
 
 var sshFlag = struct {
 	automate   bool
 	chefserver bool
 	postgres   bool
+	opensearch bool
 }{}
 
 var certRotateCmd = &cobra.Command{
@@ -40,10 +44,14 @@ func init() {
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.chefserver, "cs", false, "Chef Infra Server Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.postgres, "postgres", false, "Postgres Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.postgres, "pg", false, "Postgres Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.opensearch, "opensearch", false, "OS Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVar(&sshFlag.opensearch, "os", false, "OS Certificate Rotation")
 
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.privateCert, "private-cert", "", "Private certificate")
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.publicCert, "public-cert", "", "Public certificate")
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.rootCA, "root-ca", "", "RootCA certificate")
+	certRotateCmd.PersistentFlags().StringVar(&certFlags.adminCert, "admin-cert", "", "Admin certificate")
+	certRotateCmd.PersistentFlags().StringVar(&certFlags.adminKey, "admin-key", "", "Admin Private certificate")
 }
 
 const (
@@ -67,55 +75,44 @@ const (
 		enable = true
 		root_cert = """%v"""`
 
+	OPENSEARCH_CONFIG = `
+	[tls]
+		rootCA = """%v"""
+		admin_cert = """%v"""
+		admin_key = """%v"""
+		ssl_cert = """%v"""
+		ssl_key = """%v"""
+
+	[plugins.security.authcz]
+		admin_dn = '- %v'
+	[plugins.security.ssl.transport]
+		enforce_hostname_verification = false
+		resolve_hostname = false
+	[plugins.security]
+		nodes_dn = '- %v'`
+
+	OPENSEARCH_FRONTEND_CONFIG = `
+	[global.v1.external.opensearch.ssl]
+		root_cert = """%v"""
+		server_name = "%v"`
+
 	GET_USER_CONFIG = `
 	sudo cat /hab/user/automate-ha-%s/config/user.toml`
 
 	COPY_USER_CONFIG = `
-	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml`
+	sudo systemctl stop hab-sup.service
+	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml
+	sudo systemctl start hab-sup.service`
 )
 
+// This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func certRotate(cmd *cobra.Command, args []string) error {
-	privateCertPath := certFlags.privateCert
-	publicCertPath := certFlags.publicCert
-	rootCaPath := certFlags.rootCA
 	fileName := "cert-rotate.toml"
 	timestamp := time.Now().Format("20060102150405")
 
-	if privateCertPath == "" || publicCertPath == "" {
-		return errors.New("Please provide public and private cert paths")
-	}
-	var rootCA []byte
-	var err error
-	if sshFlag.postgres {
-		if rootCaPath == "" {
-			return errors.New("Please provide rootCA path")
-		}
-		rootCA, err = ioutil.ReadFile(rootCaPath) // nosemgrep
-		if err != nil {
-			return status.Wrap(
-				err,
-				status.FileAccessError,
-				fmt.Sprintf("failed reading data from file: %s", err.Error()),
-			)
-		}
-	}
-
-	privateCert, err := ioutil.ReadFile(privateCertPath) // nosemgrep
+	rootCA, publicCert, privateCert, adminCert, adminKey, err := getCerts()
 	if err != nil {
-		return status.Wrap(
-			err,
-			status.FileAccessError,
-			fmt.Sprintf("failed reading data from file: %s", err.Error()),
-		)
-	}
-
-	publicCert, err := ioutil.ReadFile(publicCertPath) // nosemgrep
-	if err != nil {
-		return status.Wrap(
-			err,
-			status.FileAccessError,
-			fmt.Sprintf("failed reading data from file: %s", err.Error()),
-		)
+		log.Fatal(err)
 	}
 
 	f, err := os.Create(fileName)
@@ -134,6 +131,7 @@ func certRotate(cmd *cobra.Command, args []string) error {
 		sshPort := infra.Outputs.SSHPort.Value
 
 		if sshFlag.automate || sshFlag.chefserver {
+			// Writing the required configurations in the toml file
 			config := fmt.Sprintf(FRONTEND_CONFIG, string(publicCert), string(privateCert), string(publicCert), string(privateCert))
 			_, err = f.Write([]byte(config))
 			if err != nil {
@@ -154,22 +152,15 @@ func certRotate(cmd *cobra.Command, args []string) error {
 				return errors.New(fmt.Sprintf("No %s Ips found", remoteService))
 			}
 
+			// Defining set of commands which run on frontend nodes
 			scriptCommands := fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
-			for i := 0; i < len(frontendIps); i++ {
-				err := copyFileToRemote(sskKeyFile, fileName, sshUser, frontendIps[i], remoteService+timestamp, false)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, frontendIps[i], scriptCommands)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				writer.Printf(output)
+			err := copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+			if err != nil {
+				log.Fatal(err)
 			}
 
 		} else if sshFlag.postgres {
+			// Writing the required configurations in the toml file
 			config := fmt.Sprintf(POSTGRES_CONFIG, string(privateCert), string(publicCert), string(rootCA))
 			_, err = f.Write([]byte(config))
 			if err != nil {
@@ -177,30 +168,22 @@ func certRotate(cmd *cobra.Command, args []string) error {
 			}
 			f.Close()
 
-			remoteService := "postgresql"
-			file := []string{fileName}
-			tomlFilePath, err := getMergerTOMLPath(file, infra, timestamp, remoteService, GET_USER_CONFIG)
-			if err != nil {
-				return err
-			}
-			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
 			postgresIps := infra.Outputs.PostgresqlPrivateIps.Value
-			for i := 0; i < len(postgresIps); i++ {
-				err := copyFileToRemote(sskKeyFile, tomlFilePath, sshUser, postgresIps[i], remoteService+timestamp, false)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, postgresIps[i], scriptCommands)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				writer.Printf(output)
+			if len(postgresIps) == 0 {
+				return errors.New("No Postgres IPs are found")
+			}
+			remoteService := "postgresql"
+
+			// Defining set of commands which run on postgres nodes
+			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
+			err = copyAndExecute(postgresIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+			if err != nil {
+				log.Fatal(err)
 			}
 
 			// Patching root-ca to frontend-nodes
 			filename_fe := "pg_fe.toml"
+			// Creating and Writing the required configurations in the toml file
 			config_fe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, string(rootCA))
 			fe, err := os.Create(filename_fe)
 			if err != nil {
@@ -218,21 +201,226 @@ func certRotate(cmd *cobra.Command, args []string) error {
 			}
 			remoteService = "frontend"
 
+			// Defining set of commands which run on frontend nodes
 			scriptCommands = fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
-			for i := 0; i < len(frontendIps); i++ {
-				err := copyFileToRemote(sskKeyFile, filename_fe, sshUser, frontendIps[i], remoteService+timestamp, false)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, frontendIps[i], scriptCommands)
-				if err != nil {
-					writer.Errorf("%v", err)
-					return err
-				}
-				writer.Printf(output)
+			err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, filename_fe, scriptCommands)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+		} else if sshFlag.opensearch {
+			e := existingInfra{}
+			admin_dn, err := e.getDistinguishedNameFromKey(string(adminCert))
+			if err != nil {
+				return err
+			}
+			nodes_dn, err := e.getDistinguishedNameFromKey(string(publicCert))
+			if err != nil {
+				return err
+			}
+
+			// Writing the required configurations in the toml file
+			config := fmt.Sprintf(OPENSEARCH_CONFIG, string(rootCA), string(adminCert), string(adminKey), string(publicCert), string(privateCert), fmt.Sprintf("%v", admin_dn), fmt.Sprintf("%v", nodes_dn))
+			_, err = f.Write([]byte(config))
+			if err != nil {
+				log.Fatal(err)
+			}
+			f.Close()
+
+			opensearchIps := infra.Outputs.OpensearchPrivateIps.Value
+			if len(opensearchIps) == 0 {
+				return errors.New("No Opensearch IPs are found")
+			}
+			remoteService := "opensearch"
+
+			// Defining set of commands which run on opensearch nodes
+			scriptCommands := fmt.Sprintf(COPY_USER_CONFIG, remoteService+timestamp, remoteService)
+			err = copyAndExecute(opensearchIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, fileName, scriptCommands)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// Patching root-ca to frontend-nodes
+			cn := nodes_dn.CommonName
+			filename_fe := "os_fe.toml"
+			// Creating and Writing the required configurations in the toml file
+			config_fe := fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG, string(rootCA), cn)
+			fe, err := os.Create(filename_fe)
+			if err != nil {
+				log.Fatal(err)
+			}
+			_, err = fe.Write([]byte(config_fe))
+			if err != nil {
+				log.Fatal(err)
+			}
+			fe.Close()
+
+			frontendIps := append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
+			if len(frontendIps) == 0 {
+				return errors.New("No frontend IPs are found")
+			}
+			remoteService = "frontend"
+
+			// Defining set of commands which run on frontend nodes
+			scriptCommands = fmt.Sprintf(FRONTEND_COMMANDS, remoteService+timestamp, dateFormat)
+			err = copyAndExecute(frontendIps, sshUser, sshPort, sskKeyFile, timestamp, remoteService, filename_fe, scriptCommands)
+			if err != nil {
+				log.Fatal(err)
 			}
 		}
 	}
 	return nil
+}
+
+// This function will copy the toml file to each required node and then execute the set of commands.
+func copyAndExecute(ips []string, sshUser string, sshPort string, sskKeyFile string, timestamp string, remoteService string, fileName string, scriptCommands string) error {
+
+	var err error
+	for i := 0; i < len(ips); i++ {
+		if (sshFlag.postgres || sshFlag.opensearch) && remoteService != "frontend" {
+			tomlFilePath, err := getMerger(fileName, timestamp, remoteService, GET_USER_CONFIG, sshUser, sshPort, sskKeyFile, ips[i])
+			if err != nil {
+				return err
+			}
+			// Copying the new toml file which includes both old and new configurations (for backend nodes).
+			err = copyFileToRemote(sskKeyFile, tomlFilePath, sshUser, ips[i], remoteService+timestamp, false)
+		} else {
+			// Copying the new toml file which includes new configurations (for frontend nodes).
+			err = copyFileToRemote(sskKeyFile, fileName, sshUser, ips[i], remoteService+timestamp, false)
+		}
+		if err != nil {
+			writer.Errorf("%v", err)
+			return err
+		}
+
+		fmt.Printf("Started Applying the Configurations in %s node", remoteService)
+		output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, ips[i], scriptCommands)
+		if err != nil {
+			writer.Errorf("%v", err)
+			return err
+		}
+		writer.Printf(output + "\n")
+	}
+	return nil
+}
+
+// This function will read the certificate paths, and then return the required certificates.
+func getCerts() (string, string, string, string, string, error) {
+	privateCertPath := certFlags.privateCert
+	publicCertPath := certFlags.publicCert
+	rootCaPath := certFlags.rootCA
+	adminCertPath := certFlags.adminCert
+	adminKeyPath := certFlags.adminKey
+	var rootCA, adminCert, adminKey []byte
+	var err error
+
+	if privateCertPath == "" || publicCertPath == "" {
+		return "", "", "", "", "", errors.New("Please provide public and private cert paths")
+	}
+
+	privateCert, err := ioutil.ReadFile(privateCertPath) // nosemgrep
+	if err != nil {
+		return "", "", "", "", "", status.Wrap(
+			err,
+			status.FileAccessError,
+			fmt.Sprintf("failed reading data from file: %s", err.Error()),
+		)
+	}
+
+	publicCert, err := ioutil.ReadFile(publicCertPath) // nosemgrep
+	if err != nil {
+		return "", "", "", "", "", status.Wrap(
+			err,
+			status.FileAccessError,
+			fmt.Sprintf("failed reading data from file: %s", err.Error()),
+		)
+	}
+
+	// Root CA is mandatory for PG and OS nodes.
+	if sshFlag.postgres || sshFlag.opensearch {
+		if rootCaPath == "" {
+			return "", "", "", "", "", errors.New("Please provide rootCA path")
+		}
+		rootCA, err = ioutil.ReadFile(rootCaPath) // nosemgrep
+		if err != nil {
+			return "", "", "", "", "", status.Wrap(
+				err,
+				status.FileAccessError,
+				fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			)
+		}
+	}
+
+	// Admin Cert and Admin Key is mandatory for OS nodes.
+	if sshFlag.opensearch {
+		if adminCertPath == "" || adminKeyPath == "" {
+			return "", "", "", "", "", errors.New("Please provide Admin cert and Admin key paths")
+		}
+		adminCert, err = ioutil.ReadFile(adminCertPath) // nosemgrep
+		if err != nil {
+			return "", "", "", "", "", status.Wrap(
+				err,
+				status.FileAccessError,
+				fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			)
+		}
+
+		adminKey, err = ioutil.ReadFile(adminKeyPath) // nosemgrep
+		if err != nil {
+			return "", "", "", "", "", status.Wrap(
+				err,
+				status.FileAccessError,
+				fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			)
+		}
+	}
+	return string(rootCA), string(publicCert), string(privateCert), string(adminCert), string(adminKey), nil
+}
+
+/* If we are working on backend service, then first we have to get the applied configurations
+and then merge it with new configurations, then apply that configuration.
+Because if we directly apply the new configurations, then the old applied configurations will be gone.
+So, we have to retain the old configurations also.
+
+This function will create the new toml file which includes old and new configurations.*/
+func getMerger(fileName string, timestamp string, remoteType string, config string, sshUser string, sshPort string, sskKeyFile string, remoteIP string) (string, error) {
+	tomlFile := fileName + timestamp
+	scriptCommands := fmt.Sprintf(config, remoteType)
+	rawOutput, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, remoteIP, scriptCommands)
+	if err != nil {
+		return "", err
+	}
+
+	var (
+		dest interface{}
+		err1 error
+	)
+	if remoteType == "opensearch" {
+		dest, err1 = getMergedOpensearchInterface(rawOutput, fileName, remoteType)
+	} else {
+		dest, err1 = getMergedPostgresqlInterface(rawOutput, fileName, remoteType)
+	}
+	if err1 != nil {
+		return "", err1
+	}
+
+	f, err := os.Create(tomlFile)
+
+	if err != nil {
+		// failed to create/open the file
+		writer.Bodyf("Failed to create/open the file, \n%v", err)
+		return "", err
+	}
+	if err := toml.NewEncoder(f).Encode(dest); err != nil {
+		// failed to encode
+		writer.Bodyf("Failed to encode\n%v", err)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		// failed to close the file
+		writer.Bodyf("Failed to close the file\n%v", err)
+		return "", err
+	}
+
+	return tomlFile, nil
 }

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -113,10 +113,6 @@ func certRotate(cmd *cobra.Command, args []string) error {
 	}
 
 	if isA2HARBFileExist() {
-		if isManagedServicesOn() {
-			return errors.New("You can not rotate certs for managed services")
-		}
-
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
@@ -165,6 +161,9 @@ func certRotateFrontend(publicCert, privateCert string, infra *AutomteHAInfraDet
 
 // This function will rotate the certificates of Postgres
 func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraDetails) error {
+	if isManagedServicesOn() {
+		return errors.New("You can not rotate certs for AWS managed services")
+	}
 	fileName := "cert-rotate-pg.toml"
 	timestamp := time.Now().Format("20060102150405")
 	remoteService := "postgresql"
@@ -190,6 +189,9 @@ func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraD
 
 // This function will rotate the certificates of OpenSearch
 func certRotateOS(publicCert, privateCert, rootCA, adminCert, adminKey string, infra *AutomteHAInfraDetails) error {
+	if isManagedServicesOn() {
+		return errors.New("You can not rotate certs for AWS managed services")
+	}
 	fileName := "cert-rotate-os.toml"
 	timestamp := time.Now().Format("20060102150405")
 	remoteService := "opensearch"

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -113,6 +113,10 @@ func certRotate(cmd *cobra.Command, args []string) error {
 	}
 
 	if isA2HARBFileExist() {
+		if isManagedServicesOn() {
+			return errors.New("You can not rotate certs for managed services")
+		}
+
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -364,7 +364,6 @@ func copyFileToRemote(sshKeyFile string, tomlFilePath string, sshUser string, ho
 			return err
 		}
 	}
-	writer.Print("Copied TOML file to remote\n")
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/configTemplate.go
+++ b/components/automate-cli/cmd/chef-automate/configTemplate.go
@@ -1,13 +1,13 @@
 package main
 
 type OpensearchConfig struct {
-	Action struct {
+	Action *struct {
 		DestructiveRequiresName string `protobuf:"bytes,,opt,name=destructive_requires_name,proto3" toml:"destructive_requires_name,omitempty" json:"destructive_requires_name,omitempty" mapstructure:"destructive_requires_name,omitempty"`
 	} `protobuf:"bytes,,opt,name=action,proto3" toml:"action,omitempty" json:"action,omitempty" mapstructure:"action,omitempty"`
-	Bootstrap struct {
-		MemoryLock bool `protobuf:"bytes,,opt,name=memory_lock,proto3" toml:"memory_lock,omitempty" json:"memory_lock,omitempty" mapstructure:"memory_lock,omitempty"`
+	Bootstrap *struct {
+		MemoryLock *bool `protobuf:"bytes,,opt,name=memory_lock,proto3" toml:"memory_lock,omitempty" json:"memory_lock,omitempty" mapstructure:"memory_lock,omitempty"`
 	} `protobuf:"bytes,,opt,name=bootstrap,proto3" toml:"bootstrap,omitempty" json:"bootstrap,omitempty" mapstructure:"bootstrap,omitempty"`
-	Cluster struct {
+	Cluster *struct {
 		Name    string `protobuf:"bytes,,opt,name=name,proto3" toml:"name,omitempty" json:"name,omitempty" mapstructure:"name,omitempty"`
 		Routing struct {
 			Allocation struct {
@@ -18,22 +18,22 @@ type OpensearchConfig struct {
 			} `protobuf:"bytes,,opt,name=allocation,proto3" toml:"allocation,omitempty" json:"allocation,omitempty" mapstructure:"allocation,omitempty"`
 		} `protobuf:"bytes,,opt,name=routing,proto3" toml:"routing,omitempty" json:"routing,omitempty" mapstructure:"routing,omitempty"`
 	} `protobuf:"bytes,,opt,name=cluster,proto3" toml:"cluster,omitempty" json:"cluster,omitempty" mapstructure:"cluster,omitempty"`
-	Deprecated struct {
-		ExternalOs bool `protobuf:"bytes,,opt,name=external_os,proto3" toml:"external_os,omitempty" json:"external_os,omitempty" mapstructure:"external_os,omitempty"`
+	Deprecated *struct {
+		ExternalOs *bool `protobuf:"bytes,,opt,name=external_os,proto3" toml:"external_os,omitempty" json:"external_os,omitempty" mapstructure:"external_os,omitempty"`
 	} `protobuf:"bytes,,opt,name=deprecated,proto3" toml:"deprecated,omitempty" json:"deprecated,omitempty" mapstructure:"deprecated,omitempty"`
-	Discovery struct {
-		MinimumMasterNodes int      `protobuf:"bytes,,opt,name=minimum_master_nodes,proto3" toml:"minimum_master_nodes,omitempty" json:"minimum_master_nodes,omitempty" mapstructure:"minimum_master_nodes,omitempty"`
+	Discovery *struct {
+		MinimumMasterNodes int      `protobuf:"bytes,,opt,name=minimum_master_nodes,proto3" toml:"minimum_master_nodes,omitzero" json:"minimum_master_nodes,omitzero" mapstructure:"minimum_master_nodes,omitzero"`
 		PingUnicastHosts   []string `protobuf:"bytes,,opt,name=ping_unicast_hosts,proto3" toml:"ping_unicast_hosts,omitempty" json:"ping_unicast_hosts,omitempty" mapstructure:"ping_unicast_hosts,omitempty"`
 		ZenFdPingTimeout   string   `protobuf:"bytes,,opt,name=zen_fd_ping_timeout,proto3" toml:"zen_fd_ping_timeout,omitempty" json:"zen_fd_ping_timeout,omitempty" mapstructure:"zen_fd_ping_timeout,omitempty"`
 	} `protobuf:"bytes,,opt,name=discovery,proto3" toml:"discovery,omitempty" json:"discovery,omitempty" mapstructure:"discovery,omitempty"`
-	Gateway struct {
+	Gateway *struct {
 		ExpectedDataNodes   string `protobuf:"bytes,,opt,name=expected_data_nodes,proto3" toml:"expected_data_nodes,omitempty" json:"expected_data_nodes,omitempty" mapstructure:"expected_data_nodes,omitempty"`
 		ExpectedMasterNodes string `protobuf:"bytes,,opt,name=expected_master_nodes,proto3" toml:"expected_master_nodes,omitempty" json:"expected_master_nodes,omitempty" mapstructure:"expected_master_nodes,omitempty"`
 		ExpectedNodes       string `protobuf:"bytes,,opt,name=expected_nodes,proto3" toml:"expected_nodes,omitempty" json:"expected_nodes,omitempty" mapstructure:"expected_nodes,omitempty"`
 		RecoverAfterNodes   string `protobuf:"bytes,,opt,name=recover_after_nodes,proto3" toml:"recover_after_nodes,omitempty" json:"recover_after_nodes,omitempty" mapstructure:"recover_after_nodes,omitempty"`
 		RecoverAfterTime    string `protobuf:"bytes,,opt,name=recover_after_time,proto3" toml:"recover_after_time,omitempty" json:"recover_after_time,omitempty" mapstructure:"recover_after_time,omitempty"`
 	} `protobuf:"bytes,,opt,name=gateway,proto3" toml:"gateway,omitempty" json:"gateway,omitempty" mapstructure:"gateway,omitempty"`
-	Indices struct {
+	Indices *struct {
 		Breaker struct {
 			FielddataLimit    string `protobuf:"bytes,,opt,name=fielddata_limit,proto3" toml:"fielddata_limit,omitempty" json:"fielddata_limit,omitempty" mapstructure:"fielddata_limit,omitempty"`
 			FielddataOverhead string `protobuf:"bytes,,opt,name=fielddata_overhead,proto3" toml:"fielddata_overhead,omitempty" json:"fielddata_overhead,omitempty" mapstructure:"fielddata_overhead,omitempty"`
@@ -48,70 +48,70 @@ type OpensearchConfig struct {
 			MaxBytesPerSec string `protobuf:"bytes,,opt,name=max_bytes_per_sec,proto3" toml:"max_bytes_per_sec,omitempty" json:"max_bytes_per_sec,omitempty" mapstructure:"max_bytes_per_sec,omitempty"`
 		} `protobuf:"bytes,,opt,name=recovery,proto3" toml:"recovery,omitempty" json:"recovery,omitempty" mapstructure:"recovery,omitempty"`
 	} `protobuf:"bytes,,opt,name=indices,proto3" toml:"indices,omitempty" json:"indices,omitempty" mapstructure:"indices,omitempty"`
-	Logger struct {
+	Logger *struct {
 		Level string `protobuf:"bytes,,opt,name=level,proto3" toml:"level,omitempty" json:"level,omitempty" mapstructure:"level,omitempty"`
 	} `protobuf:"bytes,,opt,name=logger,proto3" toml:"logger,omitempty" json:"logger,omitempty" mapstructure:"logger,omitempty"`
-	Network struct {
+	Network *struct {
 		Host string `protobuf:"bytes,,opt,name=host,proto3" toml:"host,omitempty" json:"host,omitempty" mapstructure:"host,omitempty"`
-		Port int    `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitempty" json:"port,omitempty" mapstructure:"port,omitempty"`
+		Port int    `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitzero" json:"port,omitzero" mapstructure:"port,omitzero"`
 	} `protobuf:"bytes,,opt,name=network,proto3" toml:"network,omitempty" json:"network,omitempty" mapstructure:"network,omitempty"`
-	Node struct {
+	Node *struct {
 		Data                 bool   `protobuf:"bytes,,opt,name=data,proto3" toml:"data,omitempty" json:"data,omitempty" mapstructure:"data,omitempty"`
 		Master               bool   `protobuf:"bytes,,opt,name=master,proto3" toml:"master,omitempty" json:"master,omitempty" mapstructure:"master,omitempty"`
-		MaxLocalStorageNodes int    `protobuf:"bytes,,opt,name=max_local_storage_nodes,proto3" toml:"max_local_storage_nodes,omitempty" json:"max_local_storage_nodes,omitempty" mapstructure:"max_local_storage_nodes,omitempty"`
+		MaxLocalStorageNodes int    `protobuf:"bytes,,opt,name=max_local_storage_nodes,proto3" toml:"max_local_storage_nodes,omitzero" json:"max_local_storage_nodes,omitzero" mapstructure:"max_local_storage_nodes,omitzero"`
 		Name                 string `protobuf:"bytes,,opt,name=name,proto3" toml:"name,omitempty" json:"name,omitempty" mapstructure:"name,omitempty"`
 		RackID               string `protobuf:"bytes,,opt,name=rack_id,proto3" toml:"rack_id,omitempty" json:"rack_id,omitempty" mapstructure:"rack_id,omitempty"`
 		Zone                 string `protobuf:"bytes,,opt,name=zone,proto3" toml:"zone,omitempty" json:"zone,omitempty" mapstructure:"zone,omitempty"`
 	} `protobuf:"bytes,,opt,name=node,proto3" toml:"node,omitempty" json:"node,omitempty" mapstructure:"node,omitempty"`
-	OpensearchAuth struct {
+	OpensearchAuth *struct {
 		AdminPassword  string `protobuf:"bytes,,opt,name=admin_password,proto3" toml:"admin_password,omitempty" json:"admin_password,omitempty" mapstructure:"admin_password,omitempty"`
 		AdminUsername  string `protobuf:"bytes,,opt,name=admin_username,proto3" toml:"admin_username,omitempty" json:"admin_username,omitempty" mapstructure:"admin_username,omitempty"`
 		HashedPassword string `protobuf:"bytes,,opt,name=hashed_password,proto3" toml:"hashed_password,omitempty" json:"hashed_password,omitempty" mapstructure:"hashed_password,omitempty"`
 	} `protobuf:"bytes,,opt,name=opensearch_auth,proto3" toml:"opensearch_auth,omitempty" json:"opensearch_auth,omitempty" mapstructure:"opensearch_auth,omitempty"`
-	Path struct {
+	Path *struct {
 		Data string `protobuf:"bytes,,opt,name=data,proto3" toml:"data,omitempty" json:"data,omitempty" mapstructure:"data,omitempty"`
 		Logs string `protobuf:"bytes,,opt,name=logs,proto3" toml:"logs,omitempty" json:"logs,omitempty" mapstructure:"logs,omitempty"`
 		Repo string `protobuf:"bytes,,opt,name=repo,proto3" toml:"repo,omitempty" json:"repo,omitempty" mapstructure:"repo,omitempty"`
 	} `protobuf:"bytes,,opt,name=path,proto3" toml:"path,omitempty" json:"path,omitempty" mapstructure:"path,omitempty"`
-	Plugins struct {
+	Plugins *struct {
 		Security struct {
 			AllowDefaultInitSecurityindex       bool   `protobuf:"bytes,,opt,name=allow_default_init_securityindex,proto3" toml:"allow_default_init_securityindex,omitempty" json:"allow_default_init_securityindex,omitempty" mapstructure:"allow_default_init_securityindex,omitempty"`
 			AllowUnsafeDemocertificates         bool   `protobuf:"bytes,,opt,name=allow_unsafe_democertificates,proto3" toml:"allow_unsafe_democertificates,omitempty" json:"allow_unsafe_democertificates,omitempty" mapstructure:"allow_unsafe_democertificates,omitempty"`
 			CheckSnapshotRestoreWritePrivileges bool   `protobuf:"bytes,,opt,name=check_snapshot_restore_write_privileges,proto3" toml:"check_snapshot_restore_write_privileges,omitempty" json:"check_snapshot_restore_write_privileges,omitempty" mapstructure:"check_snapshot_restore_write_privileges,omitempty"`
 			EnableSnapshotRestorePrivilege      bool   `protobuf:"bytes,,opt,name=enable_snapshot_restore_privilege,proto3" toml:"enable_snapshot_restore_privilege,omitempty" json:"enable_snapshot_restore_privilege,omitempty" mapstructure:"enable_snapshot_restore_privilege,omitempty"`
 			NodesDn                             string `protobuf:"bytes,,opt,name=nodes_dn,proto3" toml:"nodes_dn,omitempty" json:"nodes_dn,omitempty" mapstructure:"nodes_dn,omitempty"`
-			Audit                               struct {
+			Audit                               *struct {
 				Type string `protobuf:"bytes,,opt,name=type,proto3" toml:"type,omitempty" json:"type,omitempty" mapstructure:"type,omitempty"`
 			} `protobuf:"bytes,,opt,name=audit,proto3" toml:"audit,omitempty" json:"audit,omitempty" mapstructure:"audit,omitempty"`
 			Authcz struct {
 				AdminDn string `protobuf:"bytes,,opt,name=admin_dn,proto3" toml:"admin_dn,omitempty" json:"admin_dn,omitempty" mapstructure:"admin_dn,omitempty"`
 			} `protobuf:"bytes,,opt,name=authcz,proto3" toml:"authcz,omitempty" json:"authcz,omitempty" mapstructure:"authcz,omitempty"`
-			Restapi struct {
+			Restapi *struct {
 				RolesEnabled string `protobuf:"bytes,,opt,name=roles_enabled,proto3" toml:"roles_enabled,omitempty" json:"roles_enabled,omitempty" mapstructure:"roles_enabled,omitempty"`
 			} `protobuf:"bytes,,opt,name=restapi,proto3" toml:"restapi,omitempty" json:"restapi,omitempty" mapstructure:"restapi,omitempty"`
 			Ssl struct {
-				HTTP struct {
+				HTTP *struct {
 					Enabled               bool   `protobuf:"bytes,,opt,name=enabled,proto3" toml:"enabled,omitempty" json:"enabled,omitempty" mapstructure:"enabled,omitempty"`
 					PemcertFilepath       string `protobuf:"bytes,,opt,name=pemcert_filepath,proto3" toml:"pemcert_filepath,omitempty" json:"pemcert_filepath,omitempty" mapstructure:"pemcert_filepath,omitempty"`
 					PemkeyFilepath        string `protobuf:"bytes,,opt,name=pemkey_filepath,proto3" toml:"pemkey_filepath,omitempty" json:"pemkey_filepath,omitempty" mapstructure:"pemkey_filepath,omitempty"`
 					PemtrustedcasFilepath string `protobuf:"bytes,,opt,name=pemtrustedcas_filepath,proto3" toml:"pemtrustedcas_filepath,omitempty" json:"pemtrustedcas_filepath,omitempty" mapstructure:"pemtrustedcas_filepath,omitempty"`
 				} `protobuf:"bytes,,opt,name=http,proto3" toml:"http,omitempty" json:"http,omitempty" mapstructure:"http,omitempty"`
 				Transport struct {
-					EnforceHostnameVerification bool   `protobuf:"bytes,,opt,name=enforce_hostname_verification,proto3" toml:"enforce_hostname_verification,omitempty" json:"enforce_hostname_verification,omitempty" mapstructure:"enforce_hostname_verification,omitempty"`
+					EnforceHostnameVerification *bool  `protobuf:"bytes,,opt,name=enforce_hostname_verification,proto3" toml:"enforce_hostname_verification,omitempty" json:"enforce_hostname_verification,omitempty" mapstructure:"enforce_hostname_verification,omitempty"`
 					PemcertFilepath             string `protobuf:"bytes,,opt,name=pemcert_filepath,proto3" toml:"pemcert_filepath,omitempty" json:"pemcert_filepath,omitempty" mapstructure:"pemcert_filepath,omitempty"`
 					PemkeyFilepath              string `protobuf:"bytes,,opt,name=pemkey_filepath,proto3" toml:"pemkey_filepath,omitempty" json:"pemkey_filepath,omitempty" mapstructure:"pemkey_filepath,omitempty"`
 					PemtrustedcasFilepath       string `protobuf:"bytes,,opt,name=pemtrustedcas_filepath,proto3" toml:"pemtrustedcas_filepath,omitempty" json:"pemtrustedcas_filepath,omitempty" mapstructure:"pemtrustedcas_filepath,omitempty"`
-					ResolveHostname             bool   `protobuf:"bytes,,opt,name=resolve_hostname,proto3" toml:"resolve_hostname,omitempty" json:"resolve_hostname,omitempty" mapstructure:"resolve_hostname,omitempty"`
+					ResolveHostname             *bool  `protobuf:"bytes,,opt,name=resolve_hostname,proto3" toml:"resolve_hostname,omitempty" json:"resolve_hostname,omitempty" mapstructure:"resolve_hostname,omitempty"`
 				} `protobuf:"bytes,,opt,name=transport,proto3" toml:"transport,omitempty" json:"transport,omitempty" mapstructure:"transport,omitempty"`
 			} `protobuf:"bytes,,opt,name=ssl,proto3" toml:"ssl,omitempty" json:"ssl,omitempty" mapstructure:"ssl,omitempty"`
-			SystemIndices struct {
+			SystemIndices *struct {
 				CloudAwsSigner string `protobuf:"bytes,,opt,name=cloud_aws_signer,proto3" toml:"cloud_aws_signer,omitempty" json:"cloud_aws_signer,omitempty" mapstructure:"cloud_aws_signer,omitempty"`
-				Enabled        bool   `protobuf:"bytes,,opt,name=enabled,proto3" toml:"enabled,omitempty" json:"enabled,omitempty" mapstructure:"enabled,omitempty"`
+				Enabled        *bool  `protobuf:"bytes,,opt,name=enabled,proto3" toml:"enabled,omitempty" json:"enabled,omitempty" mapstructure:"enabled,omitempty"`
 				Indices        string `protobuf:"bytes,,opt,name=indices,proto3" toml:"indices,omitempty" json:"indices,omitempty" mapstructure:"indices,omitempty"`
 			} `protobuf:"bytes,,opt,name=system_indices,proto3" toml:"system_indices,omitempty" json:"system_indices,omitempty" mapstructure:"system_indices,omitempty"`
 		} `protobuf:"bytes,,opt,name=security,proto3" toml:"security,omitempty" json:"security,omitempty" mapstructure:"security,omitempty"`
 	} `protobuf:"bytes,,opt,name=plugins,proto3" toml:"plugins,omitempty" json:"plugins,omitempty" mapstructure:"plugins,omitempty"`
-	Runtime struct {
+	Runtime *struct {
 		EsJavaOpts                     string `protobuf:"bytes,,opt,name=es_java_opts,proto3" toml:"es_java_opts,omitempty" json:"es_java_opts,omitempty" mapstructure:"es_java_opts,omitempty"`
 		EsStartupSleepTime             string `protobuf:"bytes,,opt,name=es_startup_sleep_time,proto3" toml:"es_startup_sleep_time,omitempty" json:"es_startup_sleep_time,omitempty" mapstructure:"es_startup_sleep_time,omitempty"`
 		G1ReservePercent               string `protobuf:"bytes,,opt,name=g1ReservePercent,proto3" toml:"g1ReservePercent,omitempty" json:"g1ReservePercent,omitempty" mapstructure:"g1ReservePercent,omitempty"`
@@ -121,7 +121,7 @@ type OpensearchConfig struct {
 		MaxOpenFiles                   string `protobuf:"bytes,,opt,name=max_open_files,proto3" toml:"max_open_files,omitempty" json:"max_open_files,omitempty" mapstructure:"max_open_files,omitempty"`
 		MinHeapsize                    string `protobuf:"bytes,,opt,name=minHeapsize,proto3" toml:"minHeapsize,omitempty" json:"minHeapsize,omitempty" mapstructure:"minHeapsize,omitempty"`
 	} `protobuf:"bytes,,opt,name=runtime,proto3" toml:"runtime,omitempty" json:"runtime,omitempty" mapstructure:"runtime,omitempty"`
-	S3 struct {
+	S3 *struct {
 		Client struct {
 			Default struct {
 				Endpoint           string `protobuf:"bytes,,opt,name=endpoint,proto3" toml:"endpoint,omitempty" json:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
@@ -132,15 +132,15 @@ type OpensearchConfig struct {
 			} `protobuf:"bytes,,opt,name=default,proto3" toml:"default,omitempty" json:"default,omitempty" mapstructure:"default,omitempty"`
 		} `protobuf:"bytes,,opt,name=client,proto3" toml:"client,omitempty" json:"client,omitempty" mapstructure:"client,omitempty"`
 	} `protobuf:"bytes,,opt,name=s3,proto3" toml:"s3,omitempty" json:"s3,omitempty" mapstructure:"s3,omitempty"`
-	TLS struct {
+	TLS *struct {
 		AdminCert string `protobuf:"bytes,,opt,name=admin_cert,proto3" toml:"admin_cert,omitempty" json:"admin_cert,omitempty" mapstructure:"admin_cert,omitempty"`
 		AdminKey  string `protobuf:"bytes,,opt,name=admin_key,proto3" toml:"admin_key,omitempty" json:"admin_key,omitempty" mapstructure:"admin_key,omitempty"`
 		RootCA    string `protobuf:"bytes,,opt,name=rootCA,proto3" toml:"rootCA,omitempty" json:"rootCA,omitempty" mapstructure:"rootCA,omitempty"`
 		SslCert   string `protobuf:"bytes,,opt,name=ssl_cert,proto3" toml:"ssl_cert,omitempty" json:"ssl_cert,omitempty" mapstructure:"ssl_cert,omitempty"`
 		SslKey    string `protobuf:"bytes,,opt,name=ssl_key,proto3" toml:"ssl_key,omitempty" json:"ssl_key,omitempty" mapstructure:"ssl_key,omitempty"`
 	} `protobuf:"bytes,,opt,name=tls,proto3" toml:"tls,omitempty" json:"tls,omitempty" mapstructure:"tls,omitempty"`
-	Transport struct {
-		Port int `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitempty" json:"port,omitempty" mapstructure:"port,omitempty"`
+	Transport *struct {
+		Port int `protobuf:"bytes,,opt,name=port,proto3" toml:"port,omitzero" json:"port,omitzero" mapstructure:"port,omitzero"`
 	} `protobuf:"bytes,,opt,name=transport,proto3" toml:"transport,omitempty" json:"transport,omitempty" mapstructure:"transport,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Sahiba3108 <sgoyal@progress.com>
SanjuPal01 <sanju.sanju@progress.com>
### :nut_and_bolt: Description: What code changed, and why?
Added the cert rotate command for HA service. Now user has to pass the certificate paths to cert-rotate cmd and it will rotate the certificates of all opensearch nodes.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-231
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Add this package in your manifest while deploying HA:
sahiba3108/automate-ha-deployment/0.1.0/20221028084038

Install this cli in your bastion host:
sahiba3108/automate-cli/0.1.0/20221111124650

Run the below command in bastion:
`chef-automate cert-rotate --public-cert node1.pem --private-cert node1-key.pem --root-ca root-ca.pem --admin-cert admin.pem --admin-key admin-key.pem --os`
(You can also use --opensearch flag instead of os)
This will rotate the public, private, root, admin cert and admin key of all os nodes.
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1468" alt="Screenshot 2022-11-11 at 3 32 27 PM" src="https://user-images.githubusercontent.com/101255220/201316606-9ce30df2-ec5b-40e9-9fe6-5dcb3c549275.png">
<img width="1085" alt="Screenshot 2022-11-11 at 3 20 20 PM" src="https://user-images.githubusercontent.com/101255220/201314286-8e4c5967-b33e-476f-8bf2-02a84e8d913b.png">
<img width="914" alt="Screenshot 2022-11-11 at 3 17 11 PM" src="https://user-images.githubusercontent.com/101255220/201314360-b36d7a9b-7cbe-4598-84aa-54e34540b84c.png">
<img width="921" alt="Screenshot 2022-11-11 at 3 17 00 PM" src="https://user-images.githubusercontent.com/101255220/201314340-5bd127d6-a499-49d9-aeda-e84fa0fb3ee9.png">
<img width="689" alt="Screenshot 2022-11-11 at 3 23 55 PM" src="https://user-images.githubusercontent.com/101255220/201315594-c0a15384-ab5e-4ecd-95c9-7439a9e4f5ff.png">

Video Link: https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/ETAARk9tnmZLpuw2axg4BooBoFSUrrKa2PMXsuvLf5942Q?e=kzFyMw