### PR TITLE
Centralised logging for postgress and opensearch

### DIFF
--- a/components/automate-cli/cmd/chef-automate/centerliazed_log.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log.go
@@ -82,7 +82,7 @@ func getScriptCommandsForLogging(reqConfig *dc.AutomateConfig, existConfig *dc.A
 		config.Merge(existConfig, reqConfig, merged)
 		*reqConfig = *merged
 		//If config changed reapplying the config accordingly
-		if isConfigChanged(reqConfig, existConfig) {
+		if isConfigChanged(reqConfig.GetGlobal().GetV1().GetLog(), existConfig.GetGlobal().GetV1().GetLog()) {
 			scriptCommands = getScriptCommandsForConfigChangedLogging(reqConfig, existConfig)
 		} else {
 			//if config in unchanged do nothing and returns

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log.go
@@ -223,7 +223,6 @@ func createScriptCommandsForCentralizedLog(reqConfig *dc.AutomateConfig) string 
 //createRsyslogAndLogRotateConfig patching the config into the remote database servers
 func createRsyslogAndLogRotateConfig(sshUser string, sshPort string, sskKeyFile string, remoteIp []string, scriptCommands string) error {
 	for i := 0; i < len(remoteIp); i++ {
-		fmt.Println("Script commands got for this config", scriptCommands)
 		output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, remoteIp[i], scriptCommands)
 		if err != nil {
 			writer.Errorf("%v", err)

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log.go
@@ -54,7 +54,7 @@ func enableCentralizedLogging(reqConfig *dc.AutomateConfig, existConfig *dc.Auto
 		return nil
 	}
 
-	err := createRsyslogAndLogRotateConfig(sshUser, sshPort, sskKeyFile, remoteIp, scriptCommands)
+	err := createRsyslogAndLogRotateConfig(sshUser, sshPort, sskKeyFile, remoteIp, scriptCommands, remoteType)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func createScriptCommandsForCentralizedLog(reqConfig *dc.AutomateConfig) string 
 }
 
 //createRsyslogAndLogRotateConfig patching the config into the remote database servers
-func createRsyslogAndLogRotateConfig(sshUser string, sshPort string, sskKeyFile string, remoteIp []string, scriptCommands string) error {
+func createRsyslogAndLogRotateConfig(sshUser string, sshPort string, sskKeyFile string, remoteIp []string, scriptCommands string, remoteService string) error {
 	for i := 0; i < len(remoteIp); i++ {
 		output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, remoteIp[i], scriptCommands)
 		if err != nil {
@@ -229,6 +229,7 @@ func createRsyslogAndLogRotateConfig(sshUser string, sshPort string, sskKeyFile 
 			return err
 		}
 		writer.Printf(output)
+		writer.Success("Patching is completed on " + remoteService + " node : " + remoteIp[i] + "\n")
 
 	}
 	return nil

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log.go
@@ -65,8 +65,10 @@ func enableCentralizedLogging(reqConfig *dc.AutomateConfig, existConfig *dc.Auto
 			writer.Errorf("Unable to created toml file for postgresql toml %v", err)
 		}
 	} else {
-		createTomlFileFromConfig(&reqConfig, opensearchConfig)
-		writer.Errorf("Unable to created toml file for open-search toml %v", err)
+		_, err := createTomlFileFromConfig(&reqConfig, opensearchConfig)
+		if err != nil {
+			writer.Errorf("Unable to created toml file for postgresql toml %v", err)
+		}
 	}
 	return nil
 
@@ -101,7 +103,7 @@ func getScriptCommandsForLogging(reqConfig *dc.AutomateConfig, existConfig *dc.A
 func getScriptCommandsForConfigChangedLogging(reqConfig *dc.AutomateConfig, existConfig *dc.AutomateConfig) string {
 	var scriptCommands string
 	//Disable the centralized logging if requested
-	// if only logrorate policies are requested and there is no change in the file path created
+	// if only logrotate policies are requested and there is no change in the file path created
 	// if file path changes are requested
 	if reqConfig.GetGlobal().GetV1().GetLog().GetRedirectSysLog().GetValue() == false &&
 		existConfig.GetGlobal().GetV1().GetLog().GetRedirectSysLog().GetValue() == true {
@@ -201,12 +203,12 @@ func getConfigForArgsLogs(args []string, remoteService string) (*dc.AutomateConf
 func rollBackCentralized() string {
 	rsyslogFileRemove := fmt.Sprintf("sudo rm %s", rsyslogConfigFile)
 
-	logrorateFileRemove := fmt.Sprintf("sudo rm %s", logRotateConfigFile)
+	logRotateFileRemove := fmt.Sprintf("sudo rm %s", logRotateConfigFile)
 
-	return fmt.Sprintf(" %s; %s; %s", rsyslogFileRemove, logrorateFileRemove, restartSyslogService)
+	return fmt.Sprintf(" %s; %s; %s", rsyslogFileRemove, logRotateFileRemove, restartSyslogService)
 }
 
-//setConfigForCentralizedLog sets config for rsyslog and logrorate
+//setConfigForCentralizedLog sets config for rsyslog and logrotate
 func createScriptCommandsForCentralizedLog(reqConfig *dc.AutomateConfig) string {
 	contentForRsyslogConfig := createConfigFileForAutomateSysLog(reqConfig.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue())
 

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	dc "github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/shared"
+	config "github.com/chef/automate/api/config/shared"
+	"github.com/chef/toml"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"io/ioutil"
+)
+
+const (
+	rsyslogConfigFile    = "/etc/rsyslog.d/automate.conf"
+	logRotateConfigFile  = "/etc/logrotate.d/automate"
+	postgresLogConfig    = "/hab/a2_deploy_workspace/postgres_log.toml"
+	opensearchConfig     = "/hab/a2_deploy_workspace/opensearch_log.toml"
+	restartSyslogService = "sudo systemctl restart rsyslog.service"
+)
+
+//enableCentralizedLogConfigForHA checks for requested and existing configuration for logging
+func enableCentralizedLogConfigForHA(args []string, remoteType string, sshUser string, sshPort string, sskKeyFile string, remoteIp []string) error {
+	reqConfig, err := getConfigForArgsLogs(args, remoteType)
+	if err != nil {
+		return err
+	}
+	//Returning if there is no config set for logging
+	if reqConfig.GetGlobal().GetV1().GetLog() == nil {
+
+		return nil
+	}
+	existConfig, err := getPostgresOrOpenSearchExistingLogConfig(remoteType)
+	if err != nil {
+		return err
+	}
+
+	err = enableCentralizedLogging(reqConfig, existConfig, sshUser, sshPort, sskKeyFile, remoteIp, remoteType)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//enableCentralizedLogging gets commands for rsyslog ang logrotate
+func enableCentralizedLogging(reqConfig *dc.AutomateConfig, existConfig *dc.AutomateConfig, sshUser string, sshPort string, sskKeyFile string, remoteIp []string, remoteType string) error {
+
+	scriptCommands := getScriptCommandsForLogging(reqConfig, existConfig)
+	if scriptCommands == "" {
+		//if there are no script commands do nothing
+		return nil
+	}
+
+	err := createRsyslogAndLogRotateConfig(sshUser, sshPort, sskKeyFile, remoteIp, scriptCommands)
+	if err != nil {
+		return err
+	}
+
+	if remoteType == "postgresql" {
+		_, err := createTomlFileFromConfig(&reqConfig, postgresLogConfig)
+		if err != nil {
+			writer.Errorf("Unable to created toml file for postgresql toml %v", err)
+		}
+	} else {
+		createTomlFileFromConfig(&reqConfig, opensearchConfig)
+		writer.Errorf("Unable to created toml file for open-search toml %v", err)
+	}
+	return nil
+
+}
+
+//getScriptCommandsForLogging gets the commands to be executed for  logging
+func getScriptCommandsForLogging(reqConfig *dc.AutomateConfig, existConfig *dc.AutomateConfig) string {
+	var scriptCommands string
+
+	if existConfig.GetGlobal().GetV1().GetLog() != nil {
+		merged := &dc.AutomateConfig{}
+		//Merging both the config into the requested config for comparing
+		config.Merge(existConfig, reqConfig, merged)
+		*reqConfig = *merged
+		//If config changed reapplying the config accordingly
+		if isConfigChanged(reqConfig, existConfig) {
+			scriptCommands = getScriptCommandsForConfigChangedLogging(reqConfig, existConfig)
+		} else {
+			//if config in unchanged do nothing and returns
+			return ""
+		}
+	} else if existConfig.GetGlobal().GetV1().GetLog() == nil && reqConfig.GetGlobal().GetV1().GetLog().GetRedirectSysLog().GetValue() == true {
+		reqConfig.GetGlobal().ValidateReDirectSysLogConfig()
+		scriptCommands = createScriptCommandsForCentralizedLog(reqConfig)
+	}
+
+	return scriptCommands
+
+}
+
+//getScriptCommandsForConfigChangedLogging gets the script commands where only some values are changed
+func getScriptCommandsForConfigChangedLogging(reqConfig *dc.AutomateConfig, existConfig *dc.AutomateConfig) string {
+	var scriptCommands string
+	//Disable the centralized logging if requested
+	// if only logrorate policies are requested and there is no change in the file path created
+	// if file path changes are requested
+	if reqConfig.GetGlobal().GetV1().GetLog().GetRedirectSysLog().GetValue() == false &&
+		existConfig.GetGlobal().GetV1().GetLog().GetRedirectSysLog().GetValue() == true {
+		scriptCommands = rollBackCentralized()
+	} else if reqConfig.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue() == existConfig.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue() {
+		logrotateFileCommand := fmt.Sprintf("echo \"%s\" > %s", configLogrotate(reqConfig.GetGlobal().GetV1().GetLog()), logRotateConfigFile)
+		return fmt.Sprintf("sudo sh -c '%s'", logrotateFileCommand)
+
+	} else {
+		scriptCommands = createScriptCommandsForCentralizedLog(reqConfig)
+	}
+	return scriptCommands
+}
+
+// configLogrotate Adds a config file for logrotate as /etc/logrotate.d/automate
+// it handles all the config for rotating logs.
+func configLogrotate(req *shared.Log) string {
+	var logRotateConfigContent string
+
+	if req.GetCompressRotatedLogs().GetValue() == true {
+		logRotateConfigContent = LogRotateConf(getLogFileName(req.GetRedirectLogFilePath().GetValue()),
+			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate", "compress", "dateext")
+	} else {
+		logRotateConfigContent = LogRotateConf(getLogFileName(req.GetRedirectLogFilePath().GetValue()),
+			getConcatStringFromConfig("size", req.GetMaxSizeRotateLogs().GetValue()), getConcatStringFromConfig("rotate", req.GetMaxNumberRotatedLogs().GetValue()), "missingok", "copytruncate", "dateext")
+	}
+	// Write the byteSlice to file
+	logrus.Infof("log rotated file content created")
+
+	return logRotateConfigContent
+}
+
+//createConfigFileForAutomateSysLog created a config file as /etc/rsyslog.d/automate.conf
+// which redirects the logs to the specified location
+func createConfigFileForAutomateSysLog(pathForLog string) string {
+	return fmt.Sprintf(`if \$programname == \"bash\" then %s
+& stop`, getLogFileName(pathForLog))
+
+}
+
+//LogRotateConf gets the log rotate configuration using the values  from config
+func LogRotateConf(path string, params ...string) string {
+	if len(params) < 1 {
+		return ""
+	}
+	var buffer bytes.Buffer
+	buffer.WriteString(path + " {" + "\n")
+	for _, param := range params {
+		buffer.WriteString("\t" + param + "\n")
+	}
+	buffer.WriteString("}" + "\n")
+	return buffer.String()
+}
+
+//getLogFileName gets the log file name based on the path provided
+func getLogFileName(path string) string {
+	if string(path[len(path)-1]) == "/" {
+		return fmt.Sprintf("%sautomate.log", path)
+	} else {
+		return fmt.Sprintf("%s/automate.log", path)
+	}
+}
+
+func getConcatStringFromConfig(constant string, variable interface{}) string {
+	return fmt.Sprintf("%s %v", constant, variable)
+}
+
+//decodeLogConfig decodes the log config from the log string from file
+func decodeLogConfig(logConfig string) (*dc.AutomateConfig, error) {
+	var src dc.AutomateConfig
+	if _, err := toml.Decode(logConfig, &src); err != nil {
+		return nil, err
+	}
+
+	return &src, nil
+}
+
+//getConfigForArgsLogs get the requested config from the patched file
+func getConfigForArgsLogs(args []string, remoteService string) (*dc.AutomateConfig, error) {
+
+	pemBytes, err := ioutil.ReadFile(args[0]) // nosemgrep
+	if err != nil {
+		return nil, err
+	}
+
+	destString := string(pemBytes)
+	dest1, err := decodeLogConfig(destString)
+	if err != nil {
+		return nil, errors.Errorf("Config file must be a valid %s config", remoteService)
+	}
+
+	return dest1, nil
+
+}
+
+////rollBackCentralized removed the logrotate file and rsyslog file
+func rollBackCentralized() string {
+	rsyslogFileRemove := fmt.Sprintf("sudo rm %s", rsyslogConfigFile)
+
+	logrorateFileRemove := fmt.Sprintf("sudo rm %s", logRotateConfigFile)
+
+	return fmt.Sprintf(" %s; %s; %s", rsyslogFileRemove, logrorateFileRemove, restartSyslogService)
+}
+
+//setConfigForCentralizedLog sets config for rsyslog and logrorate
+func createScriptCommandsForCentralizedLog(reqConfig *dc.AutomateConfig) string {
+	contentForRsyslogConfig := createConfigFileForAutomateSysLog(reqConfig.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue())
+
+	//creating a file and adding content in the file
+	rsysCreateFileCommand := fmt.Sprintf("echo \"%s\" > %s", contentForRsyslogConfig, rsyslogConfigFile)
+
+	//rsyslog command for creating and added the content
+	logrotateFileCommand := fmt.Sprintf("echo \"%s\" > %s", configLogrotate(reqConfig.GetGlobal().GetV1().GetLog()), logRotateConfigFile)
+
+	return fmt.Sprintf("sudo sh -c '%s'; \n sudo sh -c '%s'; \n %s;", rsysCreateFileCommand, logrotateFileCommand, restartSyslogService)
+
+}
+
+//createRsyslogAndLogRotateConfig patching the config into the remote database servers
+func createRsyslogAndLogRotateConfig(sshUser string, sshPort string, sskKeyFile string, remoteIp []string, scriptCommands string) error {
+	for i := 0; i < len(remoteIp); i++ {
+		fmt.Println("Script commands got for this config", scriptCommands)
+		output, err := ConnectAndExecuteCommandOnRemote(sshUser, sshPort, sskKeyFile, remoteIp[i], scriptCommands)
+		if err != nil {
+			writer.Errorf("%v", err)
+			return err
+		}
+		writer.Printf(output)
+
+	}
+	return nil
+
+}

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log_test.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func Test_getScriptCommandsForConfigChangedLogging(t *testing.T) {
+func TestGetScriptCommandsForConfigChangedLogging(t *testing.T) {
 	type args struct {
 		reqConfig   *dc.AutomateConfig
 		existConfig *dc.AutomateConfig
@@ -133,7 +133,7 @@ func Test_getScriptCommandsForConfigChangedLogging(t *testing.T) {
 	}
 }
 
-func Test_getScriptCommandsForLogging(t *testing.T) {
+func TestGetScriptCommandsForLogging(t *testing.T) {
 	type args struct {
 		reqConfig   *dc.AutomateConfig
 		existConfig *dc.AutomateConfig

--- a/components/automate-cli/cmd/chef-automate/centerliazed_log_test.go
+++ b/components/automate-cli/cmd/chef-automate/centerliazed_log_test.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"fmt"
+	dc "github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/shared"
+	w "github.com/chef/automate/api/config/shared/wrappers"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_getScriptCommandsForConfigChangedLogging(t *testing.T) {
+	type args struct {
+		reqConfig   *dc.AutomateConfig
+		existConfig *dc.AutomateConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Get Script Commands if both the config is requested for disabling",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(false),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+			},
+			want: " sudo rm /etc/rsyslog.d/automate.conf; sudo rm /etc/logrotate.d/automate; sudo systemctl restart rsyslog.service",
+		}, {
+			name: "Get Script Commands if both the config is requested for logroate only and not file path",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       w.Bool(true),
+								RedirectLogFilePath:  w.String("Testing"),
+								MaxSizeRotateLogs:    w.String("100M"),
+								MaxNumberRotatedLogs: w.Int32(10),
+								CompressRotatedLogs:  w.Bool(true),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       w.Bool(true),
+								RedirectLogFilePath:  w.String("Testing"),
+								MaxSizeRotateLogs:    w.String("10M"),
+								MaxNumberRotatedLogs: w.Int32(5),
+							},
+						},
+					},
+				},
+			},
+			want: `sudo sh -c 'echo "Testing/automate.log {
+	size 100M
+	rotate 10
+	missingok
+	copytruncate
+	compress
+	dateext
+}
+" > /etc/logrotate.d/automate'`,
+		}, {
+			name: "Get Script Commands if both the config is requested for file path changed and logrotate values",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       w.Bool(true),
+								RedirectLogFilePath:  w.String("Testing1"),
+								MaxSizeRotateLogs:    w.String("100M"),
+								MaxNumberRotatedLogs: w.Int32(10),
+								CompressRotatedLogs:  w.Bool(true),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       w.Bool(true),
+								RedirectLogFilePath:  w.String("Testing"),
+								MaxSizeRotateLogs:    w.String("10M"),
+								MaxNumberRotatedLogs: w.Int32(5),
+							},
+						},
+					},
+				},
+			},
+			want: `sudo sh -c 'echo "if \$programname == \"bash\" then Testing1/automate.log
+& stop" > /etc/rsyslog.d/automate.conf'; 
+ sudo sh -c 'echo "Testing1/automate.log {
+	size 100M
+	rotate 10
+	missingok
+	copytruncate
+	compress
+	dateext
+}
+" > /etc/logrotate.d/automate'; 
+ sudo systemctl restart rsyslog.service;`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println(getScriptCommandsForConfigChangedLogging(tt.args.reqConfig, tt.args.existConfig))
+			assert.Equalf(t, tt.want, getScriptCommandsForConfigChangedLogging(tt.args.reqConfig, tt.args.existConfig), "getScriptCommandsForConfigChangedLogging(%v, %v)", tt.args.reqConfig, tt.args.existConfig)
+		})
+	}
+}
+
+func Test_getScriptCommandsForLogging(t *testing.T) {
+	type args struct {
+		reqConfig   *dc.AutomateConfig
+		existConfig *dc.AutomateConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Get Script Commands if there is no change in the requested and existed config",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "Get Script Commands if there is config changed in the requested and existed config with false value",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(false),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+			},
+			want: ` sudo rm /etc/rsyslog.d/automate.conf; sudo rm /etc/logrotate.d/automate; sudo systemctl restart rsyslog.service`,
+		},
+		{
+			name: "Get Script Commands if there is config changed in the requested and existed config has more values",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing1"),
+							},
+						},
+					},
+				},
+				existConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:       w.Bool(true),
+								RedirectLogFilePath:  w.String("Testing"),
+								MaxSizeRotateLogs:    w.String("10k"),
+								MaxNumberRotatedLogs: w.Int32(50),
+							},
+						},
+					},
+				},
+			},
+			want: `sudo sh -c 'echo "if \$programname == \"bash\" then Testing1/automate.log
+& stop" > /etc/rsyslog.d/automate.conf'; 
+ sudo sh -c 'echo "Testing1/automate.log {
+	size 10k
+	rotate 50
+	missingok
+	copytruncate
+	dateext
+}
+" > /etc/logrotate.d/automate'; 
+ sudo systemctl restart rsyslog.service;`,
+		},
+		{
+			name: "When there is no exist config and take default values",
+			args: args{
+				reqConfig: &dc.AutomateConfig{
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Log: &shared.Log{
+								RedirectSysLog:      w.Bool(true),
+								RedirectLogFilePath: w.String("Testing"),
+							},
+						},
+					},
+				},
+			},
+			want: `sudo sh -c 'echo "if \$programname == \"bash\" then Testing/automate.log
+& stop" > /etc/rsyslog.d/automate.conf'; 
+ sudo sh -c 'echo "Testing/automate.log {
+	size 100M
+	rotate 10
+	missingok
+	copytruncate
+	dateext
+}
+" > /etc/logrotate.d/automate'; 
+ sudo systemctl restart rsyslog.service;`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getScriptCommandsForLogging(tt.args.reqConfig, tt.args.existConfig), "getScriptCommandsForLogging(%v, %v)", tt.args.reqConfig, tt.args.existConfig)
+		})
+	}
+}
+
+func TestLogDecodeFromInput(t *testing.T) {
+	t.Run("If there are some parameters", func(t *testing.T) {
+		req := `[global.v1.log]
+redirect_sys_log = true
+redirect_log_file_path = "/var/tmp/"
+compress_rotated_logs = true
+max_size_rotate_logs = "10M"
+max_number_rotated_logs = 5
+`
+
+		config, _ := decodeLogConfig(req)
+
+		assert.Equal(t, config.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue(), "/var/tmp/")
+	})
+	t.Run("If there are no parameters", func(t *testing.T) {
+		req := ""
+		config, _ := decodeLogConfig(req)
+		assert.Nil(t, config.GetGlobal().GetV1().GetLog())
+	})
+	t.Run("If there are some parameters", func(t *testing.T) {
+		req := `[global.v1.log]
+redirect_sys_log = true
+redirect_log_file_path = "/var/tmp/"
+
+`
+
+		config, _ := decodeLogConfig(req)
+		fmt.Println(config)
+
+		assert.Equal(t, config.GetGlobal().GetV1().GetLog().GetRedirectLogFilePath().GetValue(), "/var/tmp/")
+	})
+}

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -60,6 +60,8 @@ const (
 	dateFormat = "%Y%m%d%H%M%S"
 )
 
