### PR TITLE
Fixing restore failing 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -258,6 +258,10 @@ var integrityBackupValidateCmd = &cobra.Command{
 }
 
 func preBackupCmd(cmd *cobra.Command, args []string) error {
+	err := commandPrePersistent(cmd)
+	if err != nil {
+		return status.Wrap(err, status.BackupError, "unable to set command parent settings")
+	}
 	if NewBackupFromBashtion().isBastionHost() {
 		//Enhancments:  need to handle airgap bundle path from bastion host
 		//Enhancments: how to pass missing opensearch credentials


### PR DESCRIPTION
Signed-off-by: jayvikramsharma <jsharma@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

When we ran restore it was failing with error
`
BackupRestoreError: Unable to restore backup: Restoring deployment-service database failed: command hab pkg exec chef/deployment-service/0.1.0/20221206141953 deployment-service restoredb failed with error '✗✗✗
✗✗✗ stream did not contain valid UTF-8
✗✗✗
': exit status 1
`
reason was cobra don't support hooks chaining for child commands, so parent hook was not getting executed.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/MADROX-402

### :+1: Definition of Done

Dev tested

### :athletic_shoe: How to Build and Test the Change

build automate-cli
then use build cli for restore

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
