### PR TITLE
fixed for unable to download medium size report in compliance

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -297,6 +297,9 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const reportQuery = this.reportQuery.getReportQuery();
     const filename = `${reportQuery.endDate.format('YYYY-M-D')}.${format}`;
 
+    let fileSize: number = 0;
+    const maxFileSizeElement: number = 1000000000;
+
     const onComplete = () => this.downloadInProgress = false;
     const onError = _e => this.downloadFailed = true;
     const onNext = data => {
@@ -311,9 +314,14 @@ export class ReportingComponent implements OnInit, OnDestroy {
         const types = { 'json': 'application/json', 'csv': 'text/csv' };
         const type = types[format];
         const blob = new Blob([data], { type });
-        saveAs(blob, filename);
+        fileSize = blob.size;
+        var fileUrl = URL.createObjectURL(blob);
+        saveAs(fileUrl, filename);
       }
       this.hideDownloadStatus();
+      if (fileSize > maxFileSizeElement) {
+        window.location.reload();
+      }
     };
 
     this.downloadList = [filename];
@@ -322,7 +330,10 @@ export class ReportingComponent implements OnInit, OnDestroy {
     }
     this.statsService.downloadReport(format, reportQuery).pipe(
       finalize(onComplete))
-      .subscribe(onNext, onError);
+      .subscribe((event: any) => {
+        onNext(event)
+        onError('')
+      });
   }
 
   showDownloadStatus() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, I should be able to download the mid-size reports of compliance nodes, right now if we ingested 2k nodes with the medium-size reports. The download functionality got failed.


### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-285
### :+1: Definition of Done
I have added some changes to download the report in any size without failing the download also the page is not going to break if the file size the large.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

# build components/automate-ui-devproxy/
# start_automate_ui_background
# start_all_services

STEP 2
open new window
go to automate UI path

For adding data we need to add the data from the `automate-load-test` repo
use the below command to add the data

$ cd automate-load-test
$ ./automate-load-test -url https://a2-dev.test/api/v0/events/data-collector -token copy_you_hab_admin_token_here numberOfElement=2000 -concurrency=100 -data=compliance -status=success

```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
