### PR TITLE
Modified the code for gather-logs

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -65,7 +65,7 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	return err
 }
 
-func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDocs string) error {
+func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDocs string, checkTerraformApply bool) error {
 	var logFilePath = filepath.Join(AUTOMATE_HA_RUN_LOG_DIR, "/a2ha-run.log")
 	if len(command) < 1 {
 		return errors.New("Invalid or empty command")
@@ -98,7 +98,7 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 	go tailFile(logFilePath, executed)
 	x, err := c.Process.Wait()
 	logString, err := fileutils.ReadFile(logFilePath)
-	if strings.Contains(string(logString), "Apply complete!") {
+	if strings.Contains(string(logString), "Apply complete!") || !checkTerraformApply {
 		isSuccess = true
 	}
 	if x.ExitCode() != 0 || !isSuccess || err != nil {

--- a/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
+++ b/components/automate-cli/cmd/chef-automate/automateHAAwsDeployment.go
@@ -72,7 +72,7 @@ func (a *awsDeployment) doProvisionJob(args []string) error {
 	args = args[1:]
 	args = append(args, "-y")
 	if isA2HARBFileExist() {
-		return executeAutomateClusterCtlCommandAsync("provision", args, provisionInfraHelpDocs)
+		return executeAutomateClusterCtlCommandAsync("provision", args, provisionInfraHelpDocs, true)
 	}
 	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }

--- a/components/automate-cli/cmd/chef-automate/deployHa.go
+++ b/components/automate-cli/cmd/chef-automate/deployHa.go
@@ -19,7 +19,7 @@ func executeDeployment(args []string) error {
 	args = append(args[:indexOfConfig], args[indexOfConfig+1:]...)
 	args = append(args, "-y")
 	if isA2HARBFileExist() {
-		return executeAutomateClusterCtlCommandAsync("deploy", args, automateHADeployHelpDocs)
+		return executeAutomateClusterCtlCommandAsync("deploy", args, automateHADeployHelpDocs, true)
 	}
 	return errors.New(AUTOMATE_HA_INVALID_BASTION)
 }

--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -120,7 +120,7 @@ var gatherLogsCmdFlags = struct {
 
 func runGatherLogsCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
-		return executeAutomateClusterCtlCommandAsync("gather-logs", args, gatherLogsHelpDoc)
+		return executeAutomateClusterCtlCommandAsync("gather-logs", args, gatherLogsHelpDoc, false)
 	}
 	// Ensure we can write to any user given log locations
 	overridePath := ""

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -227,7 +227,7 @@ func (nu *NodeUtilsImpl) readConfig(path string) (ExistingInfraConfigToml, error
 	return readConfig(path)
 }
 func (nu *NodeUtilsImpl) executeAutomateClusterCtlCommandAsync(command string, args []string, helpDocs string) error {
-	return executeAutomateClusterCtlCommandAsync(command, args, helpDocs)
+	return executeAutomateClusterCtlCommandAsync(command, args, helpDocs, true)
 }
 
 func (nu *NodeUtilsImpl) writeHAConfigFiles(templateName string, data interface{}) error {

--- a/components/automate-cli/cmd/chef-automate/testHA.go
+++ b/components/automate-cli/cmd/chef-automate/testHA.go
@@ -34,7 +34,7 @@ func runTestCmd(cmd *cobra.Command, args []string) error {
 		if testCommandFlags.full {
 			args = append(args, "--full")
 		}
-		return executeAutomateClusterCtlCommandAsync("test", args, testHAHelpDocs)
+		return executeAutomateClusterCtlCommandAsync("test", args, testHAHelpDocs, true)
 	} else {
 		return status.Wrap(errors.New(AUTOMATE_HA_INVALID_BASTION), status.ConfigError, testHAHelpDocs)
 	}

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -493,7 +493,7 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 			args = append(args, "--skip-deploy")
 		} */
 	}
-	return executeAutomateClusterCtlCommandAsync("deploy", args, upgradeHaHelpDoc)
+	return executeAutomateClusterCtlCommandAsync("deploy", args, upgradeHaHelpDoc, true)
 }
 
 func statusUpgradeCmd(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Changed the code for gather-logs, where we are getting gather-logs abruptly stops and does not exit gracefully.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/STALWART-345
### :+1: Definition of Done
Modified the code for gather-logs which stops abruptly.
### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-cli/`
`hab pkg install sahithimy/automate-cli/0.1.0/20230216052302 -bf`
`chef-automate gather-logs`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/98326242/220012219-4e7a14ca-7983-43e7-9c76-32127eeb3928.mov

