### PR TITLE
Added warn message in config show cmd for self managed deployment

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -117,7 +117,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		if isManagedServicesOn() {
 			err := errorOnSelfManaged(configCmdFlags.postgresql, configCmdFlags.opensearch)
 			if err != nil {
-				return err
+				return status.Annotate(err,status.InvalidCommandArgsError)
 			}
 		}
 
@@ -345,7 +345,7 @@ func setConfigForFrontEndNodes(args []string, sshUtil SSHUtil, frontendIps []str
 // setConfigForPostgresqlNodes patches the config for postgresql nodes in Automate HA
 func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_PATCH, "Postgresql")
+		return status.Errorf(status.InvalidCommandArgsError,ERROR_SELF_MANAGED_CONFIG_PATCH, "Postgresql")
 	}
 	if len(infra.Outputs.PostgresqlPrivateIps.Value) == 0 {
 		writer.Error("Postgres IPs not found in the config. Please contact the support team")
@@ -399,7 +399,7 @@ func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SS
 // setConfigForOpensearch patches the config for open-search nodes in Automate HA
 func setConfigForOpensearch(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_PATCH, "OpenSearch")
+		return status.Errorf(status.InvalidCommandArgsError,ERROR_SELF_MANAGED_CONFIG_PATCH, "OpenSearch")
 	}
 	if len(infra.Outputs.OpensearchPrivateIps.Value) == 0 {
 		writer.Error("OpenSearch IPs not found in the config. Please contact the support team")

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -43,6 +43,8 @@ const (
 	CERT_WARNING     = `Ignored values from [%s]
 	Please use 'cert-rotate' command to rotate certificate. 
 	For more information, run: 'chef-automate cert-rotate --help'`
+	ERROR_SELF_MANAGED_CONFIG_SHOW = "Showing the configuration for externally configured %s is not supported."
+	ERROR_SELF_MANAGED_CONFIG_PATCH = "Patching the configuration for externally configured %s is not supported."
 )
 
 var configValid = "Config file must be a valid %s config"
@@ -112,6 +114,10 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 
 	if isA2HARBFileExist() {
 
+		err := errorOnSelfManaged()
+		if err != nil {
+			return err
+		}
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
@@ -149,17 +155,6 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 			scriptCommand = fmt.Sprintf(GET_CONFIG, "opensearch")
 		default:
 			return errors.New("Missing or Unsupported flag\n Please run the following command to see all available flags \n\n`chef-automate config show --help`\n")
-		}
-
-		if isManagedServicesOn() && (configCmdFlags.postgresql || configCmdFlags.opensearch) {
-
-			if configCmdFlags.postgresql {
-				writer.Warn("Showing the configuration for externally configured Postgresql is not supported.")
-			}
-			if configCmdFlags.opensearch {
-				writer.Warn("Showing the configuration for externally configured OpenSearch is not supported.")
-			}
-			return nil
 		}
 
 		for i := 0; i < len(hostIpArray); i++ {
@@ -228,6 +223,19 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 	writer.Println(string(t))
 	return nil
 }
+
+func errorOnSelfManaged() error {
+	if isManagedServicesOn() {
+		if configCmdFlags.postgresql {
+			return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_SHOW, "Postgresql")
+		}
+		if configCmdFlags.opensearch {
+			return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_SHOW, "OpenSearch")
+		}
+	}
+	return nil
+}
+
 func runPatchCommand(cmd *cobra.Command, args []string) error {
 	/*
 		incase of a2ha mode of deployment, config file will be copied to /hab/a2_deploy_workspace/configs/automate.toml file
@@ -288,7 +296,6 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 			writer.Println(cmd.UsageString())
 		}
 		if err != nil {
-			writer.Errorf("%v", err)
 			return err
 		}
 
@@ -336,13 +343,11 @@ func setConfigForFrontEndNodes(args []string, sshUtil SSHUtil, frontendIps []str
 // setConfigForPostgresqlNodes patches the config for postgresql nodes in Automate HA
 func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for externally configured Postgresql is not supported.")
-		return nil
+		return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_PATCH,"Postgresql")
 	}
 	if len(infra.Outputs.PostgresqlPrivateIps.Value) == 0 {
 		writer.Error("Postgres IPs not found in the config. Please contact the support team")
 		return nil
-
 	}
 
 	//checking for log configuration
@@ -392,13 +397,11 @@ func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SS
 // setConfigForOpensearch patches the config for open-search nodes in Automate HA
 func setConfigForOpensearch(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for externally configured Opensearch is not supported.")
-		return nil
+		return errors.Errorf(ERROR_SELF_MANAGED_CONFIG_PATCH,"OpenSearch")
 	}
 	if len(infra.Outputs.OpensearchPrivateIps.Value) == 0 {
-		writer.Error("Opensearch IPs not found in the config. Please contact the support team")
+		writer.Error("OpenSearch IPs not found in the config. Please contact the support team")
 		return nil
-
 	}
 	//checking for log configuration
 	err := enableCentralizedLogConfigForHA(args, remoteService, sshUtil, infra.Outputs.OpensearchPrivateIps.Value)

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -150,6 +150,12 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		default:
 			return errors.New("Missing or Unsupported flag\n Please run the following command to see all available flags \n\n`chef-automate config show --help`\n")
 		}
+
+		if isManagedServicesOn() && (configCmdFlags.postgresql || configCmdFlags.opensearch) {
+			writer.Warn("Showing the configuration for third party managed services is not supported.")
+			return nil
+		}
+
 		for i := 0; i < len(hostIpArray); i++ {
 			sshUtil.getSSHConfig().hostIP = hostIpArray[i]
 			output, err := sshUtil.connectAndExecuteCommandOnRemote(scriptCommand, true)

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -152,7 +152,13 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		if isManagedServicesOn() && (configCmdFlags.postgresql || configCmdFlags.opensearch) {
-			writer.Warn("Showing the configuration for externally configured OpenSearch/Postgresql is not supported.")
+
+			if configCmdFlags.postgresql {
+				writer.Warn("Showing the configuration for externally configured Postgresql is not supported.")
+			}
+			if configCmdFlags.opensearch {
+				writer.Warn("Showing the configuration for externally configured OpenSearch is not supported.")
+			}
 			return nil
 		}
 

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -152,7 +152,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		if isManagedServicesOn() && (configCmdFlags.postgresql || configCmdFlags.opensearch) {
-			writer.Warn("Showing the configuration for third party managed services is not supported.")
+			writer.Warn("Showing the configuration for externally configured OpenSearch/Postgresql is not supported.")
 			return nil
 		}
 
@@ -330,7 +330,7 @@ func setConfigForFrontEndNodes(args []string, sshUtil SSHUtil, frontendIps []str
 // setConfigForPostgresqlNodes patches the config for postgresql nodes in Automate HA
 func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for third party managed services is not supported.")
+		writer.Warn("Patching the configuration for externally configured Postgresql is not supported.")
 		return nil
 	}
 	if len(infra.Outputs.PostgresqlPrivateIps.Value) == 0 {
@@ -386,11 +386,11 @@ func setConfigForPostgresqlNodes(args []string, remoteService string, sshUtil SS
 // setConfigForOpensearch patches the config for open-search nodes in Automate HA
 func setConfigForOpensearch(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string) error {
 	if isManagedServicesOn() {
-		writer.Warn("Patching the configuration for third party managed services is not supported.")
+		writer.Warn("Patching the configuration for externally configured Opensearch is not supported.")
 		return nil
 	}
 	if len(infra.Outputs.OpensearchPrivateIps.Value) == 0 {
-		writer.Error("Postgres IPs not found in the config. Please contact the support team")
+		writer.Error("Opensearch IPs not found in the config. Please contact the support team")
 		return nil
 
 	}


### PR DESCRIPTION
Signed-off-by: prasad927 <Prasad.Chaudhari@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Fix for config show cmd when Automate-HA on-prem deployment  is self-managed.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/SHIELD-197

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable



https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/Ef3W9i6EGbdBmxJpxIQmPIsB2IaA8h_mvcfEX4bcawlRBw?e=mvuk6b


[SHIELD-197]: https://chefio.atlassian.net/browse/SHIELD-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