### PR TITLE
update the grep msg for automate ha upgrade for FE

### DIFF
--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -139,7 +139,7 @@ wait_for_upgrade() {
             return 1
     esac
 
-    if echo "$upgrade_status_output" | grep 'up-to-date'; then
+    if echo "$upgrade_status_output" | grep 'upgraded to airgap bundle'; then
         upgrade_complete="true"
         break
     else


### PR DESCRIPTION
Signed-off-by: punitmundra <punitmundra2008@gmail.com>
sudo chef-automate upgrade status 
return that 
 ✔ Chef Automate upgraded to airgap bundle version: 4.3.22
 Find out what's new in version (4.3.22) by visiting

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
