### PR TITLE
sahithi/STALWART-305-new

### DIFF
--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -110,7 +110,7 @@ func (dni *DeleteNodeOnPremImpl) validate() error {
 	}
 	errorList := dni.validateCmdArgs()
 	if errorList != nil && errorList.Len() > 0 {
-		return status.Wrap(getSingleErrorFromList(errorList), status.ConfigError, "IP address validation failed")
+		return getSingleErrorFromList(errorList)
 	}
 	return nil
 }
@@ -204,8 +204,9 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		}
 		if !allowed {
 			errorList.PushBack(fmt.Sprintf("Unable to remove node. Automate instance count cannot be less than %d. Final count %d not allowed.", AUTOMATE_MIN_INSTANCE_COUNT, finalCount))
+		} else {
+			errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.AutomatePrivateIps, dni.automateIpList, "Automate"))
 		}
-		errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.AutomatePrivateIps, dni.automateIpList, "Automate"))
 	}
 	if len(dni.chefServerIpList) > 0 {
 		allowed, finalCount, err := isFinalInstanceCountAllowed(dni.config.ChefServer.Config.InstanceCount, -len(dni.chefServerIpList), CHEF_SERVER_MIN_INSTANCE_COUNT)
@@ -214,8 +215,9 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		}
 		if !allowed {
 			errorList.PushBack(fmt.Sprintf("Unable to remove node. Chef Server instance count cannot be less than %d. Final count %d not allowed.", CHEF_SERVER_MIN_INSTANCE_COUNT, finalCount))
+		} else {
+			errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.ChefServerPrivateIps, dni.chefServerIpList, "Chef-Server"))
 		}
-		errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.ChefServerPrivateIps, dni.chefServerIpList, "Chef-Server"))
 	}
 	if len(dni.opensearchIpList) > 0 {
 		allowed, finalCount, err := isFinalInstanceCountAllowed(dni.config.Opensearch.Config.InstanceCount, -len(dni.opensearchIpList), OPENSEARCH_MIN_INSTANCE_COUNT)
@@ -224,8 +226,9 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		}
 		if !allowed {
 			errorList.PushBack(fmt.Sprintf("Unable to remove node. OpenSearch instance count cannot be less than %d. Final count %d not allowed.", OPENSEARCH_MIN_INSTANCE_COUNT, finalCount))
+		} else {
+			errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.OpensearchPrivateIps, dni.opensearchIpList, "OpenSearch"))
 		}
-		errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.OpensearchPrivateIps, dni.opensearchIpList, "OpenSearch"))
 	}
 	if len(dni.postgresqlIp) > 0 {
 		allowed, finalCount, err := isFinalInstanceCountAllowed(dni.config.Postgresql.Config.InstanceCount, -len(dni.postgresqlIp), POSTGRESQL_MIN_INSTANCE_COUNT)
@@ -234,8 +237,10 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		}
 		if !allowed {
 			errorList.PushBack(fmt.Sprintf("Unable to remove node. Postgresql instance count cannot be less than %d. Final count %d not allowed.", POSTGRESQL_MIN_INSTANCE_COUNT, finalCount))
+			return errorList
+		} else {
+			errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.PostgresqlPrivateIps, dni.postgresqlIp, "Postgresql"))
 		}
-		errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.PostgresqlPrivateIps, dni.postgresqlIp, "Postgresql"))
 	}
 	return errorList
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -238,9 +238,8 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		if !allowed {
 			errorList.PushBack(fmt.Sprintf("Unable to remove node. Postgresql instance count cannot be less than %d. Final count %d not allowed.", POSTGRESQL_MIN_INSTANCE_COUNT, finalCount))
 			return errorList
-		} else {
-			errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.PostgresqlPrivateIps, dni.postgresqlIp, "Postgresql"))
 		}
+		errorList.PushBackList(checkIfPresentInPrivateIPList(dni.config.ExistingInfra.Config.PostgresqlPrivateIps, dni.postgresqlIp, "Postgresql"))
 	}
 	return errorList
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -49,10 +49,8 @@ func TestDeleteNodeValidateError(t *testing.T) {
 	})
 	err := nodedelete.validate()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `IP address validation failed: 
-Unable to remove node. Automate instance count cannot be less than 1. Final count 0 not allowed.
-Automate Ip 10.2.1.67 is not present in existing list of ip addresses. Please use a different private ip.
-Automate Ip ewewedw is not present in existing list of ip addresses. Please use a different private ip.`)
+	assert.Contains(t, err.Error(),
+		`Unable to remove node. Automate instance count cannot be less than 1. Final count 0 not allowed.`)
 }
 
 func TestDeleteNodeValidateErrorMultiple(t *testing.T) {
@@ -81,19 +79,11 @@ func TestDeleteNodeValidateErrorMultiple(t *testing.T) {
 	})
 	err := nodedelete.validate()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `IP address validation failed: 
-Unable to remove node. Automate instance count cannot be less than 1. Final count 0 not allowed.
-Automate Ip 10.2.1.67 is not present in existing list of ip addresses. Please use a different private ip.
-Automate Ip ewewedw is not present in existing list of ip addresses. Please use a different private ip.
+	assert.Contains(t, err.Error(),
+		`Unable to remove node. Automate instance count cannot be less than 1. Final count 0 not allowed.
 Unable to remove node. Chef Server instance count cannot be less than 1. Final count -1 not allowed.
-Chef-Server Ip 10.2.1.637 is not present in existing list of ip addresses. Please use a different private ip.
-Chef-Server Ip ewewedw is not present in existing list of ip addresses. Please use a different private ip.
 Unable to remove node. OpenSearch instance count cannot be less than 3. Final count 2 not allowed.
-OpenSearch Ip 10.2.1.61 is not present in existing list of ip addresses. Please use a different private ip.
-OpenSearch Ip ewewedw is not present in existing list of ip addresses. Please use a different private ip.
-Unable to remove node. Postgresql instance count cannot be less than 3. Final count 1 not allowed.
-Postgresql Ip 10.2.1.657 is not present in existing list of ip addresses. Please use a different private ip.
-Postgresql Ip ewewedw is not present in existing list of ip addresses. Please use a different private ip.`)
+Unable to remove node. Postgresql instance count cannot be less than 3. Final count 1 not allowed.`)
 }
 
 func TestDeleteNodeModifyAutomate(t *testing.T) {
@@ -423,8 +413,8 @@ func TestDeleteNodeDeployWithNewOSMinCountError(t *testing.T) {
 	})
 	err := nodedelete.validate()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `IP address validation failed: 
-Unable to remove node. OpenSearch instance count cannot be less than 3. Final count 2 not allowed.`)
+	assert.Contains(t, err.Error(),
+		`Unable to remove node. OpenSearch instance count cannot be less than 3. Final count 2 not allowed.`)
 }
 
 func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: SahithiMy <sahithi.mylangam@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Modified the error message for the nodes delete for opensearch nodes, postgress nodes, chefserver nodes and automate nodes in automate HA on onprem deployment.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-305
### :+1: Definition of Done
Error message is modified for deleting nodes when nodes are less than minimum count.
### :athletic_shoe: How to Build and Test the Change
```rebuild components/automate-cli/```
```hab pkg install sahithimy/automate-cli/0.1.0/20230109071130 -bf```
```chef-automate node remove -O <IP_ADDRESS>```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/98326242/211260297-908bd51d-e88f-4e98-ac53-b267738e3c5a.mov


https://user-images.githubusercontent.com/98326242/211556975-c4dac70a-30cc-4fa9-b5a7-342125a01ed6.mov

