### PR TITLE
Automate HA Prereq Common Cluster User

### DIFF
--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -27,16 +27,18 @@ This section will discuss the steps to deploy Chef Automate HA on-premise machin
 - OS Root Volume (/) must be at least 40 GB
 - TMP space (/var/tmp) must be at least 5GB
 - Separate Hab volume (/hab) provisioned at least 100 GB for OpenSearch node `/hab` volume will be more based on the data retention policy.
-- A Common user has access to all machines.
-- This common user should have sudo privileges.
-- This common user uses the same SSH Private Key file to access all machines.
-- Key-based SSH for the provisioning user for all the machines for HA-Deployment.
-- We do not support passphrases for Private Key authentication.
-- LoadBalancers are set up according to [Chef Automate HA Architecture](/automate/ha/) needs as explained in [Load Balancer Configuration page](/automate/loadbalancer_configuration/).
+- A common user has been created on all machines involved in the cluster
+- This common user has SSH access to all machines
+- This common user has the same UID on all machines
+- This common user should have sudo privileges on all machines
+- This common user uses the same SSH Private Key file to access all machines
+- Key-based SSH for the provisioning user for all the machines for HA-Deployment
+- We do not support passphrases for Private Key authentication
+- LoadBalancers are set up according to [Chef Automate HA Architecture](/automate/ha/) needs as explained in [Load Balancer Configuration page](/automate/loadbalancer_configuration/)
 - Network ports are opened as per [Chef Automate Architecture](/automate/ha/) needs as explained in [Security and Firewall page](/automate/ha_security_firewall/)
-- DNS is configured to redirect `chefautomate.example.com` to the Primary Load Balancer.
-- DNS is configured to redirect `chefinfraserver.example.com` to the Primary Load Balancer.
-- Certificates are created and added for `chefautomate.example.com`, and `chefinfraserver.example.com` in the Load Balancers.
+- DNS is configured to redirect `chefautomate.example.com` to the Primary Load Balancer
+- DNS is configured to redirect `chefinfraserver.example.com` to the Primary Load Balancer
+- Certificates are created and added for `chefautomate.example.com`, and `chefinfraserver.example.com` in the Load Balancers
 - If DNS is not used, then these records should be added to `/etc/hosts` in all the machines, including Bastion:
 
 ```bash


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

* In order to SSH login as the same user all over the cluster, that user must be created first
* Same UID is good too, if we want to share files

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) no code
- [X] Docs added/updated? (all customer-facing changes)
