### PR TITLE
Made root_ca optional for automate

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/manifest"
 	mc "github.com/chef/automate/components/automate-deployment/pkg/manifest/client"
 	"github.com/chef/automate/components/automate-deployment/pkg/manifest/parser"
+	"github.com/chef/automate/components/automate-deployment/pkg/toml"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/chef/automate/lib/version"
 	"github.com/hpcloud/tail"
@@ -572,4 +573,18 @@ func isManagedServicesOn() bool {
 		return true
 	}
 	return false
+}
+
+func writeHAConfigFiles(templateName string, data interface{}) error {
+	finalTemplate := renderSettingsToA2HARBFile(templateName, data)
+	writeToA2HARBFile(finalTemplate, filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "a2ha.rb"))
+	config, err := toml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(AUTOMATE_HA_WORKSPACE_CONFIG_FILE, config, 0600) // nosemgrep
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -582,9 +582,6 @@ func writeHAConfigFiles(templateName string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(AUTOMATE_HA_WORKSPACE_CONFIG_FILE, config, 0600) // nosemgrep
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return fileutils.WriteFile(AUTOMATE_HA_WORKSPACE_CONFIG_FILE, config, 0600)
 }

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -104,17 +104,7 @@ func (a *awsDeployment) generateConfig() error {
 		}
 		a.config.Opensearch.Config.NodesDn = nodes_dn
 	}
