### PR TITLE
Support `iam` commands from Automate HA Bastion Node

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -2,18 +2,56 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
+// CommandBuilder builds the original command from the cobra command and args
 func CommandBuilder(cmd *cobra.Command, args []string) string {
 	fullCommand := cmd.CommandPath()
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Changed {
-			fullCommand += " --" + flag.Name + " " + flag.Value.String()
+			if flag.Value.Type() != "bool" {
+				fullCommand += " --" + flag.Name + " " + flag.Value.String()
+			} else {
+				fullCommand += " --" + flag.Name
+			}
 		}
 	})
 	return fmt.Sprint("sudo " + fullCommand + " " + strings.Join(args, " "))
+}
+
+// RunCmdOnSingleAutomateNode runs the command on a single automate node
+func RunCmdOnSingleAutomateNode(cmd *cobra.Command, args []string) error {
+	script := CommandBuilder(cmd, args)
+
+	infra, err := getAutomateHAInfraDetails()
+	if err != nil {
+		return err
+	}
+
+	ips := infra.Outputs.AutomatePrivateIps.Value
+	if len(ips) == 0 {
+		writer.Fail("No automate IPs are found")
+		os.Exit(1)
+	}
+
+	sshConfig := &SSHConfig{
+		sshUser:    infra.Outputs.SSHUser.Value,
+		sshPort:    infra.Outputs.SSHPort.Value,
+		sshKeyFile: infra.Outputs.SSHKeyFile.Value,
+		hostIP:     ips[0],
+		timeout:    10,
+	}
+	sshUtil := NewSSHUtil(sshConfig)
+
+	output, err := sshUtil.connectAndExecuteCommandOnRemote(script, true)
+	if err != nil {
+		return err
+	}
+	writer.Print(output)
+	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func CommandBuilder(cmd *cobra.Command, args []string) string {
+	fullCommand := cmd.CommandPath()
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			fullCommand += " --" + flag.Name + " " + flag.Value.String()
+		}
+	})
+	return fmt.Sprint(fullCommand + " " + strings.Join(args, " "))
+}

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -15,5 +15,5 @@ func CommandBuilder(cmd *cobra.Command, args []string) string {
 			fullCommand += " --" + flag.Name + " " + flag.Value.String()
 		}
 	})
