### PR TITLE
Added support for remote certs

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -567,6 +567,7 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 	if !IsValidFilePath(remoteFilePath) {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote file path: %v", remoteFilePath))
 	}
+	remoteFilePath = filepath.Clean(remoteFilePath)
 
 	// Get the filename from the file path.
 	fileName := filepath.Base(remoteFilePath)

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -133,19 +136,21 @@ const (
 	sudo systemctl stop hab-sup.service
 	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml
 	sudo systemctl start hab-sup.service`
+
+	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 )
 
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func certRotate(cmd *cobra.Command, args []string) error {
-	rootCA, publicCert, privateCert, adminCert, adminKey, err := getCerts()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	if isA2HARBFileExist() {
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
+		}
+
+		rootCA, publicCert, privateCert, adminCert, adminKey, err := getCerts(infra)
+		if err != nil {
+			log.Fatal(err)
 		}
 
 		// we need to ignore root-ca, adminCert and adminKey in the case of each node
@@ -441,7 +446,7 @@ func getIps(remoteService string, infra *AutomteHAInfraDetails) []string {
 }
 
 // This function will read the certificate paths, and then return the required certificates.
-func getCerts() (string, string, string, string, string, error) {
+func getCerts(infra *AutomteHAInfraDetails) (string, string, string, string, string, error) {
 	privateCertPath := certFlags.privateCert
 	publicCertPath := certFlags.publicCert
 	rootCaPath := certFlags.rootCA
@@ -450,25 +455,27 @@ func getCerts() (string, string, string, string, string, error) {
 	var rootCA, adminCert, adminKey []byte
 	var err error
 
+	const fileAccessErrorMsg string = "failed reading data from the given source, %s"
+
 	if privateCertPath == "" || publicCertPath == "" {
 		return "", "", "", "", "", errors.New("Please provide public and private cert paths")
 	}
 
-	privateCert, err := ioutil.ReadFile(privateCertPath) // nosemgrep
+	privateCert, err := getCertFromFile(privateCertPath, infra)
 	if err != nil {
 		return "", "", "", "", "", status.Wrap(
 			err,
 			status.FileAccessError,
-			fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			fmt.Sprintf(fileAccessErrorMsg, err.Error()),
 		)
 	}
 
-	publicCert, err := ioutil.ReadFile(publicCertPath) // nosemgrep
+	publicCert, err := getCertFromFile(publicCertPath, infra)
 	if err != nil {
 		return "", "", "", "", "", status.Wrap(
 			err,
 			status.FileAccessError,
-			fmt.Sprintf("failed reading data from file: %s", err.Error()),
+			fmt.Sprintf(fileAccessErrorMsg, err.Error()),
 		)
 	}
 
@@ -478,12 +485,12 @@ func getCerts() (string, string, string, string, string, error) {
 			return "", "", "", "", "", errors.New("Please provide rootCA path")
 		}
 		if rootCaPath != "" {
-			rootCA, err = ioutil.ReadFile(rootCaPath) // nosemgrep
+			rootCA, err = getCertFromFile(rootCaPath, infra)
 			if err != nil {
 				return "", "", "", "", "", status.Wrap(
 					err,
 					status.FileAccessError,
-					fmt.Sprintf("failed reading data from file: %s", err.Error()),
+					fmt.Sprintf(fileAccessErrorMsg, err.Error()),
 				)
 			}
 		}
@@ -495,21 +502,21 @@ func getCerts() (string, string, string, string, string, error) {
 			return "", "", "", "", "", errors.New("Please provide Admin cert and Admin key paths")
 		}
 		if adminCertPath != "" && adminKeyPath != "" {
-			adminCert, err = ioutil.ReadFile(adminCertPath) // nosemgrep
+			adminCert, err = getCertFromFile(adminCertPath, infra)
 			if err != nil {
 				return "", "", "", "", "", status.Wrap(
 					err,
 					status.FileAccessError,
-					fmt.Sprintf("failed reading data from file: %s", err.Error()),
+					fmt.Sprintf(fileAccessErrorMsg, err.Error()),
 				)
 			}
 
-			adminKey, err = ioutil.ReadFile(adminKeyPath) // nosemgrep
+			adminKey, err = getCertFromFile(adminCertPath, infra)
 			if err != nil {
 				return "", "", "", "", "", status.Wrap(
 					err,
 					status.FileAccessError,
-					fmt.Sprintf("failed reading data from file: %s", err.Error()),
+					fmt.Sprintf(fileAccessErrorMsg, err.Error()),
 				)
 			}
 		}
@@ -518,13 +525,56 @@ func getCerts() (string, string, string, string, string, error) {
 	return string(rootCA), string(publicCert), string(privateCert), string(adminCert), string(adminKey), nil
 }
 
+// This function will read the certificate from the given path (local or remote).
+func getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, error) {
+	// Checking if the given path is remote or local.
+	if isRemotePath(certPath) {
+		// Get Host IP from the given path and validate it.
+		hostIP := getIPV4(certPath)
+		if net.ParseIP(hostIP).To4() == nil {
+			return nil, errors.New(fmt.Sprintf("%v is not a valid IPv4 address", hostIP))
+		}
+
+		// Get the file path from the given remote address.
+		certPaths := strings.Split(certPath, ":")
+		if len(certPaths) != 2 {
+			return nil, errors.New(fmt.Sprintf("Invalid remote path: %v", certPath))
+		}
+		remoteFilePath := strings.TrimSpace(certPaths[1])
+		fileName := filepath.Base(remoteFilePath)
+		if remoteFilePath == "" || fileName == "" {
+			return nil, errors.New(fmt.Sprintf("Invalid remote path: %v", certPath))
+		}
+
+		// Download certificate from remote host.
+		sshConfig := getSshDetails(infra)
+		sshUtil := NewSSHUtil(sshConfig)
+		sshUtil.getSSHConfig().hostIP = hostIP
+		filePath, err := sshUtil.copyFileFromRemote(remoteFilePath, fileName)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Unable to copy file from remote path: %v", certPath))
+		}
+		return ioutil.ReadFile(filePath) // nosemgrep
+	}
+	return ioutil.ReadFile(certPath) // nosemgrep
+}
+
+func isRemotePath(path string) bool {
+	pattern := regexp.MustCompile(IP_V4_REGEX)
+	return pattern.MatchString(path)
+}
+
+func getIPV4(path string) string {
+	pattern := regexp.MustCompile(IP_V4_REGEX)
+	return pattern.FindString(path)
+}
+
 /*
 	If we are working on backend service, then first we have to get the applied configurations
 
 and then merge it with new configurations, then apply that configuration.
 Because if we directly apply the new configurations, then the old applied configurations will be gone.
 So, we have to retain the old configurations also.
-
 This function will create the new toml file which includes old and new configurations.
 */
 func getMerger(fileName string, timestamp string, remoteType string, config string, sshUtil SSHUtil) (string, error) {

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -137,8 +137,7 @@ const (
 	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml
 	sudo systemctl start hab-sup.service`
 
-	IP_V4_REGEX     = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
-	FILE_PATH_REGEX = `^[A-Za-z0-9\/\-_]+(\.([a-zA-Z]+))$`
+	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 )
 
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
@@ -564,9 +563,6 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 
 	// Get the file path and validate it.
 	remoteFilePath := filepath.Clean(strings.TrimSpace(certPaths[1]))
-	if !IsValidFilePath(remoteFilePath) {
-		return "", "", "", errors.New(fmt.Sprintf("Invalid remote file path: %v", remoteFilePath))
-	}
 
 	// Get the filename from the file path.
 	fileName := filepath.Base(remoteFilePath)
