### PR TITLE
Desktop Configuration fix

### DIFF
--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -158,7 +158,7 @@ automate do
   ### Leave commented out if using AWS infrastructure
   {{ if .Automate.Config.Fqdn }} fqdn "{{ .Automate.Config.Fqdn }}" {{ else }} # fqdn "{{ .Automate.Config.Fqdn }}" {{ end }}
   #Deprecated Config - automate_setup_type is not supported
-  automate_setup_type {{ .Automate.Config.AutomateSetupType }}
+  automate_setup_type "{{ .Automate.Config.AutomateSetupType }}"
   ### Uncomment and set this value if the teams service
   ### port (default: 10128) conflicts with another service.
   {{ if .Automate.Config.TeamsPort }} teams_port "{{ .Automate.Config.TeamsPort }}" {{ else }} # teams_port "{{ .Automate.Config.TeamsPort }}" {{ end }}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
To set up SaaS cluster with desktop configuration, we need to add automate_setup_type = "desktop" in config.toml
The value desktop is not getting picked by terraform.tfvars, aws.auto.tfvars from a2ha.rb and the desktop configuration is not applied. In this PR, this issue is fixed

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
Now, you should be able to view desktop on automate ui

Scenarios tested:
1. Added nodes (mac and window)
2. Org and user creation
3. Node bootstrapping
4. Cookbook upload and runlist
5. SSO feature test
6. Datadog integration and logs on datadog
7. Backup and restore

### :athletic_shoe: How to Build and Test the Change
For chef-saas HA setup
1. git checkout this branch
8. rebuild "automate-cli", "automate-cluster-ctl", "automate-backend-deployment" and upload these packages to your origin
9. Install hab on your bastion
10. Install automate-cli using: `hab pkg install <your-automate-cli-hab-pkg> -bf`
11. Create manifest.json of build version 4.5.37 and add your automate-cluster-ctl, automate-backend-deployment packages
12. Create bundle using: `chef-automate airgap bundle create -c current -m manifest.json -d`
13. In config.toml, uncomment `automate_setup_type` and add
     automate_setup_type = "desktop"
14. `chef-automate provision-infra config.toml --airgap-bundle automate-4.5.37.aib --saas -d`
15. `chef-automate deploy config.toml --airgap-bundle automate-4.5.37.aib -d`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/101619541/221829760-e36f5fc3-b466-4935-a169-4a85f0bbd026.png)

Scenarios tested - demo video:
https://progresssoftware.sharepoint.com/:f:/s/ChefCoreC/ErXBRiXa8j9Lm_nS7G2zhcQBwsNJgPA5Fg3eZ3adVbqTGQ?e=w0wJsm
