### PR TITLE
Take input of Sudo Password for CLI Commands

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.toml
+++ b/components/automate-cli/cmd/chef-automate/config.toml
@@ -12,7 +12,6 @@ workspace_path = "/hab/a2_deploy_workspace"
 ssh_user = "centos"
 # private ssh key file path to access instances
 ssh_key_file = "~/.ssh/A2HA.pem"
-# sudo_password = ""
 # logging_monitoring_management = ""
 # new_elk = ""
 # existing_elk_instance_ip ""

--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -66,7 +66,7 @@ opensearch do
   {{ if .Opensearch.Config.PublicKey }} public_key "{{ .Opensearch.Config.PublicKey }}" {{ else }} # public_key "{{ .Opensearch.Config.PublicKey }}" {{ end }}
   admin_dn "{{ .Opensearch.Config.AdminDn }}"
   nodes_dn "{{ .Opensearch.Config.NodesDn }}"
-  {{ if .Opensearch.Config.CertsByIP }} certs_by_ip  "{ {{ range $index, $element := .Opensearch.Config.CertsByIP}}{{if $index}} \n {{end}} \"{{$element.IP}}\" = { private_key = <<-EOT\n{{$element.PrivateKey}}\nEOT\n\n public_key = <<-EOT\n{{$element.PublicKey}}\nEOT\n\n nodes_dn = <<EOT\n{{$element.NodesDn}}EOT\n } {{end}} }" {{end}}
+  {{ if .Opensearch.Config.CertsByIP }} certs_by_ip  "{ {{ range $index, $element := .Opensearch.Config.CertsByIP}}{{if $index}} \n {{end}} \"{{$element.IP}}\" = { private_key = <<-EOT\n{{$element.PrivateKey}}\nEOT\n\n public_key = <<-EOT\n{{$element.PublicKey}}\nEOT\n\n nodes_dn = <<-EOT\n{{$element.NodesDn}}\nEOT\n } {{end}} }" {{end}}
 end
 
 ###############################################################

--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -297,7 +297,7 @@ func (p *PullConfigsImpl) pullAutomateConfigs() (map[string]*dc.AutomateConfig, 
 			continue
 		}
 		p.sshUtil.getSSHConfig().hostIP = ip
-		rawOutput, err := p.sshUtil.connectAndExecuteCommandOnRemote(GET_FRONTEND_CONFIG, true)
+		rawOutput, err := p.sshUtil.connectAndExecuteCommandOnRemote(fmt.Sprintf(GET_FRONTEND_CONFIG, ""), true)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func (p *PullConfigsImpl) pullChefServerConfigs() (map[string]*dc.AutomateConfig
 			continue
 		}
 		p.sshUtil.getSSHConfig().hostIP = ip
-		rawOutput, err := p.sshUtil.connectAndExecuteCommandOnRemote(GET_FRONTEND_CONFIG, true)
+		rawOutput, err := p.sshUtil.connectAndExecuteCommandOnRemote(fmt.Sprintf(GET_FRONTEND_CONFIG, ""), true)
 		if err != nil {
 			return nil, err
 		}

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -205,6 +205,10 @@ func (s *SSHUtilImpl) connectAndExecuteCommandOnRemote(remoteCommands string, sp
 			output = pattern.ReplaceAllString(output, "")
 		}
 		if err != nil {
+			if strings.Contains(output, "sudo: no tty present and no askpass program specified") {
+				errCh <- errors.New("The sudo password is missing. Make sure to provide sudo_password as enviroment variable and pass -E option while running command.")
+				return
+			}
 			errCh <- err
 			return
 		}

--- a/components/automate-cli/cmd/chef-automate/sshUtils.go
+++ b/components/automate-cli/cmd/chef-automate/sshUtils.go
@@ -186,9 +186,7 @@ func (s *SSHUtilImpl) connectAndExecuteCommandOnRemote(remoteCommands string, sp
 	}
 	defer session.Close()
 
-	if spinner {
-		writer.StartSpinner()
-	}
+	startSpinnerIfRequired(spinner)
 
 	var output string
 	errCh := make(chan error)