@@ -587,12 +583,6 @@ func IsRemotePath(path string) bool {
 func GetIPV4(path string) string {
 	pattern := regexp.MustCompile(IP_V4_REGEX)
 	return pattern.FindString(path)
-}
-
-// File path should be absolute.
-func IsValidFilePath(path string) bool {
-	pattern := regexp.MustCompile(FILE_PATH_REGEX)
-	return pattern.MatchString(path)
 }
 
 /*

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -527,6 +527,7 @@ func getCerts(infra *AutomteHAInfraDetails) (string, string, string, string, str
 
 // This function will read the certificate from the given path (local or remote).
 func getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, error) {
+	certPath = strings.TrimSpace(certPath)
 	// Checking if the given path is remote or local.
 	if IsRemotePath(certPath) {
 		remoteFilePath, fileName, hostIP, err := GetRemoteFileDetails(certPath)
@@ -567,8 +568,10 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 	return remoteFilePath, fileName, hostIP, nil
 }
 
+// Path should be in this format <IPv4>:<PathToFile>
+// Example, 10.1.0.234:/home/ec2-user/certs/public.pem
 func IsRemotePath(path string) bool {
-	pattern := regexp.MustCompile(IP_V4_REGEX)
+	pattern := regexp.MustCompile(`^` + IP_V4_REGEX + `:`)
 	return pattern.MatchString(path)
 }
 

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -511,7 +511,7 @@ func getCerts(infra *AutomteHAInfraDetails) (string, string, string, string, str
 				)
 			}
 
-			adminKey, err = getCertFromFile(adminCertPath, infra)
+			adminKey, err = getCertFromFile(adminKeyPath, infra)
 			if err != nil {
 				return "", "", "", "", "", status.Wrap(
 					err,

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -539,10 +539,10 @@ func getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, err
 		sshUtil := NewSSHUtil(sshConfig)
 		sshUtil.getSSHConfig().hostIP = hostIP
 		filePath, err := sshUtil.copyFileFromRemote(remoteFilePath, fileName)
-		defer os.Remove(filePath)
 		if err != nil {
 			return nil, errors.New(fmt.Sprintf("Unable to copy file from remote path: %v", certPath))
 		}
+		defer os.Remove(filePath)
 		return ioutil.ReadFile(filePath) // nosemgrep
 	}
 	return ioutil.ReadFile(certPath) // nosemgrep

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -539,6 +539,7 @@ func getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, err
 		sshUtil := NewSSHUtil(sshConfig)
 		sshUtil.getSSHConfig().hostIP = hostIP
 		filePath, err := sshUtil.copyFileFromRemote(remoteFilePath, fileName)
+		defer os.Remove(filePath)
 		if err != nil {
 			return nil, errors.New(fmt.Sprintf("Unable to copy file from remote path: %v", certPath))
 		}

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -134,8 +134,6 @@ func init() {
 		RunE:  certRotateCmdFunc(&flagsObj),
 	}
 
-	RootCmd.AddCommand(certRotateCmd)
-
 	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.automate, "automate", "a", false, "Automate Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&flagsObj.automate, "a2", false, "Automate Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.chefserver, "chef_server", "c", false, "Chef Infra Server Certificate Rotation")
@@ -152,6 +150,8 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminKeyPath, "admin-key", "", "Admin Private certificate")
 
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.node, "node", "", "Node Ip address")
+
+	RootCmd.AddCommand(certRotateCmd)
 }
 
 func certRotateCmdFunc(flagsObj *flags) func(cmd *cobra.Command, args []string) error {

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -267,11 +267,11 @@ func (c *certRotateFlow) certRotatePG(sshUtil SSHUtil, certs *certificates, infr
 		return nil
 	}
 	// Patching root-ca to frontend-nodes for maintaining the connection.
-	filename_fe := "pg_fe.toml"
+	filenameFe := "pg_fe.toml"
 	remoteService = "frontend"
 	// Creating and patching the required configurations.
-	config_fe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, certs.rootCA)
-	err = c.patchConfig(sshUtil, config_fe, filename_fe, timestamp, remoteService, infra, flagsObj)
+	configFe := fmt.Sprintf(POSTGRES_FRONTEND_CONFIG, certs.rootCA)
+	err = c.patchConfig(sshUtil, configFe, filenameFe, timestamp, remoteService, infra, flagsObj)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -288,15 +288,15 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	remoteService := "opensearch"
 
 	e := existingInfra{}
-	var admin_dn pkix.Name
+	var adminDn pkix.Name
 	var err error
 	if flagsObj.node == "" {
-		admin_dn, err = e.getDistinguishedNameFromKey(certs.adminCert)
+		adminDn, err = e.getDistinguishedNameFromKey(certs.adminCert)
 		if err != nil {
 			return err
 		}
 	}
-	nodes_dn, err := e.getDistinguishedNameFromKey(certs.publicCert)
+	nodesDn, err := e.getDistinguishedNameFromKey(certs.publicCert)
 	if err != nil {
 		return err
 	}
@@ -304,9 +304,9 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	// Creating and patching the required configurations.
 	var config string
 	if flagsObj.node != "" {
-		config = fmt.Sprintf(OPENSEARCH_CONFIG_IGNORE_ADMIN_AND_ROOTCA, certs.publicCert, certs.privateCert, fmt.Sprintf("%v", nodes_dn))
+		config = fmt.Sprintf(OPENSEARCH_CONFIG_IGNORE_ADMIN_AND_ROOTCA, certs.publicCert, certs.privateCert, fmt.Sprintf("%v", nodesDn))
 	} else {
-		config = fmt.Sprintf(OPENSEARCH_CONFIG, certs.rootCA, certs.adminCert, certs.adminKey, certs.publicCert, certs.privateCert, fmt.Sprintf("%v", admin_dn), fmt.Sprintf("%v", nodes_dn))
+		config = fmt.Sprintf(OPENSEARCH_CONFIG, certs.rootCA, certs.adminCert, certs.adminKey, certs.publicCert, certs.privateCert, fmt.Sprintf("%v", adminDn), fmt.Sprintf("%v", nodesDn))
 	}
 	err = c.patchConfig(sshUtil, config, fileName, timestamp, remoteService, infra, flagsObj)
 	if err != nil {
@@ -314,18 +314,18 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	}
 
 	// Patching root-ca to frontend-nodes for maintaining the connection.
-	cn := nodes_dn.CommonName
-	filename_fe := "os_fe.toml"
+	cn := nodesDn.CommonName
+	filenameFe := "os_fe.toml"
 	remoteService = "frontend"
 
 	// Creating and patching the required configurations.
-	var config_fe string
+	var configFe string
 	if flagsObj.node != "" {
-		config_fe = fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG_IGNORE_ROOT_CERT, cn)
+		configFe = fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG_IGNORE_ROOT_CERT, cn)
 	} else {
-		config_fe = fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG, certs.rootCA, cn)
+		configFe = fmt.Sprintf(OPENSEARCH_FRONTEND_CONFIG, certs.rootCA, cn)
 	}
-	err = c.patchConfig(sshUtil, config_fe, filename_fe, timestamp, remoteService, infra, flagsObj)
+	err = c.patchConfig(sshUtil, configFe, filenameFe, timestamp, remoteService, infra, flagsObj)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -161,7 +161,7 @@ func certRotateCmdFunc(flagsObj *flags) func(cmd *cobra.Command, args []string) 
 	}
 }
 
-// This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
+// certRotate will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj *flags) error {
 	if isA2HARBFileExist() {
 		infra, err := getAutomateHAInfraDetails()
@@ -207,7 +207,7 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 	return nil
 }
 
-// This function will rotate the certificates of Automate and Chef Infra Server,
+// certRotateFrontend will rotate the certificates of Automate and Chef Infra Server.
 func (c *certRotateFlow) certRotateFrontend(sshUtil SSHUtil, certs *certificates, infra *AutomteHAInfraDetails, flagsObj *flags) error {
 	fileName := "cert-rotate-fe.toml"
 	timestamp := time.Now().Format("20060102150405")
@@ -240,7 +240,7 @@ func (c *certRotateFlow) certRotateFrontend(sshUtil SSHUtil, certs *certificates
 	return nil
 }
 
-// This function will rotate the certificates of Postgres
+// certRotatePG will rotate the certificates of Postgres.
 func (c *certRotateFlow) certRotatePG(sshUtil SSHUtil, certs *certificates, infra *AutomteHAInfraDetails, flagsObj *flags) error {
 	if isManagedServicesOn() {
 		return errors.New("You can not rotate certs for AWS managed services")
@@ -278,7 +278,7 @@ func (c *certRotateFlow) certRotatePG(sshUtil SSHUtil, certs *certificates, infr
 	return nil
 }
 
-// This function will rotate the certificates of OpenSearch
+// certRotateOS will rotate the certificates of OpenSearch.
 func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infra *AutomteHAInfraDetails, flagsObj *flags) error {
 	if isManagedServicesOn() {
 		return errors.New("You can not rotate certs for AWS managed services")
@@ -332,7 +332,7 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	return nil
 }
 
-// This function will patch the configurations to required nodes.
+// patchConfig will patch the configurations to required nodes.
 func (c *certRotateFlow) patchConfig(sshUtil SSHUtil, config, filename, timestamp, remoteService string, infra *AutomteHAInfraDetails, flagsObj *flags) error {
 	f, err := os.Create(filename)
 	if err != nil {
@@ -372,7 +372,7 @@ func (c *certRotateFlow) patchConfig(sshUtil SSHUtil, config, filename, timestam
 	return nil
 }
 
-// This function will rotate the root-ca in the ChefServer to maintain the connection
+// patchRootCAinCS will rotate the root-ca in the ChefServer to maintain the connection.
 func (c *certRotateFlow) patchRootCAinCS(sshUtil SSHUtil, rootCA, timestamp string, infra *AutomteHAInfraDetails, flagsObj *flags) error {
 
 	fileName := "rotate-root_CA.toml"
@@ -396,7 +396,7 @@ func (c *certRotateFlow) patchRootCAinCS(sshUtil SSHUtil, rootCA, timestamp stri
 	return nil
 }
 
-// This function will copy the toml file to each required node and then execute the set of commands.
+// copyAndExecute will copy the toml file to each required node and then execute the set of commands.
 func (c *certRotateFlow) copyAndExecute(ips []string, sshUtil SSHUtil, timestamp string, remoteService string, fileName string, scriptCommands string, flagsObj *flags) error {
 
 	var err error
@@ -430,6 +430,7 @@ func (c *certRotateFlow) copyAndExecute(ips []string, sshUtil SSHUtil, timestamp
 	return nil
 }
 
+// validateEachIp validate given ip with the remoteService cluster.
 func (c *certRotateFlow) validateEachIp(remoteService string, infra *AutomteHAInfraDetails, flagsObj *flags) bool {
 	ips := c.getIps(remoteService, infra)
 	for i := 0; i < len(ips); i++ {
@@ -440,7 +441,7 @@ func (c *certRotateFlow) validateEachIp(remoteService string, infra *AutomteHAIn
 	return false
 }
 
-// This function will return the SSH details.
+// getSshDetails will return the SSH details.
 func (c *certRotateFlow) getSshDetails(infra *AutomteHAInfraDetails) *SSHConfig {
 	sshConfig := &SSHConfig{
 		sshUser:    infra.Outputs.SSHUser.Value,
@@ -450,7 +451,7 @@ func (c *certRotateFlow) getSshDetails(infra *AutomteHAInfraDetails) *SSHConfig 
 	return sshConfig
 }
 
-// This function will return the Ips based on the given remote service.
+// getIps will return the Ips based on the given remote service.
 func (c *certRotateFlow) getIps(remoteService string, infra *AutomteHAInfraDetails) []string {
 	if remoteService == "automate" {
 		return infra.Outputs.AutomatePrivateIps.Value
@@ -466,7 +467,7 @@ func (c *certRotateFlow) getIps(remoteService string, infra *AutomteHAInfraDetai
 	return []string{}
 }
 
-// This function will read the certificate paths, and then return the required certificates.
+// getCerts will read the certificate paths, and then return the required certificates.
 func (c *certRotateFlow) getCerts(infra *AutomteHAInfraDetails, flagsObj *flags) (*certificates, error) {
 	privateCertPath := flagsObj.privateCertPath
 	publicCertPath := flagsObj.publicCertPath
@@ -554,7 +555,7 @@ func (c *certRotateFlow) getCerts(infra *AutomteHAInfraDetails, flagsObj *flags)
 	return certs, nil
 }
 
-// This function will read the certificate from the given path (local or remote).
+// getCertFromFile will read the certificate from the given path (local or remote).
 func (c *certRotateFlow) getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, error) {
 	certPath = strings.TrimSpace(certPath)
 	// Checking if the given path is remote or local.
@@ -578,7 +579,7 @@ func (c *certRotateFlow) getCertFromFile(certPath string, infra *AutomteHAInfraD
 	return c.FileUtils.ReadFile(certPath)
 }
 
-// Get the remote file details from path.
+// GetRemoteFileDetails returns the remote file details from the remotePath.
 func (c *certRotateFlow) GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 	// Get Host IP from the given path and validate it.
 	hostIP := c.GetIPV4(remotePath)
@@ -604,25 +605,30 @@ func (c *certRotateFlow) GetRemoteFileDetails(remotePath string) (string, string
 	return remoteFilePath, fileName, hostIP, nil
 }
 
-// Path should be in this format <IPv4>:<PathToFile>
-// Example, 10.1.0.234:/home/ec2-user/certs/public.pem
+/*
+IsRemotePath checks whether given path is valid remote path.
+Path should be in this format <IPv4>:<PathToFile>.
+
+Example: 10.1.0.234:/home/ec2-user/certs/public.pem
+*/
 func (c *certRotateFlow) IsRemotePath(path string) bool {
 	pattern := regexp.MustCompile(`^` + IP_V4_REGEX + `:`)
 	return pattern.MatchString(path)
 }
 
+// GetIPV4 returns ip from given path.
 func (c *certRotateFlow) GetIPV4(path string) string {
 	pattern := regexp.MustCompile(IP_V4_REGEX)
 	return pattern.FindString(path)
 }
 
 /*
-	If we are working on backend service, then first we have to get the applied configurations
+getMerger will create the new toml file which includes old and new configurations.
 
+If we are working on backend service, then first we have to get the applied configurations
 and then merge it with new configurations, then apply that configuration.
 Because if we directly apply the new configurations, then the old applied configurations will be gone.
 So, we have to retain the old configurations also.
-This function will create the new toml file which includes old and new configurations.
 */
 func (c *certRotateFlow) getMerger(fileName string, timestamp string, remoteType string, config string, sshUtil SSHUtil) (string, error) {
 	tomlFile := fileName + timestamp

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -18,23 +18,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type flags struct {
-	automate    bool
-	chefserver  bool
-	postgres    bool
-	opensearch  bool
-	privateCert string
-	publicCert  string
-	rootCA      string
-	adminCert   string
-	adminKey    string
-	node        string
-}
-
-type certRotateFlow struct {
-	FileUtils fileutils.FileUtils
-}
-
 const (
 	FRONTEND_CONFIG = `
 	[[load_balancer.v1.sys.frontend_tls]]
@@ -111,6 +94,28 @@ const (
 	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 )
 
+type flags struct {
+	//SSH
+	automate   bool
+	chefserver bool
+	postgres   bool
+	opensearch bool
+
+	// Certificates
+	privateCert string
+	publicCert  string
+	rootCA      string
+	adminCert   string
+	adminKey    string
+
+	// Node
+	node string
+}
+
+type certRotateFlow struct {
+	FileUtils fileutils.FileUtils
+}
+
 func init() {
 	flagsObj := flags{}
 
@@ -137,6 +142,7 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.rootCA, "root-ca", "", "RootCA certificate")
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminCert, "admin-cert", "", "Admin certificate")
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminKey, "admin-key", "", "Admin Private certificate")
+
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.node, "node", "", "Node Ip address")
 }
 

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -137,7 +137,8 @@ const (
 	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml
 	sudo systemctl start hab-sup.service`
 
-	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+	IP_V4_REGEX     = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
+	FILE_PATH_REGEX = `^[A-Za-z0-9\/\-_]+(\.([a-zA-Z]+))$`
 )
 
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
@@ -555,16 +556,24 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 		return "", "", "", errors.New(fmt.Sprintf("%v is not a valid IPv4 address", hostIP))
 	}
 
-	// Get the file path from the given remote address.
+	// Get the file path and filename from the given remote address.
 	certPaths := strings.Split(remotePath, ":")
 	if len(certPaths) != 2 {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote path: %v", remotePath))
 	}
+
+	// Get the file path and validate it.
 	remoteFilePath := strings.TrimSpace(certPaths[1])
+	if !IsValidFilePath(remoteFilePath) {
+		return "", "", "", errors.New(fmt.Sprintf("Invalid remote file path: %v", remoteFilePath))
+	}
+
+	// Get the filename from the file path.
 	fileName := filepath.Base(remoteFilePath)
 	if remoteFilePath == "" || fileName == string(os.PathSeparator) {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote path: %v", remotePath))
 	}
+
 	return remoteFilePath, fileName, hostIP, nil
 }
 
