### PR TITLE
Copying file by buffer to protect the attack

### DIFF
--- a/components/compliance-service/reporting/util/zip.go
+++ b/components/compliance-service/reporting/util/zip.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -53,14 +52,14 @@ func Zip2Path(zipPath string, extractPath string) error {
 			for {
 				n, err := rc.Read(buf)
 				if err != nil && err != io.EOF {
-					log.Fatal(err)
+					return err
 				}
 				if n == 0 {
 					break
 				}
 
 				if _, err := f.Write(buf[:n]); err != nil {
-					log.Fatal(err)
+					return err
 				}
 			}
 			cerr := rc.Close()


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Logic added to copy zip file by bytes and not whole at a time, which can consume the memory of the system.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/IN-897
https://chefio.atlassian.net/browse/STALWART-291

### :+1: Definition of Done

Now the file is being copied zip by zip

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/compliance_service

```

Upload a zip profile under upload profiles page

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
