### PR TITLE
Fixed for chef Automate navigation loses the chef infra server name from breadcrumb nav bar.

### DIFF
--- a/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/client-details/client-details.component.html
@@ -4,6 +4,7 @@
       <chef-loading-spinner *ngIf="clientTabLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/cookbook-details/cookbook-details.component.html
@@ -4,6 +4,7 @@
       <chef-loading-spinner *ngIf="cookbookVersionsLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]">{{org?.name}}
         </chef-breadcrumb>

--- a/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/data-bags-details/data-bags-details.component.html
@@ -9,6 +9,7 @@
       <chef-loading-spinner class="spinner" *ngIf="dataBagsDetailsLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/environment-details/environment-details.component.html
@@ -4,6 +4,7 @@
       <chef-loading-spinner *ngIf="environmentDetailsLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-node-details/infra-node-details.component.html
@@ -3,6 +3,7 @@
     <main>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/infra-role-details/infra-role-details.component.html
@@ -4,6 +4,7 @@
       <chef-loading-spinner *ngIf="infraRoleLoading" size="50" fixed></chef-loading-spinner>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/org-details/org-details.component.html
@@ -3,6 +3,7 @@
     <main>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [link]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', org?.server_id]">Organizations</chef-breadcrumb>
         {{ org?.name }}
       </chef-breadcrumbs>

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-file-details/policy-file-details.component.html
@@ -3,6 +3,7 @@
     <main>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Servers</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
+++ b/components/automate-ui/src/app/modules/infra-proxy/policy-group-details/policy-group-details.component.html
@@ -3,6 +3,7 @@
     <main>
       <chef-breadcrumbs>
         <chef-breadcrumb [link]="['/infrastructure/chef-servers']">Chef Infra Server</chef-breadcrumb>
+        <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">{{serverId}}}</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId]">Organizations</chef-breadcrumb>
         <chef-breadcrumb [routerLink]="['/infrastructure/chef-servers', serverId, 'organizations', orgId]"
           [queryParams]="{ redirect: 'cookbook'}">

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -297,8 +297,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     const reportQuery = this.reportQuery.getReportQuery();
     const filename = `${reportQuery.endDate.format('YYYY-M-D')}.${format}`;
 
-    let fileSize: number = 0;
-    const maxFileSizeElement: number = 1000000000;
+    let fileSize = 0;
+    const maxFileSizeElement = 1000000000;
 
     const onComplete = () => this.downloadInProgress = false;
     const onError = _e => this.downloadFailed = true;
@@ -315,7 +315,7 @@ export class ReportingComponent implements OnInit, OnDestroy {
         const type = types[format];
         const blob = new Blob([data], { type });
         fileSize = blob.size;
-        var fileUrl = URL.createObjectURL(blob);
+        const fileUrl = URL.createObjectURL(blob);
         saveAs(fileUrl, filename);
       }
       this.hideDownloadStatus();
@@ -331,8 +331,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
     this.statsService.downloadReport(format, reportQuery).pipe(
       finalize(onComplete))
       .subscribe((event: any) => {
-        onNext(event)
-        onError('')
+        onNext(event);
+        onError('');
       });
   }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate User, When I navigate under Infrastructure / Chef Infra Servers / Organization,  the Chef Infra Server Name gets lost from the breadcrumb navigation.

### :chains: Related Resources
https://chefio.atlassian.net/browse/KINETICS-147
### :+1: Definition of Done
I have added some UI changes in the infra proxy module to display the chef server name with a link.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

# build components/automate-ui-devproxy/
# start_automate_ui_background
# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
--> need to add server first
--> click to server --> you can see the list of org's ---> click to specific org --> you can see the org details page 
check the breadcrumb like the screenshot.
```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1791" alt="Screenshot 2023-02-22 at 7 56 25 PM" src="https://user-images.githubusercontent.com/12297653/220652469-0d439d4c-f716-4bd6-bc5c-3fe8b2664542.png">