@@ -578,6 +587,12 @@ func IsRemotePath(path string) bool {
 func GetIPV4(path string) string {
 	pattern := regexp.MustCompile(IP_V4_REGEX)
 	return pattern.FindString(path)
+}
+
+// File path should be absolute.
+func IsValidFilePath(path string) bool {
+	pattern := regexp.MustCompile(FILE_PATH_REGEX)
+	return pattern.MatchString(path)
 }
 
 /*

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -18,24 +18,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var certFlags = struct {
+type certFlagsStruct struct {
 	privateCert string
 	publicCert  string
 	rootCA      string
 	adminCert   string
 	adminKey    string
-}{}
+}
+var certFlags = certFlagsStruct{}
 
-var nodeFlag = struct {
+type nodeFlagStruct struct {
 	node string
-}{}
+}
+var nodeFlag = nodeFlagStruct{}
 
-var sshFlag = struct {
+type sshFlagStruct = struct {
 	automate   bool
 	chefserver bool
 	postgres   bool
 	opensearch bool
-}{}
+}
+var sshFlag = sshFlagStruct{}
 
 var certRotateCmd = &cobra.Command{
 	Use:   "cert-rotate",
@@ -139,7 +142,7 @@ const (
 
 	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 )
-
+var readFileFromOs = ioutil.ReadFile // nosemgrep
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func certRotate(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
@@ -543,9 +546,9 @@ func getCertFromFile(certPath string, infra *AutomteHAInfraDetails) ([]byte, err
 			return nil, errors.New(fmt.Sprintf("Unable to copy file from remote path: %v", certPath))
 		}
 		defer os.Remove(filePath)
-		return ioutil.ReadFile(filePath) // nosemgrep
+		return readFileFromOs(filePath) // nosemgrep
 	}
-	return ioutil.ReadFile(certPath) // nosemgrep
+	return readFileFromOs(certPath) // nosemgrep
 }
 
 // Get the remote file details from path.

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -563,11 +563,10 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 	}
 
 	// Get the file path and validate it.
-	remoteFilePath := strings.TrimSpace(certPaths[1])
+	remoteFilePath := filepath.Clean(strings.TrimSpace(certPaths[1]))
 	if !IsValidFilePath(remoteFilePath) {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote file path: %v", remoteFilePath))
 	}
-	remoteFilePath = filepath.Clean(remoteFilePath)
 
 	// Get the filename from the file path.
 	fileName := filepath.Base(remoteFilePath)

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -25,11 +25,13 @@ type certFlagsStruct struct {
 	adminCert   string
 	adminKey    string
 }
+
 var certFlags = certFlagsStruct{}
 
 type nodeFlagStruct struct {
 	node string
 }
+
 var nodeFlag = nodeFlagStruct{}
 
 type sshFlagStruct = struct {
@@ -38,6 +40,7 @@ type sshFlagStruct = struct {
 	postgres   bool
 	opensearch bool
 }
+
 var sshFlag = sshFlagStruct{}
 
 var certRotateCmd = &cobra.Command{
@@ -142,6 +145,7 @@ const (
 
 	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 )
+
 var readFileFromOs = ioutil.ReadFile // nosemgrep
 // This function will rotate the certificates of Automate, Chef Infra Server, Postgres and Opensearch.
 func certRotate(cmd *cobra.Command, args []string) error {
@@ -561,7 +565,7 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 
 	// Get the file path and filename from the given remote address.
 	certPaths := strings.Split(remotePath, ":")
-	if len(certPaths) != 2 {
+	if len(certPaths) != 2 || certPaths[1] == "" {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote path: %v", remotePath))
 	}
 
@@ -570,7 +574,7 @@ func GetRemoteFileDetails(remotePath string) (string, string, string, error) {
 
 	// Get the filename from the file path.
 	fileName := filepath.Base(remoteFilePath)
-	if remoteFilePath == "" || fileName == string(os.PathSeparator) {
+	if fileName == "." || fileName == string(os.PathSeparator) {
 		return "", "", "", errors.New(fmt.Sprintf("Invalid remote path: %v", remotePath))
 	}
 

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,7 @@ const (
 	RemoteFilePath = "198.51.100.0:/home/ec2-user/certs/public.pem"
 	LocalFilePath  = "/home/ec2-user/certs/public.pem"
 	ValidIP        = "198.51.100.0"
+	FileContent    = "File exist and readed successfully"
 )
 
 func TestIsRemotePath(t *testing.T) {
@@ -141,5 +144,256 @@ func TestGetRemoteFileDetails(t *testing.T) {
 		hostIPExp := ValidIP
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
+/*
+	t.Run("Invalid Remote Path (empty path)", func(t *testing.T) {
+		input := ValidIP + ":"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.Error(t, err)
+		remoteFilePathExp := ""
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := ""
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := ValidIP
+		assert.NotEqual(t, hostIPExp, hostIPRes)
+	})
+*/
+}
 
