### PR TITLE
Chef 713 status summary command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -81,6 +81,12 @@ func RunCmdOnSingleAutomateNodeNCopyReport(cmd *cobra.Command, args []string, fi
 	}
 	writer.Print(output)
 	//copy file from remote to bastion
-	sshUtil.copyFileFromRemote(fileName, fileName)
+	writer.Printf("Downloading file %s from remote node %s \n", fileName, sshConfig.hostIP)
+	destFileName, err := sshUtil.copyFileFromRemote(fileName, fileName)
+	if err != nil {
+		return err
+	}
+	writer.Printf("File downloaded %s \n", destFileName)
+
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -29,7 +29,7 @@ type CmdInputs struct {
 	Outputfiles              []string
 	ErrorCheckEnableInOutput bool
 	NodeType                 bool
-	SkipPrintOutput              bool
+	SkipPrintOutput          bool
 	HideSSHConnectionMessage bool
 	MutipleCmdWithArgs       map[string]string
 }
@@ -71,6 +71,7 @@ func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.
 
 func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 	timestamp := time.Now().Format("20060102150405")
+	cmdResult := map[string][]CmdResult{}
 
 	sshConfig := getSshDetails(c.NodeMap.Infra)
 	c.SshUtil.setSSHConfig(sshConfig)
@@ -80,7 +81,7 @@ func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 		const remoteService string = CONST_FRONTEND
 		nodeIps, err := preCmdExecCheck(c.NodeMap.Frontend, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
-			return map[string][]CmdResult{}, err
+			return cmdResult, err
 		}
 		output := c.executeCmdOnGivenNodes(c.NodeMap.Frontend.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
@@ -88,7 +89,7 @@ func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 		const remoteService string = CONST_AUTOMATE
 		nodeIps, err := preCmdExecCheck(c.NodeMap.Automate, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
-			return map[string][]CmdResult{}, err
+			return cmdResult, err
 		}
 
 		output := c.executeCmdOnGivenNodes(c.NodeMap.Automate.CmdInputs, nodeIps, remoteService, timestamp, writer)
@@ -97,7 +98,7 @@ func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 		const remoteService string = CONST_CHEF_SERVER
 		nodeIps, err := preCmdExecCheck(c.NodeMap.ChefServer, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
-			return map[string][]CmdResult{}, err
+			return cmdResult, err
 		}
 
 		output := c.executeCmdOnGivenNodes(c.NodeMap.ChefServer.CmdInputs, nodeIps, remoteService, timestamp, writer)
@@ -106,7 +107,7 @@ func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 		const remoteService string = CONST_POSTGRESQL
 		nodeIps, err := preCmdExecCheck(c.NodeMap.Postgresql, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
-			return map[string][]CmdResult{}, err
+			return cmdResult, err
 		}
 
 		output := c.executeCmdOnGivenNodes(c.NodeMap.Postgresql.CmdInputs, nodeIps, remoteService, timestamp, writer)
@@ -115,13 +116,13 @@ func (c *remoteCmdExecutor) Execute() (map[string][]CmdResult, error) {
 		const remoteService string = CONST_OPENSEARCH
 		nodeIps, err := preCmdExecCheck(c.NodeMap.Opensearch, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
-			return map[string][]CmdResult{}, err
+			return cmdResult, err
 		}
 
 		output := c.executeCmdOnGivenNodes(c.NodeMap.Opensearch.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	default:
-		return map[string][]CmdResult{}, errors.New("Missing or Unsupported flag")
+		return cmdResult, errors.New("Missing or Unsupported flag")
 	}
 }
 

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -29,7 +29,7 @@ type CmdInputs struct {
 	Outputfiles              []string
 	ErrorCheckEnableInOutput bool
 	NodeType                 bool
-	PrintOutput              bool
+	SkipPrintOutput              bool
 	HideSSHConnectionMessage bool
 	MutipleCmdWithArgs       map[string]string
 }
@@ -169,7 +169,7 @@ func (c *remoteCmdExecutor) executeCmdOnGivenNodes(input *CmdInputs, nodeIps []s
 				ouputJsonResultMapMutex.Lock()
 				ouputJsonResult[result.HostIP] = append(ouputJsonResult[result.HostIP], result)
 				ouputJsonResultMapMutex.Unlock()
-				if input.PrintOutput {
+				if !input.SkipPrintOutput {
 					cliWriter.Println("=====================================================")
 					printOutput(remoteService, result, outputFiles, c.Output)
 					cliWriter.Println("=====================================================")

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -275,7 +275,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 
 	timestamp := time.Now().Format("20060102150405")
 	file := file
-	resultChan := make(chan CmdResult, 1)
 
 	testCases := []struct {
 		testCaseName   string
@@ -285,7 +284,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 		configFile     string
 		remoteService  string
 		newSSHUtil     SSHUtil
-		resultChan     chan CmdResult
 		expectedOutput CmdResult
 		isError        bool
 	}{
@@ -298,7 +296,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, "config patch operation completed", nil, "", nil),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				HostIP: ip1,
 				Output: "config patch operation completed",
@@ -313,7 +310,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{file},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, completedMessage, nil, file, nil),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				HostIP:      ip1,
 				OutputFiles: []string{file},
@@ -331,7 +327,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, errors.Errorf("copy to remote failed"), "", nil, file, nil),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				HostIP:      ip1,
 				OutputFiles: []string{},
@@ -347,7 +342,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, "", errors.Errorf("remote execution"), "", nil),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				HostIP:      ip1,
 				OutputFiles: []string{},
@@ -363,7 +357,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{file},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, "", nil, file, errors.Errorf("copy from remote failed")),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				HostIP:      ip1,
 				OutputFiles: []string{file},
@@ -381,7 +374,6 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			outputFiles:   []string{},
 			remoteService: "automate",
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, "Error: patch failed", nil, file, nil),
-			resultChan:    resultChan,
 			expectedOutput: CmdResult{
 				ScriptName:  "",
 				HostIP:      ip1,
@@ -398,8 +390,7 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			SshUtil: testCase.newSSHUtil,
 		}
 
-		new.executeCmdOnNode(testCase.command, "", testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, &SSHConfig{}, testCase.resultChan)
-		result := <-resultChan
+		result := new.executeCmdOnNode(testCase.command, "", testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, &SSHConfig{})
 
 		if testCase.isError {
 			assert.Error(t, result.Error)

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -394,9 +394,11 @@ func TestExecuteCmdOnNode(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		new := &remoteCmdExecutor{}
-		// wg.Add(1)
-		new.executeCmdOnNode(testCase.command, "", testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, testCase.newSSHUtil, testCase.resultChan)
+		new := &remoteCmdExecutor{
+			SshUtil: testCase.newSSHUtil,
+		}
+
+		new.executeCmdOnNode(testCase.command, "", testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, &SSHConfig{}, testCase.resultChan)
 		result := <-resultChan
 
 		if testCase.isError {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -259,7 +259,7 @@ func TestExecute(t *testing.T) {
 				NodeMap: testCase.fields.NodeMap,
 				SshUtil: testCase.fields.SshUtil,
 			}
-			err := c.Execute()
+			_, err := c.Execute()
 			if testCase.wantErr {
 				assert.Error(t, err)
 				assert.EqualError(t, testCase.expectedErr, err.Error())
@@ -271,6 +271,8 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteCmdOnNode(t *testing.T) {
+	// var wg sync.WaitGroup
+
 	timestamp := time.Now().Format("20060102150405")
 	file := file
 	resultChan := make(chan CmdResult, 1)
@@ -381,6 +383,7 @@ func TestExecuteCmdOnNode(t *testing.T) {
 			newSSHUtil:    GetMockSSHUtil(&SSHConfig{hostIP: ip1}, nil, "Error: patch failed", nil, file, nil),
 			resultChan:    resultChan,
 			expectedOutput: CmdResult{
+				ScriptName:  "",
 				HostIP:      ip1,
 				OutputFiles: []string{},
 				Output:      "",
@@ -392,8 +395,8 @@ func TestExecuteCmdOnNode(t *testing.T) {
 
 	for _, testCase := range testCases {
 		new := &remoteCmdExecutor{}
-
-		new.executeCmdOnNode(testCase.command, testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, testCase.newSSHUtil, testCase.resultChan)
+		// wg.Add(1)
+		new.executeCmdOnNode(testCase.command, "", testCase.inputFiles, testCase.outputFiles, testCase.remoteService, true, testCase.newSSHUtil, testCase.resultChan)
 		result := <-resultChan
 
 		if testCase.isError {
@@ -433,8 +436,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return nil
 					},
 					CmdInputs: &CmdInputs{
-						Single: true,
-						NodeIp: "",
+						Single:  true,
+						NodeIps: []string{""},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
@@ -455,8 +458,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return nil
 					},
 					CmdInputs: &CmdInputs{
-						Single: false,
-						NodeIp: ip2,
+						Single:  false,
+						NodeIps: []string{ip2},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
@@ -495,8 +498,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return nil
 					},
 					CmdInputs: &CmdInputs{
-						Single: false,
-						NodeIp: ip4,
+						Single:  false,
+						NodeIps: []string{ip4},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
@@ -517,8 +520,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return nil
 					},
 					CmdInputs: &CmdInputs{
-						Single: false,
-						NodeIp: "256.255.255.255",
+						Single:  false,
+						NodeIps: []string{"256.255.255.255"},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
@@ -539,8 +542,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return nil
 					},
 					CmdInputs: &CmdInputs{
-						Single: true,
-						NodeIp: "",
+						Single:  true,
+						NodeIps: []string{""},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
@@ -561,8 +564,8 @@ func TestPreCmdExecCheck(t *testing.T) {
 						return errors.New(errorForPreExec)
 					},
 					CmdInputs: &CmdInputs{
-						Single: false,
-						NodeIp: ip2,
+						Single:  false,
+						NodeIps: []string{ip2},
 					},
 				},
 				sshUtil:       GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -220,7 +220,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 
 		chefServer := &Cmd{
 			CmdInputs: &CmdInputs{
-				Cmd:         frontendCommand,
+				Cmd:        frontendCommand,
 				WaitTimeout: configCmdFlags.waitTimeout,
 				Single:      false,
 				InputFiles:  []string{},
@@ -260,14 +260,14 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 			Infra:      infra,
 		}
 
-		cmdUtil := NewRemoteCmdExecutor(nodeMap)
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, writer)
 
 		if configCmdFlags.overwriteFile {
 			writer.Errorln("Overwrite flag is not supported in HA")
 		}
 
 		if configCmdFlags.automate || configCmdFlags.chef_server || configCmdFlags.postgresql || configCmdFlags.opensearch {
-			err = cmdUtil.Execute()
+			_, err = cmdUtil.Execute()
 		} else {
 			writer.Println(cmd.UsageString())
 		}
@@ -358,10 +358,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		configFile := args[0]
+		frontendCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "frontend"+"_"+timestamp+"_"+configFile, dateFormat)
 		frontend := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
-				Cmd:                      fmt.Sprintf(FRONTEND_COMMAND, PATCH, "frontend"+"_"+timestamp+"_"+configFile, dateFormat),
+				Cmd:                      frontendCmd,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
@@ -370,11 +371,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				NodeType:                 configCmdFlags.frontend,
 			},
 		}
-
+		automateCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "automate"+"_"+timestamp+"_"+configFile, dateFormat)
 		automate := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
-				Cmd:                      fmt.Sprintf(FRONTEND_COMMAND, PATCH, "automate"+"_"+timestamp+"_"+configFile, dateFormat),
+				Cmd:                      automateCmd,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
@@ -384,10 +385,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 			},
 		}
 
+		chefServerCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "chef_server"+"_"+timestamp+"_"+configFile, dateFormat)
 		chefServer := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
-				Cmd:                      fmt.Sprintf(FRONTEND_COMMAND, PATCH, "chef_server"+"_"+timestamp+"_"+configFile, dateFormat),
+				Cmd:                      chefServerCmd,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
@@ -397,10 +399,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 			},
 		}
 
+		postgresqlCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", "postgresql"+"_"+timestamp+"_"+configFile)
 		postgresql := &Cmd{
 			PreExec: prePatchCheckForPostgresqlNodes,
 			CmdInputs: &CmdInputs{
-				Cmd:                      fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", "postgresql"+"_"+timestamp+"_"+configFile),
+				Cmd:                      postgresqlCmd,
 				Args:                     args,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   true,
@@ -409,11 +412,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				NodeType:                 configCmdFlags.postgresql,
 			},
 		}
-
+		opensearchCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", "opensearch"+"_"+timestamp+"_"+configFile)
 		opensearch := &Cmd{
 			PreExec: prePatchCheckForOpensearch,
 			CmdInputs: &CmdInputs{
-				Cmd:                      fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", "opensearch"+"_"+timestamp+"_"+configFile),
+				Cmd:                      opensearchCmd,
 				Args:                     args,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   true,
@@ -432,16 +435,16 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 			Infra:      infra,
 		}
 
-		cmdUtil := NewRemoteCmdExecutor(nodeMap)
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, writer)
 
 		if configCmdFlags.frontend || configCmdFlags.automate || configCmdFlags.chef_server || configCmdFlags.postgresql || configCmdFlags.opensearch {
-			err = cmdUtil.Execute()
+			_, err := cmdUtil.Execute()
+
+			if err != nil {
+				return err
+			}
 		} else {
 			writer.Println(cmd.UsageString())
-		}
-
-		if err != nil {
-			return err
 		}
 
 	} else {

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -259,8 +259,8 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 			Opensearch: opensearch,
 			Infra:      infra,
 		}
-
-		cmdUtil := NewRemoteCmdExecutor(nodeMap, writer)
+		sshUtil := NewSSHUtil(&SSHConfig{})
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, sshUtil, writer)
 
 		if configCmdFlags.overwriteFile {
 			writer.Errorln("Overwrite flag is not supported in HA")
@@ -434,8 +434,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 			Opensearch: opensearch,
 			Infra:      infra,
 		}
