### PR TITLE
Increased timeout for cert rotate

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -101,7 +101,7 @@ const (
 	SKIP_FRONT_END_IPS_MSG_PG         = "The following %s %s will skip during root-ca patching as the following %s have same root-ca as currently provided Postgresql root-ca.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_OS         = "The following %s %s will skip during root-ca and common name patching as the following %s have same root-ca and common name as currently provided OpenSearch root-ca and common name.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_CN         = "The following %s %s will skip during common name patching as the following %s have same common name as currently provided OpenSearch common name.\n\t %s"
-	DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE = 180
+	DEFAULT_TIMEOUT = 180
 )
 
 type certificates struct {
@@ -175,7 +175,7 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminKeyPath, "admin-key", "", "Admin Private certificate")
 
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.node, "node", "", "Node Ip address")
-	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout,"wait-timeout",DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE,"Operation timeout on each individual node")
+	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout,"wait-timeout",DEFAULT_TIMEOUT,"This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process")
 
 	RootCmd.AddCommand(certRotateCmd)
 }
@@ -216,8 +216,8 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 			return errors.New("Error occured while fetching current certs.")
 		}
 
-		if flagsObj.timeout < DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE {
-			return errors.Errorf("Operation timeout on each individual node should be more than %v sec.",DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE)
+		if flagsObj.timeout < DEFAULT_TIMEOUT {
+			return errors.Errorf("The operation timeout duration for each individual node during the certificate rotation process should be set to a value greater than %v seconds.",DEFAULT_TIMEOUT)
 		}
 
 		sshConfig.timeout = flagsObj.timeout

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -101,7 +101,7 @@ const (
 	SKIP_FRONT_END_IPS_MSG_PG         = "The following %s %s will skip during root-ca patching as the following %s have same root-ca as currently provided Postgresql root-ca.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_OS         = "The following %s %s will skip during root-ca and common name patching as the following %s have same root-ca and common name as currently provided OpenSearch root-ca and common name.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_CN         = "The following %s %s will skip during common name patching as the following %s have same common name as currently provided OpenSearch common name.\n\t %s"
-	DEFAULT_TIMEOUT = 180
+	DEFAULT_TIMEOUT                   = 180
 )
 
 type certificates struct {
@@ -127,7 +127,7 @@ type certRotateFlags struct {
 	adminKeyPath    string
 
 	// Node
-	node string
+	node    string
 	timeout int
 }
 
@@ -175,7 +175,7 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminKeyPath, "admin-key", "", "Admin Private certificate")
 
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.node, "node", "", "Node Ip address")
-	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout,"wait-timeout",DEFAULT_TIMEOUT,"This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process")
+	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout, "wait-timeout", DEFAULT_TIMEOUT, "This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process")
 
 	RootCmd.AddCommand(certRotateCmd)
 }
@@ -217,7 +217,7 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 		}
 
 		if flagsObj.timeout < DEFAULT_TIMEOUT {
-			return errors.Errorf("The operation timeout duration for each individual node during the certificate rotation process should be set to a value greater than %v seconds.",DEFAULT_TIMEOUT)
+			return errors.Errorf("The operation timeout duration for each individual node during the certificate rotation process should be set to a value greater than %v seconds.", DEFAULT_TIMEOUT)
 		}
 
 		sshConfig.timeout = flagsObj.timeout
@@ -474,7 +474,7 @@ func (c *certRotateFlow) patchConfig(param *patchFnParameters) error {
 	// Defining set of commands which run on particular remoteservice nodes
 	var scriptCommands string
 	if param.remoteService == CONST_AUTOMATE || param.remoteService == CONST_CHEF_SERVER || param.remoteService == "frontend" {
-		scriptCommands = fmt.Sprintf(FRONTEND_COMMAND, PATCH ,param.remoteService+param.timestamp, dateFormat)
+		scriptCommands = fmt.Sprintf(FRONTEND_COMMAND, PATCH, param.remoteService+param.timestamp, dateFormat)
 	} else if param.remoteService == CONST_POSTGRESQL || param.remoteService == CONST_OPENSEARCH {
 		scriptCommands = fmt.Sprintf(COPY_USER_CONFIG, param.remoteService+param.timestamp, param.remoteService)
 	}

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -175,7 +175,7 @@ func init() {
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.adminKeyPath, "admin-key", "", "Admin Private certificate")
 
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.node, "node", "", "Node Ip address")
-	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout,"timeout",DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE,"Operation timeout on each individual node")
+	certRotateCmd.PersistentFlags().IntVar(&flagsObj.timeout,"wait-timeout",DEFAULT_OPERATION_TIMEOUT_ON_EACH_NODE,"Operation timeout on each individual node")
 
 	RootCmd.AddCommand(certRotateCmd)
 }

--- a/components/docs-chef-io/content/automate/ha_cert_rotation.md
+++ b/components/docs-chef-io/content/automate/ha_cert_rotation.md
@@ -31,6 +31,7 @@ The certificate rotation is also required when the key for a node, client, or CA
 
 - Below `cert-rotate` commands can only be executed from `bastion host`.
 - If you want to use certificates stored in another node of the HA cluster, you can provide the remote path to the certificates using the `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE>` format instead of the local path.
+- `--wait-timeout` This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process.
 
 {{< /note >}}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As we add timeout in ssh util due to these changes current cert rotate feature have high chance to get timeout error (specially when we rotate cert of backend)  with current default timeout i.e 150 sec thats why with this code changes i added flag for timeout and also set default timeout for cert rotate to 180 sec.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/Ebal7NNouvdCr9cwpL3ah7IB4JZVlvIf5RcWhDtU1oTnqw?e=QlyZet
https://deploy-preview-7755--chef-automate.netlify.app/automate/ha_cert_rotation/