+func TestGetCerts(t *testing.T) {
+	oldReadFileFromOs := readFileFromOs
+	oldCertFlags := certFlags
+	oldSshFlag := sshFlag
+	oldNodeFlag := nodeFlag
+
+	defer func() {
+		readFileFromOs = oldReadFileFromOs
+		certFlags = oldCertFlags
+		sshFlag = oldSshFlag
+		nodeFlag = oldNodeFlag
+	}()
+
+
+	readFileFromOs = func(filename string) ([]byte, error) {
+		if _, err := os.Stat(filename); err == nil {
+			// path/to/whatever exists
+			return []byte(FileContent), nil
+		} else if errors.Is(err, os.ErrNotExist) {
+			// path/to/whatever does *not* exist
+			return []byte{}, err
+		} else {
+			return []byte{}, err
+		}
+	}
+
+	var infra *AutomteHAInfraDetails = &AutomteHAInfraDetails{}
+
+	t.Run("All paths empty and flag for automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+
+	t.Run("All paths given and flag is automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA:      "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.NoError(t, err)
+		assert.Equal(t, FileContent, rootCARes)
+		assert.Equal(t, FileContent, publicCertRes)
+		assert.Equal(t, FileContent, privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+
+	t.Run("some invalid paths given and flag is automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./xyx-cert.go",
+			rootCA:      "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+
+	t.Run("All paths given but invalid (file not exist in (f.s)and flag is automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./xyz.go",
+			publicCert:  "./xyz.go",
+			rootCA:      "./xyx.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+
+	t.Run("All paths given except root-ca and flag is automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, _, _, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+	})
+    
+	t.Run("All paths given but root-ca path is invalid(file not exist) flag is automate service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA: "./xyx-cert.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, _, _, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+	})
+
+	t.Run("All paths given except root-ca flag is automate service and node flag given", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			automate: true,
+		}
+		nodeFlag = nodeFlagStruct{
+			node: "ip-given",
+		}
+		//root-ca ignored
+		rootCARes, publicCertRes, privateCertRes, _, _, err := getCerts(infra)
+		assert.NoError(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, FileContent, publicCertRes)
+		assert.Equal(t, FileContent, privateCertRes)
+	})
+
+	t.Run("All paths given and flag is opensearch service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA:      "./certRotate.go",
+			adminCert:   "./certRotate.go",
+			adminKey:    "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			opensearch: true,
+		}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.NoError(t, err)
+		assert.Equal(t, FileContent, rootCARes)
+		assert.Equal(t, FileContent, publicCertRes)
+		assert.Equal(t, FileContent, privateCertRes)
+		assert.Equal(t, FileContent, adminCertRes)
+		assert.Equal(t, FileContent, adminKeyRes)
+	})
+     
+	t.Run("Some mandatory path not and flag is opensearch service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA:      "./certRotate.go",
+			adminCert:   "./certRotate.go",
+			adminKey:    "",
+		}
+		sshFlag = sshFlagStruct{
+			//services
+			opensearch: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+  
+    t.Run("invalid adminCert path and flag is opensearch service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA:      "./certRotate.go",
+			adminCert:   "./xyz-cert.go",
+			adminKey:    "./certRotate.go",
+		}
+		sshFlag = sshFlagStruct{
+			//services
+			opensearch: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
+    
+    t.Run("invalid adminKey path and flag is opensearch service", func(t *testing.T) {
+		certFlags = certFlagsStruct{
+			privateCert: "./certRotate.go",
+			publicCert:  "./certRotate.go",
+			rootCA:      "./certRotate.go",
+			adminCert:   "./certRotate.go",
+			adminKey:    "./xyz-cert.go",
+		}
+		sshFlag = sshFlagStruct{
+			//services
+			opensearch: true,
+		}
+		nodeFlag = nodeFlagStruct{}
+		rootCARes, publicCertRes, privateCertRes, adminCertRes, adminKeyRes, err := getCerts(infra)
+		assert.Error(t, err)
+		assert.Equal(t, "", rootCARes)
+		assert.Equal(t, "", publicCertRes)
+		assert.Equal(t, "", privateCertRes)
+		assert.Equal(t, "", adminCertRes)
+		assert.Equal(t, "", adminKeyRes)
+	})
 }

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	RemoteFilePath = "10.1.0.234:/home/ec2-user/certs/public.pem"
+	RemoteFilePath = "198.51.100.0:/home/ec2-user/certs/public.pem"
 	LocalFilePath  = "/home/ec2-user/certs/public.pem"
+	ValidIP        = "198.51.100.0"
 )
 
 func TestIsRemotePath(t *testing.T) {
@@ -25,7 +26,7 @@ func TestIsRemotePath(t *testing.T) {
 	})
 
 	t.Run("Invalid remote path 1", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public.pem10.1.0.234"
+		input := "/home/ec2-user/certs/public.pem198.51.100.0"
 		res := IsRemotePath(input)
 		assert.False(t, res)
 	})
@@ -35,7 +36,7 @@ func TestIsRemotePath(t *testing.T) {
 		assert.False(t, res)
 	})
 	t.Run("Invalid remote path 3", func(t *testing.T) {
-		input := "\n   10.1.0.234:/home/ec2-user/certs/public.pem"
+		input := "\n   198.51.100.0:/home/ec2-user/certs/public.pem"
 		res := IsRemotePath(input)
 		assert.False(t, res)
 	})
