### PR TITLE
Setup logrotate params:

### DIFF
--- a/components/automate-deployment/pkg/server/automate_config.go
+++ b/components/automate-deployment/pkg/server/automate_config.go
@@ -299,7 +299,7 @@ func setConfigForRedirectLogs(req *api.PatchAutomateConfigRequest, existingCopy 
 
 		res, err := UpdateOfLogroateConfig(req, existingCopy)
 		if err != nil {
-			logrus.Errorf("cannot merge requested and existing structs through mergo.Merge: ", err)
+			logrus.Errorf("cannot merge requested and existing structs through mergo.Merge: %v", err)
 		}
 
 		if err = runLogrotateConfig(res); err != nil {
@@ -418,10 +418,10 @@ func configLogrotate(req *config.Log) error {
 
 	if req.GetCompressRotatedLogs().GetValue() == true {
 		logRotateConfigContent = LogRotateConf(getLogFileName(req.GetRedirectLogFilePath().GetValue()),
-			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate", "compress")
+			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate", "compress", "dateext")
 	} else {
 		logRotateConfigContent = LogRotateConf(getLogFileName(req.GetRedirectLogFilePath().GetValue()),
-			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate")
+			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate", "dateext")
 	}
 
 	// Write the byteSlice to file

--- a/components/automate-deployment/pkg/server/automate_config.go
+++ b/components/automate-deployment/pkg/server/automate_config.go
@@ -292,7 +292,7 @@ func setConfigForRedirectLogs(req *api.PatchAutomateConfigRequest, existingCopy 
 			}
 
 			if err = runLogrotateConfig(res); err != nil {
-				logrus.Errorf("cannot configure log rotate: %v", err)
+				logrus.Errorf("cannot configure log rotate with existing file path: %v", err)
 				return err
 			}
 			return nil
@@ -314,7 +314,7 @@ func setConfigForRedirectLogs(req *api.PatchAutomateConfigRequest, existingCopy 
 		}
 
 		if err = runLogrotateConfig(res); err != nil {
-			logrus.Errorf("cannot configure log rotate: %v", err)
+			logrus.Errorf("cannot configure log rotate qith new file path: %v", err)
 			return err
 		}
 

--- a/components/automate-deployment/pkg/server/automate_config.go
+++ b/components/automate-deployment/pkg/server/automate_config.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 
 	"github.com/chef/automate/api/config/deployment"
@@ -291,8 +290,8 @@ func setConfigForRedirectLogs(req *api.PatchAutomateConfigRequest, existingCopy 
 			logrus.Errorf("cannot merge requested and existing structs through mergo.Merge: %v", err)
 		}
 
-		if reflect.DeepEqual(res.Config.Global.V1.Log, existingCopy.Global.V1.Log) {
-			return errors.New("structs are equal, there is nothing to update")
+		if IfEqual(res, existingCopy) {
+			return nil
 		}
 
 		if req.GetConfig().GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue() == existingCopy.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue() {
@@ -463,4 +462,15 @@ func UpdateByMergingStructs(req *api.PatchAutomateConfigRequest, existingCopy *d
 	}
 
 	return req, nil
+}
+
+func IfEqual(req *api.PatchAutomateConfigRequest, existingCopy *deployment.AutomateConfig) bool {
+	if req.Config.Global.V1.Log.MaxNumberRotatedLogs == existingCopy.Global.V1.Log.MaxNumberRotatedLogs &&
+		req.Config.Global.V1.Log.RedirectLogFilePath == existingCopy.Global.V1.Log.RedirectLogFilePath &&
+		req.Config.Global.V1.Log.CompressRotatedLogs == existingCopy.Global.V1.Log.CompressRotatedLogs &&
+		req.Config.Global.V1.Log.MaxSizeRotateLogs == existingCopy.Global.V1.Log.MaxSizeRotateLogs {
+		return true
+	}
+
+	return false
 }

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -16,7 +16,7 @@ const (
 	filePath2 = "/var/tmp/automate.log"
 )
 
-func TestUpdateOfLogroateConfig(t *testing.T) {
+func TestUpdateOfLogroateConfigMergingStructs(t *testing.T) {
 	type args struct {
 		req          *api.PatchAutomateConfigRequest
 		existingCopy *deployment.AutomateConfig
@@ -171,7 +171,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := UpdateOfLogroateConfig(tt.args.req, tt.args.existingCopy)
+			got, err := UpdateOfLogroateConfigMergingStructs(tt.args.req, tt.args.existingCopy)
 			logrus.Printf("Final: %+v", got)
 
 			if (err != nil) != tt.wantErr {

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -76,7 +76,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 							V1: &shared.V1{
 								Log: &shared.Log{
 									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
 									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: false},
 									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
@@ -105,7 +105,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
@@ -137,7 +137,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/shared"
+	api "github.com/chef/automate/api/interservice/deployment"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func Test_editConfig(t *testing.T) {
+	type args struct {
+		req          *api.PatchAutomateConfigRequest
+		existingCopy *deployment.AutomateConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *api.PatchAutomateConfigRequest
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "If exsting value isn't set",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "10"},
+									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 3},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog: &wrapperspb.BoolValue{Value: true},
+							},
+						},
+					},
+				},
+			},
+			want: &api.PatchAutomateConfigRequest{
+				Config: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "10"},
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 3},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "If keys are missing in existing value",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: false},
+									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
+									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath: &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								CompressRotatedLogs: &wrapperspb.BoolValue{Value: true},
+
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 10},
+							},
+						},
+					},
+				},
+			},
+			want: &api.PatchAutomateConfigRequest{
+				Config: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "If keys are missing in requested value",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
+									RedirectLogFilePath: &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+									MaxSizeRotateLogs:   &wrapperspb.StringValue{Value: "30M"},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/var/automate.log"},
+								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
+							},
+						},
+					},
+				},
+			},
+			want: &api.PatchAutomateConfigRequest{
+				Config: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EditConfig(tt.args.req, tt.args.existingCopy)
+			logrus.Printf("Final: %+v", got)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("editConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.Config.Global.V1.Log.RedirectLogFilePath.Value != tt.want.Config.Global.V1.Log.RedirectLogFilePath.Value {
+				t.Errorf("Values aren't the same")
+			}
+			if got.Config.Global.V1.Log.CompressRotatedLogs.Value != tt.want.Config.Global.V1.Log.CompressRotatedLogs.Value {
+				t.Errorf("Values aren't the same")
+			}
+			if got.Config.Global.V1.Log.MaxSizeRotateLogs.Value != tt.want.Config.Global.V1.Log.MaxSizeRotateLogs.Value {
+				t.Errorf("Values aren't the same")
+			}
+			if got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value != tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value {
+				t.Errorf("Values aren't the same")
+			}
+			// b := reflect.DeepEqual(got, tt.want)
+			// logrus.Println("DeepEqual: ", b)
+			// if !b {
+			// 	t.Errorf("editConfig() = %v, want %v", got, tt.want)
+			// }
+		})
+	}
+}

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -27,7 +27,6 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 		want    *api.PatchAutomateConfigRequest
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			name: "If exsting value isn't set",
 			args: args{

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/chef/automate/api/config/deployment"
 	"github.com/chef/automate/api/config/shared"
 	api "github.com/chef/automate/api/interservice/deployment"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -172,12 +171,9 @@ func TestUpdateByMergingStructs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := UpdateByMergingStructs(tt.args.req, tt.args.existingCopy)
-			logrus.Printf("Final: %+v", got)
+			require.NoError(t, err)
+			require.False(t, tt.wantErr)
 
-			if (err != nil) != tt.wantErr {
-				t.Errorf("editConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			require.Equal(t, got.Config.Global.V1.Log.RedirectLogFilePath.Value, tt.want.Config.Global.V1.Log.RedirectLogFilePath.Value)
 			require.Equal(t, got.Config.Global.V1.Log.CompressRotatedLogs.Value, tt.want.Config.Global.V1.Log.CompressRotatedLogs.Value)
 			require.Equal(t, got.Config.Global.V1.Log.MaxSizeRotateLogs.Value, tt.want.Config.Global.V1.Log.MaxSizeRotateLogs.Value)

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -16,7 +16,7 @@ const (
 	filePath2 = "/var/tmp/automate.log"
 )
 
-func TestUpdateOfLogroateConfigMergingStructs(t *testing.T) {
+func TestUpdateByMergingStructs(t *testing.T) {
 	type args struct {
 		req          *api.PatchAutomateConfigRequest
 		existingCopy *deployment.AutomateConfig
@@ -171,7 +171,7 @@ func TestUpdateOfLogroateConfigMergingStructs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := UpdateOfLogroateConfigMergingStructs(tt.args.req, tt.args.existingCopy)
+			got, err := UpdateByMergingStructs(tt.args.req, tt.args.existingCopy)
 			logrus.Printf("Final: %+v", got)
 
 			if (err != nil) != tt.wantErr {

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -11,6 +11,11 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+const (
+	filePath1 = "/var/log/automate.log"
+	filePath2 = "/var/tmp/automate.log"
+)
+
 func TestUpdateOfLogroateConfig(t *testing.T) {
 	type args struct {
 		req          *api.PatchAutomateConfigRequest
@@ -32,7 +37,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 							V1: &shared.V1{
 								Log: &shared.Log{
 									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath2},
 									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "10"},
 									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 3},
@@ -57,7 +62,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath2},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "10"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 3},
@@ -77,7 +82,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 							V1: &shared.V1{
 								Log: &shared.Log{
 									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-									RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath1},
 									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: false},
 									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
@@ -91,7 +96,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath: &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								RedirectLogFilePath: &wrapperspb.StringValue{Value: filePath2},
 								CompressRotatedLogs: &wrapperspb.BoolValue{Value: true},
 
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 10},
@@ -106,7 +111,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath1},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
@@ -126,7 +131,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 							V1: &shared.V1{
 								Log: &shared.Log{
 									RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
-									RedirectLogFilePath: &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+									RedirectLogFilePath: &wrapperspb.StringValue{Value: filePath2},
 									MaxSizeRotateLogs:   &wrapperspb.StringValue{Value: "30M"},
 								},
 							},
@@ -138,7 +143,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/log/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath1},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
@@ -153,7 +158,7 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 						V1: &shared.V1{
 							Log: &shared.Log{
 								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
-								RedirectLogFilePath:  &wrapperspb.StringValue{Value: "/var/tmp/automate.log"},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath2},
 								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
 								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
 								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -174,16 +174,16 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 				return
 			}
 			if got.Config.Global.V1.Log.RedirectLogFilePath.Value != tt.want.Config.Global.V1.Log.RedirectLogFilePath.Value {
-				t.Errorf("Values aren't the same")
+				t.Errorf("RedirectLogFilePath Values aren't the same: %v", err)
 			}
 			if got.Config.Global.V1.Log.CompressRotatedLogs.Value != tt.want.Config.Global.V1.Log.CompressRotatedLogs.Value {
-				t.Errorf("Values aren't the same")
+				t.Errorf("CompressRotatedLogs Values aren't the same: %v", err)
 			}
 			if got.Config.Global.V1.Log.MaxSizeRotateLogs.Value != tt.want.Config.Global.V1.Log.MaxSizeRotateLogs.Value {
-				t.Errorf("Values aren't the same")
+				t.Errorf("MaxSizeRotateLogs Values aren't the same: %v", err)
 			}
 			if got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value != tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value {
-				t.Errorf("Values aren't the same")
+				t.Errorf("MaxNumberRotatedLogs Values aren't the same: %v", err)
 			}
 		})
 	}

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func Test_editConfig(t *testing.T) {
+func TestUpdateOfLogroateConfig(t *testing.T) {
 	type args struct {
 		req          *api.PatchAutomateConfigRequest
 		existingCopy *deployment.AutomateConfig
@@ -166,7 +166,7 @@ func Test_editConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := EditConfig(tt.args.req, tt.args.existingCopy)
+			got, err := UpdateOfLogroateConfig(tt.args.req, tt.args.existingCopy)
 			logrus.Printf("Final: %+v", got)
 
 			if (err != nil) != tt.wantErr {
@@ -185,11 +185,6 @@ func Test_editConfig(t *testing.T) {
 			if got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value != tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value {
 				t.Errorf("Values aren't the same")
 			}
-			// b := reflect.DeepEqual(got, tt.want)
-			// logrus.Println("DeepEqual: ", b)
-			// if !b {
-			// 	t.Errorf("editConfig() = %v, want %v", got, tt.want)
-			// }
 		})
 	}
 }

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/chef/automate/api/config/deployment"
 	"github.com/chef/automate/api/config/shared"
 	api "github.com/chef/automate/api/interservice/deployment"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -180,4 +181,114 @@ func TestUpdateByMergingStructs(t *testing.T) {
 			require.Equal(t, got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value, tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value)
 		})
 	}