-	finalTemplate := renderSettingsToA2HARBFile(awsA2harbTemplate, a.config)
-	writeToA2HARBFile(finalTemplate, filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "a2ha.rb"))
-	config, err := toml.Marshal(a.config)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(AUTOMATE_HA_WORKSPACE_CONFIG_FILE, config, 0600) // nosemgrep
-	if err != nil {
-		return err
-	}
-	return nil
+	return writeHAConfigFiles(awsA2harbTemplate, a.config)
 }
 
 func (a *awsDeployment) getDistinguishedNameFromKey(publicKey string) (string, error) {

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -259,13 +259,17 @@ func (a *awsDeployment) validateEnvFields() *list.List {
 func (a *awsDeployment) validateCerts() *list.List {
 	errorList := list.New()
 	if a.config.Automate.Config.EnableCustomCerts {
-		if len(strings.TrimSpace(a.config.Automate.Config.RootCA)) < 1 ||
-			len(strings.TrimSpace(a.config.Automate.Config.PrivateKey)) < 1 ||
+		if len(strings.TrimSpace(a.config.Automate.Config.PrivateKey)) < 1 ||
 			len(strings.TrimSpace(a.config.Automate.Config.PublicKey)) < 1 {
-			errorList.PushBack("Automate root_ca and/or public_key and/or private_key are missing. Otherwise set enable_custom_certs to false.")
+			errorList.PushBack("Automate public_key and/or private_key are missing. Otherwise set enable_custom_certs to false.")
+		}
+		// If root_ca is provided, check that it is valid
+		if len(strings.TrimSpace(a.config.Automate.Config.RootCA)) > 0 {
+			errorList.PushBackList(checkCertValid([]keydetails{
+				{key: a.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
+			}))
 		}
 		errorList.PushBackList(checkCertValid([]keydetails{
-			{key: a.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
 			{key: a.config.Automate.Config.PrivateKey, certtype: "private_key", svc: "automate"},
 			{key: a.config.Automate.Config.PublicKey, certtype: "public_key", svc: "automate"},
 		}))

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
-	"github.com/chef/automate/components/automate-deployment/pkg/toml"
 	"github.com/chef/automate/lib/stringutils"
 	ptoml "github.com/pelletier/go-toml"
 )
@@ -64,17 +63,7 @@ func (e *existingInfra) generateConfig() error {
 	if err != nil {
 		return err
 	}
-	finalTemplate := renderSettingsToA2HARBFile(existingNodesA2harbTemplate, e.config)
-	writeToA2HARBFile(finalTemplate, initConfigHabA2HAPathFlag.a2haDirPath+"a2ha.rb")
-	config, err := toml.Marshal(e.config)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(AUTOMATE_HA_WORKSPACE_CONFIG_FILE, config, 0600) // nosemgrep
-	if err != nil {
-		return err
-	}
-	return nil
+	return writeHAConfigFiles(existingNodesA2harbTemplate, e.config)
 }
 
 func (e *existingInfra) addDNTocertConfig() error {

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -254,12 +254,12 @@ func (e *existingInfra) validateCerts() *list.List {
 	// if CustomCertsEnabled is disabled, then skip validation for custom certs and use self signed certs
 	if e.config.Automate.Config.EnableCustomCerts {
 		if len(e.config.Automate.Config.CertsByIP) > 0 {
-			if len(strings.TrimSpace(e.config.Automate.Config.RootCA)) < 1 {
-				errorList.PushBack("Automate root_ca is missing. Set custom_certs_enabled to false to continue without custom certificates.")
+			// if root_ca is provided, then check if it is valid
+			if len(strings.TrimSpace(e.config.Automate.Config.RootCA)) > 0 {
+				errorList.PushBackList(checkCertValid([]keydetails{
+					{key: e.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
+				}))
 			}
-			errorList.PushBackList(checkCertValid([]keydetails{
-				{key: e.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
-			}))
 			if !stringutils.SubSlice(e.config.ExistingInfra.Config.AutomatePrivateIps, extractIPsFromCertsByIP(e.config.Automate.Config.CertsByIP)) {
 				errorList.PushBack("Missing certificates for some automate private ips. Please make sure certificates for the following ips are provided in certs_by_ip: " + strings.Join(e.config.ExistingInfra.Config.AutomatePrivateIps, ", "))
 			}
@@ -277,13 +277,17 @@ func (e *existingInfra) validateCerts() *list.List {
 			}
 		} else {
 			// check if all the default certs are given
-			if len(strings.TrimSpace(e.config.Automate.Config.RootCA)) < 1 ||
-				len(strings.TrimSpace(e.config.Automate.Config.PrivateKey)) < 1 ||
+			if len(strings.TrimSpace(e.config.Automate.Config.PrivateKey)) < 1 ||
 				len(strings.TrimSpace(e.config.Automate.Config.PublicKey)) < 1 {
-				errorList.PushBack("Automate root_ca and/or public_key and/or private_key are missing. Set custom_certs_enabled to false to continue without custom certificates.")
+				errorList.PushBack("Automate public_key and/or private_key are missing. Set custom_certs_enabled to false to continue without custom certificates.")
+			}
+			// if root_ca is provided, then check if it is valid
+			if len(strings.TrimSpace(e.config.Automate.Config.RootCA)) > 0 {
+				errorList.PushBackList(checkCertValid([]keydetails{
+					{key: e.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
+				}))
 			}
 			errorList.PushBackList(checkCertValid([]keydetails{
-				{key: e.config.Automate.Config.RootCA, certtype: "root_ca", svc: "automate"},
 				{key: e.config.Automate.Config.PrivateKey, certtype: "private_key", svc: "automate"},
 				{key: e.config.Automate.Config.PublicKey, certtype: "public_key", svc: "automate"},
 			}))

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws.go
@@ -7,7 +7,6 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
-	ptoml "github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -141,15 +140,7 @@ func (ani *AddNodeAWSImpl) runDeploy() error {
 	if err != nil {
 		return err
 	}
-	tomlbytes, err := ptoml.Marshal(ani.config)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error converting config to bytes")
-	}
-	err = ani.fileutils.WriteToFile(ani.configpath, tomlbytes)
-	if err != nil {
-		return err
-	}
-	err = ani.nodeUtils.genConfigAWS(ani.configpath)
+	err = ani.nodeUtils.writeHAConfigFiles(awsA2harbTemplate, ani.config)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
@@ -167,6 +167,7 @@ func TestAddnodeDeployWithNewOSNodeInAws(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -184,12 +185,7 @@ func TestAddnodeDeployWithNewOSNodeInAws(t *testing.T) {
 			tfArchModified = true
 			return nil
 		},
-	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -231,11 +227,7 @@ func TestAddnodeWithExecuteA2haRbNotExist(t *testing.T) {
 		isA2HARBFileExistFunc: func() bool {
 			return false
 		},
-	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -257,6 +249,7 @@ func TestAddnodeWithExecuteFuncGenConfigErr(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return errors.New("random")
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -280,12 +273,7 @@ func TestAddnodeWithExecuteFuncGenConfigErr(t *testing.T) {
 			tfArchModified = true
 			return nil
 		},
-	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -324,6 +312,7 @@ func TestAddnodeWithExecuteFunc(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -347,12 +336,7 @@ func TestAddnodeWithExecuteFunc(t *testing.T) {
 			tfArchModified = true
 			return nil
 		},
-	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
@@ -166,7 +166,7 @@ func TestAddnodeDeployWithNewOSNodeInAws(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigAWSfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -256,7 +256,7 @@ func TestAddnodeWithExecuteFuncGenConfigErr(t *testing.T) {
 		executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
 			return nil
 		},
-		genConfigAWSfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return errors.New("random")
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -323,7 +323,7 @@ func TestAddnodeWithExecuteFunc(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigAWSfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_onprem.go
@@ -12,7 +12,6 @@ import (
 	cli "github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/chef/automate/lib/stringutils"
-	ptoml "github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
 )
 
@@ -192,15 +191,7 @@ func (ani *AddNodeOnPremImpl) promptUserConfirmation() (bool, error) {
 }
 
 func (ani *AddNodeOnPremImpl) runDeploy() error {
-	tomlbytes, err := ptoml.Marshal(ani.config)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error converting config to bytes")
-	}
-	err = ani.fileutils.WriteToFile(ani.configpath, tomlbytes)
-	if err != nil {
-		return err
-	}
-	err = ani.nodeUtils.genConfig(ani.configpath)
+	err := ani.nodeUtils.writeHAConfigFiles(existingNodesA2harbTemplate, ani.config)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
@@ -385,6 +385,7 @@ func TestAddnodeDeployWithNewOSNode(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -394,12 +395,7 @@ func TestAddnodeDeployWithNewOSNode(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -451,11 +447,7 @@ func TestAddnodeDeployWithNewOSNodeGenconfigError(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -499,6 +491,7 @@ func TestAddnodeExecuteWithNewOSNodeNoCertByIP(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -527,12 +520,7 @@ func TestAddnodeExecuteWithNewOSNodeNoCertByIP(t *testing.T) {
 			cfg.Opensearch.Config.CertsByIP = []CertByIP{}
 			return &cfg, nil
 		},
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -569,6 +557,7 @@ func TestAddnodeExecuteWithNewOSNode(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -587,12 +576,7 @@ func TestAddnodeExecuteWithNewOSNode(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
@@ -384,7 +384,7 @@ func TestAddnodeDeployWithNewOSNode(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -441,7 +441,7 @@ func TestAddnodeDeployWithNewOSNodeGenconfigError(t *testing.T) {
 		executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return errors.New("random")
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -498,7 +498,7 @@ func TestAddnodeExecuteWithNewOSNodeNoCertByIP(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -568,7 +568,7 @@ func TestAddnodeExecuteWithNewOSNode(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -9,7 +9,6 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
-	ptoml "github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -179,15 +178,7 @@ func (dni *DeleteNodeOnPremImpl) promptUserConfirmation() (bool, error) {
 }
 
 func (dni *DeleteNodeOnPremImpl) runDeploy() error {
-	tomlbytes, err := ptoml.Marshal(dni.config)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error converting config to bytes")
-	}
-	err = dni.fileUtils.WriteToFile(dni.configpath, tomlbytes)
-	if err != nil {
-		return err
-	}
-	err = dni.nodeUtils.genConfig(dni.configpath)
+	err := dni.nodeUtils.writeHAConfigFiles(existingNodesA2harbTemplate, dni.config)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -336,6 +336,7 @@ func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -345,12 +346,7 @@ func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -402,11 +398,7 @@ func TestDeleteNodeDeployWithNewOSMinCountError(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			return errors.New("random")
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -430,7 +422,7 @@ func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
-			return nil
+			return errors.New("random")
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
 			return EXISTING_INFRA_MODE, nil
@@ -439,11 +431,7 @@ func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			return errors.New("random")
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -487,6 +475,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -515,12 +504,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 			cfg.Opensearch.Config.CertsByIP = []CertByIP{}
 			return &cfg, nil
 		},
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
@@ -557,6 +541,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 			return nil
 		},
 		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -575,12 +560,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 			return false
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
-	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{
-		WriteToFileFunc: func(filepath string, data []byte) error {
-			filewritten = true
-			return nil
-		},
-	}, &MockSSHUtilsImpl{
+	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -335,7 +335,7 @@ func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -392,7 +392,7 @@ func TestDeleteNodeDeployWithNewOSMinCountError(t *testing.T) {
 		executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -429,7 +429,7 @@ func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {
 		executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		getModeFromConfigFunc: func(path string) (string, error) {
@@ -486,7 +486,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {
@@ -556,7 +556,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 			deployed = true
 			return nil
 		},
-		genConfigfunc: func(path string) error {
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
 			return nil
 		},
 		isA2HARBFileExistFunc: func() bool {

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -35,8 +35,7 @@ type HAModifyAndDeploy interface {
 type MockNodeUtilsImpl struct {
 	executeAutomateClusterCtlCommandAsyncfunc func(command string, args []string, helpDocs string) error
 	getHaInfraDetailsfunc                     func() (*AutomteHAInfraDetails, *SSHConfig, error)
-	genConfigfunc                             func(path string) error
-	genConfigAWSfunc                          func(path string) error
+	writeHAConfigFilesFunc                    func(templateName string, data interface{}) error
 	taintTerraformFunc                        func(path string) error
 	isA2HARBFileExistFunc                     func() bool
 	getModeFromConfigFunc                     func(path string) (string, error)
@@ -58,11 +57,8 @@ func (mnu *MockNodeUtilsImpl) executeAutomateClusterCtlCommandAsync(command stri
 func (mnu *MockNodeUtilsImpl) getHaInfraDetails() (*AutomteHAInfraDetails, *SSHConfig, error) {
 	return mnu.getHaInfraDetailsfunc()
 }
-func (mnu *MockNodeUtilsImpl) genConfig(path string) error {
-	return mnu.genConfigfunc(path)
-}
-func (mnu *MockNodeUtilsImpl) genConfigAWS(path string) error {
-	return mnu.genConfigAWSfunc(path)
+func (mnu *MockNodeUtilsImpl) writeHAConfigFiles(templateName string, data interface{}) error {
+	return mnu.writeHAConfigFilesFunc(templateName, data)
 }
 func (mnu *MockNodeUtilsImpl) taintTerraform(path string) error {
 	return mnu.taintTerraformFunc(path)
@@ -107,8 +103,7 @@ func (mnu *MockNodeUtilsImpl) pullAndUpdateConfigAws(sshUtil *SSHUtil, exception
 type NodeOpUtils interface {
 	executeAutomateClusterCtlCommandAsync(command string, args []string, helpDocs string) error
 	getHaInfraDetails() (*AutomteHAInfraDetails, *SSHConfig, error)
-	genConfig(path string) error
-	genConfigAWS(path string) error
+	writeHAConfigFiles(templateName string, data interface{}) error
 	taintTerraform(path string) error
 	isA2HARBFileExist() bool
 	getModeFromConfig(path string) (string, error)
@@ -202,14 +197,8 @@ func (nu *NodeUtilsImpl) executeAutomateClusterCtlCommandAsync(command string, a
 	return executeAutomateClusterCtlCommandAsync(command, args, helpDocs)
 }
 
-func (nu *NodeUtilsImpl) genConfig(path string) error {
-	e := newExistingInfa(path)
-	return e.generateConfig()
-}
-
-func (nu *NodeUtilsImpl) genConfigAWS(path string) error {
-	e := newAwsDeployemnt(path)
-	return e.generateConfig()
+func (nu *NodeUtilsImpl) writeHAConfigFiles(templateName string, data interface{}) error {
+	return writeHAConfigFiles(templateName, data)
 }
 
 func (nu *NodeUtilsImpl) moveAWSAutoTfvarsFile(terraformPath string) error {

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -312,6 +312,7 @@ func modifyConfigForAddNewNode(instanceCount *string, existingPrivateIPs *[]stri
 				IP:         ip,
 				PrivateKey: (*certsIp)[len(*certsIp)-1].PrivateKey,
 				PublicKey:  (*certsIp)[len(*certsIp)-1].PublicKey,
+				NodesDn:    (*certsIp)[len(*certsIp)-1].NodesDn,
 			}
 			*certsIp = append(*certsIp, c)
 		}

--- a/components/automate-cli/cmd/chef-automate/initConfigHaExistingNode.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaExistingNode.go
@@ -18,6 +18,6 @@ func runInitConfigExistingNodeHACmd() error {
 	if err != nil {
 		return status.Wrap(err, status.FileAccessError, "Writing initial configuration failed")
 	}
-	writer.Printf("\nconfig initializatized in a generated file : %s", initConfigHAPath)
+	writer.Printf("\nconfig initializatized in a generated file : %s \n", initConfigHAPath)
 	return nil
 }

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -2,7 +2,6 @@ package fileutils
 
 import (
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -28,7 +27,7 @@ type FileUtils interface {
 	GetHabRootPath() string
 	WriteToFile(filepath string, data []byte) error
 	ReadFile(filename string) ([]byte, error)
-	WriteFile(filepath string, data []byte, perm fs.FileMode) error
+	WriteFile(filepath string, data []byte, perm os.FileMode) error
 }
 
 type FileSystemUtils struct{}
@@ -57,7 +56,7 @@ func (fsu *FileSystemUtils) WriteToFile(filepath string, data []byte) error {
 func (fsu *FileSystemUtils) ReadFile(filename string) ([]byte, error) {
 	return ReadFile(filename)
 }
-func (fsu *FileSystemUtils) WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+func (fsu *FileSystemUtils) WriteFile(filepath string, data []byte, perm os.FileMode) error {
 	return WriteFile(filepath, data, perm)
 }
 
@@ -145,6 +144,6 @@ func ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename) // nosemgrep
 }
 
-func WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+func WriteFile(filepath string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(filepath, data, perm) // nosemgrep
 }

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -2,6 +2,7 @@ package fileutils
 
 import (
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -27,6 +28,7 @@ type FileUtils interface {
 	GetHabRootPath() string
 	WriteToFile(filepath string, data []byte) error
 	ReadFile(filename string) ([]byte, error)
+	WriteFile(filepath string, data []byte, perm fs.FileMode) error
 }
 
 type FileSystemUtils struct{}
@@ -54,6 +56,9 @@ func (fsu *FileSystemUtils) WriteToFile(filepath string, data []byte) error {
 }
 func (fsu *FileSystemUtils) ReadFile(filename string) ([]byte, error) {
 	return ReadFile(filename)
+}
+func (fsu *FileSystemUtils) WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+	return WriteFile(filepath, data, perm)
 }
 
 // LogCLose closes the given io.Closer, logging any error.
@@ -133,9 +138,13 @@ func GetHabRootPath() string {
 }
 
 func WriteToFile(filepath string, data []byte) error {
-	return ioutil.WriteFile(filepath, data, 0775) // nosemgrep
+	return WriteFile(filepath, data, 0775)
 }
 
 func ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename) // nosemgrep
+}
+
+func WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+	return ioutil.WriteFile(filepath, data, perm) // nosemgrep
 }

--- a/lib/io/fileutils/mockFileUtils.go
+++ b/lib/io/fileutils/mockFileUtils.go
@@ -1,5 +1,7 @@
 package fileutils
 
+import "io/fs"
+
 type MockFileSystemUtils struct {
 	PathExistsFunc             func(path string) (bool, error)
 	IsSymlinkFunc              func(path string) (bool, error)
@@ -9,6 +11,7 @@ type MockFileSystemUtils struct {
 	GetHabRootPathFunc         func() string
 	WriteToFileFunc            func(filepath string, data []byte) error
 	ReadFileFunc               func(filepath string) ([]byte, error)
+	WriteFileFunc              func(filepath string, data []byte, perm fs.FileMode) error
 }
 
 func (fsu *MockFileSystemUtils) PathExists(path string) (bool, error) {
@@ -34,4 +37,7 @@ func (fsu *MockFileSystemUtils) WriteToFile(filepath string, data []byte) error 
 }
 func (fsu *MockFileSystemUtils) ReadFile(filepath string) ([]byte, error) {
 	return fsu.ReadFileFunc(filepath)
+}
+func (fsu *MockFileSystemUtils) WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+	return fsu.WriteFileFunc(filepath, data, perm)
 }

--- a/lib/io/fileutils/mockFileUtils.go
+++ b/lib/io/fileutils/mockFileUtils.go
@@ -1,6 +1,6 @@
 package fileutils
 
-import "io/fs"
+import "os"
 
 type MockFileSystemUtils struct {
 	PathExistsFunc             func(path string) (bool, error)
@@ -11,7 +11,7 @@ type MockFileSystemUtils struct {
 	GetHabRootPathFunc         func() string
 	WriteToFileFunc            func(filepath string, data []byte) error
 	ReadFileFunc               func(filepath string) ([]byte, error)
-	WriteFileFunc              func(filepath string, data []byte, perm fs.FileMode) error
+	WriteFileFunc              func(filepath string, data []byte, perm os.FileMode) error
 }
 
 func (fsu *MockFileSystemUtils) PathExists(path string) (bool, error) {
@@ -38,6 +38,6 @@ func (fsu *MockFileSystemUtils) WriteToFile(filepath string, data []byte) error 
 func (fsu *MockFileSystemUtils) ReadFile(filepath string) ([]byte, error) {
 	return fsu.ReadFileFunc(filepath)
 }
-func (fsu *MockFileSystemUtils) WriteFile(filepath string, data []byte, perm fs.FileMode) error {
+func (fsu *MockFileSystemUtils) WriteFile(filepath string, data []byte, perm os.FileMode) error {
 	return fsu.WriteFileFunc(filepath, data, perm)
 }


### PR DESCRIPTION
Signed-off-by: Atul Krishna <Atul.Krishna@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
During deploy or add node HA root_ca should be optional for automate in config.toml
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/SHIELD-194
https://chefio.atlassian.net/browse/SHIELD-196
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