-	return fmt.Sprint(fullCommand + " " + strings.Join(args, " "))
+	return fmt.Sprint("sudo " + fullCommand + " " + strings.Join(args, " "))
 }

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// CommandBuilder builds the original command from the cobra command and args
-func CommandBuilder(cmd *cobra.Command, args []string) string {
+// GenerateOriginalAutomateCLICommand builds the original command from the cobra command and args
+func GenerateOriginalAutomateCLICommand(cmd *cobra.Command, args []string) string {
 	fullCommand := cmd.CommandPath()
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Changed {
@@ -26,7 +26,7 @@ func CommandBuilder(cmd *cobra.Command, args []string) string {
 
 // RunCmdOnSingleAutomateNode runs the command on a single automate node
 func RunCmdOnSingleAutomateNode(cmd *cobra.Command, args []string) error {
-	script := CommandBuilder(cmd, args)
+	script := GenerateOriginalAutomateCLICommand(cmd, args)
 
 	infra, err := getAutomateHAInfraDetails()
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -35,8 +35,7 @@ func RunCmdOnSingleAutomateNode(cmd *cobra.Command, args []string) error {
 
 	ips := infra.Outputs.AutomatePrivateIps.Value
 	if len(ips) == 0 {
-		writer.Fail("No automate IPs are found")
-		os.Exit(1)
+		return errors.New("No automate IPs are found")
 	}
 
 	sshConfig := &SSHConfig{

--- a/components/automate-cli/cmd/chef-automate/cliUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandBuilder(t *testing.T) {
+	// Define a Cobra command for testing purposes
+	cmd := &cobra.Command{
+		Use:   "my-command",
+		Short: "A description of my command",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Not used in this test
+		},
+	}
+
+	// Define some flags for the Cobra command
+	cmd.Flags().String("string-flag", "", "A description of the string flag")
+	cmd.Flags().Int("int-flag", 0, "A description of the int flag")
+	cmd.Flags().Bool("bool-flag", false, "A description of the bool flag")
+
+	// Set the values of the string and int flags
+	cmd.Flags().Set("string-flag", "string-value")
+	cmd.Flags().Set("int-flag", "42")
+
+	// Call the CommandBuilder function with the defined Cobra command and arguments
+	fullCommand := CommandBuilder(cmd, []string{"arg1", "arg2"})
+	expectedCommand := "sudo my-command --int-flag 42 --string-flag string-value arg1 arg2"
+	assert.Equal(t, fullCommand, expectedCommand)
+
+	// Set the bool flag to true and test the CommandBuilder function again
+	cmd.Flag("bool-flag").Changed = true
+	fullCommand = CommandBuilder(cmd, []string{"arg1", "arg2"})
+	expectedCommand = "sudo my-command --bool-flag --int-flag 42 --string-flag string-value arg1 arg2"
+	assert.Equal(t, fullCommand, expectedCommand)
+}

--- a/components/automate-cli/cmd/chef-automate/cliUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandBuilder(t *testing.T) {
+func TestGenerateOriginalAutomateCLICommand(t *testing.T) {
 	// Define a Cobra command for testing purposes
 	cmd := &cobra.Command{
 		Use:   "my-command",
@@ -26,14 +26,14 @@ func TestCommandBuilder(t *testing.T) {
 	cmd.Flags().Set("string-flag", "string-value")
 	cmd.Flags().Set("int-flag", "42")
 
-	// Call the CommandBuilder function with the defined Cobra command and arguments
-	fullCommand := CommandBuilder(cmd, []string{"arg1", "arg2"})
+	// Call the GenerateOriginalAutomateCLICommand function with the defined Cobra command and arguments
+	fullCommand := GenerateOriginalAutomateCLICommand(cmd, []string{"arg1", "arg2"})
 	expectedCommand := "sudo my-command --int-flag 42 --string-flag string-value arg1 arg2"
 	assert.Equal(t, fullCommand, expectedCommand)
 
-	// Set the bool flag to true and test the CommandBuilder function again
+	// Set the bool flag to true and test the GenerateOriginalAutomateCLICommand function again
 	cmd.Flag("bool-flag").Changed = true
-	fullCommand = CommandBuilder(cmd, []string{"arg1", "arg2"})
+	fullCommand = GenerateOriginalAutomateCLICommand(cmd, []string{"arg1", "arg2"})
 	expectedCommand = "sudo my-command --bool-flag --int-flag 42 --string-flag string-value arg1 arg2"
 	assert.Equal(t, fullCommand, expectedCommand)
 }

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -103,13 +103,21 @@ func init() {
 
 	// config set flags
 	setConfigCmd.PersistentFlags().BoolVarP(&configCmdFlags.automate, "automate", "a", false, "Set toml configuration to the automate node")
+	setConfigCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVar(&configCmdFlags.automate, "a2", false, "Set toml configuration to the automate node[DUPLICATE]")
+	setConfigCmd.PersistentFlags().SetAnnotation("a2", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVarP(&configCmdFlags.chef_server, "chef_server", "c", false, "Set toml configuration to the chef_server node")
+	setConfigCmd.PersistentFlags().SetAnnotation("chef_server", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVar(&configCmdFlags.chef_server, "cs", false, "Set toml configuration to the chef_server node[DUPLICATE]")
+	setConfigCmd.PersistentFlags().SetAnnotation("cs", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVarP(&configCmdFlags.opensearch, "opensearch", "o", false, "Set toml configuration to the opensearch node")
+	setConfigCmd.PersistentFlags().SetAnnotation("opensearch", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVar(&configCmdFlags.opensearch, "os", false, "Set toml configuration to the opensearch node[DUPLICATE]")
+	setConfigCmd.PersistentFlags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVarP(&configCmdFlags.postgresql, "postgresql", "p", false, "Set toml configuration to the postgresql node")
+	setConfigCmd.PersistentFlags().SetAnnotation("postgresql", docs.Compatibility, []string{docs.CompatiblewithHA})
 	setConfigCmd.PersistentFlags().BoolVar(&configCmdFlags.postgresql, "pg", false, "Set toml configuration to the postgresql node[DUPLICATE]")
+	setConfigCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
 
 	configCmd.PersistentFlags().BoolVarP(&configCmdFlags.acceptMLSA, "auto-approve", "y", false, "Do not prompt for confirmation; accept defaults and continue")
 	configCmd.PersistentFlags().Int64VarP(&configCmdFlags.timeout, "timeout", "t", 10, "Request timeout in seconds")
@@ -129,6 +137,9 @@ var showConfigCmd = &cobra.Command{
 	Long:  "Show the Chef Automate configuration. When given a filepath, the output will be written to the file instead of printed to STDOUT",
 	RunE:  runShowCmd,
 	Args:  cobra.RangeArgs(0, 2),
+	Annotations: map[string]string{
+		docs.Tag: docs.BastionHost,
+	},
 }
 
 var patchConfigCmd = &cobra.Command{
@@ -136,6 +147,9 @@ var patchConfigCmd = &cobra.Command{
 	Short: "patch the Chef Automate configuration", Long: "Apply a partial Chef Automate configuration to the deployment. It will take the partial configuration, merge it with the existing configuration, and apply and required changes.",
 	RunE: runPatchCommand,
 	Args: cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		docs.Tag: docs.BastionHost,
+	},
 }
 
 var setConfigCmd = &cobra.Command{
@@ -145,7 +159,7 @@ var setConfigCmd = &cobra.Command{
 	RunE:  runSetCommand,
 	Args:  cobra.ExactArgs(1),
 	Annotations: map[string]string{
-		docs.Tag: docs.FrontEnd,
+		docs.Tag: docs.BastionHost,
 	},
 }
 
@@ -156,7 +170,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 		if isManagedServicesOn() {
 			err := errorOnSelfManaged(configCmdFlags.postgresql, configCmdFlags.opensearch)
 			if err != nil {
-				return status.Annotate(err,  status.InvalidCommandArgsError)
+				return status.Annotate(err, status.InvalidCommandArgsError)
 			}
 		}
 
@@ -459,7 +473,7 @@ func patchConfigForPostgresqlNodes(args []string, remoteService string, sshUtil 
 // patchConfigForOpensearch patches the config for open-search nodes in Automate HA
 func patchConfigForOpensearch(args []string, remoteService string, sshUtil SSHUtil, infra *AutomteHAInfraDetails, timestamp string, writer *cli.Writer) error {
 	if isManagedServicesOn() {
-		return status.Errorf(status.InvalidCommandArgsError,  ERROR_SELF_MANAGED_CONFIG_PATCH, "OpenSearch")
+		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_CONFIG_PATCH, "OpenSearch")
 	}
 
 	if len(infra.Outputs.OpensearchPrivateIps.Value) == 0 {

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -33,7 +33,7 @@ func newIAMCommand() *cobra.Command {
 		Use:   "iam COMMAND",
 		Short: "Chef Automate iam commands",
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 }
@@ -43,7 +43,7 @@ func newIAMAdminAccessCommand() *cobra.Command {
 		Use:   "admin-access COMMAND",
 		Short: "Manage and restore default admin access",
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 }
@@ -53,7 +53,7 @@ func newIAMTokensCommand() *cobra.Command {
 		Use:   "token COMMAND",
 		Short: "Manage tokens",
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 }
@@ -65,7 +65,7 @@ func newIAMCreateTokenCommand() *cobra.Command {
 		RunE:  runCreateTokenCmd,
 		Args:  cobra.ExactArgs(1),
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 	cmd.PersistentFlags().BoolVar(
@@ -90,7 +90,7 @@ func newIAMRestoreDefaultAdminAccessCmd() *cobra.Command {
 		RunE: runRestoreDefaultAdminAccessAdminCmd,
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 	cmd.PersistentFlags().BoolVar(
@@ -108,7 +108,7 @@ func newIAMVersionCmd() *cobra.Command {
 		RunE:  runIAMVersionCmd,
 		Args:  cobra.ExactArgs(0),
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -186,15 +186,15 @@ func runIAMVersionCmdOnHA(cmd *cobra.Command, args []string) error {
 		sshPort:    infra.Outputs.SSHPort.Value,
 		sshKeyFile: infra.Outputs.SSHKeyFile.Value,
 		hostIP:     ips[0],
+		timeout:    10,
 	}
 	sshUtil := NewSSHUtil(sshConfig)
 
 	output, err := sshUtil.connectAndExecuteCommandOnRemote(script, true)
 	if err != nil {
-		writer.Errorf("%v\n", err)
 		return err
 	}
-	writer.Printf(output + "\n")
+	writer.Print(output)
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -289,7 +289,7 @@ func runCreateTokenCmd(cmd *cobra.Command, args []string) error {
 func preIAMCmd(cmd *cobra.Command, args []string) error {
 	err := commandPrePersistent(cmd)
 	if err != nil {
-		return status.Wrap(err, status.BackupError, "unable to set command parent settings")
+		return status.Wrap(err, status.CommandExecutionError, "unable to set command parent settings")
 	}
 	if isA2HARBFileExist() {
 		err = RunCmdOnSingleAutomateNode(cmd, args)

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -43,6 +43,11 @@ type SSHUtilImpl struct {
 }
 
 func NewSSHUtil(sshconfig *SSHConfig) SSHUtil {
+	// Set timeout. Default is 150 seconds.
+	if sshconfig.timeout == 0 {
+		sshconfig.timeout = 150
+	}
+
 	return &SSHUtilImpl{
 		SshConfig: sshconfig,
 	}
@@ -156,12 +161,6 @@ func (s *SSHUtilImpl) connectAndExecuteCommandOnRemote(remoteCommands string, sp
 	logrus.Debug("Executing command ......")
 	logrus.Debug(remoteCommands)
 
-	// Set timeout. Default is 1 hour
-	timeout := 3600
-	if s.SshConfig.timeout > 0 {
-		timeout = s.SshConfig.timeout
-	}
-
 	conn, err := s.getConnection()
 	if err != nil {
 		return "", err
@@ -192,7 +191,7 @@ func (s *SSHUtilImpl) connectAndExecuteCommandOnRemote(remoteCommands string, sp
 	}()
 
 	select {
-	case <-time.After(time.Duration(timeout) * time.Second):
+	case <-time.After(time.Duration(s.SshConfig.timeout) * time.Second):
 		return "", errors.New("command timed out")
 	case err := <-errCh:
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Atul Krishna <Atul.Krishna@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Support `iam` commands from Automate HA Bastion Node. The `iam` commands include the following sub-commands.
- chef-automate `iam` version
- chef-automate `iam` token create <name>
- chef-automate `iam` admin-access restore <password>

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/SHIELD-216

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![Screenshot 2023-02-08 at 6 45 55 PM](https://user-images.githubusercontent.com/11033984/217575806-ade6c163-71bf-47da-920a-31f0220586e7.png)
![Screenshot 2023-02-08 at 6 49 33 PM](https://user-images.githubusercontent.com/11033984/217575840-5e7b5bfa-bdcd-44de-a90a-11f68c0a58a4.png)
![Screenshot 2023-02-08 at 6 47 13 PM](https://user-images.githubusercontent.com/11033984/217576018-3b21c310-2dec-4cc1-bc10-a0e6e998b326.png)
![Screenshot 2023-02-08 at 6 46 28 PM](https://user-images.githubusercontent.com/11033984/217576125-6b1ce90e-6936-47b3-8142-385a26fbb1cf.png)