+var configValid = "Config file must be a valid %s config"
+
 func init() {
 	configCmd.AddCommand(showConfigCmd)
 	configCmd.AddCommand(patchConfigCmd)
@@ -204,6 +206,7 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				writer.Printf(output + "\n")
 				writer.Success("Patching is completed on " + remoteService + " node : " + frontendIps[i] + "\n")
 			}
+
 		}
 		if configCmdFlags.postgresql {
 			const remoteService string = "postgresql"
@@ -450,7 +453,7 @@ func getMergedOpensearchInterface(rawOutput string, pemFilePath string, remoteSe
 	destString := string(pemBytes)
 	var dest OpensearchConfig
 	if _, err := toml.Decode(destString, &dest); err != nil {
-		return "", errors.Errorf("Config file must be a valid %s config", remoteService)
+		return "", errors.Errorf(configValid, remoteService)
 	}
 
 	mergo.Merge(&dest, src) //, mergo.WithOverride
@@ -473,7 +476,7 @@ func getMergedPostgresqlInterface(rawOutput string, pemFilePath string, remoteSe
 	destString := string(pemBytes)
 	var dest PostgresqlConfig
 	if _, err := toml.Decode(destString, &dest); err != nil {
-		return "", errors.Errorf("Config file must be a valid %s config", remoteService)
+		return "", errors.Errorf(configValid, remoteService)
 	}
 
 	mergo.Merge(&dest, src) //, mergo.WithOverride
@@ -590,7 +593,7 @@ func getConfigForArgsOpenSearch(args []string, remoteService string) (Opensearch
 
 	destString := string(pemBytes)
 	if _, err := toml.Decode(destString, &dest); err != nil {
-		return dest, errors.Errorf("Config file must be a valid %s config", remoteService)
+		return dest, errors.Errorf(configValid, remoteService)
 	}
 
 	return dest, nil
@@ -607,7 +610,7 @@ func getConfigForArgsPostgresql(args []string, remoteService string) (Postgresql
 
 	destString := string(pemBytes)
 	if _, err := toml.Decode(destString, &dest); err != nil {
-		return dest, errors.Errorf("Config file must be a valid %s config", remoteService)
+		return dest, errors.Errorf(configValid, remoteService)
 	}
 
 	return dest, nil

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -170,7 +170,6 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 	*/
 
 	if isA2HARBFileExist() {
-		fmt.Println("inside the a2ha condition")
 
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
@@ -208,13 +207,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 		if configCmdFlags.postgresql {
 			const remoteService string = "postgresql"
-			fmt.Println("Going to see centerliased Config")
 			//checking for log configuration
 			err := enableCentralizedLogConfigForHA(args, remoteService, sshUser, sshPort, sskKeyFile, infra.Outputs.PostgresqlPrivateIps.Value)
 			if err != nil {
 				return err
 			}
-			fmt.Println("Going to see port Config", infra.Outputs.SSHPort)
 			//checking database configuration
 			existConfig, reqConfig, err := getExistingAndRequestedConfigForPostgres(args, infra, remoteService, GET_CONFIG)
 			if err != nil {

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -58,6 +58,9 @@ const (
 	`
 
 	dateFormat = "%Y%m%d%H%M%S"
+
+	postgresql = "postgresql"
+	opensearch = "opensearch"
 )
 
 var configValid = "Config file must be a valid %s config"
@@ -593,14 +596,14 @@ func getConfigFromRemoteServer(infra *AutomteHAInfraDetails, remoteType string, 
 
 //getDecodedConfig gets the decoded config from the input
 func getDecodedConfig(input string, remoteService string) (interface{}, error) {
-	if remoteService == "postgresql" {
+	if remoteService == postgresql {
 		var src PostgresqlConfig
 		if _, err := toml.Decode(cleanToml(input), &src); err != nil {
 			return nil, err
 		}
 		return src, nil
 	}
-	if remoteService == "opensearch" {
+	if remoteService == opensearch {
 		var src OpensearchConfig
 		if _, err := toml.Decode(cleanToml(input), &src); err != nil {
 			return nil, err
@@ -649,18 +652,18 @@ func getExistingAndRequestedConfigForPostgres(args []string, infra *AutomteHAInf
 	//Getting Existing config from server
 	var existingConfig PostgresqlConfig
 	var reqConfig PostgresqlConfig
-	srcInputString, err := getConfigFromRemoteServer(infra, "postgresql", config)
+	srcInputString, err := getConfigFromRemoteServer(infra, postgresql, config)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
 	}
-	existingConfigInterface, err := getDecodedConfig(srcInputString, "postgresql")
+	existingConfigInterface, err := getDecodedConfig(srcInputString, postgresql)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}
 	existingConfig = existingConfigInterface.(PostgresqlConfig)
 
 	//Getting Requested Config
-	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, "postgresql")
+	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, postgresql)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}
@@ -674,18 +677,18 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomteHAI
 	//Getting Existing config from server
 	var existingConfig OpensearchConfig
 	var reqConfig OpensearchConfig
-	srcInputString, err := getConfigFromRemoteServer(infra, "opensearch", config)
+	srcInputString, err := getConfigFromRemoteServer(infra, opensearch, config)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
 	}
-	existingConfigInterface, err := getDecodedConfig(srcInputString, "opensearch")
+	existingConfigInterface, err := getDecodedConfig(srcInputString, opensearch)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}
 	existingConfig = existingConfigInterface.(OpensearchConfig)
 
 	//Getting Requested Config
-	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, "opensearch")
+	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, opensearch)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -59,8 +59,8 @@ const (
 
 	dateFormat = "%Y%m%d%H%M%S"
 
-	postgresql = "postgresql"
-	opensearch = "opensearch"
+	postgresql       = "postgresql"
+	opensearch_const = "opensearch"
 )
 
 var configValid = "Config file must be a valid %s config"
@@ -603,7 +603,7 @@ func getDecodedConfig(input string, remoteService string) (interface{}, error) {
 		}
 		return src, nil
 	}
-	if remoteService == opensearch {
+	if remoteService == opensearch_const {
 		var src OpensearchConfig
 		if _, err := toml.Decode(cleanToml(input), &src); err != nil {
 			return nil, err
@@ -677,18 +677,18 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomteHAI
 	//Getting Existing config from server
 	var existingConfig OpensearchConfig
 	var reqConfig OpensearchConfig
-	srcInputString, err := getConfigFromRemoteServer(infra, opensearch, config)
+	srcInputString, err := getConfigFromRemoteServer(infra, opensearch_const, config)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
 	}
-	existingConfigInterface, err := getDecodedConfig(srcInputString, opensearch)
+	existingConfigInterface, err := getDecodedConfig(srcInputString, opensearch_const)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}
 	existingConfig = existingConfigInterface.(OpensearchConfig)
 
 	//Getting Requested Config
-	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, opensearch)
+	reqConfigInterface, err := getConfigForArgsPostgresqlOrOpenSearch(args, opensearch_const)
 	if err != nil {
 		return existingConfig, reqConfig, err
 	}

--- a/components/automate-cli/cmd/chef-automate/config_test.go
+++ b/components/automate-cli/cmd/chef-automate/config_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	dc "github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/shared"
+	w "github.com/chef/automate/api/config/shared/wrappers"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsConfigChanged(t *testing.T) {
+
+	t.Run("check if the values are changed For Postgresql", func(t *testing.T) {
+		reqConfig := PostgresqlConfig{
+			Host: "a2.test.com",
+			Port: 80,
+		}
+
+		existingConfig := PostgresqlConfig{
+			Host: "a5.test.com",
+			Port: 22,
+		}
+
+		isChanged := isConfigChanged(existingConfig, reqConfig)
+		assert.True(t, isChanged)
+
+	})
+	t.Run("check if the some values are added For Postgresql", func(t *testing.T) {
+		reqConfig := PostgresqlConfig{
+			Host:              "a2.test.com",
+			Port:              80,
+			CheckpointTimeout: "10c",
+		}
+
+		existingConfig := PostgresqlConfig{
+			Host: "a5.test.com",
+		}
+
+		isChanged := isConfigChanged(existingConfig, reqConfig)
+		assert.True(t, isChanged)
+
+	})
+	t.Run("check if the no values are added or changed", func(t *testing.T) {
+		reqConfig := PostgresqlConfig{
+			Host:              "a2.test.com",
+			Port:              80,
+			CheckpointTimeout: "10c",
+		}
+
+		existingConfig := PostgresqlConfig{
+			Host:              "a2.test.com",
+			Port:              80,
+			CheckpointTimeout: "10c",
+		}
+
+		isChanged := isConfigChanged(existingConfig, reqConfig)
+		assert.False(t, isChanged)
+
+	})
+
+}
+
+func TestPostgresSqlDecodeFromInput(t *testing.T) {
+	t.Run("If there are some parameters", func(t *testing.T) {
+		req := `[pg_dump]
+enable = true
+path = "/mnt/automate_backups/postgresql/pg_dump"
+[replication]
+lag_health_threshold = 20480
+max_replay_lag_before_restart_s = 180
+name = "replication"
+password = "replication"`
+
+		config, _ := getDecodedConfig(req, "postgresql")
+
+		decodedConfig := config.(PostgresqlConfig)
+
+		assert.Equal(t, decodedConfig.PgDump.Enable, true)
+	})
+
+}
+
+func TestTomlFileCreateFromReqConfigLog(t *testing.T) {
+	req := dc.AutomateConfig{
+		Global: &shared.GlobalConfig{
+			V1: &shared.V1{
+				Log: &shared.Log{
+					RedirectSysLog:      w.Bool(true),
+					RedirectLogFilePath: w.String("/var/tmp/"),
+				},
+			},
+		},
+	}
+
+	createTomlFileFromConfig(req, "logtoml.toml")
+	assert.FileExists(t, "logtoml.toml")
+}

--- a/components/automate-cli/cmd/chef-automate/config_test.go
+++ b/components/automate-cli/cmd/chef-automate/config_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 )
 
+var fqdn = "a2.test.com"
+
 func TestIsConfigChanged(t *testing.T) {
 
 	t.Run("check if the values are changed For Postgresql", func(t *testing.T) {
 		reqConfig := PostgresqlConfig{
-			Host: "a2.test.com",
+			Host: fqdn,
 			Port: 80,
 		}
 
@@ -27,7 +29,7 @@ func TestIsConfigChanged(t *testing.T) {
 	})
 	t.Run("check if the some values are added For Postgresql", func(t *testing.T) {
 		reqConfig := PostgresqlConfig{
-			Host:              "a2.test.com",
+			Host:              fqdn,
 			Port:              80,
 			CheckpointTimeout: "10c",
 		}
@@ -42,13 +44,13 @@ func TestIsConfigChanged(t *testing.T) {
 	})
 	t.Run("check if the no values are added or changed", func(t *testing.T) {
 		reqConfig := PostgresqlConfig{
-			Host:              "a2.test.com",
+			Host:              fqdn,
 			Port:              80,
 			CheckpointTimeout: "10c",
 		}
 
 		existingConfig := PostgresqlConfig{
-			Host:              "a2.test.com",
+			Host:              fqdn,
 			Port:              80,
 			CheckpointTimeout: "10c",
 		}

--- a/components/automate-cli/cmd/chef-automate/config_test.go
+++ b/components/automate-cli/cmd/chef-automate/config_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/chef/automate/api/config/shared"
 	w "github.com/chef/automate/api/config/shared/wrappers"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 )
 
@@ -83,6 +84,7 @@ password = "replication"`
 }
 
 func TestTomlFileCreateFromReqConfigLog(t *testing.T) {
+	fileName := "logtoml.toml"
 	req := dc.AutomateConfig{
 		Global: &shared.GlobalConfig{
 			V1: &shared.V1{
@@ -94,6 +96,7 @@ func TestTomlFileCreateFromReqConfigLog(t *testing.T) {
 		},
 	}
 
-	createTomlFileFromConfig(req, "logtoml.toml")
-	assert.FileExists(t, "logtoml.toml")
+	createTomlFileFromConfig(req, fileName)
+	assert.FileExists(t, fileName)
+	os.Remove(fileName)
 }

--- a/components/automate-cli/cmd/chef-automate/logtoml.toml
+++ b/components/automate-cli/cmd/chef-automate/logtoml.toml
@@ -1,5 +1,0 @@
-[global]
-  [global.v1]
-    [global.v1.log]
-      redirect_sys_log = true
-      redirect_log_file_path = "/var/tmp/"

--- a/components/automate-cli/cmd/chef-automate/logtoml.toml
+++ b/components/automate-cli/cmd/chef-automate/logtoml.toml
@@ -1,0 +1,5 @@
+[global]
+  [global.v1]
+    [global.v1.log]
+      redirect_sys_log = true
+      redirect_log_file_path = "/var/tmp/"

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	dc "github.com/chef/automate/api/config/deployment"
 	"io/ioutil"
 	"strconv"
@@ -289,7 +288,6 @@ func getIPOfRequestedServers(servername string, d *AutomteHAInfraDetails) ([]str
 }
 
 func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateConfig, error) {
-	fmt.Println("Inside the function getPostgresOrOpenSearchExistingLogConfig")
 	var log dc.AutomateConfig
 	var fileName string
 	if remoteType == "postgresql" {
@@ -298,7 +296,6 @@ func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateCo
 		fileName = opensearchConfig
 	}
 	if checkIfFileExist(fileName) {
-		fmt.Println("Got file name as fileName with inside loginc for file exist", fileName)
 		contents, err := ioutil.ReadFile(fileName)
 		if err != nil {
 			return &log, err

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -296,7 +296,7 @@ func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateCo
 		fileName = opensearchConfig
 	}
 	if checkIfFileExist(fileName) {
-		contents, err := ioutil.ReadFile(fileName) // nosemgrep //
+		contents, err := ioutil.ReadFile(fileName) // nosemgrep
 		if err != nil {
 			return nil, err
 		}

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	dc "github.com/chef/automate/api/config/deployment"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -297,11 +296,10 @@ func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateCo
 		fileName = opensearchConfig
 	}
 	if checkIfFileExist(fileName) {
-		file, err := os.Open(fileName)
+		contents, err := ioutil.ReadFile(fileName) // nosemgrep //
 		if err != nil {
-			return &log, err
+			return nil, err
 		}
-		contents, err := ioutil.ReadAll(file)
 		destString := string(contents)
 		log1, err := decodeLogConfig(destString)
 		log = *log1

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	dc "github.com/chef/automate/api/config/deployment"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -284,4 +286,30 @@ func getIPOfRequestedServers(servername string, d *AutomteHAInfraDetails) ([]str
 	default:
 		return nil, errors.New("invalid hostname possible values should be any one of automate/a2, chef_server/cs, postgresql/pg or opensearch/os")
 	}
+}
+
+func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateConfig, error) {
+	fmt.Println("Inside the function getPostgresOrOpenSearchExistingLogConfig")
+	var log dc.AutomateConfig
+	var fileName string
+	if remoteType == "postgresql" {
+		fileName = postgresLogConfig
+	} else {
+		fileName = opensearchConfig
+	}
+	if checkIfFileExist(fileName) {
+		fmt.Println("Got file name as fileName with inside loginc for file exist", fileName)
+		contents, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return &log, err
+		}
+		destString := string(contents)
+		log1, err := decodeLogConfig(destString)
+		log = *log1
+		if err != nil {
+			return &log, err
+		}
+	}
+	return &log, nil
+
 }

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	dc "github.com/chef/automate/api/config/deployment"
 	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -296,10 +297,11 @@ func getPostgresOrOpenSearchExistingLogConfig(remoteType string) (*dc.AutomateCo
 		fileName = opensearchConfig
 	}
 	if checkIfFileExist(fileName) {
-		contents, err := ioutil.ReadFile(fileName)
+		file, err := os.Open(fileName)
 		if err != nil {
 			return &log, err
 		}
+		contents, err := ioutil.ReadAll(file)
 		destString := string(contents)
 		log1, err := decodeLogConfig(destString)
 		log = *log1


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Added the config for adding centralised logging open-seach and postgresql nodes.

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-233

### :+1: Definition of Done
 Added the logic for checking existing and requesting config for database and patch only when its changed.
Added the logic for having centralised logs for open-search and postgresql nodes.
If any of the config is changed it will patch accordingly to rsyslog and logrotate and existing config will be set in a file under /hab/a2_deploy_workspace/ 

If the config has not given any values, it will take for default values.

### :athletic_shoe: How to Build and Test the Change

deploy che-automate HA.
rebuild components/automate-cli/
Add the build into the chef-automate HA instance.
Patch the following config using 
for postgresql : chef-automate config patch log1.toml --postgresql
opensearch : chef-automate config patch log1.toml --opensearch

```
[global.v1.log]
redirect_sys_log = true
redirect_log_file_path = "/var/tmp/"
compress_rotated_logs = true
max_size_rotate_logs = "10M"
max_number_rotated_logs = 2
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
