### PR TITLE
Fixing the centralised logging for postgres and opensearch for manage…

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -316,10 +316,10 @@ func setConfigForFrontEndNodes(args []string, sshUtil SSHUtil, frontendIps []str
 // setConfigForPostgresqlNodes patches the config for postgresql nodes in Automate HA
 func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for managed services is not possible!")
+		writer.Warn("Patching the configuration for third party managed services is not supported.")
 		return nil
 	}
-	if !(len(infra.Outputs.PostgresqlPrivateIps.Value) > 0) {
+	if len(infra.Outputs.PostgresqlPrivateIps.Value) == 0 {
 		writer.Error("Postgres IPs not found in the config. Please contact the support team")
 		return nil
 
@@ -368,10 +368,10 @@ func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SS
 // setConfigForOpensearch patches the config for open-search nodes in Automate HA
 func setConfigForOpensearch(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for managed services is not possible!")
+		writer.Warn("Patching the configuration for third party managed services is not supported.")
 		return nil
 	}
-	if !(len(infra.Outputs.OpensearchPrivateIps.Value) > 0) {
+	if len(infra.Outputs.OpensearchPrivateIps.Value) == 0 {
 		writer.Error("Postgres IPs not found in the config. Please contact the support team")
 		return nil
 


### PR DESCRIPTION
…d services

Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Added the check for managed services, that automate will not be able to apply config to managed services for postgress and open-search

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/wiki/spaces/CPAHM/pages/2693562383/Release+Test+Plan

### :+1: Definition of Done

A warning has been added if the user is trying to patch config for opensearch and postgresql in managed services

If the postgres private ips and opensearch private ips are not populated, it will throw an error.

### :athletic_shoe: How to Build and Test the Change

install chef-automate HA

```
rebuild components/automate-cli/
hab pkg upload <automate cli build>
```
in AHA
```
hab pkg install <build> -bf
```
Patch the following config using chef-automate config patch log.toml -p (for postgresql)
or 
chef-automate config patch log.toml -o (for opensearch)

```
[global.v1.log]
redirect_sys_log = true
redirect_log_file_path = "/var/tmp/"
compress_rotated_logs = true
max_size_rotate_logs = "10M"
max_number_rotated_logs = 2
```


### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
