### PR TITLE
MADROX-416: Event feed date selection.

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -23,7 +23,8 @@ export class DateTime {
 
   // Format for date labels in event feed graph
   // Tue, 24 Sept
-  public static readonly EVENT_GRAPH_DATE_LABEL: string = 'ddd, DD MMM';
+  // We are using @angular/common DatePipe. Ref: https://angular.io/api/common/DatePipe
+  public static readonly EVENT_GRAPH_DATE_LABEL: string = 'EEE, dd LLL';
 
   // Format for time labels in event feed table
   // 09:59

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
@@ -8,12 +8,12 @@
           [attr.x]="zoomButtonPosition(i)"
           y="0"
           tabindex="0"
-          [attr.aria-label]="date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL"
+          [attr.aria-label]="date | date: DateTime.EVENT_GRAPH_DATE_LABEL"
           (click)="dateSelected(date, i)"
           (keydown.enter)="dateSelected(date, i)"/>
         <text class="guitar-string-zoom-date"
           [attr.x]="zoomTextPosition(i)" y="18">
-            {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
+            {{date | date: DateTime.EVENT_GRAPH_DATE_LABEL}}
         </text>
       </ng-container>
       <rect class="slider-overlay start" x="0" y="0" width="0" height="100%"/>
@@ -73,7 +73,7 @@
       [width]="graphicProportions.sectionWidth"
       [index]="i"
       *ngFor="let date of guitarStringDataContainer.sectionDates; let i = index">
-      {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
+      {{date | date: DateTime.EVENT_GRAPH_DATE_LABEL}}
     </svg:g>
 
   </chef-guitar-string-collection>


### PR DESCRIPTION
Signed-off-by: Agam Mathur agmathur@progress.com

### :nut_and_bolt: Description: What code changed, and why?

Changed the pipe from our custom datetime pipe to @angular/common DatePipe. This resolved the bug that we were seeing where our custom filter was showing the previous day date as per the selected date format.

On debugging, I found that we were passing the current date as the end-date but our custom filter was showing the previous day date, due to which there was the mismatch between the label of the graph vs the actual log date. This bug was resolved when I used the Angular DatePipe and since, there is a difference between the format used by our custom pipe and Angular pipe, I changed the date format as well, so that the output format remains the same.


### :chains: Related Resources

https://chefio.atlassian.net/browse/MADROX-416
https://angular.io/api/common/DatePipe


### :+1: Definition of Done

The end date shown in the graph label should be same as the current date.

### :athletic_shoe: How to Build and Test the Change

Run a EC2 instance having some event logs, checkout the branch and run below commands:
build components/automate-ui-devproxy
start_automate_ui_background
start_all_services

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://user-images.githubusercontent.com/108087313/222045587-d3afeac7-7c7d-4d33-a52a-c43338004ac4.mov


