### PR TITLE
Changes for creating a OS nodes DN list

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -86,30 +86,30 @@ func (e *existingInfra) addDNTocertConfig() error {
 			e.config.Opensearch.Config.NodesDn = fmt.Sprintf("%v", nodes_dn)
 		}
 
-		nodes_dn := ""
+		NodesDn := ""
 
 		//Set the admin_dn and nodes_dn in the config for all IP addresses
 		for i := 0; i < len(e.config.Opensearch.Config.CertsByIP); i++ {
-			//If PublicKey is given then get the nodes_dn from the cert
+			//If PublicKey is given then get the node_dn from the cert
 			publicKey := e.config.Opensearch.Config.CertsByIP[i].PublicKey
 			if len(strings.TrimSpace(publicKey)) > 0 {
 				node_dn, err := getDistinguishedNameFromKey(publicKey)
 				if err != nil {
 					return err
 				}
-				if nodes_dn == "" {
-					nodes_dn = nodes_dn + fmt.Sprintf("%v", node_dn) + "\\n  "
+				if NodesDn == "" {
+					NodesDn = NodesDn + fmt.Sprintf("%v", node_dn) + "\\n  "
 				} else {
-					nodes_dn = nodes_dn + fmt.Sprintf("- %v", node_dn) + "\\n  "
+					NodesDn = NodesDn + fmt.Sprintf("- %v", node_dn) + "\\n  "
 				}
 			}
 		}
 
 		for i := 0; i < len(e.config.Opensearch.Config.CertsByIP); i++ {
-			//If PublicKey is given then get the nodes_dn from the cert
+			//If PublicKey is given then set the nodes_dn from the cert
 			publicKey := e.config.Opensearch.Config.CertsByIP[i].PublicKey
 			if len(strings.TrimSpace(publicKey)) > 0 {
-				e.config.Opensearch.Config.CertsByIP[i].NodesDn = strings.TrimSpace(nodes_dn)
+				e.config.Opensearch.Config.CertsByIP[i].NodesDn = strings.TrimSpace(NodesDn)
 			}
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -93,14 +93,14 @@ func (e *existingInfra) addDNTocertConfig() error {
 			//If PublicKey is given then get the node_dn from the cert
 			publicKey := e.config.Opensearch.Config.CertsByIP[i].PublicKey
 			if len(strings.TrimSpace(publicKey)) > 0 {
-				node_dn, err := getDistinguishedNameFromKey(publicKey)
+				nodeDn, err := getDistinguishedNameFromKey(publicKey)
 				if err != nil {
 					return err
 				}
 				if NodesDn == "" {
-					NodesDn = NodesDn + fmt.Sprintf("%v", node_dn) + "\\n  "
+					NodesDn = NodesDn + fmt.Sprintf("%v", nodeDn) + "\\n  "
 				} else {
-					NodesDn = NodesDn + fmt.Sprintf("- %v", node_dn) + "\\n  "
+					NodesDn = NodesDn + fmt.Sprintf("- %v", nodeDn) + "\\n  "
 				}
 			}
 		}

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -86,16 +86,32 @@ func (e *existingInfra) addDNTocertConfig() error {
 			e.config.Opensearch.Config.NodesDn = fmt.Sprintf("%v", nodes_dn)
 		}
 
+		nodes_dn := ""
+
 		//Set the admin_dn and nodes_dn in the config for all IP addresses
 		for i := 0; i < len(e.config.Opensearch.Config.CertsByIP); i++ {
 			//If PublicKey is given then get the nodes_dn from the cert
 			publicKey := e.config.Opensearch.Config.CertsByIP[i].PublicKey
 			if len(strings.TrimSpace(publicKey)) > 0 {
-				nodes_dn, err := getDistinguishedNameFromKey(publicKey)
+				node_dn, err := getDistinguishedNameFromKey(publicKey)
 				if err != nil {
 					return err
 				}
-				e.config.Opensearch.Config.CertsByIP[i].NodesDn = fmt.Sprintf("%v", nodes_dn)
+				if nodes_dn == "" {
+					nodes_dn = nodes_dn + fmt.Sprintf("%v", node_dn) + "\\n  "
+				} else {
+					nodes_dn = nodes_dn + fmt.Sprintf("- %v", node_dn) + "\\n  "
+				}
+				fmt.Println("Nodes DN: ", nodes_dn)
+				//e.config.Opensearch.Config.CertsByIP[i].NodesDn = fmt.Sprintf("%v", nodes_dn)
+			}
+		}
+
+		for i := 0; i < len(e.config.Opensearch.Config.CertsByIP); i++ {
+			//If PublicKey is given then get the nodes_dn from the cert
+			publicKey := e.config.Opensearch.Config.CertsByIP[i].PublicKey
+			if len(strings.TrimSpace(publicKey)) > 0 {
+				e.config.Opensearch.Config.CertsByIP[i].NodesDn = strings.TrimSpace(nodes_dn)
 			}
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
+++ b/components/automate-cli/cmd/chef-automate/automateHADeployExistingInfra.go
@@ -102,8 +102,6 @@ func (e *existingInfra) addDNTocertConfig() error {
 				} else {
 					nodes_dn = nodes_dn + fmt.Sprintf("- %v", node_dn) + "\\n  "
 				}
-				fmt.Println("Nodes DN: ", nodes_dn)
-				//e.config.Opensearch.Config.CertsByIP[i].NodesDn = fmt.Sprintf("%v", nodes_dn)
 			}
 		}
 

--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -67,7 +67,7 @@ opensearch do
   {{ if .Opensearch.Config.PublicKey }} public_key "{{ .Opensearch.Config.PublicKey }}" {{ else }} # public_key "{{ .Opensearch.Config.PublicKey }}" {{ end }}
   admin_dn "{{ .Opensearch.Config.AdminDn }}"
   nodes_dn "{{ .Opensearch.Config.NodesDn }}"
-  {{ if .Opensearch.Config.CertsByIP }} certs_by_ip  "{ {{ range $index, $element := .Opensearch.Config.CertsByIP}}{{if $index}} \n {{end}} \"{{$element.IP}}\" = { private_key = <<-EOT\n{{$element.PrivateKey}}\nEOT\n\n public_key = <<-EOT\n{{$element.PublicKey}}\nEOT\n\n nodes_dn = \"{{$element.NodesDn}}\" } {{end}} }" {{end}}
+  {{ if .Opensearch.Config.CertsByIP }} certs_by_ip  "{ {{ range $index, $element := .Opensearch.Config.CertsByIP}}{{if $index}} \n {{end}} \"{{$element.IP}}\" = { private_key = <<-EOT\n{{$element.PrivateKey}}\nEOT\n\n public_key = <<-EOT\n{{$element.PublicKey}}\nEOT\n\n nodes_dn = <<EOT\n{{$element.NodesDn}}EOT\n } {{end}} }" {{end}}
 end
 
 ###############################################################

--- a/terraform/a2ha-terraform/modules/opensearch/templates/opensearch_user.toml.tpl
+++ b/terraform/a2ha-terraform/modules/opensearch/templates/opensearch_user.toml.tpl
@@ -36,6 +36,8 @@ admin_dn = "- ${opensearch_admin_dn}"
 enforce_hostname_verification = false
 resolve_hostname = false
 [plugins.security]
-nodes_dn = "- ${opensearch_nodes_dn}"
+nodes_dn = """
+- ${opensearch_nodes_dn}
+"""
 EOT
 : "" }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Opensearch cluster will have 3 or more than 3 nodes at any given time and for these nodes can either have same certs with same CN or they can have different certs with different CN. 
The problem with different CN is that the nodes were not able to communicate with each other, resulting in the failure of service.

PR contains the changes that will ensure that all the nodes will have a complete list of all the node's CN as part of the DN which will ensure that the nodes are able to communicate with each other.

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-1037

### :+1: Definition of Done
Opensearch cluster with multiple nodes having separate certs and different CN should be up an running
All services should be in healthy state

### :athletic_shoe: How to Build and Test the Change
- Rebuild the automate-cli, automate-ha-cluster-ctl and automate-ha-deployment packages.
- Generate separate certificates for nodes with different CN
- In config.toml, provide the different nodes certs using opensearch.config.certs_by_ip settings
- Deploy the cluster. The cluster setup should be successful

### Scenarios Tested
- Deployment of the cluster with 3 OS nodes having different certs and CN
- Deployment of the cluster with 3 OS nodes having different certs and same CN
- Deployment of the cluster with 3 OS nodes having same cert and CN
- Added the orgs and users in the setup
- Added the compliance and client scan data for around 100 nodes using the load-test lib

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Video: 
https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/Ef4wE_QJyD9LmwiA2-8ClGUB9jvwrEiEMXZVhpDnUUfSvw?e=skpCQt