### PR TITLE
update session_key to be session_token

### DIFF
--- a/components/docs-chef-io/content/automate/backup.md
+++ b/components/docs-chef-io/content/automate/backup.md
@@ -89,7 +89,7 @@ To store backups in an existing AWS S3 bucket, use the supported S3-related sett
   # AWS environment variables or through the shared AWS config files.
   access_key = "<access_key>"
   secret_key = "<secret_key>"
-  session_key = "<session_key>"
+  session_token = "<session_token>"
 
 [global.v1.backups.s3.ssl]
   # root_cert (optional): The root certificate used for SSL validation.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Update documentation example to use session_token not session_key. Session_key is invalid config.
