### PR TITLE
Displaying unsupported config

### DIFF
--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -1224,7 +1224,25 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 			}
 		}()
 	}
+
 	sshUtil.getSSHConfig().hostIP = automateIps[0]
+
+	// If managed service and filesystem backup, info: "we don't have support for this configurations"
+	config, err := getExistingHAConfig()
+	if err != nil {
+		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
+	}
+
+	sharedConfigToml, err := getAwsHAConfig()
+	if err != nil {
+		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
+	}
+
+	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && sharedConfigToml.Aws.Config.SetupManagedServices == true {
+		writer.Printf("INFO: currently we don't have support for file_system backup and menaged service")
+		return nil
+	}
+
 	if pooling {
 		cmdRes, err := sshUtil.connectAndExecuteCommandOnRemote(commandString, true)
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -798,7 +798,7 @@ func runDeleteBackupCmd(cmd *cobra.Command, args []string) error {
 	start := 0
 	var validIds []string
 	var backup []*api.BackupTask
-	
+
 	if strings.Contains(args[0], "/") || strings.Contains(args[0], "\\") {
 		location = args[0]
 		start = 1
@@ -1234,7 +1234,7 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 	}
 
 	if config.Architecture.ConfigInitials.BackupConfig == BACKUP_CONFIG && isManagedServicesOn() {
-		writer.Printf("currently we don't have support for file_system backup with AWS managed DB\n")
+		writer.Printf("As of now, we do not support file_system backup with AWS managed DB.\n")
 		return nil
 	}
 

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -44,6 +44,7 @@ var allPassedFlags string = ""
 const (
 	AUTOMATE_CMD_STOP  = "sudo chef-automate stop"
 	AUTOMATE_CMD_START = "sudo chef-automate start"
+	BACKUP_CONFIG      = "file_system"
 )
 
 type BackupFromBashtion interface {
@@ -1232,8 +1233,8 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
 	}
 
-	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && isManagedServicesOn() {
-		writer.Printf("INFO: currently we don't have support for file_system backup and managed service\n")
+	if config.Architecture.ConfigInitials.BackupConfig == BACKUP_CONFIG && isManagedServicesOn() {
+		writer.Printf("currently we don't have support for file_system backup with AWS managed DB\n")
 		return nil
 	}
 

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -1224,7 +1224,6 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 			}
 		}()
 	}
-
 	sshUtil.getSSHConfig().hostIP = automateIps[0]
 
 	// If managed service and filesystem backup, info: "we don't have support for this configurations"
@@ -1233,12 +1232,12 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
 	}
 
-	sharedConfigToml, err := getAwsHAConfig()
+	awsHAConfig, err := getAwsHAConfig()
 	if err != nil {
 		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
 	}
 
-	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && sharedConfigToml.Aws.Config.SetupManagedServices == true {
+	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && awsHAConfig.Aws.Config.SetupManagedServices == true {
 		writer.Printf("INFO: currently we don't have support for file_system backup and menaged service")
 		return nil
 	}

--- a/components/automate-cli/cmd/chef-automate/backup.go
+++ b/components/automate-cli/cmd/chef-automate/backup.go
@@ -1232,13 +1232,8 @@ func (ins *BackupFromBashtionImp) executeOnRemoteAndPoolStatus(commandString str
 		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
 	}
 
-	awsHAConfig, err := getAwsHAConfig()
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "unable to fetch HA config")
-	}
-
-	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && awsHAConfig.Aws.Config.SetupManagedServices == true {
-		writer.Printf("INFO: currently we don't have support for file_system backup and menaged service")
+	if config.Architecture.ConfigInitials.BackupConfig == "file_system" && isManagedServicesOn() {
+		writer.Printf("INFO: currently we don't have support for file_system backup and managed service\n")
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Pappu Kumar <pappu.kumar@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
An Automate user should get notified properly when they try to take EFS backup of Automate HA deployed in these scenarios:
 - On Prem deployment with AWS managed DB 
 - AWS deployment
 - The command should indicate that EFS backup is not supported with AWS managed DB.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
- The backup command should not error out for On Prem deployment with AWS managed DB to EFS. A corresponding message should be shown informing the reason for failure.
- The backup command should not error out for AWS deployment to EFS. A corresponding message should be shown informing the reason for failure.
- The backup command should work for all the other different types of deployments in Automate HA even when backed up to EFS.
- The backup command should work for AWS deployment and On Prem deployment with AWS managed DB when the backup location is other than EFS.

### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-cli/`\
`hab pkg upload results/pappuk-automate-cli-0.1.0-20230105125020-x86_64-linux.hart`
Go to bastion and run the following command
`hab pkg install pappuk-automate-cli-0.1.0-20230105125020-x86_64-linux.hart -bf`
`chef-automate backup create`

Video of testing:

https://user-images.githubusercontent.com/36985548/210786701-6cc533f6-a85f-4c81-9e8f-0c375a7d206e.mov


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
