### PR TITLE
ebs volume config is not mandatory in automate ha-managed

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -40,14 +40,14 @@ func (a *awsDeployment) doDeployWork(args []string) error {
 		archBytes, err := ioutil.ReadFile(filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "terraform", ".tf_arch")) // nosemgrep
 		if err != nil {
 			writer.Errorf("%s", err.Error())
-			return  err
+			return err
 		}
 		var arch = strings.Trim(string(archBytes), "\n")
 		sharedConfigToml.Architecture.ConfigInitials.Architecture = arch
 		writer.Println("Reference architecture type : " + arch)
 		shardConfig, err := toml.Marshal(sharedConfigToml)
 		if err != nil {
-			return  status.Wrap(err, status.ConfigError, "unable to marshal config to file")
+			return status.Wrap(err, status.ConfigError, "unable to marshal config to file")
 		}
 		err = ioutil.WriteFile(filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "config.toml"), shardConfig, 0644) // nosemgrep
 		if err != nil {
@@ -233,22 +233,22 @@ func (a *awsDeployment) validateEnvFields() *list.List {
 	if len(a.config.Aws.Config.ChefEbsVolumeType) < 1 {
 		errorList.PushBack("Invalid or empty aws chef_ebs_volume_type")
 	}
-	if len(a.config.Aws.Config.OpensearchEbsVolumeIops) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeIops) < 1 {
 		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_iops")
 	}
-	if len(a.config.Aws.Config.OpensearchEbsVolumeSize) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeSize) < 1 {
 		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_size")
 	}
-	if len(a.config.Aws.Config.OpensearchEbsVolumeType) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeType) < 1 {
 		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_type")
 	}
-	if len(a.config.Aws.Config.PostgresqlEbsVolumeIops) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeIops) < 1 {
 		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_iops")
 	}
-	if len(a.config.Aws.Config.PostgresqlEbsVolumeSize) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeSize) < 1 {
 		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_size")
 	}
-	if len(a.config.Aws.Config.PostgresqlEbsVolumeType) < 1 {
+	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeType) < 1 {
 		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_type")
 	}
 	return errorList

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -233,23 +233,25 @@ func (a *awsDeployment) validateEnvFields() *list.List {
 	if len(a.config.Aws.Config.ChefEbsVolumeType) < 1 {
 		errorList.PushBack("Invalid or empty aws chef_ebs_volume_type")
 	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeIops) < 1 {
-		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_iops")
-	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeSize) < 1 {
-		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_size")
-	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.OpensearchEbsVolumeType) < 1 {
-		errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_type")
-	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeIops) < 1 {
-		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_iops")
-	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeSize) < 1 {
-		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_size")
-	}
-	if !a.config.Aws.Config.SetupManagedServices && len(a.config.Aws.Config.PostgresqlEbsVolumeType) < 1 {
-		errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_type")
+	if !a.config.Aws.Config.SetupManagedServices {
+		if len(a.config.Aws.Config.OpensearchEbsVolumeIops) < 1 {
+			errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_iops")
+		}
+		if len(a.config.Aws.Config.OpensearchEbsVolumeSize) < 1 {
+			errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_size")
+		}
+		if len(a.config.Aws.Config.OpensearchEbsVolumeType) < 1 {
+			errorList.PushBack("Invalid or empty aws opensearch_ebs_volume_type")
+		}
+		if len(a.config.Aws.Config.PostgresqlEbsVolumeIops) < 1 {
+			errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_iops")
+		}
+		if len(a.config.Aws.Config.PostgresqlEbsVolumeSize) < 1 {
+			errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_size")
+		}
+		if len(a.config.Aws.Config.PostgresqlEbsVolumeType) < 1 {
+			errorList.PushBack("Invalid or empty aws postgresql_ebs_volume_type")
+		}
 	}
 	return errorList
 }


### PR DESCRIPTION
Signed-off-by: Sahiba3108 <sgoyal@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
As an automate user, when I am doing automate HA deployment with managed services, I should not be forced to enter ebs volumes for pg and os, as it is no longer required.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-295
### :+1: Definition of Done
I have made the required changes, and now you can skip ebs volume configurations in automate HA deployment with managed services.
### :athletic_shoe: How to Build and Test the Change
Install this cli: 

- sahiba3108/automate-cli/0.1.0/20230110063253

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Video Link: https://progresssoftware-my.sharepoint.com/:v:/g/personal/sgoyal_progress_com/EdZP9HEvBj1Cs3H1RfyVbAQB0AgHOfpo1ixxS9v6yiXgJw?e=jdkraY
SS after running provisioning cmd: 
<img width="578" alt="Screenshot 2023-01-09 at 5 43 21 PM" src="https://user-images.githubusercontent.com/108404805/211305501-5b7bdf22-3d79-4a0b-ba1e-b1c22f79f4b4.png">