-
-		cmdUtil := NewRemoteCmdExecutor(nodeMap, writer)
+		sshUtil := NewSSHUtil(&SSHConfig{})
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, sshUtil, writer)
 
 		if configCmdFlags.frontend || configCmdFlags.automate || configCmdFlags.chef_server || configCmdFlags.postgresql || configCmdFlags.opensearch {
 			_, err := cmdUtil.Execute()

--- a/components/automate-cli/cmd/chef-automate/pre_flight_check.go
+++ b/components/automate-cli/cmd/chef-automate/pre_flight_check.go
@@ -137,10 +137,12 @@ func runPreflightCheckCmd(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		nodeMap := constructAndGetNodeMap(infra)
-		cmdUtil := NewRemoteCmdExecutor(nodeMap)
+		sshUtil := NewSSHUtil(&SSHConfig{})
+
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, sshUtil, writer)
 
 		if preflightCmdFlags.automate || preflightCmdFlags.chef_server || preflightCmdFlags.frontend {
-			err = cmdUtil.Execute()
+			_, err = cmdUtil.Execute()
 		} else {
 			writer.Println(cmd.UsageString())
 		}
@@ -502,7 +504,7 @@ func constructAndGetNodeMap(infra *AutomteHAInfraDetails) *NodeTypeAndCmd {
 				WaitTimeout:              preflightCmdFlags.waitTimeout,
 				ErrorCheckEnableInOutput: true,
 				Single:                   false,
-				NodeIp:                   preflightCmdFlags.node,
+				NodeIps:                  []string{preflightCmdFlags.node},
 				InputFiles:               []string{inputFilePath},
 				Outputfiles:              []string{},
 				NodeType:                 preflightCmdFlags.frontend,
@@ -514,7 +516,7 @@ func constructAndGetNodeMap(infra *AutomteHAInfraDetails) *NodeTypeAndCmd {
 				WaitTimeout:              preflightCmdFlags.waitTimeout,
 				ErrorCheckEnableInOutput: true,
 				Single:                   false,
-				NodeIp:                   preflightCmdFlags.node,
+				NodeIps:                  []string{preflightCmdFlags.node},
 				InputFiles:               []string{inputFilePath},
 				Outputfiles:              []string{},
 				NodeType:                 preflightCmdFlags.automate,
@@ -526,7 +528,7 @@ func constructAndGetNodeMap(infra *AutomteHAInfraDetails) *NodeTypeAndCmd {
 				WaitTimeout:              preflightCmdFlags.waitTimeout,
 				ErrorCheckEnableInOutput: true,
 				Single:                   false,
-				NodeIp:                   preflightCmdFlags.node,
+				NodeIps:                  []string{preflightCmdFlags.node},
 				InputFiles:               []string{inputFilePath},
 				Outputfiles:              []string{},
 				NodeType:                 preflightCmdFlags.chef_server,

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -318,7 +318,6 @@ func (s *SSHUtilImpl) copyFileToRemote(srcFilePath string, destFileName string, 
 
 // This function will copy file from remote to local and return new local file path
 func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName string) (string, error) {
-	writer.Printf("Downloading file %s from remote node %s \n", remoteFilePath, s.SshConfig.hostIP)
 	cmd := "scp"
 	destFileName := "/tmp/" + outputFileName
 	execArgs := []string{"-P " + s.SshConfig.sshPort, "-o StrictHostKeyChecking=no", "-o ConnectTimeout=30", "-i", s.SshConfig.sshKeyFile, "-r", s.SshConfig.sshUser + "@" + s.SshConfig.hostIP + ":" + remoteFilePath, destFileName}
@@ -326,7 +325,6 @@ func (s *SSHUtilImpl) copyFileFromRemote(remoteFilePath string, outputFileName s
 		writer.Printf("Failed to copy file from remote %s\n", err.Error())
 		return "", err
 	}
-	writer.Printf("File downloaded %s \n", destFileName)
 	return destFileName, nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -41,7 +41,6 @@ type FeStatusValue struct {
 }
 
 type BeStatusValue struct {
-	// | Service    | IP Address | Health | Process        | Uptime      | Role
 	serviceName string
 	ipAddress   string
 	health      string

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -87,13 +87,13 @@ func newStatusSummaryCmd() *cobra.Command {
 		RunE:  runStatusSummaryCmdFunc(&statusSummaryCmdFlags),
 	}
 	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.automateIp, "automate-ips", "A", "", "Get automate Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isAutomate, "automate", "a", false, "Get only automate Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isAutomate, "automate", "a2", false, "Get only automate Status")
 	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.chefServerIp, "chef-server-ips", "C", "", "Get chef server Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isChefServer, "chef-server", "c", false, "Get only chef server Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isChefServer, "chef-server", "cs", false, "Get only chef server Status")
 	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.opensearchIp, "opensearch-ips", "O", "", "Get opensearch Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isOpenSearch, "opensearch", "o", false, "Get only opensearch Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isOpenSearch, "opensearch", "os", false, "Get only opensearch Status")
 	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.postgresqlIp, "postgresql-ips", "P", "", "Get postgresql Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isPostgresql, "postgresql", "p", false, "Get only postgresql Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isPostgresql, "postgresql", "pg", false, "Get only postgresql Status")
 	return statusSummaryCmd
 }
 

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -4,13 +4,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
-	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -137,16 +137,22 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		if err != nil {
 			return err
 		}
-		statusSummary := NewStatusSummary(infra, &fileutils.FileSystemUtils{}, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
-		err = statusSummary.Run()
+		statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
+		sshUtil := statusSummary.(*Summary).setSSHConfig()
+
+		err = statusSummary.Run(sshUtil)
 		if err != nil {
 			return err
 		}
 		if isManagedServicesOn() {
-			statusSummary.FEDisplay()
+			fe := statusSummary.FEDisplay()
+			fmt.Println(fe)
 		} else {
-			statusSummary.FEDisplay()
-			statusSummary.BEDisplay()
+			fe := statusSummary.FEDisplay()
+			fmt.Println(fe)
+			be := statusSummary.BEDisplay()
+			fmt.Println(be)
+
 		}
 	} else {
 		return errors.New("This command only works on HA deployment")

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -137,7 +137,7 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		if err != nil {
 			return err
 		}
-		statusSummary := NewStatusSummary(writer, infra, &fileutils.FileSystemUtils{}, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
+		statusSummary := NewStatusSummary(infra, &fileutils.FileSystemUtils{}, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
 		err = statusSummary.Run()
 		if err != nil {
 			return err

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -126,30 +126,29 @@ func runStatusSummaryCmdFunc(statusSummaryCmdFlags *StatusSummaryCmdFlags) func(
 }
 
 func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFlags *StatusSummaryCmdFlags) error {
-	if isA2HARBFileExist() {
-		infra, err := getAutomateHAInfraDetails()
-		if err != nil {
-			return err
-		}
-		statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
-		sshUtil := statusSummary.(*Summary).getSSHConfig()
 
-		err = statusSummary.Prepare(sshUtil)
-		if err != nil {
-			return err
-		}
-		if isManagedServicesOn() {
-			fe := statusSummary.ShowFEStatus()
-			fmt.Println(fe)
-		} else {
-			fe := statusSummary.ShowFEStatus()
-			fmt.Println(fe)
-			be := statusSummary.ShowBEStatus()
-			fmt.Println(be)
-
-		}
-	} else {
+	if !isA2HARBFileExist() {
 		return errors.New("This command only works on HA deployment")
+	}
+
+	infra, err := getAutomateHAInfraDetails()
+	if err != nil {
+		return err
+	}
+	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
+	sshUtil := statusSummary.(*Summary).getSSHConfig()
+
+	err = statusSummary.Prepare(sshUtil)
+	if err != nil {
+		return err
+	}
+
+	// Display Status summary
+	fe := statusSummary.ShowFEStatus()
+	fmt.Println(fe)
+	if !isManagedServicesOn() {
+		be := statusSummary.ShowBEStatus()
+		fmt.Println(be)
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -132,9 +132,9 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 			return err
 		}
 		statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
-		sshUtil := statusSummary.(*Summary).setSSHConfig()
+		sshUtil := statusSummary.(*Summary).getSSHConfig()
 
-		err = statusSummary.Run(sshUtil)
+		err = statusSummary.Prepare(sshUtil)
 		if err != nil {
 			return err
 		}

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -23,10 +23,7 @@ var statusCmdFlags = struct {
 }{}
 
 type StatusSummaryCmdFlags struct {
-	automateIp   string
-	chefServerIp string
-	opensearchIp string
-	postgresqlIp string
+	node         string
 	isAutomate   bool
 	isChefServer bool
 	isOpenSearch bool
@@ -86,14 +83,12 @@ func newStatusSummaryCmd() *cobra.Command {
 		Long:  "Retrieve Chef Automate status node summary for HA deployment",
 		RunE:  runStatusSummaryCmdFunc(&statusSummaryCmdFlags),
 	}
-	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.automateIp, "automate-ips", "A", "", "Get automate Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isAutomate, "automate", "a2", false, "Get only automate Status")
-	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.chefServerIp, "chef-server-ips", "C", "", "Get chef server Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isChefServer, "chef-server", "cs", false, "Get only chef server Status")
-	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.opensearchIp, "opensearch-ips", "O", "", "Get opensearch Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isOpenSearch, "opensearch", "os", false, "Get only opensearch Status")
-	statusSummaryCmd.PersistentFlags().StringVarP(&statusSummaryCmdFlags.postgresqlIp, "postgresql-ips", "P", "", "Get postgresql Status by ip addresses")
-	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isPostgresql, "postgresql", "pg", false, "Get only postgresql Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isAutomate, "automate", "a", false, "Get only automate Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isChefServer, "chef-server", "c", false, "Get only chef server Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isOpenSearch, "opensearch", "o", false, "Get only opensearch Status")
+	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isPostgresql, "postgresql", "p", false, "Get only postgresql Status")
+	statusSummaryCmd.PersistentFlags().StringVar(&statusSummaryCmdFlags.node, "node", "", "Node Ip address")
+
 	return statusSummaryCmd
 }
 
@@ -144,12 +139,12 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 			return err
 		}
 		if isManagedServicesOn() {
-			fe := statusSummary.FEDisplay()
+			fe := statusSummary.ShowFEStatus()
 			fmt.Println(fe)
 		} else {
-			fe := statusSummary.FEDisplay()
+			fe := statusSummary.ShowFEStatus()
 			fmt.Println(fe)
-			be := statusSummary.BEDisplay()
+			be := statusSummary.ShowBEStatus()
 			fmt.Println(be)
 
 		}

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -158,7 +158,7 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		be := statusSummary.ShowBEStatus()
 		fmt.Println(be)
 	} else {
-		writer.Warn("Your using managed services\n")
+		writer.Warn("-o and -p flag is not supported for deployment with managed services\n")
 	}
 	writer.BufferWriter().Flush()
 

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -84,10 +84,19 @@ func newStatusSummaryCmd() *cobra.Command {
 		RunE:  runStatusSummaryCmdFunc(&statusSummaryCmdFlags),
 	}
 	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isAutomate, "automate", "a", false, "Get only automate Status")
+	statusSummaryCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
+
 	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isChefServer, "chef-server", "c", false, "Get only chef server Status")
+	statusSummaryCmd.PersistentFlags().SetAnnotation("chef-server", docs.Compatibility, []string{docs.CompatiblewithHA})
+
 	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isOpenSearch, "opensearch", "o", false, "Get only opensearch Status")
+	statusSummaryCmd.PersistentFlags().SetAnnotation("opensearch", docs.Compatibility, []string{docs.CompatiblewithHA})
+
 	statusSummaryCmd.PersistentFlags().BoolVarP(&statusSummaryCmdFlags.isPostgresql, "postgresql", "p", false, "Get only postgresql Status")
+	statusSummaryCmd.PersistentFlags().SetAnnotation("postgresql", docs.Compatibility, []string{docs.CompatiblewithHA})
+
 	statusSummaryCmd.PersistentFlags().StringVar(&statusSummaryCmdFlags.node, "node", "", "Node Ip address")
+	statusSummaryCmd.PersistentFlags().SetAnnotation("node", docs.Compatibility, []string{docs.CompatiblewithHA})
 
 	return statusSummaryCmd
 }

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -157,6 +157,8 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 	if !isManagedServicesOn() {
 		be := statusSummary.ShowBEStatus()
 		fmt.Println(be)
+	} else {
+		writer.Warn("Your using managed services\n")
 	}
 	writer.BufferWriter().Flush()
 

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -135,9 +135,8 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 	if err != nil {
 		return err
 	}
-	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
-	// sshUtil := statusSummary.(*Summary).getSSHConfig()
-
+	sshUtil := NewSSHUtil(&SSHConfig{})
+	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags, sshUtil)
 	err = statusSummary.Prepare()
 	if err != nil {
 		return err

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -136,9 +136,9 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		return err
 	}
 	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags)
-	sshUtil := statusSummary.(*Summary).getSSHConfig()
+	// sshUtil := statusSummary.(*Summary).getSSHConfig()
 
-	err = statusSummary.Prepare(sshUtil)
+	err = statusSummary.Prepare()
 	if err != nil {
 		return err
 	}
@@ -150,6 +150,8 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		be := statusSummary.ShowBEStatus()
 		fmt.Println(be)
 	}
+	writer.BufferWriter().Flush()
+
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -188,7 +188,6 @@ func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceTyp
 	if err != nil {
 		return BeStatusValue{}, err
 	}
-	// memeber_id
 	memeber_id := defaultServiceDetails["sys"].(map[string]interface{})["member_id"]
 	serviceState := defaultServiceDetails["process"].(map[string]interface{})["state"].(string)
 	servicePid := fmt.Sprint(defaultServiceDetails["process"].(map[string]interface{})["pid"])
@@ -208,7 +207,6 @@ func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceTyp
 
 	health := fmt.Sprint(ServiceHealth["status"])
 
