### PR TITLE
fix compliance graph not showing data of past n days  (IN-864)

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-overview/reporting-overview.component.spec.ts
@@ -109,7 +109,6 @@ describe('ReportingOverviewComponent', () => {
       it('gets node status data', () => {
         spyOn(component, 'getNodeStatusData');
         component.selectedButtonTab = 'Node Status';
-        localStorage.setItem('current-url', 'reporting/controls');
         component.getData(reportQuery);
         expect(component.getNodeStatusData).toHaveBeenCalledWith(reportQuery);
       });
@@ -119,7 +118,6 @@ describe('ReportingOverviewComponent', () => {
       it('gets profile status data', () => {
         spyOn(component, 'getProfileStatusData');
         component.selectedButtonTab = 'Profile Status';
-        localStorage.setItem('current-url', 'reporting/controls');
         component.getData(reportQuery);
         expect(component.getProfileStatusData).toHaveBeenCalledWith(reportQuery);
       });
@@ -128,14 +126,12 @@ describe('ReportingOverviewComponent', () => {
     describe('getNodeStatusData()', () => {
       it('gets node status failure data', () => {
         spyOn(component, 'getNodeStatusFailures');
-        localStorage.setItem('current-url', 'reporting/controls');
         component.getNodeStatusData(reportQuery);
         expect(component.getNodeStatusFailures).toHaveBeenCalledWith(reportQuery);
       });
 
       it('gets node status summary data', () => {
         spyOn(component, 'getNodeSummary');
-        localStorage.setItem('current-url', 'reporting/controls');
         component.getNodeStatusData(reportQuery);
         expect(component.getNodeSummary).toHaveBeenCalledWith(reportQuery);
       });
@@ -150,7 +146,6 @@ describe('ReportingOverviewComponent', () => {
     describe('getProfileStatusData()', () => {
       it('gets profile status failure data', () => {
         spyOn(component, 'getProfileStatusFailures');
-        localStorage.setItem('current-url', 'reporting/controls');
         component.getProfileStatusData(reportQuery);
         expect(component.getProfileStatusFailures).toHaveBeenCalledWith(reportQuery);
       });
@@ -286,7 +281,6 @@ describe('ReportingOverviewComponent', () => {
     });
 
     describe('getControlsTrend()', () => {
-      localStorage.setItem('current-url', 'reporting/controls');
       beforeEach(() => {
         spyOn(statsService, 'getControlsTrend').and.returnValue(observableOf([
           {
@@ -439,7 +433,6 @@ describe('ReportingOverviewComponent', () => {
       }
     ];
 
-    localStorage.setItem('current-url', 'reporting/controls');
 
     beforeEach(() => {
       spyOn(statsService, 'getNodeTrend').and.returnValue(observableOf(data));
@@ -464,7 +457,6 @@ describe('ReportingOverviewComponent', () => {
       filters: [ {type: { name: 'node'}, value: { id: '1231'}}],
       last24h: false
     };
-    localStorage.setItem('current-url', 'reporting/controls');
     const data = [
       {
         'report_time': dateRange.end,

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.spec.ts
@@ -494,7 +494,6 @@ describe('StatsService', () => {
         last24h: false
       };
 
-      localStorage.setItem('current-url', 'reporting/controls');
       const expectedUrl = `${COMPLIANCE_URL}/reporting/stats/trend`;
       const expectedResponse = [{
         'time': '2017-03-05T00:00:00+0000',
@@ -529,7 +528,6 @@ describe('StatsService', () => {
         filters: filters,
         last24h: false
       };
-      localStorage.setItem('current-url', 'test');
 
       const expectedUrl = `${COMPLIANCE_URL}/reporting/stats/trend`;
       const expectedResponse = [{

--- a/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
+++ b/components/automate-ui/src/app/pages/+compliance/shared/reporting/stats.service.ts
@@ -41,6 +41,7 @@ export class StatsService {
 
   getFailures(types: Array<string>, reportQuery: ReportQuery): Observable<any> {
     const url = `${CC_API_URL}/reporting/stats/failures`;
+    reportQuery = this.getStartDate(reportQuery);
     const formatted = this.formatFilters(reportQuery);
     formatted.push({ type: 'types', values: types });
     const body = { filters: formatted };
@@ -50,6 +51,7 @@ export class StatsService {
 
   getNodeSummary(reportQuery: ReportQuery): Observable<any> {
     const url = `${CC_API_URL}/reporting/stats/summary`;
+    reportQuery = this.getStartDate(reportQuery);
     const formatted = this.formatFilters(reportQuery);
     const body = { type: 'nodes', filters: formatted };
 
@@ -59,6 +61,7 @@ export class StatsService {
 
   getControlsSummary(reportQuery: ReportQuery): Observable<any> {
     const url = `${CC_API_URL}/reporting/stats/summary`;
+    reportQuery = this.getStartDate(reportQuery);
     const formatted = this.formatFilters(reportQuery);
     const body = { type: 'controls', filters: formatted };
 
@@ -89,14 +92,8 @@ export class StatsService {
   getNodeTrend(reportQuery: ReportQuery) {
     const url = `${CC_API_URL}/reporting/stats/trend`;
     const interval = 86400;
-    const prev = localStorage.getItem('current-url');
-    const url_array = ['reporting/nodes' , 'reporting/profiles' , 'reporting/controls'];
-    const urlcheck = url_array.some(urlVar => prev.includes(urlVar));
-    if (urlcheck) {
-      const timeInterval = reportQuery.interval;
-      this.getTimeInterval(timeInterval, reportQuery);
-      localStorage.setItem('current-url', url);
-    }
+    const timeInterval = reportQuery.interval;
+    this.getTimeInterval(timeInterval, reportQuery);
     const formatted = this.formatFilters(reportQuery, false);
     const body = {type: 'nodes', interval, filters: formatted};
 
@@ -107,14 +104,8 @@ export class StatsService {
   getControlsTrend(reportQuery: ReportQuery) {
     const url = `${CC_API_URL}/reporting/stats/trend`;
     const interval = 86400;
-    const prev = localStorage.getItem('current-url');
-    const url_array = ['reporting/nodes' , 'reporting/profiles' , 'reporting/controls'];
-    const urlcheck = url_array.some(urlVar => prev.includes(urlVar));
-    if (urlcheck) {
-      const timeInterval = reportQuery.interval;
-      this.getTimeInterval(timeInterval, reportQuery);
-      localStorage.setItem('current-url', url);
-    }
+    const timeInterval = reportQuery.interval;
+    this.getTimeInterval(timeInterval, reportQuery);
     const formatted = this.formatFilters(reportQuery, false);
     const body = {type: 'controls', interval, filters: formatted};
 
@@ -151,8 +142,6 @@ export class StatsService {
 
   getNodes(reportQuery: ReportQuery, listParams: any): Observable<any> {
     const url = `${CC_API_URL}/reporting/nodes/search`;
-    localStorage.setItem('current-url', url);
-
     reportQuery = this.getStartDate(reportQuery);
     let formatted = this.formatFilters(reportQuery);
     formatted = this.addStatusParam(formatted);
@@ -189,7 +178,6 @@ export class StatsService {
 
   getProfiles(reportQuery: ReportQuery, listParams: any): Observable<any> {
     const url = `${CC_API_URL}/reporting/profiles`;
-    localStorage.setItem('current-url', url);
     reportQuery = this.getStartDate(reportQuery);
 
     let formatted = this.formatFilters(reportQuery);
@@ -213,7 +201,6 @@ export class StatsService {
 
   getControls(reportQuery: ReportQuery): Observable<{total: any, items: any}> {
     const url = `${CC_API_URL}/reporting/controls`;
-    localStorage.setItem('current-url', url);
     reportQuery = this.getStartDate(reportQuery);
     let formatted = this.formatFilters(reportQuery);
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

On first switch to Compliance tab, graph was not populating points for past 10 days, as it should by default. It was only showing for 1 day.
The reason was that api was not being hit with correct start date on first visit. Start date was being calculated correctly on switching tabs( nodes/profiles/controls).

Also, found that the start date was being incorrectly sent for other sections such as node status, node failures.. It should always be one day data and not past n days

### :chains: Related Resources
https://chefio.atlassian.net/browse/IN-864
https://chefio.atlassian.net/browse/CHEF-359

### :+1: Definition of Done

fixed the start date to be sent correctly for the API calls.

### :athletic_shoe: How to Build and Test the Change

On first visit to Compliance Tab , graph should be loaded for past 10 days by default.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*


### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/91519463/221227317-9cdffce5-8d1d-40d1-9512-3a12e27febbc.mov


