### PR TITLE
Filesystem Permissions for Automate Operation

### DIFF
--- a/components/docs-chef-io/content/automate/system_requirements.md
+++ b/components/docs-chef-io/content/automate/system_requirements.md
@@ -31,6 +31,8 @@ Chef Automate requires
 * `useradd`
 * `curl` or `wget`
 * The shell that starts Chef Automate should have a max open files setting of at least 65535
+* The root user should have a umask of 0022
+* The /etc/passwd file should have a permission setting of 0644
 
 Commercial support for Chef Automate is available for platforms that satisfy these
 criteria.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Chef Automate requires certain additional permissions in order to operate:

* Files created by the system's automation should be done while the root user has perms of 0022, so that other services can use the created files
* The OS where Automate is running should have 0644 permissions on the password file so that the postgresql `initdb` program can read the file. It uses this information to decide how to assign permissions as the program creates database files.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)* No code
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)* No code
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)* No code
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)* No code

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) No code
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*