-	// /census
 	args = []string{
 		"-s",
 		fmt.Sprintf("%s/census", habUrl),
@@ -237,7 +235,7 @@ func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceTyp
 	t := time.Unix(int64(startingTime), 0)
 	duration := t.Sub(time.Unix(0, 0))
 
-	// Format the duration as "148h 43m 31s"
+	// Format the duration as "1d 148h 43m 31s"
 	formatted := fmt.Sprintf("%dd %dh %dm %ds", int(duration.Hours())/24, int(duration.Hours())%24, int(duration.Minutes())%60, int(duration.Seconds())%60)
 
 	return BeStatusValue{

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -189,7 +189,7 @@ func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceTyp
 	if err != nil {
 		return BeStatusValue{}, err
 	}
-	memeber_id := defaultServiceDetails["sys"].(map[string]interface{})["member_id"]
+	memeberId := defaultServiceDetails["sys"].(map[string]interface{})["member_id"]
 	serviceState := defaultServiceDetails["process"].(map[string]interface{})["state"].(string)
 	servicePid := fmt.Sprint(defaultServiceDetails["process"].(map[string]interface{})["pid"])
 	startingTime := defaultServiceDetails["process"].(map[string]interface{})["state_entered"].(float64)
@@ -220,7 +220,7 @@ func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceTyp
 		return BeStatusValue{}, err
 	}
 
-	populationData := censusData["census_groups"].(map[string]interface{})[service+".default"].(map[string]interface{})["population"].(map[string]interface{})[fmt.Sprintf("%s", memeber_id)]
+	populationData := censusData["census_groups"].(map[string]interface{})[service+".default"].(map[string]interface{})["population"].(map[string]interface{})[fmt.Sprintf("%s", memeberId)]
 	getrole, ok := populationData.(map[string]interface{})
 	role := "Unknown"
 	if ok {

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -51,7 +51,7 @@ type A2haHabitatAutoTfvars struct {
 // Display Frontend Status
 func (ss *Summary) ShowFEStatus() string {
 	if len(ss.feStatus) != 0 {
-		fmt.Println("Frontend Services")
+		writer.Println("Frontend Services")
 		t := table.NewWriter()
 		tTemp := table.Table{}
 		tTemp.Render()
@@ -67,7 +67,7 @@ func (ss *Summary) ShowFEStatus() string {
 // Display Backend Status
 func (ss *Summary) ShowBEStatus() string {
 	if len(ss.beStatus) != 0 {
-		fmt.Println("Backend Services")
+		writer.Println("Backend Services")
 		t := table.NewWriter()
 		tTemp := table.Table{}
 		tTemp.Render()
@@ -94,7 +94,7 @@ func (ss *Summary) Prepare(sshUtil SSHUtil) error {
 	if err != nil {
 		return err
 	}
-	err = ss.prepareBEScript(sshUtil, opensearchIps, "Open Search", "BE")
+	err = ss.prepareBEScript(sshUtil, opensearchIps, "OpenSearch", "BE")
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (ss *Summary) readA2haHabitatAutoTfvarsAuthToken(getConfigJsonString string
 
 func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceType string) (BeStatusValue, error) {
 	service := ""
-	if serviceType == "Open Search" {
+	if serviceType == "OpenSearch" {
 		service = "automate-ha-opensearch"
 	} else if serviceType == "Postgresql" {
 		service = "automate-ha-postgresql"
@@ -360,7 +360,7 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 				automateIps = datafound
 				nodes = dataNotFound
 				if err != nil && err.Len() > 0 {
-					errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), ipAddressError))
+					errorList.PushBack(getSingleErrorFromList(err).Error() + ipAddressError)
 				}
 			}
 			if ss.statusSummaryCmdFlags.isChefServer {
@@ -368,16 +368,16 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 				chefServerIps = datafound
 				nodes = dataNotFound
 				if err != nil && err.Len() > 0 {
-					errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), ipAddressError))
+					errorList.PushBack(getSingleErrorFromList(err).Error() + ipAddressError)
 				}
 			}
 			if ss.statusSummaryCmdFlags.isOpenSearch {
-				datafound, dataNotFound, err := validateIPAddresses(nodes, ss.infra.Outputs.OpensearchPrivateIps.Value, "open search")
+				datafound, dataNotFound, err := validateIPAddresses(nodes, ss.infra.Outputs.OpensearchPrivateIps.Value, "OpenSearch")
 				opensearchIps = datafound
 				nodes = dataNotFound
 
 				if err != nil && err.Len() > 0 {
-					errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), ipAddressError))
+					errorList.PushBack(getSingleErrorFromList(err).Error() + ipAddressError)
 				}
 			}
 			if ss.statusSummaryCmdFlags.isPostgresql {
@@ -385,7 +385,7 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 				postgresqlIps = datafound
 				nodes = dataNotFound
 				if err != nil && err.Len() > 0 {
-					errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), ipAddressError))
+					errorList.PushBack(getSingleErrorFromList(err).Error() + ipAddressError)
 				}
 			}
 
