### PR TITLE
added check for node flag

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -183,7 +183,9 @@ func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraD
 	// Creating and patching the required configurations.
 	var config string
 	if nodeFlag.node != "" {
-		writer.Warn("root-ca flag will be ignored when node flag is provided")
+		if rootCA != "" {
+			writer.Warn("root-ca flag will be ignored when node flag is provided")
+		}
 		config = fmt.Sprintf(POSTGRES_CONFIG_IGNORE_ISSUER_CERT, privateCert, publicCert)
 	} else {
 		config = fmt.Sprintf(POSTGRES_CONFIG, privateCert, publicCert, rootCA)

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -198,7 +198,7 @@ func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraD
 	}
 
 	// ignore patching of root-ca when node flag is provided
-	if rootCA == "" {
+	if nodeFlag.node != "" {
 		return nil
 	}
 	// Patching root-ca to frontend-nodes for maintaining the connection.
@@ -392,7 +392,7 @@ func getCerts() (string, string, string, string, string, error) {
 	// Root CA is mandatory for PG and OS nodes. But root CA is ignored when node flag
 	// is provided
 	if sshFlag.postgres || sshFlag.opensearch {
-		if rootCaPath == "" && (nodeFlag.node == "") {
+		if rootCaPath == "" && nodeFlag.node == "" {
 			return "", "", "", "", "", errors.New("Please provide rootCA path")
 		}
 		if rootCaPath != "" {

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -21,15 +21,15 @@ var certFlags = struct {
 	adminKey    string
 }{}
 
+var nodeFlag = struct {
+	node string
+}{}
+
 var sshFlag = struct {
 	automate   bool
 	chefserver bool
 	postgres   bool
 	opensearch bool
-}{}
-
-var nodeFlag = struct {
-	node string
 }{}
 
 var certRotateCmd = &cobra.Command{
@@ -56,8 +56,7 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.rootCA, "root-ca", "", "RootCA certificate")
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.adminCert, "admin-cert", "", "Admin certificate")
 	certRotateCmd.PersistentFlags().StringVar(&certFlags.adminKey, "admin-key", "", "Admin Private certificate")
-
-	certRotateCmd.PersistentFlags().StringVar(&nodeFlag.node, "ip", "", "IP of a particular node")
+	certRotateCmd.PersistentFlags().StringVar(&nodeFlag.node, "node", "", "Node Ip address")
 }
 
 const (
@@ -75,6 +74,13 @@ const (
 		ssl_key = """%v"""
 		ssl_cert = """%v"""
 		issuer_cert = """%v"""`
+
+	POSTGRES_CONFIG_IGNORE_ISSUER_CERT = `
+	[ssl]
+		enable = true
+		ssl_key = """%v"""
+		ssl_cert = """%v"""
+		`
 
 	POSTGRES_FRONTEND_CONFIG = `
 	[global.v1.external.postgresql.ssl]
@@ -175,12 +181,23 @@ func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraD
 	remoteService := "postgresql"
 
 	// Creating and patching the required configurations.
-	config := fmt.Sprintf(POSTGRES_CONFIG, privateCert, publicCert, rootCA)
+	var config string
+	if nodeFlag.node != "" {
+		writer.Warn("root-ca flag will be ignored when node flag is provided")
+		config = fmt.Sprintf(POSTGRES_CONFIG_IGNORE_ISSUER_CERT, privateCert, publicCert)
+	} else {
+		config = fmt.Sprintf(POSTGRES_CONFIG, privateCert, publicCert, rootCA)
+	}
+
 	err := patchConfig(config, fileName, timestamp, remoteService, infra)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// ignore patching of root-ca when node flag is provided
+	if nodeFlag.node != "" {
+		return nil
+	}
 	// Patching root-ca to frontend-nodes for maintaining the connection.
 	filename_fe := "pg_fe.toml"
 	remoteService = "frontend"

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -186,7 +186,7 @@ func certRotatePG(publicCert, privateCert, rootCA string, infra *AutomteHAInfraD
 
 	// Creating and patching the required configurations.
 	var config string
-	if rootCA == "" {
+	if nodeFlag.node != "" {
 		config = fmt.Sprintf(POSTGRES_CONFIG_IGNORE_ISSUER_CERT, privateCert, publicCert)
 	} else {
 		config = fmt.Sprintf(POSTGRES_CONFIG, privateCert, publicCert, rootCA)


### PR DESCRIPTION
Signed-off-by: Abdul-Az <aazeez@progress.com>
https://chefio.atlassian.net/browse/KINETICS-236

### :nut_and_bolt: Description: What code changed, and why?
chef-automate cert-rotate --pg --root-ca "<>" --private-cert "<>" --public-cert "<>" --node ”<>”
This will rotate the certificate in the given Postgres node.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
chef-automate cert-rotate --pg --root-ca "<>" --private-cert "<>" --public-cert "<>" --node ”<>”
Note: root-ca is ignored when --node flag is provided

### :athletic_shoe: How to Build and Test the Change
Add this package in your manifest while deploying HA:
sahiba3108/automate-ha-deployment/0.1.0/20221028084038

Install this pkg in your bastion host:
hab pkg install aazeez/automate-cli/0.1.0/20221114103738 -bf

Run the below command in bastion:
chef-automate cert-rotate --public-cert client.pem --private-cert client-key.pem --root-ca root-ca.pem --pg --node ""
(You can also use --postgres flag instead of pg)
This will rotate the public and private cert in given pg node when root cert is same.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Below is the link of testing demo video.
https://progresssoftware-my.sharepoint.com/:v:/g/personal/aazeez_progress_com/EYH4jNY5ttdMiSqhj7fZ_tABjb8O0jbrulpT9wRkHx4rXQ?e=RTWSBF

<img width="1792" alt="Screenshot 2022-11-14 at 4 14 33 PM" src="https://user-images.githubusercontent.com/38317160/201641351-30b62ce3-812e-4a82-950f-9ecce90bae1a.png">
<img width="1792" alt="Screenshot 2022-11-14 at 4 14 39 PM" src="https://user-images.githubusercontent.com/38317160/201641357-2a21776f-04e0-461d-b53c-7d8745bb7003.png">
