### PR TITLE
Pulling backup_config from Automate node

### DIFF
--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -457,6 +457,9 @@ func (p *PullConfigsImpl) fetchInfraConfig() (*ExistingInfraConfigToml, error) {
 		sharedConfigToml.ObjectStorage.Config.Endpoint = objectStorageConfig.endpoint
 	}
 
+	storageType := getStorageType(a2ConfigMap)
+	sharedConfigToml.Architecture.ConfigInitials.BackupConfig = storageType
+
 	return sharedConfigToml, nil
 }
 
@@ -1073,6 +1076,31 @@ func getModeOfDeployment() string {
 		return AWS_MODE
 	}
 	return AWS_MODE
+}
+
+func getStorageType(config map[string]*dc.AutomateConfig) string {
+	for _, ele := range config {
+		if ele.Global != nil && ele.Global.V1 != nil && ele.Global.V1.External != nil && ele.Global.V1.External.Opensearch.Backup != nil && len(strings.TrimSpace(ele.Global.V1.External.Opensearch.Backup.Location.Value)) > 0 {
+			// writer.Bodyf("Storage: %v \n", ele.Global.V1.Backups.Location.Value)
+			deploymentType := getModeOfDeployment()
+			if deploymentType == EXISTING_INFRA_MODE {
+				return getInfraBackupType(ele.Global.V1.Backups.Location.Value)
+			}
+			return ele.Global.V1.Backups.Location.Value
+		}
+	}
+	return ""
+}
+
+func getInfraBackupType(backupLocation string) string {
+	switch backupLocation {
+	case "s3":
+		return "object_storage"
+	case "filesystem", "fs":
+		return "file_system"
+	default:
+		return "file_system"
+	}
 }
 
 func getS3BackConfig(config map[string]*dc.AutomateConfig) *ObjectStorageConfig {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When the user is upgrading from 4.2.47 to the latest, the `backup_config` field is missing inside config.toml in the workspace directory. This is fixed in this PR. Now the same is pulled from the Automate Node's OpenSearch configuration.

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/MADROX-440

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