@@ -414,7 +414,7 @@ func validateIPAddresses(IpsFromcmd, ips []string, errorPrefix string) ([]string
 	for _, ip := range IpsFromcmd {
 		err := checkIPAddress(ip)
 		if err != nil {
-			errorList.PushBack(fmt.Sprintf("Incorrect %s IP address format for ip %s", errorPrefix, ip))
+			errorList.PushBack("Incorrect " + errorPrefix + " IP address format for ip " + ip)
 
 		}
 		if stringutils.SliceContains(ips, ip) {

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -29,7 +29,7 @@ const (
 )
 
 type StatusSummary interface {
-	Run(sshUtil SSHUtil) error
+	Prepare(sshUtil SSHUtil) error
 	ShowFEStatus() string
 	ShowBEStatus() string
 }
@@ -81,7 +81,7 @@ func (ss *Summary) ShowBEStatus() string {
 }
 
 // Run Status summary
-func (ss *Summary) Run(sshUtil SSHUtil) error {
+func (ss *Summary) Prepare(sshUtil SSHUtil) error {
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.checkIPAddresses()
 	if errList != nil && errList.Len() > 0 {
 		return status.Wrap(getSingleErrorFromList(errList), status.ConfigError, ipAddressError)
@@ -106,7 +106,7 @@ func (ss *Summary) Run(sshUtil SSHUtil) error {
 }
 
 // get sshConfig
-func (ss *Summary) setSSHConfig() SSHUtil {
+func (ss *Summary) getSSHConfig() SSHUtil {
 	sshconfig := &SSHConfig{}
 	sshconfig.sshUser = ss.infra.Outputs.SSHUser.Value
 	sshconfig.sshKeyFile = ss.infra.Outputs.SSHKeyFile.Value

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -1,0 +1,411 @@
+package main
+
+import (
+	"container/list"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/stringutils"
+	"github.com/jedib0t/go-pretty/v5/table"
+	"github.com/spf13/cobra"
+)
+
+type StatusSummary interface {
+	Run() error
+	FEDisplay()
+	BEDisplay()
+}
+
+type Summary struct {
+	writer                *cli.Writer
+	fileutils             fileutils.FileUtils
+	feStatus              FeStatus
+	beStatus              BeStatus
+	timeout               int64
+	spinnerTimeout        time.Duration
+	infra                 *AutomteHAInfraDetails
+	statusSummaryCmdFlags *StatusSummaryCmdFlags
+}
+
+type A2haHabitatAutoTfvars struct {
+	HabSupHttpGatewayAuthToken string `json:"hab_sup_http_gateway_auth_token"`
+	HabSupRingKey              string `json:"hab_sup_ring_key"`
+}
+
+
+// Display implements StatusSummary
+func (ss *Summary) FEDisplay() {
+	if len(ss.feStatus) != 0 {
+		fmt.Println("Frontend Services")
+		t := table.NewWriter()
+		tTemp := table.Table{}
+		tTemp.Render()
+		for _, status := range ss.feStatus {
+			t.AppendRow(table.Row{status.serviceName, status.ipAddress, status.status, status.Opensearch})
+		}
+		t.AppendHeader(table.Row{"Name", "IP Address", "Status", "Opensearch"})
+		fmt.Println(t.Render())
+	}
+}
+
+// Display implements StatusSummary
+func (ss *Summary) BEDisplay() {
+	if len(ss.beStatus) != 0 {
+		fmt.Println("Backend Services")
+		t := table.NewWriter()
+		tTemp := table.Table{}
+		tTemp.Render()
+		for _, status := range ss.beStatus {
+			t.AppendRow(table.Row{status.serviceName, status.ipAddress, status.health, status.process, status.upTime, status.role})
+		}
+		t.AppendHeader(table.Row{"Name", "IP Address", "Health", "Process", "Uptime", "Role"})
+		fmt.Println(t.Render())
+	}
+}
+
+// Run implements StatusSummary
+func (ss *Summary) Run() error {
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.CheckIPAddresses()
+	if errList != nil && errList.Len() > 0 {
+		return status.Wrap(getSingleErrorFromList(errList), status.ConfigError, "IP address validation failed")
+	}
+	sshUtil := ss.setSSHConfig()
+	err := ss.connectToFeNode(sshUtil, automateIps, "Automate", "FE")
+	if err != nil {
+		return err
+	}
+	err = ss.connectToFeNode(sshUtil, chefServerIps, "Chef Server", "FE")
+	if err != nil {
+		return err
+	}
+	err = ss.connectToBeNode(sshUtil, opensearchIps, "Open Search", "BE")
+	if err != nil {
+		return err
+	}
+	err = ss.connectToBeNode(sshUtil, postgresqlIps, "Postgresql", "BE")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ss *Summary) setSSHConfig() SSHUtil {
+	sshconfig := &SSHConfig{}
+	sshconfig.sshUser = ss.infra.Outputs.SSHUser.Value
+	sshconfig.sshKeyFile = ss.infra.Outputs.SSHKeyFile.Value
+	sshconfig.sshPort = ss.infra.Outputs.SSHPort.Value
+	sshUtil := NewSSHUtil(sshconfig)
+	return sshUtil
+}
+
+func (ss *Summary) connectToBeNode(sshUtil SSHUtil, serviceIps []string, serviceName, serviceType string) error {
+	script := ""
+	err := ss.executeCommandForArrayofIPs(sshUtil, serviceIps, script, serviceName, serviceType)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ss *Summary) connectToFeNode(sshUtil SSHUtil, serviceIps []string, serviceName, serviceType string) error {
+	script := GenerateOriginalAutomateCLICommand(
+		&cobra.Command{
+			Use: "chef-automate",
+		}, []string{
+			"status",
+			"-t",
+			"150",
+		})
+
+	err := ss.executeCommandForArrayofIPs(sshUtil, serviceIps, script, serviceName, serviceType)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ss *Summary) executeCommandForArrayofIPs(sshUtil SSHUtil, remoteIps []string, script, serviceName, serviceType string) error {
+	getConfigJsonString := convTfvarToJson(terraformPath + "/a2ha_habitat.auto.tfvars")
+	for i := 0; i < len(remoteIps); i++ {
+		sshUtil.getSSHConfig().hostIP = remoteIps[i]
+		if serviceType == "FE" {
+			status := ss.getFEStatus(sshUtil, script, remoteIps[i], serviceName)
+			ss.feStatus = append(ss.feStatus, status)
+		}
+		if serviceType == "BE" {
+			authToken, err := ss.readA2haHabitatAutoTfvarsAuthToken(getConfigJsonString)
+			if err != nil {
+				return err
+			}
+			status, err := ss.getBEStatus(sshUtil, remoteIps[i], authToken, serviceName)
+			if err != nil {
+				return err
+			}
+			ss.beStatus = append(ss.beStatus, status)
+		}
+
+	}
+	return nil
+}
+
+func (ss *Summary) readA2haHabitatAutoTfvarsAuthToken(getConfigJsonString string) (string, error) {
+	config := A2haHabitatAutoTfvars{}
+	err := json.Unmarshal([]byte(getConfigJsonString), &config)
+	if err != nil {
+		return "", err
+	}
+	authToken := config.HabSupHttpGatewayAuthToken
+
+	return authToken, nil
+}
+func (ss *Summary) getBEStatus(sshUtil SSHUtil, ip string, authToken, serviceType string) (BeStatusValue, error) {
+	// curl --location --request GET 'https://localhost:9631/services/automate-ha-opensearch/default' --header 'Authorization: Bearer zeLm+WL26/S2DRpGL9z2d8G+Q8HM0Ht0Jdq5ytqg3ik=' -k
+	service := ""
+	if serviceType == "Open Search" {
+		service = "automate-ha-opensearch"
+	} else if serviceType == "Postgresql" {
+		service = "automate-ha-postgresql"
+	}
+	args := []string{
+		"-s",
+		fmt.Sprintf("https://localhost:9631/services/%s/default", service),
+		"--header",
+		fmt.Sprintf("'Authorization: Bearer %s'", authToken),
+		"-k",
+	}
+	defaultServiceDetails, err := executeCmd(sshUtil, "curl", args)
+	if err != nil {
+		return BeStatusValue{}, err
+	}
+	// memeber_id
+	memeber_id := defaultServiceDetails["sys"].(map[string]interface{})["member_id"]
+	serviceState := defaultServiceDetails["process"].(map[string]interface{})["state"].(string)
+	servicePid := fmt.Sprint(defaultServiceDetails["process"].(map[string]interface{})["pid"])
+	startingTime := defaultServiceDetails["process"].(map[string]interface{})["state_entered"].(float64)
+	startingTime = float64(time.Now().UTC().Unix()) - startingTime
+	// curl --location --request GET 'https://localhost:9631/services/automate-ha-opensearch/default/health' --header 'Authorization: Bearer zeLm+WL26/S2DRpGL9z2d8G+Q8HM0Ht0Jdq5ytqg3ik=' -k
+	args = []string{
+		"-s",
+		fmt.Sprintf("https://localhost:9631/services/%s/default/health", service),
+		"--header",
+		fmt.Sprintf("'Authorization: Bearer %s'", authToken),
+		"-k",
+	}
+	ServiceHealth, err := executeCmd(sshUtil, "curl", args)
+	if err != nil {
+		return BeStatusValue{}, err
+	}
+
+	health := fmt.Sprint(ServiceHealth["status"])
+
+	// /census
+	args = []string{
+		"-s",
+		"https://localhost:9631/census",
+		"--header",
+		fmt.Sprintf("'Authorization: Bearer %s'", authToken),
+		"-k",
+	}
+	censusData, err := executeCmd(sshUtil, "curl", args)
+	if err != nil {
+		return BeStatusValue{}, err
+	}
+
+	populationData := censusData["census_groups"].(map[string]interface{})[service+".default"].(map[string]interface{})["population"].(map[string]interface{})[fmt.Sprintf("%s", memeber_id)]
+	getrole, ok := populationData.(map[string]interface{})
+	role := "Unknown"
+	if ok {
+		isleader, _ := strconv.ParseBool(fmt.Sprint(getrole["leader"]))
+		isfollower, _ := strconv.ParseBool(fmt.Sprint(getrole["follower"]))
+		if isleader {
+			role = "Leader"
+		} else if isfollower {
+			role = "Follower"
+		}
+	}
+
+	t := time.Unix(int64(startingTime), 0)
+	duration := t.Sub(time.Unix(0, 0))
+
+	// Format the duration as "148h 43m 31s"
+	formatted := fmt.Sprintf("%dd %dh %dm %ds", int(duration.Hours())/24, int(duration.Hours())%24, int(duration.Minutes())%60, int(duration.Seconds())%60)
+
+	return BeStatusValue{
+		serviceName: serviceType,
+		ipAddress:   ip,
+		health:      health,
+		process:     fmt.Sprintf("%s (pid: %s)", serviceState, servicePid),
+		upTime:      formatted,
+		role:        role,
+	}, nil
+}
+func (ss *Summary) getFEStatus(sshUtil SSHUtil, script string, ip string, serviceType string) FeStatusValue {
+	entry := FeStatusValue{}
+	osStatus := ss.opensearchStatusInFE(sshUtil)
+	_, err := sshUtil.connectAndExecuteCommandOnRemote(script, true)
+	entry.ipAddress = ip
+	entry.serviceName = serviceType
+	entry.ipAddress = ip
+	entry.Opensearch = osStatus
+	if err != nil {
+		_, ok := err.(*exec.ExitError)
+		if ok {
+			entry.status = "ERROR"
+		} else {
+			entry.status = "WARN"
+		}
+	} else {
+		entry.status = "OK"
+	}
+	return entry
+}
+func (ss *Summary) opensearchStatusInFE(sshUtil SSHUtil) string {
+	arg := []string{
+		"-s",
+		"http://localhost:10144/_cluster/health",
+	}
+	curlOSStatusScript := GenerateOriginalAutomateCLICommand(
+		&cobra.Command{
+			Use: "curl",
+		}, arg)
+	osStatusJson, _ := sshUtil.connectAndExecuteCommandOnRemote(curlOSStatusScript, true)
+
+	body := []byte(osStatusJson)
+	esHealthData := make(map[string]json.RawMessage)
+
+	err := json.Unmarshal(body, &esHealthData)
+	if err != nil {
+		return "Unknown"
+	}
+
+	return fmt.Sprintf("%s Active: %s", esHealthData["status"], esHealthData["active_shards_percent_as_number"])
+}
+
+func executeCmd(sshUtil SSHUtil, cmd string, args []string) (map[string]interface{}, error) {
+	script := GenerateOriginalAutomateCLICommand(&cobra.Command{
+		Use: "curl",
+	}, args)
+	output, err := sshUtil.connectAndExecuteCommandOnRemote(script, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var body map[string]interface{}
+	err = json.Unmarshal([]byte(output), &body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// ValidateIPAddresses implements StatusSummary
+func (ss *Summary) CheckIPAddresses() ([]string, []string, []string, []string, *list.List) {
+	errorList := list.New()
+	var automateIps, chefServerIps, opensearchIps, postgresqlIps []string
+	if ss.statusSummaryCmdFlags.automateIp != "" ||
+		ss.statusSummaryCmdFlags.chefServerIp != "" ||
+		ss.statusSummaryCmdFlags.opensearchIp != "" ||
+		ss.statusSummaryCmdFlags.postgresqlIp != "" {
+		automateIpsFromcmd, chefServerIpsFromcmd, opensearchIpsFromcmd, postgresqlIpsFromcmd := splitIPCSV(
+			ss.statusSummaryCmdFlags.automateIp,
+			ss.statusSummaryCmdFlags.chefServerIp,
+			ss.statusSummaryCmdFlags.opensearchIp,
+			ss.statusSummaryCmdFlags.postgresqlIp,
+		)
+		if len(automateIpsFromcmd) != 0 {
+			datafound, dataNotFound, err := validateIPAddresses(automateIpsFromcmd, ss.infra.Outputs.AutomatePrivateIps.Value, "Automate")
+			automateIps = datafound
+			if len(dataNotFound) != 0 {
+				errorList.PushBack(fmt.Sprintf("List of IpAddress not found %s", dataNotFound))
+			}
+			if err != nil && err.Len() > 0 {
+				errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), "IP address validation failed"))
+			}
+		}
+		if len(chefServerIpsFromcmd) != 0 {
+			datafound, dataNotFound, err := validateIPAddresses(chefServerIpsFromcmd, ss.infra.Outputs.ChefServerPrivateIps.Value, "chef-server")
+			chefServerIps = datafound
+			if len(dataNotFound) != 0 {
+				errorList.PushBack(fmt.Sprintf("List of IpAddress not found %s", dataNotFound))
+			}
+			if err != nil && err.Len() > 0 {
+				errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), "IP address validation failed"))
+			}
+		}
+		if len(opensearchIpsFromcmd) != 0 {
+			datafound, dataNotFound, err := validateIPAddresses(opensearchIpsFromcmd, ss.infra.Outputs.OpensearchPrivateIps.Value, "open search")
+			if len(dataNotFound) != 0 {
+				errorList.PushBack(fmt.Sprintf("List of IpAddress not found %s", dataNotFound))
+			}
+			opensearchIps = datafound
+			if err != nil && err.Len() > 0 {
+				errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), "IP address validation failed"))
+			}
+		}
+		if len(postgresqlIpsFromcmd) != 0 {
+			datafound, dataNotFound, err := validateIPAddresses(postgresqlIpsFromcmd, ss.infra.Outputs.PostgresqlPrivateIps.Value, "postgres")
+			opensearchIps = datafound
+			if len(dataNotFound) != 0 {
+				errorList.PushBack(fmt.Sprintf("List of IpAddress not found %s", dataNotFound))
+			}
+			if err != nil && err.Len() > 0 {
+				errorList.PushBack(fmt.Sprintf(getSingleErrorFromList(err).Error(), "IP address validation failed"))
+			}
+		}
+	} else {
+		if ss.statusSummaryCmdFlags.isAutomate {
+			automateIps = ss.infra.Outputs.AutomatePrivateIps.Value
+		} else if ss.statusSummaryCmdFlags.isChefServer {
+			chefServerIps = ss.infra.Outputs.ChefServerPrivateIps.Value
+		} else if ss.statusSummaryCmdFlags.isOpenSearch {
+			opensearchIps = ss.infra.Outputs.OpensearchPrivateIps.Value
+		} else if ss.statusSummaryCmdFlags.isPostgresql {
+			postgresqlIps = ss.infra.Outputs.PostgresqlPrivateIps.Value
+		} else {
+			automateIps = ss.infra.Outputs.AutomatePrivateIps.Value
+			chefServerIps = ss.infra.Outputs.ChefServerPrivateIps.Value
+			opensearchIps = ss.infra.Outputs.OpensearchPrivateIps.Value
+			postgresqlIps = ss.infra.Outputs.PostgresqlPrivateIps.Value
+		}
+	}
+	return automateIps, chefServerIps, opensearchIps, postgresqlIps, errorList
+}
+
+func validateIPAddresses(IpsFromcmd, ips []string, errorPrefix string) ([]string, []string, *list.List) {
+	errorList := list.New()
+	var ipFound, ipNotFound []string
+
+	for _, ip := range IpsFromcmd {
+		err := checkIPAddress(ip)
+		if err != nil {
+			errorList.PushBack(fmt.Sprintf("Incorrect %s IP address format for ip %s", errorPrefix, ip))
+
+		}
+		if stringutils.SliceContains(ips, ip) {
+			ipFound = append(ipFound, ip)
+		} else {
+			ipNotFound = append(ipNotFound, ip)
+		}
+	}
+	return ipFound, ipNotFound, errorList
+}
+
+func NewStatusSummary(writer *cli.Writer, infra *AutomteHAInfraDetails, fileutils fileutils.FileUtils, feStatus FeStatus, beStatus BeStatus, timeout int64, spinnerTimeout time.Duration, flags *StatusSummaryCmdFlags) StatusSummary {
+	return &Summary{
+		writer:                writer,
+		fileutils:             fileutils,
+		feStatus:              feStatus,
+		beStatus:              beStatus,
+		timeout:               timeout,
+		spinnerTimeout:        spinnerTimeout,
+		infra:                 infra,
+		statusSummaryCmdFlags: flags,
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -558,7 +558,7 @@ func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd []string
 	for _, ip := range IpsFromcmd {
 		err := checkIPAddress(ip)
 		if err != nil {
-			errorList.PushBack("Incorrect " + nodeType + "-ip, " + ip + errorMessage)
+			errorList.PushBack("Incorrect " + nodeType + " IP, " + ip + errorMessage)
 		}
 		if stringutils.SliceContains(ips, ip) {
 			ipFound = append(ipFound, ip)

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -190,16 +190,16 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 		)
 		if len(nodes) != 0 {
 			if ss.statusSummaryCmdFlags.isAutomate {
-				automateIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, ss.infra.Outputs.AutomatePrivateIps.Value, "Automate", ipAddressError)
+				automateIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "Automate", ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isChefServer {
-				chefServerIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, ss.infra.Outputs.ChefServerPrivateIps.Value, "chef-server", ipAddressError)
+				chefServerIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "chef-server", ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isOpenSearch {
-				opensearchIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, ss.infra.Outputs.OpensearchPrivateIps.Value, "OpenSearch", ipAddressError)
+				opensearchIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "OpenSearch", ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isPostgresql {
-				postgresqlIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, ss.infra.Outputs.PostgresqlPrivateIps.Value, "postgres", ipAddressError)
+				postgresqlIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "postgresql", ipAddressError)
 			}
 			if len(nodes) != 0 {
 				errorList.PushBack(fmt.Sprintf("List of  ip address not found %s", nodes))
@@ -531,13 +531,14 @@ func (ss *Summary) splitIP(node string) (nodes []string) {
 	return
 }
 
-func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd, ips []string, errorPrefix, errorMessage string) ([]string, []string, *list.List) {
+func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd []string, nodeType, errorMessage string) ([]string, []string, *list.List) {
+	ips := ss.getNodeIPs(nodeType)
 	var ipFound, ipNotFound []string
 
 	for _, ip := range IpsFromcmd {
 		err := checkIPAddress(ip)
 		if err != nil {
-			errorList.PushBack("Incorrect " + errorPrefix + " IP address format for ip " + ip + errorMessage)
+			errorList.PushBack("Incorrect " + nodeType + " IP address format for ip " + ip + errorMessage)
 		}
 		if stringutils.SliceContains(ips, ip) {
 			ipFound = append(ipFound, ip)
@@ -546,6 +547,19 @@ func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd, ips []s
 		}
 	}
 	return ipFound, ipNotFound, errorList
+}
+func (ss *Summary) getNodeIPs(NodeType string) []string {
+	switch NodeType {
+	case "Automate":
+		return ss.infra.Outputs.AutomatePrivateIps.Value
+	case "chef-server":
+		return ss.infra.Outputs.ChefServerPrivateIps.Value
+	case "OpenSearch":
+		return ss.infra.Outputs.OpensearchPrivateIps.Value
+	case "postgresql":
+		return ss.infra.Outputs.PostgresqlPrivateIps.Value
+	}
+	return []string{}
 }
 
 // Display Frontend Status

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -23,7 +23,7 @@ var (
 )
 
 const (
-	ipAddressError           = "IP address validation failed"
+	ipAddressError           = " IP address validation failed"
 	curlHeaderFlag           = "--header"
 	curlAuthorization        = "'Authorization: Bearer %s'"
 	initialServiceState      = "down"
@@ -74,22 +74,7 @@ func (ss *Summary) Prepare() error {
 	}
 
 	if len(automateIps) != 0 {
-		automateNodeMap := &NodeTypeAndCmd{
-			Frontend: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Automate: &Cmd{
-				CmdInputs: &CmdInputs{
-					Cmd:                      "",
-					NodeIps:                  automateIps,
-					Single:                   false,
-					NodeType:                 true,
-					SkipPrintOutput:          true,
-					HideSSHConnectionMessage: true,
-				},
-			},
-			Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Infra:      ss.infra,
-		}
+		automateNodeMap := ss.automateNodeMap(automateIps)
 		err := ss.prepareFEScript(automateIps, automateNodeMap, "automate", "FE")
 		if err != nil {
 			return err
@@ -97,23 +82,7 @@ func (ss *Summary) Prepare() error {
 	}
 
 	if len(chefServerIps) != 0 {
-		chefServerNodeMap := &NodeTypeAndCmd{
-			Frontend: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Automate: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			ChefServer: &Cmd{
-				CmdInputs: &CmdInputs{
-					Cmd:                      "",
-					NodeIps:                  chefServerIps,
-					Single:                   false,
-					NodeType:                 true,
-					SkipPrintOutput:          true,
-					HideSSHConnectionMessage: true,
-				},
-			},
-			Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Infra:      ss.infra,
-		}
+		chefServerNodeMap := ss.chefServerNodeMap(chefServerIps)
 		err := ss.prepareFEScript(chefServerIps, chefServerNodeMap, "chef-server", "FE")
 		if err != nil {
 			return err
@@ -121,23 +90,7 @@ func (ss *Summary) Prepare() error {
 	}
 
 	if len(opensearchIps) != 0 {
-		openSearchNodeMap := &NodeTypeAndCmd{
-			Frontend:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Automate:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			ChefServer: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Opensearch: &Cmd{
-				CmdInputs: &CmdInputs{
-					Cmd:                      "",
-					NodeIps:                  opensearchIps,
-					Single:                   false,
-					NodeType:                 true,
-					SkipPrintOutput:          true,
-					HideSSHConnectionMessage: true,
-				},
-			},
-			Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Infra:      ss.infra,
-		}
+		openSearchNodeMap := ss.openSearchNodeMap(opensearchIps)
 		err := ss.prepareBEScript(opensearchIps, openSearchNodeMap, "opensearch", "BE")
 		if err != nil {
 			return err
@@ -145,29 +98,96 @@ func (ss *Summary) Prepare() error {
 	}
 
 	if len(postgresqlIps) != 0 {
-		postgresqlNodeMap := &NodeTypeAndCmd{
-			Frontend:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Automate:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			ChefServer: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
-			Postgresql: &Cmd{
-				CmdInputs: &CmdInputs{
-					Cmd:                      "",
-					NodeIps:                  postgresqlIps,
-					Single:                   false,
-					NodeType:                 true,
-					SkipPrintOutput:          true,
-					HideSSHConnectionMessage: true,
-				},
-			},
-			Infra: ss.infra,
-		}
+		postgresqlNodeMap := ss.postgresqlNodeMap(postgresqlIps)
 		err := ss.prepareBEScript(postgresqlIps, postgresqlNodeMap, "postgresql", "BE")
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (ss *Summary) postgresqlNodeMap(postgresqlIps []string) *NodeTypeAndCmd {
+	postgresqlNodeMap := &NodeTypeAndCmd{
+		Frontend:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Automate:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		ChefServer: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Postgresql: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      "",
+				NodeIps:                  postgresqlIps,
+				Single:                   false,
+				NodeType:                 true,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Infra: ss.infra,
+	}
+	return postgresqlNodeMap
+}
+
+func (ss *Summary) openSearchNodeMap(opensearchIps []string) *NodeTypeAndCmd {
+	openSearchNodeMap := &NodeTypeAndCmd{
+		Frontend:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Automate:   &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		ChefServer: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Opensearch: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      "",
+				NodeIps:                  opensearchIps,
+				Single:                   false,
+				NodeType:                 true,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Infra:      ss.infra,
+	}
+	return openSearchNodeMap
+}
+
+func (ss *Summary) chefServerNodeMap(chefServerIps []string) *NodeTypeAndCmd {
+	chefServerNodeMap := &NodeTypeAndCmd{
+		Frontend: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Automate: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		ChefServer: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      "",
+				NodeIps:                  chefServerIps,
+				Single:                   false,
+				NodeType:                 true,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Infra:      ss.infra,
+	}
+	return chefServerNodeMap
+}
+
+func (ss *Summary) automateNodeMap(automateIps []string) *NodeTypeAndCmd {
+	automateNodeMap := &NodeTypeAndCmd{
+		Frontend: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Automate: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      "",
+				NodeIps:                  automateIps,
+				Single:                   false,
+				NodeType:                 true,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Opensearch: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Postgresql: &Cmd{CmdInputs: &CmdInputs{NodeType: false}},
+		Infra:      ss.infra,
+	}
+	return automateNodeMap
 }
 
 func (ss *Summary) getIPAddressesFromFlagOrInfra() ([]string, []string, []string, []string, *list.List) {
@@ -201,8 +221,8 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 			if ss.statusSummaryCmdFlags.isPostgresql {
 				postgresqlIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "postgresql", ipAddressError)
 			}
-			if len(nodes) != 0 {
-				errorList.PushBack(fmt.Sprintf("List of  ip address not found %s", nodes))
+			if len(nodes) != 0 && errorList.Len() == 0 {
+				errorList.PushBack(fmt.Sprintf("List of  ip address not found %s does not match any node for Automate, PostgreSQL or ChefServer services", nodes))
 			}
 		}
 		return automateIps, chefServerIps, opensearchIps, postgresqlIps, errorList
@@ -538,7 +558,7 @@ func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd []string
 	for _, ip := range IpsFromcmd {
 		err := checkIPAddress(ip)
 		if err != nil {
-			errorList.PushBack("Incorrect " + nodeType + " IP address format for ip " + ip + errorMessage)
+			errorList.PushBack("Incorrect " + nodeType + "-ip, " + ip + errorMessage)
 		}
 		if stringutils.SliceContains(ips, ip) {
 			ipFound = append(ipFound, ip)

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -70,7 +70,7 @@ func NewStatusSummary(infra *AutomteHAInfraDetails, feStatus FeStatus, beStatus 
 func (ss *Summary) Prepare() error {
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.getIPAddressesFromFlagOrInfra()
 	if errList != nil && errList.Len() > 0 {
-		return status.Wrap(getSingleErrorFromList(errList), status.ConfigError, ipAddressError)
+		return status.Wrap(getSingleErrorFromList(errList), status.InvalidCommandArgsError, ipAddressError)
 	}
 
 	if len(automateIps) != 0 {
@@ -82,7 +82,7 @@ func (ss *Summary) Prepare() error {
 					NodeIps:                  automateIps,
 					Single:                   false,
 					NodeType:                 true,
-					PrintOutput:              false,
+					SkipPrintOutput:          true,
 					HideSSHConnectionMessage: true,
 				},
 			},
@@ -106,7 +106,7 @@ func (ss *Summary) Prepare() error {
 					NodeIps:                  chefServerIps,
 					Single:                   false,
 					NodeType:                 true,
-					PrintOutput:              false,
+					SkipPrintOutput:          true,
 					HideSSHConnectionMessage: true,
 				},
 			},
@@ -131,7 +131,7 @@ func (ss *Summary) Prepare() error {
 					NodeIps:                  opensearchIps,
 					Single:                   false,
 					NodeType:                 true,
-					PrintOutput:              false,
+					SkipPrintOutput:          true,
 					HideSSHConnectionMessage: true,
 				},
 			},
@@ -156,7 +156,7 @@ func (ss *Summary) Prepare() error {
 					NodeIps:                  postgresqlIps,
 					Single:                   false,
 					NodeType:                 true,
-					PrintOutput:              false,
+					SkipPrintOutput:          true,
 					HideSSHConnectionMessage: true,
 				},
 			},

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -33,6 +33,10 @@ const (
 	defaultServiceDetails       = "DefaultServiceDetails"
 	defaultServiceHealthDetails = "DefaultServiceHealthDetails"
 	censusDetails               = "CensusDetails"
+	opensearchName              = "opensearch"
+	automateName                = "automate"
+	chefServerName              = "chef-server"
+	postgresqlName              = "postgresql"
 )
 
 type StatusSummary interface {
@@ -77,7 +81,7 @@ func (ss *Summary) Prepare() error {
 
 	if len(automateIps) != 0 {
 		automateNodeMap := ss.automateNodeMap(automateIps)
-		err := ss.prepareFEScript(automateIps, automateNodeMap, "automate", "FE")
+		err := ss.prepareFEScript(automateIps, automateNodeMap, automateName, "FE")
 		if err != nil {
 			return err
 		}
@@ -85,7 +89,7 @@ func (ss *Summary) Prepare() error {
 
 	if len(chefServerIps) != 0 {
 		chefServerNodeMap := ss.chefServerNodeMap(chefServerIps)
-		err := ss.prepareFEScript(chefServerIps, chefServerNodeMap, "chef-server", "FE")
+		err := ss.prepareFEScript(chefServerIps, chefServerNodeMap, chefServerName, "FE")
 		if err != nil {
 			return err
 		}
@@ -93,7 +97,7 @@ func (ss *Summary) Prepare() error {
 
 	if len(opensearchIps) != 0 {
 		openSearchNodeMap := ss.openSearchNodeMap(opensearchIps)
-		err := ss.prepareBEScript(opensearchIps, openSearchNodeMap, "opensearch", "BE")
+		err := ss.prepareBEScript(opensearchIps, openSearchNodeMap, opensearchName, "BE")
 		if err != nil {
 			return err
 		}
@@ -101,7 +105,7 @@ func (ss *Summary) Prepare() error {
 
 	if len(postgresqlIps) != 0 {
 		postgresqlNodeMap := ss.postgresqlNodeMap(postgresqlIps)
-		err := ss.prepareBEScript(postgresqlIps, postgresqlNodeMap, "postgresql", "BE")
+		err := ss.prepareBEScript(postgresqlIps, postgresqlNodeMap, postgresqlName, "BE")
 		if err != nil {
 			return err
 		}
@@ -212,16 +216,16 @@ func (ss *Summary) getIpAddressesFromFlag(errorList *list.List) ([]string, []str
 		)
 		if len(nodes) != 0 {
 			if ss.statusSummaryCmdFlags.isAutomate {
-				automateIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "Automate", ipAddressError)
+				automateIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, automateName, ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isChefServer {
-				chefServerIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "chef-server", ipAddressError)
+				chefServerIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, chefServerName, ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isOpenSearch {
-				opensearchIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "OpenSearch", ipAddressError)
+				opensearchIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, opensearchName, ipAddressError)
 			}
 			if ss.statusSummaryCmdFlags.isPostgresql {
-				postgresqlIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, "postgresql", ipAddressError)
+				postgresqlIps, nodes, errorList = ss.validateIPAddresses(errorList, nodes, postgresqlName, ipAddressError)
 			}
 			if len(nodes) != 0 && errorList.Len() == 0 {
 				errorList.PushBack(fmt.Sprintf("List of  ip address not found %s does not match any node for Automate, PostgreSQL or ChefServer services", nodes))
@@ -311,11 +315,11 @@ func (ss *Summary) prepareBEScript(serviceIps []string, nodeMap *NodeTypeAndCmd,
 		censusDetails:               censusDetailsCmd,
 	}
 
-	if serviceName == "opensearch" {
+	if serviceName == opensearchName {
 		nodeMap.Opensearch.CmdInputs.MutipleCmdWithArgs = script
 	}
 
-	if serviceName == "postgresql" {
+	if serviceName == postgresqlName {
 		nodeMap.Postgresql.CmdInputs.MutipleCmdWithArgs = script
 	}
 
@@ -360,11 +364,11 @@ func (ss *Summary) prepareFEScript(serviceIps []string, nodeMap *NodeTypeAndCmd,
 		"OsStatus": osStatus,
 	}
 
-	if serviceName == "automate" {
+	if serviceName == automateName {
 		nodeMap.Automate.CmdInputs.MutipleCmdWithArgs = script
 	}
 
-	if serviceName == "chef-server" {
+	if serviceName == chefServerName {
 		nodeMap.ChefServer.CmdInputs.MutipleCmdWithArgs = script
 	}
 
@@ -468,7 +472,7 @@ func (ss *Summary) getBEServiceHealth(output string) (string, error) {
 
 func (ss *Summary) getBECensus(output, service, memeberId string) (string, error) {
 	role := initialRole
-	if service == "opensearch" {
+	if service == opensearchName {
 		role = "OS node"
 	}
 
@@ -570,13 +574,13 @@ func (ss *Summary) validateIPAddresses(errorList *list.List, IpsFromcmd []string
 }
 func (ss *Summary) getNodeIPs(NodeType string) []string {
 	switch NodeType {
-	case "Automate":
+	case automateName:
 		return ss.infra.Outputs.AutomatePrivateIps.Value
-	case "chef-server":
+	case chefServerName:
 		return ss.infra.Outputs.ChefServerPrivateIps.Value
-	case "OpenSearch":
+	case opensearchName:
 		return ss.infra.Outputs.OpensearchPrivateIps.Value
-	case "postgresql":
+	case postgresqlName:
 		return ss.infra.Outputs.PostgresqlPrivateIps.Value
 	}
 	return []string{}
@@ -612,13 +616,4 @@ func (ss *Summary) ShowBEStatus() string {
 		return t.Render()
 	}
 	return ""
-}
-
-func getIndexOf(value CmdResult, order []string) int {
-	for i := 0; i < len(order); i++ {
-		if value.ScriptName == order[i] {
-			return i
-		}
-	}
-	return -1
 }

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -15,7 +15,6 @@ func TestCheckIPAddressesFromInfra(t *testing.T) {
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
-	// func TestIPValidation(t *testing.T) {
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -56,7 +56,7 @@ func TestCheckIPAddressesByServicesAndIpFromFlag(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
-		node:         fmt.Sprintf("%s,%s,%s,%s", ValidIP, ValidIP3, ValidIP5, ValidIP8),
+		node:        fmt.Sprintf("%s,%s,%s,%s", ValidIP, ValidIP3, ValidIP5, ValidIP8),
 		isAutomate:   true,
 		isChefServer: true,
 		isOpenSearch: true,
@@ -101,8 +101,8 @@ func TestCheckIPAddressesError(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
-		node:       fmt.Sprintf("%s,%s", "127.0.0.1", "127.0.0.2"),
-		isAutomate: true,
+		node:         "127.0.0.1,127.0.0.2",
+		isAutomate:   true,
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
@@ -121,7 +121,7 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
-		node:         fmt.Sprintf("%s,%s,%s,%s", "127.0.0", "127.0.1", "127.0.2", "127.0.3"),
+		node:         "127.0.0,127.0.1,127.0.2,127.0.3",
 		isAutomate:   true,
 		isChefServer: true,
 		isOpenSearch: true,
@@ -129,12 +129,12 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 	})
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
-	assert.Equal(t, errList.Len(), 4)
+	assert.Equal(t, errList.Len(), 5)
 	assert.Equal(t, automateIps, []string(nil))
 	assert.Equal(t, chefServerIps, []string(nil))
 	assert.Equal(t, opensearchIps, []string(nil))
 	assert.Equal(t, postgresqlIps, []string(nil))
-	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\n\nIncorrect Automate IP address format for ip 127.0.0\nIncorrect Automate IP address format for ip 127.0.1\nIncorrect Automate IP address format for ip 127.0.2\nIncorrect Automate IP address format for ip 127.0.3%!(EXTRA string=IP address validation failed)\n\nIncorrect chef-server IP address format for ip 127.0.0\nIncorrect chef-server IP address format for ip 127.0.1\nIncorrect chef-server IP address format for ip 127.0.2\nIncorrect chef-server IP address format for ip 127.0.3%!(EXTRA string=IP address validation failed)\n\nIncorrect open search IP address format for ip 127.0.0\nIncorrect open search IP address format for ip 127.0.1\nIncorrect open search IP address format for ip 127.0.2\nIncorrect open search IP address format for ip 127.0.3%!(EXTRA string=IP address validation failed)\n\nIncorrect postgres IP address format for ip 127.0.0\nIncorrect postgres IP address format for ip 127.0.1\nIncorrect postgres IP address format for ip 127.0.2\nIncorrect postgres IP address format for ip 127.0.3%!(EXTRA string=IP address validation failed)")
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\n\nIncorrect Automate IP address format for ip 127.0.0\nIncorrect Automate IP address format for ip 127.0.1\nIncorrect Automate IP address format for ip 127.0.2\nIncorrect Automate IP address format for ip 127.0.3IP address validation failed\n\nIncorrect chef-server IP address format for ip 127.0.0\nIncorrect chef-server IP address format for ip 127.0.1\nIncorrect chef-server IP address format for ip 127.0.2\nIncorrect chef-server IP address format for ip 127.0.3IP address validation failed\n\nIncorrect OpenSearch IP address format for ip 127.0.0\nIncorrect OpenSearch IP address format for ip 127.0.1\nIncorrect OpenSearch IP address format for ip 127.0.2\nIncorrect OpenSearch IP address format for ip 127.0.3IP address validation failed\n\nIncorrect postgres IP address format for ip 127.0.0\nIncorrect postgres IP address format for ip 127.0.1\nIncorrect postgres IP address format for ip 127.0.2\nIncorrect postgres IP address format for ip 127.0.3IP address validation failed\nList of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]")
 }
 
 func TestRunFENode(t *testing.T) {
@@ -184,7 +184,7 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
-	assert.Contains(t, be, "+-------------+--------------+--------+----------------+------------------+---------+\n| NAME        | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+-------------+--------------+--------+----------------+------------------+---------+\n| Open Search | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql  | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+-------------+--------------+--------+----------------+------------------+---------+")
+	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
 }
 
 func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chef/automate/lib/io/fileutils"
+)
+
+func TestIPValidation(t *testing.T) {
+	// &MockSSHUtilsImpl{}
+	// w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+
+	NewStatusSummary(&AutomteHAInfraDetails{
+		
+	}, &fileutils.MockFileSystemUtils{}, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+}

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -161,7 +161,7 @@ func TestRunFENodeDiaplay(t *testing.T) {
 	assert.Equal(t, fe, "+-------------+--------------+--------+------------+\n| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |\n+-------------+--------------+--------+------------+\n| Automate    | 198.51.100.0 | OK     | Unknown    |\n| Automate    | 198.51.100.1 | OK     | Unknown    |\n| Chef Server | 198.51.100.2 | OK     | Unknown    |\n| Chef Server | 198.51.100.3 | OK     | Unknown    |\n+-------------+--------------+--------+------------+")
 }
 
-func TestRunBENod(t *testing.T) {
+func TestRunBENode(t *testing.T) {
 	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
@@ -184,7 +184,7 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
-	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
+	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
 }
 
 func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -144,7 +144,7 @@ func TestRunFENode(t *testing.T) {
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
-	err := ss.Run(sshUtilsImpl)
+	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 }
 
@@ -155,7 +155,7 @@ func TestRunFENodeDiaplay(t *testing.T) {
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
-	err := ss.Run(sshUtilsImpl)
+	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 	fe := ss.ShowFEStatus()
 	assert.Equal(t, fe, "+-------------+--------------+--------+------------+\n| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |\n+-------------+--------------+--------+------------+\n| Automate    | 198.51.100.0 | OK     | Unknown    |\n| Automate    | 198.51.100.1 | OK     | Unknown    |\n| Chef Server | 198.51.100.2 | OK     | Unknown    |\n| Chef Server | 198.51.100.3 | OK     | Unknown    |\n+-------------+--------------+--------+------------+")
@@ -168,7 +168,7 @@ func TestRunBENod(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 	sshUtilsImpl := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
-	err := ss.Run(sshUtilsImpl)
+	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 }
 func TestRunBENodeDiaplay(t *testing.T) {
@@ -181,7 +181,7 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	// Mock the time to a specific time
 	mockTime := time.Date(2023, 3, 15, 12, 0, 0, 0, time.UTC)
 	nowFunc = func() time.Time { return mockTime }
-	err := ss.Run(sshUtilsImpl)
+	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
 	assert.Contains(t, be, "+-------------+--------------+--------+----------------+------------------+---------+\n| NAME        | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+-------------+--------------+--------+----------------+------------------+---------+\n| Open Search | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql  | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+-------------+--------------+--------+----------------+------------------+---------+")

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -1,17 +1,265 @@
 package main
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestIPValidation(t *testing.T) {
-	// &MockSSHUtilsImpl{}
-	// w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+func TestCheckIPAddressesFromInfra(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+	// func TestIPValidation(t *testing.T) {
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 
-	NewStatusSummary(&AutomteHAInfraDetails{
-		
-	}, &fileutils.MockFileSystemUtils{}, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	assert.Equal(t, errList.Len(), 0)
+	assert.Equal(t, automateIps, []string{ValidIP, ValidIP1})
+	assert.Equal(t, chefServerIps, []string{ValidIP2, ValidIP3})
+	assert.Equal(t, opensearchIps, []string{ValidIP4, ValidIP5, ValidIP6})
+	assert.Equal(t, postgresqlIps, []string{ValidIP7, ValidIP8, ValidIP9})
+}
+
+func TestCheckIPAddressesFromCmd(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		automateIp:   ValidIP,
+		chefServerIp: ValidIP3,
+		opensearchIp: ValidIP5,
+		postgresqlIp: ValidIP8,
+	})
+
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	assert.Equal(t, errList.Len(), 0)
+	assert.Equal(t, automateIps, []string{ValidIP})
+	assert.Equal(t, chefServerIps, []string{ValidIP3})
+	assert.Equal(t, opensearchIps, []string{ValidIP5})
+	assert.Equal(t, postgresqlIps, []string{ValidIP8})
+}
+
+func TestCheckIPAddressesByServicesAndIpFromFlag(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		automateIp:   ValidIP,
+		chefServerIp: ValidIP3,
+		opensearchIp: ValidIP5,
+		postgresqlIp: ValidIP8,
+		isAutomate:   true,
+		isChefServer: true,
+		isOpenSearch: true,
+		isPostgresql: true,
+	})
+
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	assert.Equal(t, errList.Len(), 0)
+	assert.Equal(t, automateIps, []string{ValidIP})
+	assert.Equal(t, chefServerIps, []string{ValidIP3})
+	assert.Equal(t, opensearchIps, []string{ValidIP5})
+	assert.Equal(t, postgresqlIps, []string{ValidIP8})
+}
+
+func TestCheckIPAddressesOnlyByServices(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		isAutomate:   true,
+		isChefServer: true,
+		isOpenSearch: true,
+		isPostgresql: true,
+	})
+
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	assert.Equal(t, errList.Len(), 0)
+	assert.Equal(t, automateIps, []string{ValidIP, ValidIP1})
+	assert.Equal(t, chefServerIps, []string{ValidIP2, ValidIP3})
+	assert.Equal(t, opensearchIps, []string{ValidIP4, ValidIP5, ValidIP6})
+	assert.Equal(t, postgresqlIps, []string{ValidIP7, ValidIP8, ValidIP9})
+}
+
+func TestCheckIPAddressesError(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		automateIp:   ValidIP3,
+		chefServerIp: ValidIP,
+		opensearchIp: ValidIP8,
+		postgresqlIp: ValidIP5,
+	})
+
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	fmt.Println(automateIps, chefServerIps, opensearchIps, postgresqlIps, errList)
+	assert.Equal(t, errList.Len(), 4)
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nList of automate ip address not found [198.51.100.3]\nList of chef server ip address not found [198.51.100.0]\nList of openSearch ip address not found [198.51.100.8]\nList of postgresql ip address not found [198.51.100.5]")
+}
+
+func TestCheckIPAddressesValidation(t *testing.T) {
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		automateIp:   "127.0.0",
+		chefServerIp: "127.0.1",
+		opensearchIp: "127.0.2",
+		postgresqlIp: "127.0.3",
+	})
+
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	assert.Equal(t, errList.Len(), 8)
+	assert.Equal(t, automateIps, []string(nil))
+	assert.Equal(t, chefServerIps, []string(nil))
+	assert.Equal(t, opensearchIps, []string(nil))
+	assert.Equal(t, postgresqlIps, []string(nil))
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nList of automate ip address not found [127.0.0]\n\nIncorrect Automate IP address format for ip 127.0.0%!(EXTRA string=IP address validation failed)\nList of chef server ip address not found [127.0.1]\n\nIncorrect chef-server IP address format for ip 127.0.1%!(EXTRA string=IP address validation failed)\nList of openSearch ip address not found [127.0.2]\n\nIncorrect open search IP address format for ip 127.0.2%!(EXTRA string=IP address validation failed)\nList of postgresql ip address not found [127.0.3]\n\nIncorrect postgres IP address format for ip 127.0.3%!(EXTRA string=IP address validation failed)")
+}
+
+func TestRunFENode(t *testing.T) {
+	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
+	err := ss.Run(sshUtilsImpl)
+	assert.NoError(t, err)
+}
+
+func TestRunFENodeDiaplay(t *testing.T) {
+	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
+	err := ss.Run(sshUtilsImpl)
+	assert.NoError(t, err)
+	fe := ss.FEDisplay()
+	assert.Equal(t, fe, "+-------------+--------------+--------+------------+\n| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |\n+-------------+--------------+--------+------------+\n| Automate    | 198.51.100.0 | OK     | Unknown    |\n| Automate    | 198.51.100.1 | OK     | Unknown    |\n| Chef Server | 198.51.100.2 | OK     | Unknown    |\n| Chef Server | 198.51.100.3 | OK     | Unknown    |\n+-------------+--------------+--------+------------+")
+}
+
+func TestRunBENod(t *testing.T) {
+	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	sshUtilsImpl := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
+	err := ss.Run(sshUtilsImpl)
+	assert.NoError(t, err)
+}
+func TestRunBENodeDiaplay(t *testing.T) {
+	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	infra := &AutomteHAInfraDetails{}
+	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	sshUtilsImpl := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
+	// Mock the time to a specific time
+	mockTime := time.Date(2023, 3, 15, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return mockTime }
+	// Get the mocked time
+	now := getCurrentTime()
+	fmt.Println("Mocked time:", now)
+	err := ss.Run(sshUtilsImpl)
+	assert.NoError(t, err)
+	be := ss.BEDisplay()
+	assert.Contains(t, be, "+-------------+--------------+--------+----------------+------------------+---------+\n| NAME        | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+-------------+--------------+--------+----------------+------------------+---------+\n| Open Search | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Open Search | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql  | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql  | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+-------------+--------------+--------+----------------+------------------+---------+")
+}
+
+func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {
+	return &MockSSHUtilsImpl{
+		getSSHConfigFunc: func() *SSHConfig {
+			return sshConfig
+		},
+		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+			if strings.Contains(remoteCommands, "/default/health --header") {
+				return `{"status":"OK","stdout":"","stderr":""}`, CSECORError
+			}
+			if strings.Contains(remoteCommands, "/default --header") {
+				return `{
+					"process": {
+						"pid": 4173,
+						"state": "up",
+						"state_entered": 0
+					},
+					"sys": {
+						"version": "1.6.521/20220603161331",
+						"member_id": "7b945d6006e34463a1901b3d0a997369",
+						"ip": "10.1.0.16",
+						"hostname": "ip-10-1-0-16.ap-south-1.compute.internal",
+						"gossip_ip": "0.0.0.0",
+						"gossip_port": 9638,
+						"ctl_gateway_ip": "127.0.0.1",
+						"ctl_gateway_port": 9632,
+						"http_gateway_ip": "0.0.0.0",
+						"http_gateway_port": 9631,
+						"permanent": true
+					}
+				}`, CSECORError
+			}
+			if strings.Contains(remoteCommands, "/census --header") {
+				return `{
+					"changed": true,
+					"census_groups": {
+						"automate-ha-postgresql.default": {
+							"service_group": "automate-ha-postgresql.default",
+							"population": {
+								"7b945d6006e34463a1901b3d0a997369": {
+									"member_id": "7b945d6006e34463a1901b3d0a997369",
+									"leader": true,
+									"follower": false,
+									"update_leader": false,
+									"update_follower": false
+							}
+							}
+						},
+						"automate-ha-opensearch.default": {
+							"service_group": "automate-ha-opensearch.default",
+							"election_status": "None",
+							"update_election_status": "None",
+							"leader_id": null,
+							"service_config": null,
+							"local_member_id": "7b945d6006e34463a1901b3d0a997369",
+							"population": {
+								"7b945d6006e34463a1901b3d0a997369": {
+									"member_id": "29e25e5164644ebbb1475fdf12468960",
+									"leader": false,
+									"follower": false,
+									"update_leader": false,
+									"update_follower": false
+								}
+							}
+						}
+					}
+				}`, CSECORError
+			}
+			return "", CSECORError
+		},
+	}
 }

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -17,7 +17,7 @@ func TestCheckIPAddressesFromInfra(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
 
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
 	assert.Equal(t, automateIps, []string{ValidIP, ValidIP1})
 	assert.Equal(t, chefServerIps, []string{ValidIP2, ValidIP3})
@@ -40,7 +40,7 @@ func TestCheckIPAddressesFromCmd(t *testing.T) {
 		isPostgresql: true,
 	})
 
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
 	assert.Equal(t, automateIps, []string{ValidIP})
 	assert.Equal(t, chefServerIps, []string{ValidIP3})
@@ -56,14 +56,14 @@ func TestCheckIPAddressesByServicesAndIpFromFlag(t *testing.T) {
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
 
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
-		node:        fmt.Sprintf("%s,%s,%s,%s", ValidIP, ValidIP3, ValidIP5, ValidIP8),
+		node:         fmt.Sprintf("%s,%s,%s,%s", ValidIP, ValidIP3, ValidIP5, ValidIP8),
 		isAutomate:   true,
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
 	})
 
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
 	assert.Equal(t, automateIps, []string{ValidIP})
 	assert.Equal(t, chefServerIps, []string{ValidIP3})
@@ -85,7 +85,7 @@ func TestCheckIPAddressesOnlyByServices(t *testing.T) {
 		isPostgresql: true,
 	})
 
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
 	assert.Equal(t, automateIps, []string{ValidIP, ValidIP1})
 	assert.Equal(t, chefServerIps, []string{ValidIP2, ValidIP3})
@@ -108,7 +108,7 @@ func TestCheckIPAddressesError(t *testing.T) {
 		isPostgresql: true,
 	})
 
-	_, _, _, _, errList := ss.(*Summary).checkIPAddresses()
+	_, _, _, _, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 1)
 	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nList of  ip address not found [127.0.0.1 127.0.0.2]")
 }
@@ -128,13 +128,13 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 		isPostgresql: true,
 	})
 
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).checkIPAddresses()
-	assert.Equal(t, errList.Len(), 5)
+	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
+	assert.Equal(t, errList.Len(), 17)
 	assert.Equal(t, automateIps, []string(nil))
 	assert.Equal(t, chefServerIps, []string(nil))
 	assert.Equal(t, opensearchIps, []string(nil))
 	assert.Equal(t, postgresqlIps, []string(nil))
-	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\n\nIncorrect Automate IP address format for ip 127.0.0\nIncorrect Automate IP address format for ip 127.0.1\nIncorrect Automate IP address format for ip 127.0.2\nIncorrect Automate IP address format for ip 127.0.3IP address validation failed\n\nIncorrect chef-server IP address format for ip 127.0.0\nIncorrect chef-server IP address format for ip 127.0.1\nIncorrect chef-server IP address format for ip 127.0.2\nIncorrect chef-server IP address format for ip 127.0.3IP address validation failed\n\nIncorrect OpenSearch IP address format for ip 127.0.0\nIncorrect OpenSearch IP address format for ip 127.0.1\nIncorrect OpenSearch IP address format for ip 127.0.2\nIncorrect OpenSearch IP address format for ip 127.0.3IP address validation failed\n\nIncorrect postgres IP address format for ip 127.0.0\nIncorrect postgres IP address format for ip 127.0.1\nIncorrect postgres IP address format for ip 127.0.2\nIncorrect postgres IP address format for ip 127.0.3IP address validation failed\nList of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]")
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nIncorrect Automate IP address format for ip 127.0.0IP address validation failed\nIncorrect Automate IP address format for ip 127.0.1IP address validation failed\nIncorrect Automate IP address format for ip 127.0.2IP address validation failed\nIncorrect Automate IP address format for ip 127.0.3IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.0IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.1IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.2IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.3IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.0IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.1IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.2IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.3IP address validation failed\nIncorrect postgres IP address format for ip 127.0.0IP address validation failed\nIncorrect postgres IP address format for ip 127.0.1IP address validation failed\nIncorrect postgres IP address format for ip 127.0.2IP address validation failed\nIncorrect postgres IP address format for ip 127.0.3IP address validation failed\nList of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]")
 }
 
 func TestRunFENode(t *testing.T) {
@@ -184,7 +184,7 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	err := ss.Prepare(sshUtilsImpl)
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
-	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
+	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Os Node |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
 }
 
 func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -59,29 +59,6 @@ func TestCheckIPAddressesFromInfra(t *testing.T) {
 	assert.Equal(t, postgresqlIps, []string{ValidIP7, ValidIP8, ValidIP9})
 }
 
-func TestCheckIPAddressesFromCmd(t *testing.T) {
-	infra := &AutomteHAInfraDetails{}
-	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
-	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
-	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
-	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
-
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
-		node:         fmt.Sprintf("%s,%s,%s,%s", ValidIP, ValidIP3, ValidIP5, ValidIP8),
-		isAutomate:   true,
-		isChefServer: true,
-		isOpenSearch: true,
-		isPostgresql: true,
-	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
-
-	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
-	assert.Equal(t, errList.Len(), 0)
-	assert.Equal(t, automateIps, []string{ValidIP})
-	assert.Equal(t, chefServerIps, []string{ValidIP3})
-	assert.Equal(t, opensearchIps, []string{ValidIP5})
-	assert.Equal(t, postgresqlIps, []string{ValidIP8})
-}
-
 func TestCheckIPAddressesByServicesAndIpFromFlag(t *testing.T) {
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -15,7 +15,7 @@ func TestCheckIPAddressesFromInfra(t *testing.T) {
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
@@ -38,7 +38,7 @@ func TestCheckIPAddressesFromCmd(t *testing.T) {
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
-	})
+	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
@@ -61,7 +61,7 @@ func TestCheckIPAddressesByServicesAndIpFromFlag(t *testing.T) {
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
-	})
+	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
@@ -83,7 +83,7 @@ func TestCheckIPAddressesOnlyByServices(t *testing.T) {
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
-	})
+	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 0)
@@ -106,7 +106,7 @@ func TestCheckIPAddressesError(t *testing.T) {
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
-	})
+	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	_, _, _, _, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 1)
@@ -126,7 +126,7 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 		isChefServer: true,
 		isOpenSearch: true,
 		isPostgresql: true,
-	})
+	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 17)
@@ -136,29 +136,17 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 	assert.Equal(t, postgresqlIps, []string(nil))
 	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nIncorrect Automate IP address format for ip 127.0.0IP address validation failed\nIncorrect Automate IP address format for ip 127.0.1IP address validation failed\nIncorrect Automate IP address format for ip 127.0.2IP address validation failed\nIncorrect Automate IP address format for ip 127.0.3IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.0IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.1IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.2IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.3IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.0IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.1IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.2IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.3IP address validation failed\nIncorrect postgres IP address format for ip 127.0.0IP address validation failed\nIncorrect postgres IP address format for ip 127.0.1IP address validation failed\nIncorrect postgres IP address format for ip 127.0.2IP address validation failed\nIncorrect postgres IP address format for ip 127.0.3IP address validation failed\nList of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]")
 }
