### PR TITLE
Disable prompting the workspace upgrade

### DIFF
--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -436,6 +436,8 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 	}
 
 	if offlineMode {
+		// Always upgrade the workspace
+		upgradeRunCmdFlags.upgradeHAWorkspace = "yes"
 		uperr, upgraded := upgradeWorspace(upgradeRunCmdFlags.airgap, upgradeRunCmdFlags.saas)
 		if uperr != nil {
 			return status.Annotate(uperr, status.UpgradeError)


### PR DESCRIPTION
Signed-off-by: Durga Sarat Chandra Maddu <dmaddu@progress.com>

https://chefio.atlassian.net/browse/KINETICS-284

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

`rebuild components/automate-cli/`

Use the new automate-cli and upgrade from 4.2.47 to 4.4.0
It Won't prompt the end user confirmation for workspace upgrade and it considers the workspace upgrade as true

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1091" alt="Screenshot 2022-12-29 at 4 23 26 PM" src="https://user-images.githubusercontent.com/44021874/209942043-02ab2612-16e6-4d68-bfd2-0a93650306d9.png">

