### PR TITLE
The project assigned name is Changed automatically, when we toggle from active to inactive status and back to active status in automate API-token

### DIFF
--- a/components/automate-ui/src/app/entities/api-tokens/api-token.effects.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.effects.ts
@@ -115,8 +115,8 @@ export class ApiTokenEffects {
 
   toggleToken$ = createEffect(() =>
     this.actions$.pipe(ofType<ToggleTokenActive>(ApiTokenActionTypes.TOGGLE),
-    mergeMap(({ payload: { id, name, active } }: ToggleTokenActive) =>
-      this.requests.toggleActive(id, name, active).pipe(
+    mergeMap(({ payload: { id, name, active, projects } }: ToggleTokenActive) =>
+      this.requests.toggleActive(id, name, active, projects).pipe(
         map(resp => new ToggleTokenActiveSuccess(resp.token)),
         catchError((error: HttpErrorResponse) => of(new ToggleTokenActiveFailure(error))))
     )));

--- a/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
@@ -39,9 +39,9 @@ export class ApiTokenRequests {
 
   // Note: toggleActive takes the EXISTING value in `active`, and will take care
   // of flipping it.
-  public toggleActive(id: string, name: string, active: boolean): Observable<TokenPayloadResponse> {
+  public toggleActive(id: string, name: string, active: boolean, projects: string[]): Observable<TokenPayloadResponse> {
     return this.http.put<TokenPayloadResponse>(`${env.iam_url}/tokens/${id}`,
-      { name, active: !active });
+      { name, active: !active,projects: projects});
   }
 
   public delete(id: string): Observable<Object> {

--- a/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
+++ b/components/automate-ui/src/app/entities/api-tokens/api-token.requests.ts
@@ -41,7 +41,7 @@ export class ApiTokenRequests {
   // of flipping it.
   public toggleActive(id: string, name: string, active: boolean, projects: string[]): Observable<TokenPayloadResponse> {
     return this.http.put<TokenPayloadResponse>(`${env.iam_url}/tokens/${id}`,
-      { name, active: !active,projects: projects});
+      { name, active: !active, projects: projects });
   }
 
   public delete(id: string): Observable<Object> {


### PR DESCRIPTION
Signed-off-by: Atul Krishna <Atul.Krishna@progress.com>

### :nut_and_bolt: Description: What code changed, and why?
The project assigned name is Changed automatically, when we toggle from active to inactive status and back to active status in automate API-token.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/SHIELD-204

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![Screenshot 2023-02-13 at 5 38 11 PM](https://user-images.githubusercontent.com/11033984/220586430-d4b2b502-213d-450a-9876-fb8decd79b37.png)

![Screenshot 2023-02-13 at 5 38 43 PM](https://user-images.githubusercontent.com/11033984/220586501-85709efd-cb5a-4127-a4aa-abc1036f7b99.png)

![Screenshot 2023-02-13 at 5 39 13 PM](https://user-images.githubusercontent.com/11033984/220586539-94c991df-91a6-40ad-8263-b805eda572e6.png)