-
-func TestRunFENode(t *testing.T) {
-	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
-	infra := &AutomteHAInfraDetails{}
-	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
-	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
-	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
-	err := ss.Prepare(sshUtilsImpl)
-	assert.NoError(t, err)
-}
-
 func TestRunFENodeDiaplay(t *testing.T) {
 	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
-	sshUtilsImpl := getMockSSHUtil(&SSHConfig{}, nil, "", nil)
-	err := ss.Prepare(sshUtilsImpl)
+	sshUtil := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, sshUtil)
+	err := ss.Prepare()
 	assert.NoError(t, err)
 	fe := ss.ShowFEStatus()
-	assert.Equal(t, fe, "+-------------+--------------+--------+------------+\n| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |\n+-------------+--------------+--------+------------+\n| Automate    | 198.51.100.0 | OK     | Unknown    |\n| Automate    | 198.51.100.1 | OK     | Unknown    |\n| Chef Server | 198.51.100.2 | OK     | Unknown    |\n| Chef Server | 198.51.100.3 | OK     | Unknown    |\n+-------------+--------------+--------+------------+")
+	assert.Equal(t, fe, "+-------------+------------+--------+-------------------------+\n| NAME        | IP ADDRESS | STATUS | OPENSEARCH              |\n+-------------+------------+--------+-------------------------+\n| automate    |            | OK     | \"green\" (Active: 100.0) |\n| chef-server |            | OK     | \"green\" (Active: 100.0) |\n+-------------+------------+--------+-------------------------+")
 }
 
 func TestRunBENode(t *testing.T) {
@@ -166,9 +154,8 @@ func TestRunBENode(t *testing.T) {
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
-	sshUtilsImpl := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
-	err := ss.Prepare(sshUtilsImpl)
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
+	err := ss.Prepare()
 	assert.NoError(t, err)
 }
 func TestRunBENodeDiaplay(t *testing.T) {
@@ -176,15 +163,15 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{})
-	sshUtilsImpl := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 	// Mock the time to a specific time
 	mockTime := time.Date(2023, 3, 15, 12, 0, 0, 0, time.UTC)
 	nowFunc = func() time.Time { return mockTime }
-	err := ss.Prepare(sshUtilsImpl)
+	// c.Execute()
+	err := ss.Prepare()
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
-	assert.Contains(t, be, "+------------+--------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+--------------+--------+----------------+------------------+---------+\n| OpenSearch | 198.51.100.4 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.5 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| OpenSearch | 198.51.100.6 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Unknown |\n| Postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.8 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n| Postgresql | 198.51.100.9 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+--------------+--------+----------------+------------------+---------+")
+	assert.Equal(t, be, "+------------+------------+--------+----------------+------------------+---------+\n| NAME       | IP ADDRESS | HEALTH | PROCESS        | UPTIME           | ROLE    |\n+------------+------------+--------+----------------+------------------+---------+\n| opensearch |            | OK     | up (pid: 4173) | 19431d 12h 0m 0s | OS node |\n| postgresql |            | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader  |\n+------------+------------+--------+----------------+------------------+---------+")
 }
 
 func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {
@@ -193,6 +180,7 @@ func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError
 			return sshConfig
 		},
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+			fmt.Println(remoteCommands, "remoteCommands")
 			if strings.Contains(remoteCommands, "/default/health --header") {
 				return `{"status":"OK","stdout":"","stderr":""}`, CSECORError
 			}
