### PR TITLE
Changing the logic from 90 to one day

### DIFF
--- a/components/compliance-service/ingest/ingestic/ingestic.go
+++ b/components/compliance-service/ingest/ingestic/ingestic.go
@@ -396,7 +396,7 @@ func (backend *ESClient) UpdateDayLatestToFalse(ctx context.Context, nodeId stri
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
 
 	if backend.Conf.EnableEnhancedReporting {
-		return updateDayLatestToFalseForEnhancedCompliance(ctx, backend, boolQueryDayLatestThisNodeNotThisReport, index, mapping, useSummaryIndex, script)
+		return errors.Wrap(updateDayLatestToFalseForEnhancedCompliance(ctx, backend, boolQueryDayLatestThisNodeNotThisReport, index, mapping, useSummaryIndex, script), "setDayLatestToFalseEnhancedReporting")
 	}
 
 	indexOneDayAgo := mapping.IndexTimeseriesFmt(oneDayAgo)

--- a/components/docs-chef-io/content/automate/enhanced_compliance_report.md
+++ b/components/docs-chef-io/content/automate/enhanced_compliance_report.md
@@ -1,7 +1,7 @@
 +++
 title = "Enhanced Compliance Report Ingestion"
 
-draft = false
+draft = true
 
 gh_repo = "automate"
 [menu]


### PR DESCRIPTION
Signed-off-by: Yashvi Jain <yashvi.jain@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

Day latest will be mark for one day now rather than 90 days which is causing memory to shoot in opensearch 1.3.7

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/STALWART-336

### :+1: Definition of Done

Day latest false is marked for yesterday only.

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/compliance-service/
```

Ingest the data in compliance service

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
