### PR TITLE
Bump minimist version from 1.2.6 to 1.2.7 in automate UI

### DIFF
--- a/components/automate-ui/package-lock.json
+++ b/components/automate-ui/package-lock.json
@@ -7998,9 +7998,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-          "integrity": "sha512-2RbeLaM/Hbo9vJ1+iRrxzfDnX9108qb2m923U+s+Ot2eMey0IYGdSjzHmvtg2XsxoCuMnzOMw7qc573RvnLgwg==",
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
           "dev": true
         }
       }

--- a/components/automate-ui/package.json
+++ b/components/automate-ui/package.json
@@ -56,7 +56,7 @@
     "immutable": "^3.8.2",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
-    "minimist": "^1.2.6",
+    "minimist": "^1.2.7",
     "moment": "^2.29.1",
     "ngx-cookie": "^5.0.2",
     "ngx-infinite-scroll": "^10.0.1",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The latest possible version that can be installed is 1.2.7 because of the following conflicting dependency:

sass-lint@1.13.1 requires minimist@1.1.x via gonzales-pe-sl@4.2.3
The earliest fixed version is 1.2.7.
https://github.com/chef/automate/security/dependabot/295

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-334
### :+1: Definition of Done
I have updated the `minimist` version to 1.2.7
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