@@ -252,6 +240,26 @@ func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError
 							}
 						}
 					}
+				}`, CSECORError
+			}
+			if strings.Contains(remoteCommands, "/_cluster/health") {
+				return `{
+					"cluster_name": "opensearch",
+					"status": "green",
+					"timed_out": false,
+					"number_of_nodes": 3,
+					"number_of_data_nodes": 3,
+					"discovered_master": true,
+					"active_primary_shards": 50,
+					"active_shards": 104,
+					"relocating_shards": 0,
+					"initializing_shards": 0,
+					"unassigned_shards": 0,
+					"delayed_unassigned_shards": 0,
+					"number_of_pending_tasks": 0,
+					"number_of_in_flight_fetch": 0,
+					"task_max_waiting_in_queue_millis": 0,
+					"active_shards_percent_as_number": 100.0
 				}`, CSECORError
 			}
 			return "", CSECORError

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -27,17 +27,19 @@ Incorrect postgresql-ip, 127.0.0 IP address validation failed
 Incorrect postgresql-ip, 127.0.1 IP address validation failed
 Incorrect postgresql-ip, 127.0.2 IP address validation failed
 Incorrect postgresql-ip, 127.0.3 IP address validation failed`
-	displayBE = `+------------+--------------+--------+----------------+------------------+--------+
-| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE   |
-+------------+--------------+--------+----------------+------------------+--------+
-| postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader |
-+------------+--------------+--------+----------------+------------------+--------+`
-	displayFE = `+-------------+------------+--------+-------------------------+
-| NAME        | IP ADDRESS | STATUS | OPENSEARCH              |
-+-------------+------------+--------+-------------------------+
-| automate    |            | OK     | "green" (Active: 100.0) |
-| chef-server |            | OK     | "green" (Active: 100.0) |
-+-------------+------------+--------+-------------------------+`
+displayBE = `+------------+--------------+--------+--------------+-------------+---------+
+| NAME       | IP ADDRESS   | HEALTH | PROCESS      | UPTIME      | ROLE    |
++------------+--------------+--------+--------------+-------------+---------+
+| postgresql | 198.51.100.7 | ERROR  | down (pid: ) | 0d 0h 0m 0s | Unknown |
++------------+--------------+--------+--------------+-------------+---------+`
+displayFE = `+-------------+--------------+--------+------------+
+| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |
++-------------+--------------+--------+------------+
+| automate    | 198.51.100.1 | ERROR  | Unknown    |
+| automate    | 198.51.100.0 | ERROR  | Unknown    |
+| chef-server | 198.51.100.2 | ERROR  | Unknown    |
+| chef-server | 198.51.100.3 | ERROR  | Unknown    |
++-------------+--------------+--------+------------+`
 	mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
 )
 