@@ -220,16 +218,12 @@ func (s *SSHUtilImpl) connectAndExecuteCommandOnRemote(remoteCommands string, sp
 		return "", errors.New("command timed out")
 	case err := <-errCh:
 		if err != nil {
-			if spinner {
-				writer.StopSpinner()
-			}
+			stopSpinnerIfRequired(spinner)
 			return output, err
 		}
 	}
 
-	if spinner {
-		writer.StopSpinner()
-	}
+	stopSpinnerIfRequired(spinner)
 
 	logrus.Debug("Execution of command done......")
 	return output, nil
@@ -410,4 +404,16 @@ func isSudoPasswordEnabled() bool {
 func getSudoPassword() string {
 	sudoPassword := os.Getenv(SUDO_PASSWORD)
 	return sudoPassword
+}
+
+func startSpinnerIfRequired(spinner bool) {
+	if spinner {
+		writer.StartSpinner()
+	}
+}
+
+func stopSpinnerIfRequired(spinner bool) {
+	if spinner {
+		writer.StopSpinner()
+	}
 }

--- a/components/automate-cli/pkg/testfiles/aws/config.toml
+++ b/components/automate-cli/pkg/testfiles/aws/config.toml
@@ -11,8 +11,6 @@ ssh_port = "22"
 # Private SSH key file path, which has access to all the instances.
 # Eg.: ssh_key_file = "~/.ssh/A2HA.pem"
 ssh_key_file = "/home/ec2-user/XYZ.pem"
-# Provide Password if needed to run sudo commands.
-#sudo_password = "chefautomate"
 # Eg.: backup_config = "efs" or "s3"
 backup_config = "s3"
 # If s3 is selected for backup_config,

--- a/components/automate-cli/pkg/testfiles/onprem/config.toml
+++ b/components/automate-cli/pkg/testfiles/onprem/config.toml
@@ -14,9 +14,6 @@ ssh_key_file = "/home/ec2-user/A2HA.pem"
 # custome ssh port no to connect instances, default will be 22
 # Eg.: ssh_port = "22"
 ssh_port = "22"
-
-# Provide Password if needed to run sudo commands.
-sudo_password = ""
 ## === ===
 
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"

--- a/components/automate-cluster-ctl/libexec/cluster-gather-logs
+++ b/components/automate-cluster-ctl/libexec/cluster-gather-logs
@@ -70,10 +70,14 @@ class AutomateClusterGatherlogs < AutomateCluster::Command
 
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
-    # Set a new secret
-    secrets.set('sudo_password',  ENV['sudo_password'])
-    # Save the updated secrets store to disk
-    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    sudo_password = ENV['sudo_password']
+    # If the sudo_password is set, store it in the secrets hash
+    if sudo_password
+      # Set a new secret
+      secrets.set('sudo_password', sudo_password)
+      # Save the updated secrets store to disk
+      secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    end
   end
 
   def sudo_cmd(backend)

--- a/components/automate-cluster-ctl/libexec/cluster-gather-logs
+++ b/components/automate-cluster-ctl/libexec/cluster-gather-logs
@@ -22,6 +22,9 @@ class AutomateClusterGatherlogs < AutomateCluster::Command
     ssh = AutomateCluster::SSH.new
     timestamp = Time.now.strftime('%Y%m%d%H%M%S')
 
+    # store the secret envs so we can pass them to the command
+    store_secret_envs
+
     ssh.connections do |type, conn|
       frontend = %w{automate chef_server}.include?(type)
 
@@ -63,6 +66,14 @@ class AutomateClusterGatherlogs < AutomateCluster::Command
     else
       fe_sudo_password
     end
+  end
+
+  # store the sudo_password from the env variable in the secrets hash
+  def store_secret_envs
+    # Set a new secret
+    secrets.set('sudo_password',  ENV['sudo_password'])
+    # Save the updated secrets store to disk
+    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
   end
 
   def sudo_cmd(backend)

--- a/components/automate-cluster-ctl/libexec/cluster-status
+++ b/components/automate-cluster-ctl/libexec/cluster-status
@@ -17,6 +17,10 @@ class AutomateClusterStatus < AutomateCluster::Command
   def execute
     be_service_data = []
     fe_service_data = []
+
+    # store the secret envs so we can pass them to the command
+    store_secret_envs
+    
     if AutomateCluster::Config.aws.setup_managed_services == true
       wait_while 'Fetching service status' do
         fe_service_data += fe_status('automate') if name.nil? || name == 'automate'
@@ -52,6 +56,14 @@ class AutomateClusterStatus < AutomateCluster::Command
 
   def fe_sudo_password
     @fe_sudo_password ||= AutomateCluster.secrets['fe_sudo_password'] || AutomateCluster.secrets['sudo_password']
+  end
+
+  # store the sudo_password from the env variable in the secrets hash
+  def store_secret_envs
+    # Set a new secret
+    secrets.set('sudo_password',  ENV['sudo_password'])
+    # Save the updated secrets store to disk
+    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
   end
 
   def fe_status(service)

--- a/components/automate-cluster-ctl/libexec/cluster-status
+++ b/components/automate-cluster-ctl/libexec/cluster-status
@@ -60,10 +60,14 @@ class AutomateClusterStatus < AutomateCluster::Command
 
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
-    # Set a new secret
-    secrets.set('sudo_password',  ENV['sudo_password'])
-    # Save the updated secrets store to disk
-    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    sudo_password = ENV['sudo_password']
+    # If the sudo_password is set, store it in the secrets hash
+    if sudo_password
+      # Set a new secret
+      secrets.set('sudo_password', sudo_password)
+      # Save the updated secrets store to disk
+      secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    end
   end
 
   def fe_status(service)

--- a/components/automate-cluster-ctl/libexec/cluster-test
+++ b/components/automate-cluster-ctl/libexec/cluster-test
@@ -33,6 +33,9 @@ class AutomateClusterTest < AutomateCluster::Command
   def execute
     results = []
 
+    # store the secret envs so we can pass them to the command
+    store_secret_envs
+
     INSPEC_PROFILES.each do |name, profiles|
       next unless service_name.nil? || name == service_name.to_sym
 
@@ -64,6 +67,14 @@ class AutomateClusterTest < AutomateCluster::Command
 
   def backend?(name)
     [:elasticsearch, :postgresql].include?(name)
+  end
+
+  # store the sudo_password from the env variable in the secrets hash
+  def store_secret_envs
+    # Set a new secret
+    secrets.set('sudo_password',  ENV['sudo_password'])
+    # Save the updated secrets store to disk
+    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
   end
 
   # def default_sudo_password

--- a/components/automate-cluster-ctl/libexec/cluster-test
+++ b/components/automate-cluster-ctl/libexec/cluster-test
@@ -71,10 +71,14 @@ class AutomateClusterTest < AutomateCluster::Command
 
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
-    # Set a new secret
-    secrets.set('sudo_password',  ENV['sudo_password'])
-    # Save the updated secrets store to disk
-    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    sudo_password = ENV['sudo_password']
+    # If the sudo_password is set, store it in the secrets hash
+    if sudo_password
+      # Set a new secret
+      secrets.set('sudo_password', sudo_password)
+      # Save the updated secrets store to disk
+      secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    end
   end
 
   # def default_sudo_password

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -102,7 +102,6 @@ Run the following steps on Bastion Host Machine:
    - Give `ssh_user` which has access to all the machines. Example: `ubuntu`
    - Give `ssh_port` in case your AMI is running on custom ssh port, default will be 22.
    - Give `ssh_key_file` path, this should have been download from AWS SSH Key Pair which we want to use to create all the VM's. Thus, we will be able to access all VM's using this.
-   - `sudo_password` is only meant to switch to sudo user. If you have configured password for sudo user, please provide it here.
    - We support only private key authentication.
    - Set `backup_config` to `"efs"` or `"s3"`
    - If `backup_config` is `s3` then set `s3_bucketName` to a Unique Value.
@@ -219,7 +218,6 @@ Check if Chef Automate UI is accessible by going to (Domain used for Chef Automa
 ssh_user = "ec2-user"
 ssh_port = "22"
 ssh_key_file = "~/.ssh/my-key.pem"
-# sudo_password = ""
 backup_config = "s3"
 s3_bucketName = "My-Bucket-Name"
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -54,7 +54,7 @@ Follow the steps below to deploy Chef Automate High Availability (HA) on AWS (Am
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](/automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -54,7 +54,7 @@ Follow the steps below to deploy Chef Automate High Availability (HA) on AWS (Am
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -105,7 +105,6 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
    - Give `ssh_user` which has access to all the machines. Example: `ubuntu`.
    - Give `ssh_port` if your AMI runs on custom **ssh port**. The default value is 22.
    - Give `ssh_key_file` path, downloaded from **AWS SSH Key Pair**, which you want to use to create all the VMs. This will let you access all the VMs.
-   - `sudo_password` is only meant to switch to sudo user. If you have configured password for sudo user, please provide it here.
    - We support only private key authentication.
    - Set `backup_config` to `"s3"`. If `backup_config` is `s3`, set `s3_bucketName`.
    - Set `admin_password` to access Chef Automate UI for user `admin`.
@@ -224,7 +223,6 @@ Check if Chef Automate UI is accessible by going to (Domain used for Chef Automa
 ssh_user = "ec2-user"
 ssh_port = "22"
 ssh_key_file = "~/.ssh/my-key.pem"
-# sudo_password = ""
 backup_config = "s3"
 s3_bucketName = "My-Bucket-Name"
 secrets_key_file = "/hab/a2_deploy_workspace/secrets.key"

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -67,7 +67,7 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_managed_deploy_steps.md
@@ -67,7 +67,7 @@ Set the above prerequisites in `~/.aws/credentials` in Bastion Host:
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](/automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_chef_backend_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_chef_backend_to_automate_ha.md
@@ -179,7 +179,6 @@ workspace_path = "/hab/a2_deploy_workspace"
 ssh_user = "myusername"
 ssh_port = "22"
 ssh_key_file = "~/.ssh/mykey.pem"
-sudo_password = ""
 
 # DON'T MODIFY THE BELOW LINE (backup_mount)
 backup_mount = "/mnt/automate_backups"

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -112,7 +112,6 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
    - Give `ssh_user` which has access to all the machines. Example: `ubuntu`
    - Give `ssh_port` in case your AMI is running on custom ssh port, default will be 22.
    - Give the `ssh_key_file` path; this key should have access to all the Machines or VMs.
-   - `sudo_password` is only meant to switch to sudo user. If you have configured a password for the sudo user, please provide it here.
    - We support only private key authentication.
    - Provide `backup_config` based on the type of backup storage you have. This field can be optionally left empty during deployment and can be patched at later point. Allowed values are `object_storage` and `file_system`.
    - If `backup_config` is `object_storage`, make sure to fill values under `[object_storage.config]`

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -55,7 +55,7 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -55,7 +55,7 @@ sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 
 - PLEASE DONOT MODIFY THE WORKSPACE PATH it should always be "/hab/a2_deploy_workspace"
 - We currently don't support AD managed users in nodes. We only support local linux users.
-- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](automate/ha_sudo_password/) for details.
+- If you have configured sudo password for the user, then you need to create an environment variable `sudo_password` and set the password as the value of the variable. Example: `export sudo_password=<password>`. And then run all sudo commands with `sudo -E or --preserve-env` option. Example: `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate.aib`. This is required for the `chef-automate` CLI to run the commands with sudo privileges. Please refer [this](/automate/ha_sudo_password/) for details.
 
 {{< /warning >}}
 

--- a/components/docs-chef-io/content/automate/ha_sudo_password.md
+++ b/components/docs-chef-io/content/automate/ha_sudo_password.md
@@ -7,7 +7,7 @@ gh_repo = "automate"
     title = "Sudo Password"
     parent = "automate/deploy_high_availability/reference"
     identifier = "automate/deploy_high_availability/reference/ha_sudo_password.md Sudo Password"
-    weight = 250
+    weight = 210
 +++
 
 {{< warning >}}

--- a/components/docs-chef-io/content/automate/ha_sudo_password.md
+++ b/components/docs-chef-io/content/automate/ha_sudo_password.md
@@ -1,0 +1,32 @@
++++
+title = "Sudo Password"
+
+draft = false
+
+gh_repo = "automate"
+
+[menu]
+  [menu.automate]
+    title = "Sudo Password"
+    parent = "automate/deploy_high_availability/reference"
+    identifier = "automate/deploy_high_availability/reference/ha_sudo_password.md Sudo Password"
+    weight = 210
++++
+
+{{< warning >}}
+{{% automate/ha-warn %}}
+{{< /warning >}}
+
+This page explains how to enable the `sudo password` for the Chef Automate High Availability (HA) deployment.
+
+If you have configured sudo password for the user, then you need to create an environment variable sudo_password and set the password as the value of the variable. Example: `export sudo_password=YOUR_SUDO_PASSWORD`. And then run all sudo commands with `sudo -E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version`. This is required for the chef-automate CLI to run the commands with sudo privileges.
+
+## Steps to Enable Sudo Password
+
+To enable the `sudo password` for the Chef Automate HA deployment, follow the steps below:
+
+1. Create a `sudo_password` environment variable. Example: `export sudo_password=1234`.
+2. Pass the `sudo_password` environment variable to the `chef-automate` CLI commands. Example: `sudo -E chef-automate iam version`.
+   a. To pass all your environment variables including the `sudo_password` to the `chef-automate` CLI commands, you can use the `-E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version` or `sudo --preserve-env chef-automate iam version`.
+   b. To just pass `sudo_password` environment variable to the `chef-automate` CLI commands, you can supply environment variable name to the `--preserve-env` argument. Example: `sudo --preserve-env=sudo_password chef-automate iam version`.
+3. You can also set environment variables directly in the sudo command. Example: `sudo sudo_password=1234 chef-automate iam version`.

--- a/components/docs-chef-io/content/automate/ha_sudo_password.md
+++ b/components/docs-chef-io/content/automate/ha_sudo_password.md
@@ -27,6 +27,10 @@ To enable the `sudo password` for the Chef Automate HA deployment, follow the st
 
 1. Create a `sudo_password` environment variable. Example: `export sudo_password=1234`.
 2. Pass the `sudo_password` environment variable to the `chef-automate` CLI commands. Example: `sudo -E chef-automate iam version`.
+
    a. To pass all your environment variables including the `sudo_password` to the `chef-automate` CLI commands, you can use the `-E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version` or `sudo --preserve-env chef-automate iam version`.
+
    b. To just pass `sudo_password` environment variable to the `chef-automate` CLI commands, you can supply environment variable name to the `--preserve-env` argument. Example: `sudo --preserve-env=sudo_password chef-automate iam version`.
 3. You can also set environment variables directly in the sudo command. Example: `sudo sudo_password=1234 chef-automate iam version`.
+
+Make sure to pass the `sudo_password` environment variable to all the `chef-automate` CLI commands.

--- a/components/docs-chef-io/content/automate/ha_sudo_password.md
+++ b/components/docs-chef-io/content/automate/ha_sudo_password.md
@@ -1,25 +1,22 @@
 +++
 title = "Sudo Password"
-
 draft = false
-
 gh_repo = "automate"
-
 [menu]
   [menu.automate]
     title = "Sudo Password"
     parent = "automate/deploy_high_availability/reference"
     identifier = "automate/deploy_high_availability/reference/ha_sudo_password.md Sudo Password"
-    weight = 210
+    weight = 250
 +++
 
 {{< warning >}}
 {{% automate/ha-warn %}}
 {{< /warning >}}
 
-This page explains how to enable the `sudo password` for the Chef Automate High Availability (HA) deployment.
+This page explains enabling the `sudo password` for the Chef Automate High Availability (HA) deployment.
 
-If you have configured sudo password for the user, then you need to create an environment variable sudo_password and set the password as the value of the variable. Example: `export sudo_password=YOUR_SUDO_PASSWORD`. And then run all sudo commands with `sudo -E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version`. This is required for the chef-automate CLI to run the commands with sudo privileges.
+If you have configured the sudo password for the user, you need to create an environment variable **sudo_password** and set the password as the variable's value. Example: `export sudo_password=YOUR_SUDO_PASSWORD`. One done, run all sudo commands with the `sudo -E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version`. This is required for the chef-automate CLI to run the commands with sudo privileges.
 
 ## Steps to Enable Sudo Password
 
@@ -28,9 +25,10 @@ To enable the `sudo password` for the Chef Automate HA deployment, follow the st
 1. Create a `sudo_password` environment variable. Example: `export sudo_password=1234`.
 2. Pass the `sudo_password` environment variable to the `chef-automate` CLI commands. Example: `sudo -E chef-automate iam version`.
 
-   a. To pass all your environment variables including the `sudo_password` to the `chef-automate` CLI commands, you can use the `-E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version` or `sudo --preserve-env chef-automate iam version`.
+   a. To pass all your environment variables, including the `sudo_password` to the `chef-automate` CLI commands, you can use the `-E` or `--preserve-env` option. Example: `sudo -E chef-automate iam version` or `sudo --preserve-env chef-automate iam version`.
 
-   b. To just pass `sudo_password` environment variable to the `chef-automate` CLI commands, you can supply environment variable name to the `--preserve-env` argument. Example: `sudo --preserve-env=sudo_password chef-automate iam version`.
+   b. To pass the `sudo_password` environment variable to the `chef-automate` CLI commands, you can supply the environment variable name to the `--preserve-env` argument. Example: `sudo --preserve-env=sudo_password chef-automate iam version`.
+
 3. You can also set environment variables directly in the sudo command. Example: `sudo sudo_password=1234 chef-automate iam version`.
 
-Make sure to pass the `sudo_password` environment variable to all the `chef-automate` CLI commands.
+Pass the `sudo_password` environment variable to all the `chef-automate` CLI commands.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added sudo_password support for HA cmd in ruby
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-795
https://github.com/chef/automate/pull/7774
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
- Rebuild `automate-cli` (`rebuild components/automate-cli/`) or can use (`akrishna/automate-cli/0.1.0/20230412082516`), `automate-ha-cluster-ctl` (`rebuild components/automate-cluster-ctl/`) or can use (`akrishna/automate-ha-cluster-ctl/0.1.0/20230411133555`), and `automate-ha-deployment`(`rebuild components/automate-backend-deployment/`) or can use (`akrishna/automate-ha-deployment/0.1.0/20230411141141`).
- Upload the above packages `hab pkg upload <PATH_TO_PACKAGE_HART_FILE>`.
- Create an airgap bundle with new packages `sudo ./chef-automate airgap bundle create -m latest_semver.json --channel dev`. Update this [latest_semver.json](https://packages.chef.io/manifests/dev/automate/latest_semver.json) manifest file with your origins. 
Note: Do not update the `automate-cli` origin in the manifest file,  just install the new `automate-cli` on Bastion.
- Set the environment variable `sudo_password`. For eg. `export sudo_password=1234`.
- Run deployment command with -E flag to preserve environment variable. For eg. `sudo -E ./chef-automate deploy config.toml --airgap-bundle automate-4.5.104.aib`. Refer [here](https://www.petefreitag.com/item/877.cfm) for passing environment variables to the sudo command.
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![Screenshot 2023-04-12 at 1 42 43 PM](https://user-images.githubusercontent.com/11033984/231395369-6da25e63-ecb8-4969-8507-5a7afef6d480.png)

![Screenshot 2023-04-12 at 1 41 54 PM](https://user-images.githubusercontent.com/11033984/231395292-e5067f01-9652-4c56-a0bc-8c3f2d012a31.png)

Video: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EacHYiZu7aFBgNkiBpoRPwkB0f_Ngkk_CR2vOxTCdbtMfA?e=janCk5