@@ -43,9 +44,9 @@ func TestIsRemotePath(t *testing.T) {
 
 func TestGetIPV4(t *testing.T) {
 	t.Run("Valid IP V4", func(t *testing.T) {
-		input := "198.51.100.0:/home/ec2-user/certs/public.pem"
+		input := RemoteFilePath
 		res := GetIPV4(input)
-		expected := "198.51.100.0"
+		expected := ValidIP
 		assert.Equal(t, expected, res)
 	})
 
@@ -80,14 +81,14 @@ func TestGetIPV4(t *testing.T) {
 
 func TestGetRemoteFileDetails(t *testing.T) {
 	t.Run("Valid Remote Path", func(t *testing.T) {
-		input := "198.51.100.0:/home/ec2-user/certs/public.pem"
+		input := RemoteFilePath
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.NoError(t, err)
 		remoteFilePathExp := LocalFilePath
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
 		fileNameExp := "public.pem"
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := "198.51.100.0"
+		hostIPExp := ValidIP
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 
@@ -118,26 +119,26 @@ func TestGetRemoteFileDetails(t *testing.T) {
 	})
 
 	t.Run("Invalid Remote Path - No filename", func(t *testing.T) {
-		input := "10.1.0.234:/home/ec2-user/certs/public/"
+		input := "198.51.100.0:/home/ec2-user/certs/public/"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.NoError(t, err)
 		remoteFilePathExp := "/home/ec2-user/certs/public"
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
 		fileNameExp := "public"
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := "10.1.0.234"
+		hostIPExp := ValidIP
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 
 	t.Run("Invalid Remote Path - Reverse", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public/:10.1.0.234"
+		input := "/home/ec2-user/certs/public/:198.51.100.0"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.NoError(t, err)
-		remoteFilePathExp := "10.1.0.234"
+		remoteFilePathExp := ValidIP
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
-		fileNameExp := "10.1.0.234"
+		fileNameExp := ValidIP
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := "10.1.0.234"
+		hostIPExp := ValidIP
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -200,9 +200,7 @@ func TestGetCerts(t *testing.T) {
 
 	type testCaseInfo struct {
 		testCaseDescription string
-		certFlagObjInput    certFlags
-		sshFlagObjInput     sshFlag
-		nodeFlagObjInput    nodeFlag
+		flagsObj            flags
 		rootCaWant          string
 		publicCertWant      string
 		privateCertWant     string
@@ -214,33 +212,26 @@ func TestGetCerts(t *testing.T) {
 	testCases := []testCaseInfo{
 		{
 			testCaseDescription: "All paths given and flag is automate service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      ValidCertPath,
 			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       FileContent,
-			publicCertWant:   FileContent,
-			privateCertWant:  FileContent,
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          false,
+			rootCaWant:      FileContent,
+			publicCertWant:  FileContent,
+			privateCertWant: FileContent,
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         false,
 		},
 		{
 			testCaseDescription: "All paths given except root-ca flag is automate service and node flag given",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
-			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{
-				node: "ip-given",
+				node:        "ip-given",
 			},
 			rootCaWant:      "",
 			publicCertWant:  FileContent,
@@ -251,29 +242,24 @@ func TestGetCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "All paths given and flag is opensearch service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				opensearch:  true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      ValidCertPath,
 				adminCert:   ValidCertPath,
 				adminKey:    ValidCertPath,
 			},
-			sshFlagObjInput: sshFlag{
-				opensearch: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       FileContent,
-			publicCertWant:   FileContent,
-			privateCertWant:  FileContent,
-			adminCertWant:    FileContent,
-			adminKeyWant:     FileContent,
-			isError:          false,
+			rootCaWant:      FileContent,
+			publicCertWant:  FileContent,
+			privateCertWant: FileContent,
+			adminCertWant:   FileContent,
+			adminKeyWant:    FileContent,
+			isError:         false,
 		},
 		{
 			testCaseDescription: "All paths empty and flag for automate service",
-			certFlagObjInput:    certFlags{},
-			sshFlagObjInput:     sshFlag{},
-			nodeFlagObjInput:    nodeFlag{},
+			flagsObj:            flags{},
 			rootCaWant:          "",
 			publicCertWant:      "",
 			privateCertWant:     "",
@@ -283,140 +269,119 @@ func TestGetCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "some invalid paths given and flag is automate service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: ValidCertPath,
 				publicCert:  "./xyx-cert.go",
 				rootCA:      ValidCertPath,
 			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "All paths given but invalid (file not exist in (f.s)and flag is automate service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: "./xyz.go",
 				publicCert:  "./xyz.go",
 				rootCA:      "./xyx.go",
 			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "All paths given except root-ca and flag is automate service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "All paths given but root-ca path is invalid(file not exist) flag is automate service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				automate:    true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      "./xyx-cert.go",
 			},
-			sshFlagObjInput: sshFlag{
-				automate: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "Some mandatory path not given and flag is opensearch service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				opensearch:  true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      ValidCertPath,
 				adminCert:   ValidCertPath,
 				adminKey:    "",
 			},
-			sshFlagObjInput: sshFlag{
-				opensearch: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "Invalid adminCert path and flag is opensearch service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				opensearch:  true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      ValidCertPath,
 				adminCert:   "./xyz-cert.go",
 				adminKey:    ValidCertPath,
 			},
-			sshFlagObjInput: sshFlag{
-				opensearch: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 		{
 			testCaseDescription: "Invalid adminKey path and flag is opensearch service",
-			certFlagObjInput: certFlags{
+			flagsObj: flags{
+				opensearch:  true,
 				privateCert: ValidCertPath,
 				publicCert:  ValidCertPath,
 				rootCA:      ValidCertPath,
 				adminCert:   ValidCertPath,
 				adminKey:    "./xyz-cert.go",
 			},
-			sshFlagObjInput: sshFlag{
-				opensearch: true,
-			},
-			nodeFlagObjInput: nodeFlag{},
-			rootCaWant:       "",
-			publicCertWant:   "",
-			privateCertWant:  "",
-			adminCertWant:    "",
-			adminKeyWant:     "",
-			isError:          true,
+			rootCaWant:      "",
+			publicCertWant:  "",
+			privateCertWant: "",
+			adminCertWant:   "",
+			adminKeyWant:    "",
+			isError:         true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testCaseDescription, func(t *testing.T) {
-			rootCaGot, publicCertGot, privateCertGot, adminCertGot, adminKeyGot, err := c.getCerts(infra, &tc.sshFlagObjInput, &tc.certFlagObjInput, &tc.nodeFlagObjInput)
+			rootCaGot, publicCertGot, privateCertGot, adminCertGot, adminKeyGot, err := c.getCerts(infra, &tc.flagsObj)
 			if tc.isError {
 				assert.Error(t, err)
 			} else {

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -13,6 +13,7 @@ const (
 	LocalFilePath  = "/home/ec2-user/certs/public.pem"
 	ValidIP        = "198.51.100.0"
 	FileContent    = "File exist and readed successfully"
+	ValidCertPath  = "./certRotate.go"
 )
 
 func TestIsRemotePath(t *testing.T) {
@@ -204,9 +205,9 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("All paths given and flag is automate service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
-			rootCA:      "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
+			rootCA:      ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			automate: true,
@@ -223,9 +224,9 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("some invalid paths given and flag is automate service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
+			privateCert: ValidCertPath,
 			publicCert:  "./xyx-cert.go",
-			rootCA:      "./certRotate.go",
+			rootCA:      ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			automate: true,
@@ -261,8 +262,8 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("All paths given except root-ca and flag is automate service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			automate: true,
@@ -277,8 +278,8 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("All paths given but root-ca path is invalid(file not exist) flag is automate service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
 			rootCA:      "./xyx-cert.go",
 		}
 		sshFlag = sshFlagStruct{
@@ -294,8 +295,8 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("All paths given except root-ca flag is automate service and node flag given", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			automate: true,
@@ -313,11 +314,11 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("All paths given and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
-			rootCA:      "./certRotate.go",
-			adminCert:   "./certRotate.go",
-			adminKey:    "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
+			rootCA:      ValidCertPath,
+			adminCert:   ValidCertPath,
+			adminKey:    ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			opensearch: true,
@@ -333,10 +334,10 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("Some mandatory path not and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
-			rootCA:      "./certRotate.go",
-			adminCert:   "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
+			rootCA:      ValidCertPath,
+			adminCert:   ValidCertPath,
 			adminKey:    "",
 		}
 		sshFlag = sshFlagStruct{
@@ -355,11 +356,11 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("invalid adminCert path and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
-			rootCA:      "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
+			rootCA:      ValidCertPath,
 			adminCert:   "./xyz-cert.go",
-			adminKey:    "./certRotate.go",
+			adminKey:    ValidCertPath,
 		}
 		sshFlag = sshFlagStruct{
 			//services
@@ -377,10 +378,10 @@ func TestGetCerts(t *testing.T) {
 
 	t.Run("invalid adminKey path and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
-			privateCert: "./certRotate.go",
-			publicCert:  "./certRotate.go",
-			rootCA:      "./certRotate.go",
-			adminCert:   "./certRotate.go",
+			privateCert: ValidCertPath,
+			publicCert:  ValidCertPath,
+			rootCA:      ValidCertPath,
+			adminCert:   ValidCertPath,
 			adminKey:    "./xyz-cert.go",
 		}
 		sshFlag = sshFlagStruct{

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -213,10 +213,10 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given and flag is automate service",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      ValidCertPath,
+				automate:        true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      ValidCertPath,
 			},
 			rootCaWant:      FileContent,
 			publicCertWant:  FileContent,
@@ -228,10 +228,10 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given except root-ca flag is automate service and node flag given",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				node:        "ip-given",
+				automate:        true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				node:            "ip-given",
 			},
 			rootCaWant:      "",
 			publicCertWant:  FileContent,
@@ -243,12 +243,12 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given and flag is opensearch service",
 			flagsObj: flags{
-				opensearch:  true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      ValidCertPath,
-				adminCert:   ValidCertPath,
-				adminKey:    ValidCertPath,
+				opensearch:      true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      ValidCertPath,
+				adminCertPath:   ValidCertPath,
+				adminKeyPath:    ValidCertPath,
 			},
 			rootCaWant:      FileContent,
 			publicCertWant:  FileContent,
@@ -270,10 +270,10 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "some invalid paths given and flag is automate service",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: ValidCertPath,
-				publicCert:  "./xyx-cert.go",
-				rootCA:      ValidCertPath,
+				automate:        true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  "./xyx-cert.go",
+				rootCAPath:      ValidCertPath,
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -285,10 +285,10 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given but invalid (file not exist in (f.s)and flag is automate service",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: "./xyz.go",
-				publicCert:  "./xyz.go",
-				rootCA:      "./xyx.go",
+				automate:        true,
+				privateCertPath: "./xyz.go",
+				publicCertPath:  "./xyz.go",
+				rootCAPath:      "./xyx.go",
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -300,9 +300,9 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given except root-ca and flag is automate service",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
+				automate:        true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -314,10 +314,10 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "All paths given but root-ca path is invalid(file not exist) flag is automate service",
 			flagsObj: flags{
-				automate:    true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      "./xyx-cert.go",
+				automate:        true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      "./xyx-cert.go",
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -329,12 +329,12 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "Some mandatory path not given and flag is opensearch service",
 			flagsObj: flags{
-				opensearch:  true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      ValidCertPath,
-				adminCert:   ValidCertPath,
-				adminKey:    "",
+				opensearch:      true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      ValidCertPath,
+				adminCertPath:   ValidCertPath,
+				adminKeyPath:    "",
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -346,12 +346,12 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "Invalid adminCert path and flag is opensearch service",
 			flagsObj: flags{
-				opensearch:  true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      ValidCertPath,
-				adminCert:   "./xyz-cert.go",
-				adminKey:    ValidCertPath,
+				opensearch:      true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      ValidCertPath,
+				adminCertPath:   "./xyz-cert.go",
+				adminKeyPath:    ValidCertPath,
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -363,12 +363,12 @@ func TestGetCerts(t *testing.T) {
 		{
 			testCaseDescription: "Invalid adminKey path and flag is opensearch service",
 			flagsObj: flags{
-				opensearch:  true,
-				privateCert: ValidCertPath,
-				publicCert:  ValidCertPath,
-				rootCA:      ValidCertPath,
-				adminCert:   ValidCertPath,
-				adminKey:    "./xyz-cert.go",
+				opensearch:      true,
+				privateCertPath: ValidCertPath,
+				publicCertPath:  ValidCertPath,
+				rootCAPath:      ValidCertPath,
+				adminCertPath:   ValidCertPath,
+				adminKeyPath:    "./xyz-cert.go",
 			},
 			rootCaWant:      "",
 			publicCertWant:  "",
@@ -381,17 +381,21 @@ func TestGetCerts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testCaseDescription, func(t *testing.T) {
-			rootCaGot, publicCertGot, privateCertGot, adminCertGot, adminKeyGot, err := c.getCerts(infra, &tc.flagsObj)
+			certsGot, err := c.getCerts(infra, &tc.flagsObj)
 			if tc.isError {
 				assert.Error(t, err)
+				assert.Nil(t, certsGot)
 			} else {
 				assert.NoError(t, err)
+				assert.NotNil(t, certsGot)
 			}
-			assert.Equal(t, tc.rootCaWant, rootCaGot)
-			assert.Equal(t, tc.publicCertWant, publicCertGot)
-			assert.Equal(t, tc.privateCertWant, privateCertGot)
-			assert.Equal(t, tc.adminCertWant, adminCertGot)
-			assert.Equal(t, tc.adminKeyWant, adminKeyGot)
+			if certsGot != nil {
+				assert.Equal(t, tc.rootCaWant, certsGot.rootCA)
+				assert.Equal(t, tc.publicCertWant, certsGot.publicCert)
+				assert.Equal(t, tc.privateCertWant, certsGot.privateCert)
+				assert.Equal(t, tc.adminCertWant, certsGot.adminCert)
+				assert.Equal(t, tc.adminKeyWant, certsGot.adminKey)
+			}
 		})
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -6,15 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	RemoteFilePath = "10.1.0.234:/home/ec2-user/certs/public.pem"
+	LocalFilePath  = "/home/ec2-user/certs/public.pem"
+)
+
 func TestIsRemotePath(t *testing.T) {
 	t.Run("Valid remote path", func(t *testing.T) {
-		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		input := RemoteFilePath
 		res := IsRemotePath(input)
 		assert.True(t, res)
 	})
 
 	t.Run("Local path instead of remote path", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public.pem"
+		input := LocalFilePath
 		res := IsRemotePath(input)
 		assert.False(t, res)
 	})
@@ -25,7 +30,7 @@ func TestIsRemotePath(t *testing.T) {
 		assert.False(t, res)
 	})
 	t.Run("Invalid remote path 2", func(t *testing.T) {
-		input := "10.1.0.234/home/ec2-user/certs/public.pem"
+		input := "198.51.100.0/home/ec2-user/certs/public.pem"
 		res := IsRemotePath(input)
 		assert.False(t, res)
 	})
@@ -37,26 +42,26 @@ func TestIsRemotePath(t *testing.T) {
 }
 
 func TestIsValidFilePath(t *testing.T) {
-	t.Run("Valid file path", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public.pem"
+	t.Run("Valid file path 1", func(t *testing.T) {
+		input := LocalFilePath
 		res := IsValidFilePath(input)
 		assert.True(t, res)
 	})
 
-	t.Run("Valid file path", func(t *testing.T) {
+	t.Run("Valid file path 2", func(t *testing.T) {
 		input := "/public.pem"
 		res := IsValidFilePath(input)
 		assert.True(t, res)
 	})
 
-	t.Run("Valid file path", func(t *testing.T) {
+	t.Run("Valid file path 3", func(t *testing.T) {
 		input := "public.pem"
 		res := IsValidFilePath(input)
 		assert.True(t, res)
 	})
 
 	t.Run("Invalid file path - remote path", func(t *testing.T) {
-		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		input := RemoteFilePath
 		res := IsValidFilePath(input)
 		assert.False(t, res)
 	})
@@ -67,13 +72,13 @@ func TestIsValidFilePath(t *testing.T) {
 		assert.False(t, res)
 	})
 
-	t.Run("Invalid remote path 2", func(t *testing.T) {
+	t.Run("Invalid file path 2", func(t *testing.T) {
 		input := "~/public.pem"
 		res := IsValidFilePath(input)
 		assert.False(t, res)
 	})
 
-	t.Run("Invalid remote path 3", func(t *testing.T) {
+	t.Run("Invalid file path 3", func(t *testing.T) {
 		input := "./public.pem"
 		res := IsValidFilePath(input)
 		assert.False(t, res)
@@ -82,9 +87,9 @@ func TestIsValidFilePath(t *testing.T) {
 
 func TestGetIPV4(t *testing.T) {
 	t.Run("Valid IP V4", func(t *testing.T) {
-		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		input := "198.51.100.0:/home/ec2-user/certs/public.pem"
 		res := GetIPV4(input)
-		expected := "10.1.0.234"
+		expected := "198.51.100.0"
 		assert.Equal(t, expected, res)
 	})
 
@@ -119,19 +124,19 @@ func TestGetIPV4(t *testing.T) {
 
 func TestGetRemoteFileDetails(t *testing.T) {
 	t.Run("Valid Remote Path", func(t *testing.T) {
-		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		input := "198.51.100.0:/home/ec2-user/certs/public.pem"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.NoError(t, err)
-		remoteFilePathExp := "/home/ec2-user/certs/public.pem"
+		remoteFilePathExp := LocalFilePath
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
 		fileNameExp := "public.pem"
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := "10.1.0.234"
+		hostIPExp := "198.51.100.0"
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 
 	t.Run("Invalid Remote Path - Local path", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public.pem"
+		input := LocalFilePath
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.Error(t, err)
 		assert.Equal(t, " is not a valid IPv4 address", err.Error())
@@ -144,10 +149,10 @@ func TestGetRemoteFileDetails(t *testing.T) {
 	})
 
 	t.Run("Invalid Remote Path - Colon missing", func(t *testing.T) {
-		input := "10.1.0.234/home/ec2-user/certs/public.pem"
+		input := "198.51.100.0/home/ec2-user/certs/public.pem"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.Error(t, err)
-		assert.Equal(t, "Invalid remote path: 10.1.0.234/home/ec2-user/certs/public.pem", err.Error())
+		assert.Equal(t, "Invalid remote path: 198.51.100.0/home/ec2-user/certs/public.pem", err.Error())
 		remoteFilePathExp := ""
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
 		fileNameExp := ""
@@ -169,7 +174,7 @@ func TestGetRemoteFileDetails(t *testing.T) {
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 
-	t.Run("Invalid Remote Path - No filename", func(t *testing.T) {
+	t.Run("Invalid Remote Path - Reverse", func(t *testing.T) {
 		input := "/home/ec2-user/certs/public/:10.1.0.234"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.Error(t, err)

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -144,11 +144,12 @@ func TestGetRemoteFileDetails(t *testing.T) {
 		hostIPExp := ValidIP
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
-/*
+
 	t.Run("Invalid Remote Path (empty path)", func(t *testing.T) {
 		input := ValidIP + ":"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
 		assert.Error(t, err)
+		assert.Equal(t, "Invalid remote path: 198.51.100.0:", err.Error())
 		remoteFilePathExp := ""
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
 		fileNameExp := ""
@@ -156,7 +157,7 @@ func TestGetRemoteFileDetails(t *testing.T) {
 		hostIPExp := ValidIP
 		assert.NotEqual(t, hostIPExp, hostIPRes)
 	})
-*/
+
 }
 
 func TestGetCerts(t *testing.T) {
@@ -171,7 +172,6 @@ func TestGetCerts(t *testing.T) {
 		sshFlag = oldSshFlag
 		nodeFlag = oldNodeFlag
 	}()
-
 
 	readFileFromOs = func(filename string) ([]byte, error) {
 		if _, err := os.Stat(filename); err == nil {
@@ -274,12 +274,12 @@ func TestGetCerts(t *testing.T) {
 		assert.Equal(t, "", publicCertRes)
 		assert.Equal(t, "", privateCertRes)
 	})
-    
+
 	t.Run("All paths given but root-ca path is invalid(file not exist) flag is automate service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
 			privateCert: "./certRotate.go",
 			publicCert:  "./certRotate.go",
-			rootCA: "./xyx-cert.go",
+			rootCA:      "./xyx-cert.go",
 		}
 		sshFlag = sshFlagStruct{
 			automate: true,
@@ -330,7 +330,7 @@ func TestGetCerts(t *testing.T) {
 		assert.Equal(t, FileContent, adminCertRes)
 		assert.Equal(t, FileContent, adminKeyRes)
 	})
-     
+
 	t.Run("Some mandatory path not and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
 			privateCert: "./certRotate.go",
@@ -352,8 +352,8 @@ func TestGetCerts(t *testing.T) {
 		assert.Equal(t, "", adminCertRes)
 		assert.Equal(t, "", adminKeyRes)
 	})
-  
-    t.Run("invalid adminCert path and flag is opensearch service", func(t *testing.T) {
+
+	t.Run("invalid adminCert path and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
 			privateCert: "./certRotate.go",
 			publicCert:  "./certRotate.go",
@@ -374,8 +374,8 @@ func TestGetCerts(t *testing.T) {
 		assert.Equal(t, "", adminCertRes)
 		assert.Equal(t, "", adminKeyRes)
 	})
-    
-    t.Run("invalid adminKey path and flag is opensearch service", func(t *testing.T) {
+
+	t.Run("invalid adminKey path and flag is opensearch service", func(t *testing.T) {
 		certFlags = certFlagsStruct{
 			privateCert: "./certRotate.go",
 			publicCert:  "./certRotate.go",

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -41,50 +41,6 @@ func TestIsRemotePath(t *testing.T) {
 	})
 }
 
-func TestIsValidFilePath(t *testing.T) {
-	t.Run("Valid file path 1", func(t *testing.T) {
-		input := LocalFilePath
-		res := IsValidFilePath(input)
-		assert.True(t, res)
-	})
-
-	t.Run("Valid file path 2", func(t *testing.T) {
-		input := "/public.pem"
-		res := IsValidFilePath(input)
-		assert.True(t, res)
-	})
-
-	t.Run("Valid file path 3", func(t *testing.T) {
-		input := "public.pem"
-		res := IsValidFilePath(input)
-		assert.True(t, res)
-	})
-
-	t.Run("Invalid file path - remote path", func(t *testing.T) {
-		input := RemoteFilePath
-		res := IsValidFilePath(input)
-		assert.False(t, res)
-	})
-
-	t.Run("Invalid file path 1", func(t *testing.T) {
-		input := "/home/ec2-user/certs/public.pem:10.1.0.234"
-		res := IsValidFilePath(input)
-		assert.False(t, res)
-	})
-
-	t.Run("Invalid file path 2", func(t *testing.T) {
-		input := "~/public.pem"
-		res := IsValidFilePath(input)
-		assert.False(t, res)
-	})
-
-	t.Run("Invalid file path 3", func(t *testing.T) {
-		input := "./public.pem"
-		res := IsValidFilePath(input)
-		assert.False(t, res)
-	})
-}
-
 func TestGetIPV4(t *testing.T) {
 	t.Run("Valid IP V4", func(t *testing.T) {
 		input := "198.51.100.0:/home/ec2-user/certs/public.pem"
@@ -164,26 +120,24 @@ func TestGetRemoteFileDetails(t *testing.T) {
 	t.Run("Invalid Remote Path - No filename", func(t *testing.T) {
 		input := "10.1.0.234:/home/ec2-user/certs/public/"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
-		assert.Error(t, err)
-		assert.Equal(t, "Invalid remote file path: /home/ec2-user/certs/public/", err.Error())
-		remoteFilePathExp := ""
+		assert.NoError(t, err)
+		remoteFilePathExp := "/home/ec2-user/certs/public"
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
-		fileNameExp := ""
+		fileNameExp := "public"
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := ""
+		hostIPExp := "10.1.0.234"
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 
 	t.Run("Invalid Remote Path - Reverse", func(t *testing.T) {
 		input := "/home/ec2-user/certs/public/:10.1.0.234"
 		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
-		assert.Error(t, err)
-		assert.Equal(t, "Invalid remote file path: 10.1.0.234", err.Error())
-		remoteFilePathExp := ""
+		assert.NoError(t, err)
+		remoteFilePathExp := "10.1.0.234"
 		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
-		fileNameExp := ""
+		fileNameExp := "10.1.0.234"
 		assert.Equal(t, fileNameExp, fileNameRes)
-		hostIPExp := ""
+		hostIPExp := "10.1.0.234"
 		assert.Equal(t, hostIPExp, hostIPRes)
 	})
 

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRemotePath(t *testing.T) {
+	t.Run("Valid remote path", func(t *testing.T) {
+		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		res := IsRemotePath(input)
+		assert.True(t, res)
+	})
+
+	t.Run("Local path instead of remote path", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem"
+		res := IsRemotePath(input)
+		assert.False(t, res)
+	})
+
+	t.Run("Invalid remote path 1", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem10.1.0.234"
+		res := IsRemotePath(input)
+		assert.False(t, res)
+	})
+	t.Run("Invalid remote path 2", func(t *testing.T) {
+		input := "10.1.0.234/home/ec2-user/certs/public.pem"
+		res := IsRemotePath(input)
+		assert.False(t, res)
+	})
+	t.Run("Invalid remote path 3", func(t *testing.T) {
+		input := "\n   10.1.0.234:/home/ec2-user/certs/public.pem"
+		res := IsRemotePath(input)
+		assert.False(t, res)
+	})
+}
+
+func TestIsValidFilePath(t *testing.T) {
+	t.Run("Valid file path", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem"
+		res := IsValidFilePath(input)
+		assert.True(t, res)
+	})
+
+	t.Run("Valid file path", func(t *testing.T) {
+		input := "/public.pem"
+		res := IsValidFilePath(input)
+		assert.True(t, res)
+	})
+
+	t.Run("Valid file path", func(t *testing.T) {
+		input := "public.pem"
+		res := IsValidFilePath(input)
+		assert.True(t, res)
+	})
+
+	t.Run("Invalid file path - remote path", func(t *testing.T) {
+		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		res := IsValidFilePath(input)
+		assert.False(t, res)
+	})
+
+	t.Run("Invalid file path 1", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem:10.1.0.234"
+		res := IsValidFilePath(input)
+		assert.False(t, res)
+	})
+
+	t.Run("Invalid remote path 2", func(t *testing.T) {
+		input := "~/public.pem"
+		res := IsValidFilePath(input)
+		assert.False(t, res)
+	})
+
+	t.Run("Invalid remote path 3", func(t *testing.T) {
+		input := "./public.pem"
+		res := IsValidFilePath(input)
+		assert.False(t, res)
+	})
+}
+
+func TestGetIPV4(t *testing.T) {
+	t.Run("Valid IP V4", func(t *testing.T) {
+		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		res := GetIPV4(input)
+		expected := "10.1.0.234"
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Valid IP V4 but invalid remote path 1", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem:127.0.0.1"
+		res := GetIPV4(input)
+		expected := "127.0.0.1"
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Valid IP V4 but invalid remote path 2", func(t *testing.T) {
+		input := "/home/ec2-user/:0.0.0.0:/certs/public.pem"
+		res := GetIPV4(input)
+		expected := "0.0.0.0"
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Invalid IP v4 and valid path", func(t *testing.T) {
+		input := "256.256.256.256:/home/ec2-user/certs/public.pem"
+		res := GetIPV4(input)
+		expected := ""
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("Invalid IP v4 and invalid path", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem:1.2.3"
+		res := GetIPV4(input)
+		expected := ""
+		assert.Equal(t, expected, res)
+	})
+}
+
+func TestGetRemoteFileDetails(t *testing.T) {
+	t.Run("Valid Remote Path", func(t *testing.T) {
+		input := "10.1.0.234:/home/ec2-user/certs/public.pem"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.NoError(t, err)
+		remoteFilePathExp := "/home/ec2-user/certs/public.pem"
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := "public.pem"
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := "10.1.0.234"
+		assert.Equal(t, hostIPExp, hostIPRes)
+	})
+
+	t.Run("Invalid Remote Path - Local path", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public.pem"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.Error(t, err)
+		assert.Equal(t, " is not a valid IPv4 address", err.Error())
+		remoteFilePathExp := ""
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := ""
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := ""
+		assert.Equal(t, hostIPExp, hostIPRes)
+	})
+
+	t.Run("Invalid Remote Path - Colon missing", func(t *testing.T) {
+		input := "10.1.0.234/home/ec2-user/certs/public.pem"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.Error(t, err)
+		assert.Equal(t, "Invalid remote path: 10.1.0.234/home/ec2-user/certs/public.pem", err.Error())
+		remoteFilePathExp := ""
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := ""
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := ""
+		assert.Equal(t, hostIPExp, hostIPRes)
+	})
+
+	t.Run("Invalid Remote Path - No filename", func(t *testing.T) {
+		input := "10.1.0.234:/home/ec2-user/certs/public/"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.Error(t, err)
+		assert.Equal(t, "Invalid remote file path: /home/ec2-user/certs/public/", err.Error())
+		remoteFilePathExp := ""
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := ""
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := ""
+		assert.Equal(t, hostIPExp, hostIPRes)
+	})
+
+	t.Run("Invalid Remote Path - No filename", func(t *testing.T) {
+		input := "/home/ec2-user/certs/public/:10.1.0.234"
+		remoteFilePathRes, fileNameRes, hostIPRes, err := GetRemoteFileDetails(input)
+		assert.Error(t, err)
+		assert.Equal(t, "Invalid remote file path: 10.1.0.234", err.Error())
+		remoteFilePathExp := ""
+		assert.Equal(t, remoteFilePathExp, remoteFilePathRes)
+		fileNameExp := ""
+		assert.Equal(t, fileNameExp, fileNameRes)
+		hostIPExp := ""
+		assert.Equal(t, hostIPExp, hostIPRes)
+	})
+
+}

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -255,14 +255,16 @@ func (s *SSHUtilImpl) copyFileToRemote(srcFilePath string, destFileName string, 
 
 // This function will copy file from remote to local and return new local file path
 func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName string) (string, error) {
+	writer.Printf("doing scp file transfer from remote node %s \n", s.SshConfig.hostIP)
 	cmd := "scp"
 	ts := time.Now().Format("20060102150405")
 	destFileName := "/tmp/" + ts + "_" + outputFileName
 	execArgs := []string{"-P " + s.SshConfig.sshPort, "-o StrictHostKeyChecking=no", "-i", s.SshConfig.sshKeyFile, "-r", s.SshConfig.sshUser + "@" + s.SshConfig.hostIP + ":" + remoteFilePath, destFileName}
 	if err := exec.Command(cmd, execArgs...).Run(); err != nil {
-		writer.Print("Failed to copy file from remote\n")
+		writer.Printf("Failed to copy file from remote %s\n", err.Error())
 		return "", err
 	}
+	writer.Print("Copied file from remote\n")
 	return destFileName, nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -255,7 +255,7 @@ func (s *SSHUtilImpl) copyFileToRemote(srcFilePath string, destFileName string, 
 
 // This function will copy file from remote to local and return new local file path
 func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName string) (string, error) {
-	writer.Printf("doing scp file transfer from remote node %s \n", s.SshConfig.hostIP)
+	writer.Printf("Doing scp file transfer of file %s from remote node %s \n", remoteFilePath, s.SshConfig.hostIP)
 	cmd := "scp"
 	ts := time.Now().Format("20060102150405")
 	destFileName := "/tmp/" + ts + "_" + outputFileName
@@ -264,7 +264,7 @@ func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName s
 		writer.Printf("Failed to copy file from remote %s\n", err.Error())
 		return "", err
 	}
-	writer.Print("Copied file from remote\n")
+	writer.Printf("Copied file from remote to %s \n", destFileName)
 	return destFileName, nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -255,7 +255,7 @@ func (s *SSHUtilImpl) copyFileToRemote(srcFilePath string, destFileName string, 
 
 // This function will copy file from remote to local and return new local file path
 func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName string) (string, error) {
-	writer.Printf("Doing scp file transfer of file %s from remote node %s \n", remoteFilePath, s.SshConfig.hostIP)
+	writer.Printf("Downloading file %s from remote node %s \n", remoteFilePath, s.SshConfig.hostIP)
 	cmd := "scp"
 	ts := time.Now().Format("20060102150405")
 	destFileName := "/tmp/" + ts + "_" + outputFileName
@@ -264,7 +264,7 @@ func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName s
 		writer.Printf("Failed to copy file from remote %s\n", err.Error())
 		return "", err
 	}
-	writer.Printf("Copied file from remote to %s \n", destFileName)
+	writer.Printf("File downloaded %s \n", destFileName)
 	return destFileName, nil
 }
 

--- a/components/docs-chef-io/content/automate/ha_cert_rotation.md
+++ b/components/docs-chef-io/content/automate/ha_cert_rotation.md
@@ -30,7 +30,7 @@ The certificate rotation is also required when the key for a node, client, or CA
 {{< note >}}
 
 - Below `cert-rotate` commands can only be executed from `bastion host`.
-- If you want to use certificates stored in another node of the HA cluster, then you can provide the remote path to the certificates using `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE` format instead of local path.
+- If you want to use certificates stored in another node of the HA cluster, you can provide the remote path to the certificates using the `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE>` format instead of the local path.
 
 {{< /note >}}
 

--- a/components/docs-chef-io/content/automate/ha_cert_rotation.md
+++ b/components/docs-chef-io/content/automate/ha_cert_rotation.md
@@ -9,7 +9,7 @@ gh_repo = "automate"
   [menu.automate]
     title = "Certificate Rotation"
     parent = "automate/deploy_high_availability/certificates"
-    identifier = "automate/deploy_high_availability/certificates/ha_cert_rotaion.md Certificate Rotation"
+    identifier = "automate/deploy_high_availability/certificates/ha_cert_rotation.md Certificate Rotation"
     weight = 230
 +++
 
@@ -27,7 +27,10 @@ The certificate rotation is also required when the key for a node, client, or CA
 
 ## Rotate using Cert-Rotate Command
 
-{{< note >}} Below `cert-rotate` commands can only be executed from `bastion host` {{< /note >}}
+{{< note >}}
+  Below `cert-rotate` commands can only be executed from `bastion host`.
+  If you want to use certificates stored in another node of the HA cluster, then you can provide the remote path to the certificates using `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE` format instead of local path.
+{{< /note >}}
 
 ### Rotate Certificates of each service
 

--- a/components/docs-chef-io/content/automate/ha_cert_rotation.md
+++ b/components/docs-chef-io/content/automate/ha_cert_rotation.md
@@ -28,8 +28,10 @@ The certificate rotation is also required when the key for a node, client, or CA
 ## Rotate using Cert-Rotate Command
 
 {{< note >}}
-  Below `cert-rotate` commands can only be executed from `bastion host`.
-  If you want to use certificates stored in another node of the HA cluster, then you can provide the remote path to the certificates using `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE` format instead of local path.
+
+- Below `cert-rotate` commands can only be executed from `bastion host`.
+- If you want to use certificates stored in another node of the HA cluster, then you can provide the remote path to the certificates using `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE` format instead of local path.
+
 {{< /note >}}
 
 ### Rotate Certificates of each service

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -18,6 +18,44 @@ const (
 	HAB_DIR      string = "/hab"
 )
 
+type FileUtils interface {
+	PathExists(path string) (bool, error)
+	IsSymlink(path string) (bool, error)
+	CalDirSizeInGB(path string) (float64, error)
+	CheckSpaceAvailability(dir string, minSpace float64) (bool, error)
+	GetFreeSpaceinGB(dir string) (float64, error)
+	GetHabRootPath() string
+	WriteToFile(filepath string, data []byte) error
+	ReadFile(filename string) ([]byte, error)
+}
+
+type FileSystemUtils struct{}
+
+func (fsu *FileSystemUtils) PathExists(path string) (bool, error) {
+	return PathExists(path)
+}
+func (fsu *FileSystemUtils) IsSymlink(path string) (bool, error) {
+	return IsSymlink(path)
+}
+func (fsu *FileSystemUtils) CalDirSizeInGB(path string) (float64, error) {
+	return CalDirSizeInGB(path)
+}
+func (fsu *FileSystemUtils) CheckSpaceAvailability(dir string, minSpace float64) (bool, error) {
+	return CheckSpaceAvailability(dir, minSpace)
+}
+func (fsu *FileSystemUtils) GetFreeSpaceinGB(dir string) (float64, error) {
+	return GetFreeSpaceinGB(dir)
+}
+func (fsu *FileSystemUtils) GetHabRootPath() string {
+	return GetHabRootPath()
+}
+func (fsu *FileSystemUtils) WriteToFile(filepath string, data []byte) error {
+	return WriteToFile(filepath, data)
+}
+func (fsu *FileSystemUtils) ReadFile(filename string) ([]byte, error) {
+	return ReadFile(filename)
+}
+
 // LogCLose closes the given io.Closer, logging any error.
 func LogClose(c io.Closer, log logrus.FieldLogger, msg string) {
 	if err := c.Close(); err != nil {
@@ -80,21 +118,6 @@ func GetFreeSpaceinGB(dir string) (float64, error) {
 	return float64(v) / (1024 * 1024), nil
 }
 
-func WriteToFile(filepath string, data []byte) error {
-	return ioutil.WriteFile(filepath, data, 775) // nosemgrep
-}
-
-type FileUtils interface {
-	PathExists(path string) (bool, error)
-	IsSymlink(path string) (bool, error)
-	CalDirSizeInGB(path string) (float64, error)
-	CheckSpaceAvailability(dir string, minSpace float64) (bool, error)
-	GetFreeSpaceinGB(dir string) (float64, error)
-	GetHabRootPath() string
-	WriteToFile(filepath string, data []byte) error
-	ReadFile(filename string) ([]byte, error)
-}
-
 func GetHabRootPath() string {
 	out, err := exec.Command("/bin/sh", "-c", HAB_ROOT_CMD).Output()
 	if err != nil {
@@ -109,29 +132,10 @@ func GetHabRootPath() string {
 	return rootHab
 }
 
-type FileSystemUtils struct{}
+func WriteToFile(filepath string, data []byte) error {
+	return ioutil.WriteFile(filepath, data, 0775) // nosemgrep
+}
 
-func (fsu *FileSystemUtils) PathExists(path string) (bool, error) {
-	return PathExists(path)
-}
-func (fsu *FileSystemUtils) IsSymlink(path string) (bool, error) {
-	return IsSymlink(path)
-}
-func (fsu *FileSystemUtils) CalDirSizeInGB(path string) (float64, error) {
-	return CalDirSizeInGB(path)
-}
-func (fsu *FileSystemUtils) CheckSpaceAvailability(dir string, minSpace float64) (bool, error) {
-	return CheckSpaceAvailability(dir, minSpace)
-}
-func (fsu *FileSystemUtils) GetFreeSpaceinGB(dir string) (float64, error) {
-	return GetFreeSpaceinGB(dir)
-}
-func (fsu *FileSystemUtils) GetHabRootPath() string {
-	return GetHabRootPath()
-}
-func (fsu *FileSystemUtils) WriteToFile(filepath string, data []byte) error {
-	return WriteToFile(filepath, data)
-}
-func (fsu *FileSystemUtils) ReadFile(filename string) ([]byte, error) {
+func ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename) // nosemgrep
 }

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -92,6 +92,7 @@ type FileUtils interface {
 	GetFreeSpaceinGB(dir string) (float64, error)
 	GetHabRootPath() string
 	WriteToFile(filepath string, data []byte) error
+	ReadFile(filename string) ([]byte, error)
 }
 
 func GetHabRootPath() string {
@@ -130,4 +131,7 @@ func (fsu *FileSystemUtils) GetHabRootPath() string {
 }
 func (fsu *FileSystemUtils) WriteToFile(filepath string, data []byte) error {
 	return WriteToFile(filepath, data)
+}
+func (fsu *FileSystemUtils) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename) // nosemgrep
 }

--- a/lib/io/fileutils/mockFileUtils.go
+++ b/lib/io/fileutils/mockFileUtils.go
@@ -8,6 +8,7 @@ type MockFileSystemUtils struct {
 	GetFreeSpaceinGBFunc       func(dir string) (float64, error)
 	GetHabRootPathFunc         func() string
 	WriteToFileFunc            func(filepath string, data []byte) error
+	ReadFileFunc               func(filepath string) ([]byte, error)
 }
 
 func (fsu *MockFileSystemUtils) PathExists(path string) (bool, error) {
@@ -30,4 +31,7 @@ func (fsu *MockFileSystemUtils) GetHabRootPath() string {
 }
 func (fsu *MockFileSystemUtils) WriteToFile(filepath string, data []byte) error {
 	return fsu.WriteToFileFunc(filepath, data)
+}
+func (fsu *MockFileSystemUtils) ReadFile(filepath string) ([]byte, error) {
+	return fsu.ReadFileFunc(filepath)
 }


### PR DESCRIPTION
Signed-off-by: Atul Krishna <Atul.Krishna@progress.com>
### :nut_and_bolt: Description: What code changed, and why?
Added support for remote certs in Automate HA.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/pull/7526
https://chefio.atlassian.net/browse/SHIELD-173
### :+1: Definition of Done
- Cert rotate command should accept the remote path for certificate flag values.

- Each flag value should accept either a remote path or a local path(but not both at the same time).

- The remote path should be in one of the associated nodes of HA cluster.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1792" alt="automate-cmd-output-24" src="https://user-images.githubusercontent.com/11033984/203772759-83cd576d-c41e-485e-9662-199e73bc44a4.png">

----------------------------

<img width="1792" alt="cs-cmd-output-24" src="https://user-images.githubusercontent.com/11033984/203772970-9ae8b53a-4e2b-4698-92e3-2d034ff824c1.png">

----------------------------

<img width="1792" alt="MicrosoftTeams-image (8)" src="https://user-images.githubusercontent.com/11033984/203773175-1206250e-dcae-4f6f-904c-1e8d010f70fa.png">

----------------------------

<img width="1792" alt="MicrosoftTeams-image (9)" src="https://user-images.githubusercontent.com/11033984/203773395-e61852e2-fd40-416f-87e8-10db042020c9.png">

----------------------------

<img width="1792" alt="MicrosoftTeams-image (10)" src="https://user-images.githubusercontent.com/11033984/203773426-41815de4-cefa-4212-a009-2bd8b9227205.png">

----------------------------

<img width="1792" alt="MicrosoftTeams-image (11)" src="https://user-images.githubusercontent.com/11033984/203773503-c5df8fb7-b1fb-4a6f-ad3a-270b1d730d0c.png">


Video: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/Eae5hfRjmSBJvDNJiCSDYfgBJxhLq8fJZqBtyFfyIcitUQ?e=osjPOq