@@ -178,17 +180,7 @@ func TestRunFENodeDiaplay(t *testing.T) {
 	err := ss.Prepare()
 	assert.NoError(t, err)
 	fe := ss.ShowFEStatus()
-	assert.Equal(t, fe, displayFE)
-}
-
-func TestRunBENode(t *testing.T) {
-	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars
-	infra := &AutomteHAInfraDetails{}
-	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4}
-	sshUtil := getMockSSHUtilRunSummary(&SSHConfig{hostIP: ValidIP4}, nil, nil)
-	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, sshUtil)
-	err := ss.Prepare()
-	assert.NoError(t, err)
+	assert.Contains(t, fe, displayFE)
 }
 func TestRunBENodeDiaplay(t *testing.T) {
 	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -11,18 +11,18 @@ import (
 
 const (
 	invalidIpAddress = `
-Incorrect Automate IP, 127.0.0 IP address validation failed
-Incorrect Automate IP, 127.0.1 IP address validation failed
-Incorrect Automate IP, 127.0.2 IP address validation failed
-Incorrect Automate IP, 127.0.3 IP address validation failed
+Incorrect automate IP, 127.0.0 IP address validation failed
+Incorrect automate IP, 127.0.1 IP address validation failed
+Incorrect automate IP, 127.0.2 IP address validation failed
+Incorrect automate IP, 127.0.3 IP address validation failed
 Incorrect chef-server IP, 127.0.0 IP address validation failed
 Incorrect chef-server IP, 127.0.1 IP address validation failed
 Incorrect chef-server IP, 127.0.2 IP address validation failed
 Incorrect chef-server IP, 127.0.3 IP address validation failed
-Incorrect OpenSearch IP, 127.0.0 IP address validation failed
-Incorrect OpenSearch IP, 127.0.1 IP address validation failed
-Incorrect OpenSearch IP, 127.0.2 IP address validation failed
-Incorrect OpenSearch IP, 127.0.3 IP address validation failed
+Incorrect opensearch IP, 127.0.0 IP address validation failed
+Incorrect opensearch IP, 127.0.1 IP address validation failed
+Incorrect opensearch IP, 127.0.2 IP address validation failed
+Incorrect opensearch IP, 127.0.3 IP address validation failed
 Incorrect postgresql IP, 127.0.0 IP address validation failed
 Incorrect postgresql IP, 127.0.1 IP address validation failed
 Incorrect postgresql IP, 127.0.2 IP address validation failed

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
+const (
 	invalidIpAddress = `
 Incorrect Automate IP address format for ip 127.0.0IP address validation failed
 Incorrect Automate IP address format for ip 127.0.1IP address validation failed
@@ -39,7 +39,7 @@ List of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]`
 | automate    |            | OK     | "green" (Active: 100.0) |
 | chef-server |            | OK     | "green" (Active: 100.0) |
 +-------------+------------+--------+-------------------------+`
-mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
 )
 
 func TestCheckIPAddressesFromInfra(t *testing.T) {

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -9,6 +9,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	invalidIpAddress = `
+Incorrect Automate IP address format for ip 127.0.0IP address validation failed
+Incorrect Automate IP address format for ip 127.0.1IP address validation failed
+Incorrect Automate IP address format for ip 127.0.2IP address validation failed
+Incorrect Automate IP address format for ip 127.0.3IP address validation failed
+Incorrect chef-server IP address format for ip 127.0.0IP address validation failed
+Incorrect chef-server IP address format for ip 127.0.1IP address validation failed
+Incorrect chef-server IP address format for ip 127.0.2IP address validation failed
+Incorrect chef-server IP address format for ip 127.0.3IP address validation failed
+Incorrect OpenSearch IP address format for ip 127.0.0IP address validation failed
+Incorrect OpenSearch IP address format for ip 127.0.1IP address validation failed
+Incorrect OpenSearch IP address format for ip 127.0.2IP address validation failed
+Incorrect OpenSearch IP address format for ip 127.0.3IP address validation failed
+Incorrect postgres IP address format for ip 127.0.0IP address validation failed
+Incorrect postgres IP address format for ip 127.0.1IP address validation failed
+Incorrect postgres IP address format for ip 127.0.2IP address validation failed
+Incorrect postgres IP address format for ip 127.0.3IP address validation failed
+List of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]`
+	displayBE = `+------------+--------------+--------+----------------+------------------+--------+
+| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE   |
++------------+--------------+--------+----------------+------------------+--------+
+| postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader |
++------------+--------------+--------+----------------+------------------+--------+`
+	displayFE = `+-------------+------------+--------+-------------------------+
+| NAME        | IP ADDRESS | STATUS | OPENSEARCH              |
++-------------+------------+--------+-------------------------+
+| automate    |            | OK     | "green" (Active: 100.0) |
+| chef-server |            | OK     | "green" (Active: 100.0) |
++-------------+------------+--------+-------------------------+`
+mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+)
+
 func TestCheckIPAddressesFromInfra(t *testing.T) {
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
@@ -134,10 +167,10 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 	assert.Equal(t, chefServerIps, []string(nil))
 	assert.Equal(t, opensearchIps, []string(nil))
 	assert.Equal(t, postgresqlIps, []string(nil))
-	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nIncorrect Automate IP address format for ip 127.0.0IP address validation failed\nIncorrect Automate IP address format for ip 127.0.1IP address validation failed\nIncorrect Automate IP address format for ip 127.0.2IP address validation failed\nIncorrect Automate IP address format for ip 127.0.3IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.0IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.1IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.2IP address validation failed\nIncorrect chef-server IP address format for ip 127.0.3IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.0IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.1IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.2IP address validation failed\nIncorrect OpenSearch IP address format for ip 127.0.3IP address validation failed\nIncorrect postgres IP address format for ip 127.0.0IP address validation failed\nIncorrect postgres IP address format for ip 127.0.1IP address validation failed\nIncorrect postgres IP address format for ip 127.0.2IP address validation failed\nIncorrect postgres IP address format for ip 127.0.3IP address validation failed\nList of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]")
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), invalidIpAddress)
 }
 func TestRunFENodeDiaplay(t *testing.T) {
-	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
 	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
@@ -146,11 +179,11 @@ func TestRunFENodeDiaplay(t *testing.T) {
 	err := ss.Prepare()
 	assert.NoError(t, err)
 	fe := ss.ShowFEStatus()
-	assert.Equal(t, fe, "+-------------+------------+--------+-------------------------+\n| NAME        | IP ADDRESS | STATUS | OPENSEARCH              |\n+-------------+------------+--------+-------------------------+\n| automate    |            | OK     | \"green\" (Active: 100.0) |\n| chef-server |            | OK     | \"green\" (Active: 100.0) |\n+-------------+------------+--------+-------------------------+")
+	assert.Equal(t, fe, displayFE)
 }
 
 func TestRunBENode(t *testing.T) {
-	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars
 	infra := &AutomteHAInfraDetails{}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4}
 	sshUtil := getMockSSHUtilRunSummary(&SSHConfig{hostIP: ValidIP4}, nil, nil)
@@ -159,7 +192,7 @@ func TestRunBENode(t *testing.T) {
 	assert.NoError(t, err)
 }
 func TestRunBENodeDiaplay(t *testing.T) {
-	a2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
+	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars
 	infra := &AutomteHAInfraDetails{}
 	// infra.Outputs.OpensearchPrivateIps.Value = []string{ValidIP4, ValidIP5, ValidIP6}
 	infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7}
@@ -172,7 +205,7 @@ func TestRunBENodeDiaplay(t *testing.T) {
 	err := ss.Prepare()
 	assert.NoError(t, err)
 	be := ss.ShowBEStatus()
-	assert.Equal(t, be, "+------------+--------------+--------+----------------+------------------+--------+\n| NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE   |\n+------------+--------------+--------+----------------+------------------+--------+\n| postgresql | 198.51.100.7 | OK     | up (pid: 4173) | 19431d 12h 0m 0s | Leader |\n+------------+--------------+--------+----------------+------------------+--------+")
+	assert.Equal(t, be, displayBE)
 }
 
 func getMockSSHUtilRunSummary(sshConfig *SSHConfig, CFTRError error, CSECORError error) *MockSSHUtilsImpl {

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -11,22 +11,22 @@ import (
 
 const (
 	invalidIpAddress = `
-Incorrect Automate-ip, 127.0.0 IP address validation failed
-Incorrect Automate-ip, 127.0.1 IP address validation failed
-Incorrect Automate-ip, 127.0.2 IP address validation failed
-Incorrect Automate-ip, 127.0.3 IP address validation failed
-Incorrect chef-server-ip, 127.0.0 IP address validation failed
-Incorrect chef-server-ip, 127.0.1 IP address validation failed
-Incorrect chef-server-ip, 127.0.2 IP address validation failed
-Incorrect chef-server-ip, 127.0.3 IP address validation failed
-Incorrect OpenSearch-ip, 127.0.0 IP address validation failed
-Incorrect OpenSearch-ip, 127.0.1 IP address validation failed
-Incorrect OpenSearch-ip, 127.0.2 IP address validation failed
-Incorrect OpenSearch-ip, 127.0.3 IP address validation failed
-Incorrect postgresql-ip, 127.0.0 IP address validation failed
-Incorrect postgresql-ip, 127.0.1 IP address validation failed
-Incorrect postgresql-ip, 127.0.2 IP address validation failed
-Incorrect postgresql-ip, 127.0.3 IP address validation failed`
+Incorrect Automate IP, 127.0.0 IP address validation failed
+Incorrect Automate IP, 127.0.1 IP address validation failed
+Incorrect Automate IP, 127.0.2 IP address validation failed
+Incorrect Automate IP, 127.0.3 IP address validation failed
+Incorrect chef-server IP, 127.0.0 IP address validation failed
+Incorrect chef-server IP, 127.0.1 IP address validation failed
+Incorrect chef-server IP, 127.0.2 IP address validation failed
+Incorrect chef-server IP, 127.0.3 IP address validation failed
+Incorrect OpenSearch IP, 127.0.0 IP address validation failed
+Incorrect OpenSearch IP, 127.0.1 IP address validation failed
+Incorrect OpenSearch IP, 127.0.2 IP address validation failed
+Incorrect OpenSearch IP, 127.0.3 IP address validation failed
+Incorrect postgresql IP, 127.0.0 IP address validation failed
+Incorrect postgresql IP, 127.0.1 IP address validation failed
+Incorrect postgresql IP, 127.0.2 IP address validation failed
+Incorrect postgresql IP, 127.0.3 IP address validation failed`
 displayBE = `+------------+--------------+--------+--------------+-------------+---------+
 | NAME       | IP ADDRESS   | HEALTH | PROCESS      | UPTIME      | ROLE    |
 +------------+--------------+--------+--------------+-------------+---------+

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -11,23 +11,22 @@ import (
 
 const (
 	invalidIpAddress = `
-Incorrect Automate IP address format for ip 127.0.0IP address validation failed
-Incorrect Automate IP address format for ip 127.0.1IP address validation failed
-Incorrect Automate IP address format for ip 127.0.2IP address validation failed
-Incorrect Automate IP address format for ip 127.0.3IP address validation failed
-Incorrect chef-server IP address format for ip 127.0.0IP address validation failed
-Incorrect chef-server IP address format for ip 127.0.1IP address validation failed
-Incorrect chef-server IP address format for ip 127.0.2IP address validation failed
-Incorrect chef-server IP address format for ip 127.0.3IP address validation failed
-Incorrect OpenSearch IP address format for ip 127.0.0IP address validation failed
-Incorrect OpenSearch IP address format for ip 127.0.1IP address validation failed
-Incorrect OpenSearch IP address format for ip 127.0.2IP address validation failed
-Incorrect OpenSearch IP address format for ip 127.0.3IP address validation failed
-Incorrect postgres IP address format for ip 127.0.0IP address validation failed
-Incorrect postgres IP address format for ip 127.0.1IP address validation failed
-Incorrect postgres IP address format for ip 127.0.2IP address validation failed
-Incorrect postgres IP address format for ip 127.0.3IP address validation failed
-List of  ip address not found [127.0.0 127.0.1 127.0.2 127.0.3]`
+Incorrect Automate-ip, 127.0.0 IP address validation failed
+Incorrect Automate-ip, 127.0.1 IP address validation failed
+Incorrect Automate-ip, 127.0.2 IP address validation failed
+Incorrect Automate-ip, 127.0.3 IP address validation failed
+Incorrect chef-server-ip, 127.0.0 IP address validation failed
+Incorrect chef-server-ip, 127.0.1 IP address validation failed
+Incorrect chef-server-ip, 127.0.2 IP address validation failed
+Incorrect chef-server-ip, 127.0.3 IP address validation failed
+Incorrect OpenSearch-ip, 127.0.0 IP address validation failed
+Incorrect OpenSearch-ip, 127.0.1 IP address validation failed
+Incorrect OpenSearch-ip, 127.0.2 IP address validation failed
+Incorrect OpenSearch-ip, 127.0.3 IP address validation failed
+Incorrect postgresql-ip, 127.0.0 IP address validation failed
+Incorrect postgresql-ip, 127.0.1 IP address validation failed
+Incorrect postgresql-ip, 127.0.2 IP address validation failed
+Incorrect postgresql-ip, 127.0.3 IP address validation failed`
 	displayBE = `+------------+--------------+--------+----------------+------------------+--------+
 | NAME       | IP ADDRESS   | HEALTH | PROCESS        | UPTIME           | ROLE   |
 +------------+--------------+--------+----------------+------------------+--------+
@@ -143,7 +142,7 @@ func TestCheckIPAddressesError(t *testing.T) {
 
 	_, _, _, _, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
 	assert.Equal(t, errList.Len(), 1)
-	assert.Contains(t, getSingleErrorFromList(errList).Error(), "\nList of  ip address not found [127.0.0.1 127.0.0.2]")
+	assert.Contains(t, getSingleErrorFromList(errList).Error(), "List of  ip address not found [127.0.0.1 127.0.0.2] does not match any node for Automate, PostgreSQL or ChefServer services")
 }
 
 func TestCheckIPAddressesValidation(t *testing.T) {
@@ -162,7 +161,7 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 	}, getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil))
 
 	automateIps, chefServerIps, opensearchIps, postgresqlIps, errList := ss.(*Summary).getIPAddressesFromFlagOrInfra()
-	assert.Equal(t, errList.Len(), 17)
+	assert.Equal(t, errList.Len(), 16)
 	assert.Equal(t, automateIps, []string(nil))
 	assert.Equal(t, chefServerIps, []string(nil))
 	assert.Equal(t, opensearchIps, []string(nil))

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -27,19 +27,13 @@ Incorrect postgresql IP, 127.0.0 IP address validation failed
 Incorrect postgresql IP, 127.0.1 IP address validation failed
 Incorrect postgresql IP, 127.0.2 IP address validation failed
 Incorrect postgresql IP, 127.0.3 IP address validation failed`
-displayBE = `+------------+--------------+--------+--------------+-------------+---------+
+	displayBE = `+------------+--------------+--------+--------------+-------------+---------+
 | NAME       | IP ADDRESS   | HEALTH | PROCESS      | UPTIME      | ROLE    |
 +------------+--------------+--------+--------------+-------------+---------+
 | postgresql | 198.51.100.7 | ERROR  | down (pid: ) | 0d 0h 0m 0s | Unknown |
 +------------+--------------+--------+--------------+-------------+---------+`
-displayFE = `+-------------+--------------+--------+------------+
-| NAME        | IP ADDRESS   | STATUS | OPENSEARCH |
-+-------------+--------------+--------+------------+
-| automate    | 198.51.100.1 | ERROR  | Unknown    |
-| automate    | 198.51.100.0 | ERROR  | Unknown    |
-| chef-server | 198.51.100.2 | ERROR  | Unknown    |
-| chef-server | 198.51.100.3 | ERROR  | Unknown    |
-+-------------+--------------+--------+------------+`
+	displayFEAutomate         = `| automate    | 198.51.100.1 | ERROR  | Unknown    |`
+	displayFECS               = `| chef-server | 198.51.100.2 | ERROR  | Unknown    |`
 	mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"
 )
 
@@ -150,14 +144,16 @@ func TestCheckIPAddressesValidation(t *testing.T) {
 func TestRunFENodeDiaplay(t *testing.T) {
 	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars
 	infra := &AutomteHAInfraDetails{}
-	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP, ValidIP1}
-	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2, ValidIP3}
+	infra.Outputs.AutomatePrivateIps.Value = []string{ValidIP1}
+	infra.Outputs.ChefServerPrivateIps.Value = []string{ValidIP2}
 	sshUtil := getMockSSHUtilRunSummary(&SSHConfig{}, nil, nil)
 	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{}, sshUtil)
 	err := ss.Prepare()
 	assert.NoError(t, err)
 	fe := ss.ShowFEStatus()
-	assert.Contains(t, fe, displayFE)
+	assert.Contains(t, fe, displayFEAutomate)
+	assert.Contains(t, fe, displayFECS)
+
 }
 func TestRunBENodeDiaplay(t *testing.T) {
 	a2haHabitatAutoTfvars = mockA2haHabitatAutoTfvars

--- a/components/automate-cli/pkg/testfiles/a2ha_habitat.auto.tfvars
+++ b/components/automate-cli/pkg/testfiles/a2ha_habitat.auto.tfvars
@@ -1,0 +1,2 @@
+hab_sup_http_gateway_auth_token = "M+W20H+Q8Htd8GJdq5ytqL26/S2DRg0zeLmpGL9z3ik="
+hab_sup_ring_key = "SYM-SEC-1\nautomate-20230306082218\n\n9rqIxZlOHjCrs7wwrxtJn+V+4KajDdNus/0bDA=" 

--- a/components/automate-deployment/pkg/a1upgrade/preflight.go
+++ b/components/automate-deployment/pkg/a1upgrade/preflight.go
@@ -33,7 +33,7 @@ const (
 	// allowed Automate v1 version that we will upgrade from.
 	A1RequiredMinorVersion = 8
 	// A1RequiredPatchVersion is patch component of the minimum
-	// allowed Automate v1 version that we will upgrade from.
+	// allowed Autoxmate v1 version that we will upgrade from.
 	A1RequiredPatchVersion = 38
 )
 

--- a/components/automate-deployment/pkg/a1upgrade/preflight.go
+++ b/components/automate-deployment/pkg/a1upgrade/preflight.go
@@ -33,7 +33,7 @@ const (
 	// allowed Automate v1 version that we will upgrade from.
 	A1RequiredMinorVersion = 8
 	// A1RequiredPatchVersion is patch component of the minimum
-	// allowed Autoxmate v1 version that we will upgrade from.
+	// allowed Automate v1 version that we will upgrade from.
 	A1RequiredPatchVersion = 38
 )
 

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -153,7 +153,7 @@ Run the following steps on Bastion Host Machine:
     chef-automate deploy config.toml --airgap-bundle automate.aib
 
     #After Deployment is done successfully. Check status of Chef Automate HA services
-    chef-automate status
+    chef-automate status summary
 
     #Check Chef Automate HA deployment information, using the following command
     chef-automate info

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -153,7 +153,7 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
    chef-automate deploy config.toml --airgap-bundle automate.aib
 
    #After Deployment is done successfully. Check status of Chef Automate HA services
-   chef-automate status
+   chef-automate status summary
    
    #Check Chef Automate HA deployment information, using the following command
    chef-automate info

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -133,7 +133,7 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
    chef-automate deploy config.toml --airgap-bundle automate.aib
 
    #After Deployment is done successfully. Check the status of Chef Automate HA services
-   chef-automate status
+   chef-automate status summary
    "
    ```
 
@@ -297,7 +297,7 @@ Continue with the deployment after updating the config:
    chef-automate deploy config.toml --airgap-bundle automate.aib
 
    #After Deployment is done successfully. Check the status of Chef Automate HA services
-   chef-automate status
+   chef-automate status summary
    "
 ```
 
@@ -380,7 +380,7 @@ Continue with the deployment after updating the config:
    chef-automate deploy config.toml --airgap-bundle automate.aib
 
    #After Deployment is done successfully. Check the status of Chef Automate HA services
-   chef-automate status
+   chef-automate status summary
    "
 ```
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
get status summary for HA deployment
There are 3 ways, user can get status summary
1. Get status summary for ( automate, chef-server, open-search, postgresql ) nodes at-once
2. Get status summary by ip address
3. Get status summary only by (automate, chef-server, open-search, postgresql) 


> [root@ip-127-0-0-1 ec2-user]# chef-automate status summary -h
> Retrieve Chef Automate status node summary for HA deployment
> 
> Usage:
>   chef-automate status summary [flags]
> 
> Flags:
> Shorthand | Flags | Details | Type
> -- | -- | -- | --
>   -a |--automate                | Get only automate Status | bool
>   -c |--chef-server             | Get only chef server Status | bool
>   -o |--opensearch              | Get only opensearch Status | bool
>   -p |--postgresql              | Get only postgresql Status | bool
>    -- |--node    |Get Status by ip addresses | string
> 

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-730

### :athletic_shoe: How to Build and Test the Change

- locally
    - hab studio enter
    - rebuild components/automate-cli/
    -  hab pkg upload /hab/cache/artifacts/smudassi-automate-cli-0.1.0-**timestamp**-x86_64-linux.hart ( upload artifact )
-  Bastion machine
    - hab pkg install **userOrigin**/automate-cli/0.1.0/**timestamp** -bf
    - sudo chef-automate status summary


**output**
<img width="805" alt="Screenshot 2023-03-16 at 3 09 50 PM" src="https://user-images.githubusercontent.com/47217471/225577294-cd14a41a-97f1-4f13-ac58-731f1be0fae1.png">

Demo Video:
[Click here](https://progresssoftware-my.sharepoint.com/:v:/g/personal/smudassi_progress_com/EX6aFlbis31DjANbTXh6J6oBZDZXYgsWDyGhX_uVDAT7kg?e=rbIShu)

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
test coverage
<img width="1095" alt="Screenshot 2023-03-15 at 9 43 32 AM" src="https://user-images.githubusercontent.com/47217471/225204737-ac4a7d3e-8f98-4a32-b598-e931aa8db0c8.png">


