### PR TITLE
Default the max_request_size to 4MB

### DIFF
--- a/api/config/erchef/config_request.go
+++ b/api/config/erchef/config_request.go
@@ -47,7 +47,7 @@ func DefaultConfigRequest() *ConfigRequest {
 
 	c.V1.Sys.Api.AuthSkew = w.Int32(900)
 	c.V1.Sys.Api.BulkFetchBatchSize = w.Int32(5)
-	c.V1.Sys.Api.MaxRequestSize = w.Int32(2000000)
+	c.V1.Sys.Api.MaxRequestSize = w.Int32(4000000)
 	c.V1.Sys.Api.BaseResourceUrl = w.String("host_header")
 	c.V1.Sys.Api.StrictSearchResultAcls = w.Bool(false)
 	c.V1.Sys.Api.ActionsFqdn = w.String("")


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

We need to set the default value for `chef_server_default_max_size` to 4MB instead of 2MB.

### :chains: Related Resources

https://chefio.atlassian.net/browse/IN-969

### :+1: Definition of Done
- The config size should be set in the `opscode_erchef['max_request_size']` in `/etc/opscode/chef-server.rb` files in CS nodes in case of Automate HA and in the Automate instance

### :athletic_shoe: How to Build and Test the Change

- hab studio enter
- start_all_services
- start_chef_server
- check the config 

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
