### PR TITLE
Restricting Cert rotation via `patch` command

### DIFF
--- a/components/automate-cluster-ctl/templates/terraform.tfvars.erb
+++ b/components/automate-cluster-ctl/templates/terraform.tfvars.erb
@@ -272,6 +272,8 @@ opensearch_certs_by_ip = <%= config.opensearch.certs_by_ip %>
 
 nfs_mount_path = "<%= config.backup_mount %>"
 postgresql_instance_count = <%= config.postgresql.instance_count %>
+automate_archive_disk_fs_path = "<%= config.backup_mount %>/automate"
+opensearch_archive_disk_fs_path = "<%= config.backup_mount %>/opensearch"
 postgresql_archive_disk_fs_path = "<%= config.backup_mount %>/postgresql"
 
 habitat_uid_gid = "<%= config.habitat_uid_gid %>"

--- a/components/automate-cluster-ctl/templates/terraform.tfvars.erb
+++ b/components/automate-cluster-ctl/templates/terraform.tfvars.erb
@@ -272,8 +272,6 @@ opensearch_certs_by_ip = <%= config.opensearch.certs_by_ip %>
 
 nfs_mount_path = "<%= config.backup_mount %>"
 postgresql_instance_count = <%= config.postgresql.instance_count %>
-automate_archive_disk_fs_path = "<%= config.backup_mount %>/automate"
-opensearch_archive_disk_fs_path = "<%= config.backup_mount %>/opensearch"
 postgresql_archive_disk_fs_path = "<%= config.backup_mount %>/postgresql"
 
 habitat_uid_gid = "<%= config.habitat_uid_gid %>"

--- a/components/docs-chef-io/content/automate/ha_patching.md
+++ b/components/docs-chef-io/content/automate/ha_patching.md
@@ -44,5 +44,6 @@ For Example: `chef-automate config patch --frontend /home/frontend.toml`
 {{< warning >}}
 
 -   For certificate rotation, don't use `config patch`. Instead `cert-rotate` command can be used. To know more about certificate rotation click [here](/automate/ha_cert_rotaion)
+-   While patching the same from **the provision host**, structures such as TLS from OpenSearch configuration toml file and SSL from PostgreQL configuration toml file will be ignored.
 
 {{< /warning >}}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
For Automate HA as a product, when the use tried to patch some configuration, especially certificates, via `chef-automate config patch --[pg/os] file.toml`, it overwrites the certs in all nodes in the backend clusers, which causes an issue when the nodes are using unique certificates. So, in this PR, the cert values are deliberately removed before patching via config patch.

For OS node, TLS and for PG node, SSL is removed before patching.

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/MADROX-391

### :+1: Definition of Done
It's dev done and tested.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/54614142/207259534-0f141d54-284a-448a-9cb6-7ad244590efd.png)

![image](https://user-images.githubusercontent.com/54614142/207260529-d432a48d-61fe-4b3b-ada2-d19e9bec9bc0.png)