+}
+
+func TestSetConfigForRedirectLogs(t *testing.T) {
+	type args struct {
+		req          *api.PatchAutomateConfigRequest
+		existingCopy *deployment.AutomateConfig
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "RedirectSysLog is true for patch and existing",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+									RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath2},
+									CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+									MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "10"},
+									MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 3},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog: &wrapperspb.BoolValue{Value: true},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "If merge result and existing are equal",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog: &wrapperspb.BoolValue{Value: true},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath:  &wrapperspb.StringValue{Value: filePath1},
+								CompressRotatedLogs:  &wrapperspb.BoolValue{Value: true},
+								MaxSizeRotateLogs:    &wrapperspb.StringValue{Value: "30M"},
+								MaxNumberRotatedLogs: &wrapperspb.Int32Value{Value: 11},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "If requested RedirectLogFilePath is same as existing",
+			args: args{
+				req: &api.PatchAutomateConfigRequest{
+					Config: &deployment.AutomateConfig{
+						Global: &shared.GlobalConfig{
+							V1: &shared.V1{
+								Log: &shared.Log{
+									RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
+									RedirectLogFilePath: &wrapperspb.StringValue{Value: filePath1},
+								},
+							},
+						},
+					},
+				},
+				existingCopy: &deployment.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      &wrapperspb.BoolValue{Value: true},
+								RedirectLogFilePath: &wrapperspb.StringValue{Value: filePath1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	{
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := setConfigForRedirectLogs(tt.args.req, tt.args.existingCopy)
+				if err == nil {
+					assert.NoError(t, err)
+				} else {
+					assert.Error(t, err)
+				}
+			})
+		}
+	}
+
 }

