### PR TITLE
sahithi/STALWART-308

### DIFF
--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -797,7 +797,7 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 		location := "/var/opt/chef-automate/backups/" + args[i]
 		_, err := parseLocationSpecFromCLIArgs(location)
 		if err != nil {
-			writer.Failf("Oops! The backup Id %s is either removed or typed incorrect.", args[i])
+			writer.Failf("The backup Id %s is either removed or typed incorrect.", args[i])
 		} else {
 			newArgs = append(newArgs, args[i])
 		}

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -802,7 +802,7 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 	var newArgs []string
 	var backup []*api.BackupTask
 
-	if strings.Contains(args[0], "//") || strings.Contains(args[0], "\\") {
+	if strings.Contains(args[0], "/") || strings.Contains(args[0], "\\") {
 		location = args[0]
 		start = 1
 	}

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -797,7 +797,7 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 		location := "/var/opt/chef-automate/backups/" + args[i]
 		_, err := parseLocationSpecFromCLIArgs(location)
 		if err != nil {
-			writer.Failf("%s %s", args[i], "Invalid backupId")
+			writer.Failf("Oops! The backup Id %s is either removed or typed incorrect.", args[i])
 		} else {
 			newArgs = append(newArgs, args[i])
 		}

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -797,24 +797,23 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 		location := "/var/opt/chef-automate/backups/" + args[i]
 		_, err := parseLocationSpecFromCLIArgs(location)
 		if err != nil {
-			writer.Errorf("%s %s", "Invalid backupId", args[i])
+			writer.Failf("%s %s", args[i], "Invalid backupId")
 		} else {
 			newArgs = append(newArgs, args[i])
 		}
 	}
-	if len(newArgs) > 0 {
-		if !backupDeleteCmdFlags.yes {
-			yes, err := writer.Confirm(
-				fmt.Sprintf("The following backups will be permanently deleted:\n%s\nAre you sure you want to continue?",
-					strings.Join(newArgs, "\n"),
-				),
-			)
-			if err != nil {
-				return status.Annotate(err, status.BackupError)
-			}
-			if !yes {
-				return status.New(status.InvalidCommandArgsError, "failed to confirm backup deletion")
-			}
+
+	if !backupDeleteCmdFlags.yes && len(newArgs) > 0 {
+		yes, err := writer.Confirm(
+			fmt.Sprintf("The following backups will be permanently deleted:\n%s\nAre you sure you want to continue?",
+				strings.Join(newArgs, "\n"),
+			),
+		)
+		if err != nil {
+			return status.Annotate(err, status.BackupError)
+		}
+		if !yes {
+			return status.New(status.InvalidCommandArgsError, "failed to confirm backup deletion")
 		}
 
 		_, err = client.DeleteBackups(
@@ -827,6 +826,7 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 		}
 		writer.Success("Backups deleted")
 	}
+
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -658,11 +658,7 @@ func getBackupTask(location string) ([]*api.BackupTask, error) {
 		writer.Printf("Listing backups from %s\n", locationSpec)
 		backups, err = listBackupsLocally(ctx, locationSpec)
 		if err != nil {
-			return nil, status.Wrapf(
-				err,
-				status.BackupError,
-				"Listing local backup directory %s failed",
-			)
+			return nil, err
 		}
 	} else {
 		res, err := client.ListBackups(


### PR DESCRIPTION
Signed-off-by: SahithiMy <sahithi.mylangam@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Deleting the backupID which is already deleted should return the error message and deleting the invalid backupID should return error message.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-308
### :+1: Definition of Done

- Delete the same backup returns the error message
- Delete the invalid backup shows the error message
### :athletic_shoe: How to Build and Test the Change
```rebuild components/automate-cli/```
```chef-automate backup delete BACKUPID```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


https://user-images.githubusercontent.com/98326242/210206142-4b977038-7475-4b5d-9ef9-6b1607dc43ee.mov



