### PR TITLE
fixed the error log issue

### DIFF
--- a/components/automate-ui/src/app/page-components/resource-item/resource-item.component.html
+++ b/components/automate-ui/src/app/page-components/resource-item/resource-item.component.html
@@ -24,7 +24,7 @@
       <span *ngIf="resource.delta && resource.delta.length" class="link" (click)="toggleDelta()">
         <span>diff</span><chef-icon>expand_{{ showDelta === true ? 'more' : 'less' }}</chef-icon>
       </span>
-      <span *ngIf="resource.status === 'failed'" class="link" (click)="showModal(resource.id)">
+      <span *ngIf="resource.status === 'failed'" class="link" (click)="showModal()">
         <span>error log</span>
       </span>
       <span *ngIf="(!resource.delta || resource.delta.length === 0) && resource.status !== 'failed'"

--- a/components/automate-ui/src/app/page-components/resource-item/resource-item.component.ts
+++ b/components/automate-ui/src/app/page-components/resource-item/resource-item.component.ts
@@ -17,8 +17,8 @@ export class ResourceItemComponent {
     this.showDelta = !this.showDelta;
   }
 
-  showModal(resourceId: string) {
-    this.eventsService.showModal(true, resourceId);
+  showModal() {
+    this.eventsService.showModal(true);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ghanavishmathi Macharla <gmacharl@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
Fixed the issue of Node error log data in the Automate UI.
Minor change in resource-item component .html and .ts file to view the node error log data properly.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-254

### :+1: Definition of Done
- Code changes in resource-item component
- After changes verified the UI

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Issue (before code changes): https://progresssoftware-my.sharepoint.com/:v:/r/personal/ssanju_progress_com/Documents/Chef/Client%20Run%20report%20view,%20search%20by%20filter%20and%20download/Backtrace%20error.mov?csf=1&web=1&e=iyh35B
After:

https://user-images.githubusercontent.com/105190316/216926616-0709e8cd-c4c2-4c30-94ee-b82ee5cbcf32.mov