--- a/components/automate-deployment/pkg/server/automate_config_test.go
+++ b/components/automate-deployment/pkg/server/automate_config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chef/automate/api/config/shared"
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -173,18 +174,10 @@ func TestUpdateOfLogroateConfig(t *testing.T) {
 				t.Errorf("editConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got.Config.Global.V1.Log.RedirectLogFilePath.Value != tt.want.Config.Global.V1.Log.RedirectLogFilePath.Value {
-				t.Errorf("RedirectLogFilePath Values aren't the same: %v", err)
-			}
-			if got.Config.Global.V1.Log.CompressRotatedLogs.Value != tt.want.Config.Global.V1.Log.CompressRotatedLogs.Value {
-				t.Errorf("CompressRotatedLogs Values aren't the same: %v", err)
-			}
-			if got.Config.Global.V1.Log.MaxSizeRotateLogs.Value != tt.want.Config.Global.V1.Log.MaxSizeRotateLogs.Value {
-				t.Errorf("MaxSizeRotateLogs Values aren't the same: %v", err)
-			}
-			if got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value != tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value {
-				t.Errorf("MaxNumberRotatedLogs Values aren't the same: %v", err)
-			}
+			require.Equal(t, got.Config.Global.V1.Log.RedirectLogFilePath.Value, tt.want.Config.Global.V1.Log.RedirectLogFilePath.Value)
+			require.Equal(t, got.Config.Global.V1.Log.CompressRotatedLogs.Value, tt.want.Config.Global.V1.Log.CompressRotatedLogs.Value)
+			require.Equal(t, got.Config.Global.V1.Log.MaxSizeRotateLogs.Value, tt.want.Config.Global.V1.Log.MaxSizeRotateLogs.Value)
+			require.Equal(t, got.Config.Global.V1.Log.MaxNumberRotatedLogs.Value, tt.want.Config.Global.V1.Log.MaxNumberRotatedLogs.Value)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Pappu Kumar <pappu.kumar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
The code is basically changed to allow user to change log-rotate configurations and rsyslog path.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
The Video:

https://user-images.githubusercontent.com/36985548/201336685-3be0c884-b1a0-464c-aa39-7d3f2b76203e.mov


### :+1: Definition of Done
- the user should be able to change log-rotate parameters like:
    - no of rotated file
    - size of files
    - path pointing to the files etc
    
### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-deployment/`
`rebuild components/automate-cli/`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
