### PR TITLE
Take input of Sudo Password for Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .tmp
 /nodes/
+test/vendor/
 
 # Habitat
 .secrets
@@ -12,6 +13,9 @@ src
 
 # InSpec
 inspec.lock
+
+# Ruby
+Gemfile.lock
 
 # Terraform
 terraform/.terraform/

--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -44,6 +44,7 @@ func executeAutomateClusterCtlCommand(command string, args []string, helpDocs st
 	c := exec.Command("automate-cluster-ctl", args...)
 	c.Dir = "/hab/a2_deploy_workspace"
 	c.Stdin = os.Stdin
+	c.Env = os.Environ()
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	c.Stdout = io.MultiWriter(&out)
@@ -81,6 +82,7 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 	c := exec.Command("automate-cluster-ctl", args...)
 	c.Dir = AUTOMATE_HA_WORKSPACE_DIR
 	c.Stdin = os.Stdin
+	c.Env = os.Environ()
 	outfile, err := os.Create(logFilePath)
 	if err != nil {
 		panic(err)

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -66,4 +66,6 @@ const (
 	source <(sudo cat /hab/sup/default/SystemdEnvironmentFile.sh);
 	automate-backend-ctl applied --svc=automate-ha-%s
 	`
+
+	SUDO_PASSWORD_CMD = `echo "%s" | sudo -S bash -c "`
 )

--- a/components/automate-cli/cmd/chef-automate/constants.go
+++ b/components/automate-cli/cmd/chef-automate/constants.go
@@ -8,4 +8,5 @@ const (
 	CONST_OPENSEARCH  = "opensearch"
 	SET               = "set"
 	PATCH             = "patch"
+	SUDO_PASSWORD     = "sudo_password"
 )

--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -8,7 +8,6 @@ workspace_path "{{ .Architecture.ConfigInitials.WorkspacePath }}"
 ssh_user "{{ .Architecture.ConfigInitials.SSHUser }}"
 ssh_key_file "{{ .Architecture.ConfigInitials.SSHKeyFile }}"
 {{ if .Architecture.ConfigInitials.SSHPort }} ssh_port "{{ .Architecture.ConfigInitials.SSHPort }}" {{ else }} ssh_port "22" {{ end }}
-{{ if .Architecture.ConfigInitials.SudoPassword }} sudo_password "{{ .Architecture.ConfigInitials.SudoPassword }}" {{ else }} # sudo_password "{{ .Architecture.ConfigInitials.SudoPassword }}" {{ end }}
 
 # logging_monitoring_management "true"
 # ew_elk "false"
@@ -136,7 +135,6 @@ ssh_port "{{ .Architecture.ConfigInitials.SSHPort }}"
 backup_mount "{{ .Architecture.ConfigInitials.BackupMount }}"
 backup_config "{{ .Architecture.ConfigInitials.BackupConfig }}"
 {{ if  .Architecture.ConfigInitials.S3BucketName }} s3_bucketName "{{ .Architecture.ConfigInitials.S3BucketName }}" {{ else }} # s3_bucketName "{{ .Architecture.ConfigInitials.S3BucketName }}" {{ end }}
-{{ if .Architecture.ConfigInitials.SudoPassword }} sudo_password "{{ .Architecture.ConfigInitials.SudoPassword }}" {{ else }} # sudo_password "{{ .Architecture.ConfigInitials.SudoPassword }}" {{ end }}
 # logging_monitoring_management "true"
 # new_elk "false"
 # existing_elk "false"

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -35,7 +35,6 @@ type AwsConfigToml struct {
 			SSHUser                     string `toml:"ssh_user"`
 			SSHKeyFile                  string `toml:"ssh_key_file"`
 			SSHPort                     string `toml:"ssh_port"`
-			SudoPassword                string `toml:"sudo_password"`
 			LoggingMonitoringManagement string `toml:"logging_monitoring_management"`
 			NewElk                      string `toml:"new_elk"`
 			ExistingElkInstanceIP       string `toml:"existing_elk_instance_ip"`
@@ -173,7 +172,6 @@ type ExistingInfraConfigToml struct {
 			SSHUser                     string `toml:"ssh_user,omitempty"`
 			SSHKeyFile                  string `toml:"ssh_key_file,omitempty"`
 			SSHPort                     string `toml:"ssh_port,omitempty"`
-			SudoPassword                string `toml:"sudo_password,omitempty"`
 			LoggingMonitoringManagement string `toml:"logging_monitoring_management,omitempty"`
 			NewElk                      string `toml:"new_elk,omitempty"`
 			ExistingElkInstanceIP       string `toml:"existing_elk_instance_ip,omitempty"`

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -18,9 +18,6 @@ ssh_port = ""
 # Eg.: ssh_key_file = "~/.ssh/A2HA.pem"
 ssh_key_file = ""
 
-# Provide Password if needed to run sudo commands.
-# sudo_password = ""
-
 # Eg.: backup_config = "efs" or "s3"
 backup_config = ""
 
@@ -315,10 +312,6 @@ ssh_key_file = ""
 # custome ssh port no to connect instances, default will be 22
 # Eg.: ssh_port = "22"
 ssh_port = ""
-
-# Provide Password if needed to run sudo commands.
-sudo_password = ""
-## === ===
 
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"
 secrets_store_file = "/hab/a2_deploy_workspace/secrets.json"

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -343,7 +343,7 @@ region = ""
 ## === INPUT NEEDED ===
 
 # Password for Automate UI for 'admin' user.
-# admin_password = ""
+admin_password = ""
 
 
 # Automate Load Balancer FQDN eg.: "chefautomate.example.com"

--- a/components/automate-cluster-ctl/lib/cluster/config.rb
+++ b/components/automate-cluster-ctl/lib/cluster/config.rb
@@ -48,7 +48,6 @@ module AutomateCluster
     default :ssh_user, 'centos'
     default :ssh_port, '22'
     default(:ssh_key_file, '~/.ssh/id_rsa').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
-    default :sudo_password, ''
     default(:workspace_path, '/hab/a2_deploy_workspace').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
     default(:secrets_key_file, '/etc/chef-automate/secrets.key').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
     default(:secrets_store_file, 'secrets.json').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }

--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -207,6 +207,9 @@ class AutomateClusterSetup < AutomateCluster::Command
     changes_found = true
     plan_output = nil
 
+    # store the terraform secret envs so we can pass them to the deploy command
+    store_secret_envs
+
     # TODO: this feels akward to have a skip-deploy for the deploy command.
     #       we should probably have the above logic live in an `airgap update` command instead.
     return if skip_deploy?
@@ -214,7 +217,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     terraform_destroy if tf_destroy? && !prompt.no?("Are you sure you want to run `terraform destroy`? This cannot be undone")
 
     wait_while 'Checking terraform state' do |spinner|
-      opts = command_opts({ returns: [0,2], environment: new_terraform_secret_envs })
+      opts = command_opts({ returns: [0,2], environment: terraform_secret_envs })
       plan = terraform_run("plan -detailed-exitcode -input=false", opts)
 
       if plan.error?
@@ -242,20 +245,19 @@ class AutomateClusterSetup < AutomateCluster::Command
       
   end
 
-  # def terraform_secret_envs
-  #   secrets.inject({}) do |col, item|
-  #     col["TF_VAR_#{item[0]}"] = item[1]
-  #     col
-  #   end
-  # end
-
-  # Made changes to the above method to get the sudo_password from the env variable
-  def new_terraform_secret_envs
-    new_secrets = { 'sudo_password' => ENV['sudo_password'] }
-    new_secrets.inject({}) do |col, item|
+  def terraform_secret_envs
+    secrets.inject({}) do |col, item|
       col["TF_VAR_#{item[0]}"] = item[1]
       col
     end
+  end
+
+  # store the sudo_password from the env variable in the secrets hash
+  def store_secret_envs
+    # Set a new secret
+    secrets.set('sudo_password',  ENV['sudo_password'])
+    # Save the updated secrets store to disk
+    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
   end
 
   def ask_for_action
@@ -269,7 +271,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   def terraform_destroy
     opts = command_opts({
       live_stdout: STDOUT,
-      environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
+      environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
     })
     tfrun = terraform_run("destroy -auto-approve", opts)
 
@@ -296,7 +298,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     if run_apply
       opts = command_opts({
         live_stdout: STDOUT,
-        environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
+        environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
       })
 
       terraform_run("apply -parallelism=#{parallelism} -input=false -auto-approve", opts)

--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -214,7 +214,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     terraform_destroy if tf_destroy? && !prompt.no?("Are you sure you want to run `terraform destroy`? This cannot be undone")
 
     wait_while 'Checking terraform state' do |spinner|
-      opts = command_opts({ returns: [0,2], environment: terraform_secret_envs })
+      opts = command_opts({ returns: [0,2], environment: new_terraform_secret_envs })
       plan = terraform_run("plan -detailed-exitcode -input=false", opts)
 
       if plan.error?
@@ -242,8 +242,17 @@ class AutomateClusterSetup < AutomateCluster::Command
       
   end
 
-  def terraform_secret_envs
-    secrets.inject({}) do |col, item|
+  # def terraform_secret_envs
+  #   secrets.inject({}) do |col, item|
+  #     col["TF_VAR_#{item[0]}"] = item[1]
+  #     col
+  #   end
+  # end
+
+  # Made changes to the above method to get the sudo_password from the env variable
+  def new_terraform_secret_envs
+    new_secrets = { 'sudo_password' => ENV['sudo_password'] }
+    new_secrets.inject({}) do |col, item|
       col["TF_VAR_#{item[0]}"] = item[1]
       col
     end
@@ -260,7 +269,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   def terraform_destroy
     opts = command_opts({
       live_stdout: STDOUT,
-      environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
+      environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
     })
     tfrun = terraform_run("destroy -auto-approve", opts)
 
@@ -287,7 +296,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     if run_apply
       opts = command_opts({
         live_stdout: STDOUT,
-        environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
+        environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
       })
 
       terraform_run("apply -parallelism=#{parallelism} -input=false -auto-approve", opts)

--- a/components/automate-cluster-ctl/libexec/cluster-provision
+++ b/components/automate-cluster-ctl/libexec/cluster-provision
@@ -50,7 +50,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     terraform_destroy if tf_destroy? && !prompt.no?("Are you sure you want to run `terraform destroy`? This cannot be undone")
 
     wait_while 'Checking terraform state' do |spinner|
-      opts = command_opts({ returns: [0,2], environment: terraform_secret_envs })
+      opts = command_opts({ returns: [0,2], environment: new_terraform_secret_envs })
       plan = terraform_run("plan -detailed-exitcode -input=false -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate", opts)
 
       if plan.error?
@@ -78,8 +78,17 @@ class AutomateClusterSetup < AutomateCluster::Command
 
   end
 
-  def terraform_secret_envs
-    secrets.inject({}) do |col, item|
+  # def terraform_secret_envs
+  #   secrets.inject({}) do |col, item|
+  #     col["TF_VAR_#{item[0]}"] = item[1]
+  #     col
+  #   end
+  # end
+
+  # Made changes to the above method to get the sudo_password from the env variable
+  def new_terraform_secret_envs
+    new_secrets = { 'sudo_password' => ENV['sudo_password'] }
+    new_secrets.inject({}) do |col, item|
       col["TF_VAR_#{item[0]}"] = item[1]
       col
     end
@@ -96,7 +105,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   def terraform_destroy
     opts = command_opts({
       live_stdout: STDOUT,
-      environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
+      environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
     })
     tfrun = terraform_run("destroy -state-out=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -auto-approve", opts)
 
@@ -123,7 +132,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     if run_apply
       opts = command_opts({
         live_stdout: STDOUT,
-        environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
+        environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
       })
 
       terraform_run("apply -parallelism=#{parallelism} -input=false -auto-approve -state-out=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate", opts)

--- a/components/automate-cluster-ctl/libexec/cluster-provision
+++ b/components/automate-cluster-ctl/libexec/cluster-provision
@@ -47,10 +47,13 @@ class AutomateClusterSetup < AutomateCluster::Command
     changes_found = true
     plan_output = nil
 
+    # store the terraform secret envs so we can pass them to the deploy command
+    store_secret_envs
+
     terraform_destroy if tf_destroy? && !prompt.no?("Are you sure you want to run `terraform destroy`? This cannot be undone")
 
     wait_while 'Checking terraform state' do |spinner|
-      opts = command_opts({ returns: [0,2], environment: new_terraform_secret_envs })
+      opts = command_opts({ returns: [0,2], environment: terraform_secret_envs })
       plan = terraform_run("plan -detailed-exitcode -input=false -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate", opts)
 
       if plan.error?
@@ -78,20 +81,19 @@ class AutomateClusterSetup < AutomateCluster::Command
 
   end
 
-  # def terraform_secret_envs
-  #   secrets.inject({}) do |col, item|
-  #     col["TF_VAR_#{item[0]}"] = item[1]
-  #     col
-  #   end
-  # end
-
-  # Made changes to the above method to get the sudo_password from the env variable
-  def new_terraform_secret_envs
-    new_secrets = { 'sudo_password' => ENV['sudo_password'] }
-    new_secrets.inject({}) do |col, item|
+  def terraform_secret_envs
+    secrets.inject({}) do |col, item|
       col["TF_VAR_#{item[0]}"] = item[1]
       col
     end
+  end
+
+  # store the sudo_password from the env variable in the secrets hash
+  def store_secret_envs
+    # Set a new secret
+    secrets.set('sudo_password',  ENV['sudo_password'])
+    # Save the updated secrets store to disk
+    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
   end
 
   def ask_for_action
@@ -105,7 +107,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   def terraform_destroy
     opts = command_opts({
       live_stdout: STDOUT,
-      environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
+      environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
     })
     tfrun = terraform_run("destroy -state-out=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -auto-approve", opts)
 
@@ -132,7 +134,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     if run_apply
       opts = command_opts({
         live_stdout: STDOUT,
-        environment: { TF_LOG: ENV['TF_LOG'] }.merge(new_terraform_secret_envs)
+        environment: { TF_LOG: ENV['TF_LOG'] }.merge(terraform_secret_envs)
       })
 
       terraform_run("apply -parallelism=#{parallelism} -input=false -auto-approve -state-out=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate", opts)

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -50,9 +50,12 @@ Follow the steps below to deploy Chef Automate High Availability (HA) on AWS (Am
 - Preferred key type will be ed25519
 - Make sure your linux has `sysctl` utility available in all nodes.
 
-{{< warning >}} 
+{{< warning >}}
+
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+
 {{< /warning >}}
 
 ### Deployment

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -54,7 +54,7 @@ Follow the steps below to deploy Chef Automate High Availability (HA) on AWS (Am
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -62,9 +62,12 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
 - If you choose `backup_config` as `s3` then provide the bucket name to feild `s3_bucketName`. If `s3_bucketName` exist it is directly used for backup configuration and if it doesn't exist then deployment process will create `s3_bucketName`.
 - We recommended to use `backup_config` to be set to `s3` at the time of deployment.
 
-{{< warning >}} 
+{{< warning >}}
+
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+
 {{< /warning >}}
 
 ### Run these steps on Bastion Host Machine

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -48,6 +48,7 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
   echo "aws_secret_access_key=<SECRET_KEY>" >> ~/.aws/credentials
   echo "region=<AWS-REGION>" >> ~/.aws/credentials
   ```
+
 - Have SSH Key Pair ready in AWS, so new VM's are created using that pair.\
   Reference for [AWS SSH Key Pair creation](https://docs.aws.amazon.com/ground-station/latest/ug/create-ec2-ssh-key-pair.html)
 - We do not support passphrase for Private Key authentication.
@@ -66,7 +67,7 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
 
 {{< /warning >}}
 
@@ -192,10 +193,12 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
    chef-automate config patch cs.fqdn.toml --chef_server
   ```
 
-{{< note >}} 
-  - Have DNS certificate ready in ACM for 2 DNS entries: Example: `chefautomate.example.com`, `chefinfraserver.example.com`\
+{{< note >}}
+
+- Have DNS certificate ready in ACM for 2 DNS entries: Example: `chefautomate.example.com`, `chefinfraserver.example.com`\
   Reference for [Creating new DNS Certificate in ACM](/automate/ha_aws_cert_mngr/).
-  - DNS should have entry for `chefautomate.example.com` and `chefinfraserver.example.com` pointing to respective Load Balancers as shown in `chef-automate info` command
+- DNS should have entry for `chefautomate.example.com` and `chefinfraserver.example.com` pointing to respective Load Balancers as shown in `chef-automate info` command
+
 {{< /note >}}
 
 Check if Chef Automate UI is accessible by going to (Domain used for Chef Automate) [https://chefautomate.example.com](https://chefautomate.example.com).

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -52,8 +52,11 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 ```
 
 {{< warning >}}
+
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+
 {{< /warning >}}
 
 ### Run these steps on Bastion Host Machine

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -55,7 +55,7 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Click [here](https://www.petefreitag.com/item/877.cfm) to know more.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
 
 {{< /warning >}}
 

--- a/terraform/a2ha-terraform/modules/postgresql/main.tf
+++ b/terraform/a2ha-terraform/modules/postgresql/main.tf
@@ -87,7 +87,7 @@ resource "null_resource" "postgresql" {
   provisioner "remote-exec" {
     inline = [
       "chmod 0700 ${var.tmp_path}/pre_mount.sh",
-      "${var.tmp_path}/pre_mount.sh",
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S ${var.tmp_path}/pre_mount.sh",
     ]
   }
 

--- a/terraform/a2ha-terraform/modules/system/main.tf
+++ b/terraform/a2ha-terraform/modules/system/main.tf
@@ -20,7 +20,11 @@ resource "null_resource" "create_temp_path" {
   }
 
   provisioner "remote-exec" {
-    inline = [ "echo tmp_path: ${var.tmp_path}", "sudo mkdir -p ${var.tmp_path}", "sudo chown -R ${var.ssh_user}:${var.ssh_user} ${var.tmp_path}" ]
+    inline = [ 
+      "echo tmp_path: ${var.tmp_path}", 
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S mkdir -p ${var.tmp_path}", 
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S chown -R ${var.ssh_user}:${var.ssh_user} ${var.tmp_path}" 
+      ]
    }
 }
 

--- a/terraform/a2ha-terraform/modules/system_hardening/main.tf
+++ b/terraform/a2ha-terraform/modules/system_hardening/main.tf
@@ -28,7 +28,7 @@ resource "null_resource" "system_hardening" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo -E /bin/bash -x ${var.tmp_path}/hardening.sh",
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S bash -ex ${var.tmp_path}/hardening.sh",
     ]
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added support for sudo password for HA deployment.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-789
https://chefio.atlassian.net/browse/CHEF-794
https://chefio.atlassian.net/browse/CHEF-357
https://chefio.atlassian.net/browse/IN-956

https://chefio.atlassian.net/browse/CHEF-791
https://chefio.atlassian.net/browse/CHEF-795

### :+1: Definition of Done
A user should be able to give input of Sudo password to the deployment flow.

### :athletic_shoe: How to Build and Test the Change
- Rebuild `automate-cli` (`rebuild components/automate-cli/`) or can use (`akrishna/automate-cli/0.1.0/20230324092019`), `automate-ha-cluster-ctl` (`rebuild components/automate-cluster-ctl/`) or can use (`akrishna/automate-ha-cluster-ctl/0.1.0/20230323055913`), and `automate-ha-deployment`(`rebuild components/automate-backend-deployment/`) or can use (`akrishna/automate-ha-deployment/0.1.0/20230323063326`).
- Upload the above packages `hab pkg upload <PATH_TO_PACKAGE_HART_FILE>`.
- Create an airgap bundle with new packages `sudo ./chef-automate airgap bundle create -m latest_semver.json --channel dev`. Update this [latest_semver.json](https://packages.chef.io/manifests/dev/automate/latest_semver.json) manifest file with your origins. 
Note: Do not update the `automate-cli` origin in the manifest file,  just install the new `automate-cli` on Bastion.
- Set the environment variable `sudo_password`. For eg. `export sudo_password=1234`.
- Run deployment command with -E flag to preserve environment variable. For eg. `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate-4.5.79.aib`. Refer [here](https://www.petefreitag.com/item/877.cfm) for passing environment variables to the sudo command.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![Screenshot 2023-03-15 at 3 50 53 PM](https://user-images.githubusercontent.com/11033984/225280402-9b000f20-0b57-433b-8260-28d293b96b09.png)

![Screenshot 2023-03-15 at 3 49 53 PM](https://user-images.githubusercontent.com/11033984/225280447-33172389-cf49-4ab9-8301-2e9900d47427.png)

AWS:
![Screenshot 2023-03-16 at 4 24 47 PM](https://user-images.githubusercontent.com/11033984/225628217-68e04d27-f43b-46a0-bd21-3f704be98a76.png)

Video: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/ERFybiRTsNdIguajoQ-f_JsB3EQcy84V6EdZzn5-FGlDuQ?e=uOU6yB
