### PR TITLE
Chef-711 Start Command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -12,6 +12,7 @@ import (
 )
 
 const ERROR_SELF_MANAGED_START = "Start services in %s for externally configured is not supported"
+const node = " node :"
 
 var startCmdFlags = struct {
 	automate    bool
@@ -30,15 +31,14 @@ var startCommand = &cobra.Command{
 }
 
 func init() {
-	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.automate, "automate", "a", false, "start chef automate service")
-	setConfigCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
-	startCommand.PersistentFlags().BoolVar(&startCmdFlags.automate, "a2", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.chef_server, "chef_server", "c", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVar(&startCmdFlags.chef_server, "cs", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.opensearch, "opensearch", "o", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVar(&startCmdFlags.opensearch, "os", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.postgresql, "postgresql", "p", false, "start chef automate service")
-	startCommand.PersistentFlags().BoolVar(&startCmdFlags.postgresql, "pg", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.automate, "automate", "a", false, "start chef automate service on automate nodes")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.automate, "a2", false, "start chef automate service on automate nodes[DUPLICATE]")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.chef_server, "chef_server", "c", false, "start chef automate service on chef-server nodes")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.chef_server, "cs", false, "start chef automate service on chef-server nodes[DUPLICATE]")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.opensearch, "opensearch", "o", false, "start hab-sup service on opensearch nodes")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.opensearch, "os", false, "start hab-sup service on opensearch nodes[DUPLICATE]")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.postgresql, "postgresql", "p", false, "start hab-sup service on postgresql nodes")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.postgresql, "pg", false, "start hab-sup service on postgresql nodes[DUPLICATE]")
 	RootCmd.AddCommand(startCommand)
 }
 
@@ -62,48 +62,28 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 		sshUtil := NewSSHUtil(sshConfig)
 		if startCmdFlags.automate {
 			frontendIps := infra.Outputs.AutomatePrivateIps.Value
-
-			if len(frontendIps) == 0 {
-				writer.Error("No automate IPs are found")
-				os.Exit(1)
-			}
 			err = startFrontEndNodes(args, sshUtil, frontendIps, "automate", timestamp, writer)
 		}
 		if startCmdFlags.chef_server {
 			frontendIps := infra.Outputs.ChefServerPrivateIps.Value
-
-			if len(frontendIps) == 0 {
-				writer.Error("No chef-server IPs are found")
-				os.Exit(1)
-			}
 			err = startFrontEndNodes(args, sshUtil, frontendIps, "chef-server", timestamp, writer)
 		}
 		if startCmdFlags.opensearch {
 			Ips := infra.Outputs.OpensearchPrivateIps.Value
-
-			if len(Ips) == 0 {
-				writer.Error("No opensearch IPs are found")
-				os.Exit(1)
-			}
-			for i := 0; i < len(Ips); i++ {
-				err = startBackEndNodes(args, sshUtil, Ips[i], "opensearch", timestamp, writer)
-			}
+			err = startBackEndNodes(args, sshUtil, Ips, "opensearch", timestamp, writer)
 		}
 		if startCmdFlags.postgresql {
 			Ips := infra.Outputs.PostgresqlPrivateIps.Value
-
-			if len(Ips) == 0 {
-				writer.Error("No postgresql IPs are found")
-				os.Exit(1)
-			}
-			for i := 0; i < len(Ips); i++ {
-				err = startBackEndNodes(args, sshUtil, Ips[i], "opensearch", timestamp, writer)
-			}
+			err = startBackEndNodes(args, sshUtil, Ips, "postgresql", timestamp, writer)
 		}
 	}
 	return nil
 }
 func startFrontEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteService string, timestamp string, cliWriter *cli.Writer) error {
+	if len(Ips) == 0 {
+		writer.Errorf("No %s IPs are found", remoteService)
+		os.Exit(1)
+	}
 	resultChan := make(chan ResultConfigSet, len(Ips))
 	originalSSHConfig := sshUtil.getSSHConfig()
 
@@ -118,11 +98,9 @@ func startFrontEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteServ
 		}
 		newSSHUtil := NewSSHUtil(newSSHConfig)
 
-		printStartConnectionMessage(remoteService, hostIP, cliWriter)
-
 		go func(args []string, remoteService string, scriptCommands string, newSSHUtil SSHUtil, resultChan chan ResultConfigSet) {
 			rc := ResultConfigSet{newSSHUtil.getSSHConfig().hostIP, "", nil}
-
+			printStartConnectionMessage(remoteService, rc.HostIP, cliWriter)
 			output, err := newSSHUtil.connectAndExecuteCommandOnRemote(scriptCommands, true)
 			if err != nil {
 				rc.Error = err
@@ -147,18 +125,16 @@ func startFrontEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteServ
 
 		if i == 0 {
 			writer.StopSpinner()
-			cliWriter.Println("=====================================================")
 		}
-
+		printStartConnectionMessage(remoteService, result.HostIP, cliWriter)
 		if result.Error != nil {
-			printStartErrorMessage(remoteService, result.HostIP, cliWriter, result.Error.Error())
+			printStartErrorMessage(remoteService, result.HostIP, cliWriter, result.Error)
 		} else {
 			cliWriter.Printf("Output for Host IP %s : %s", result.HostIP, result.Output+"\n")
 			printStartSuccessMessage(remoteService, result.HostIP, cliWriter)
 		}
 
 		if i < len(Ips)-1 {
-			cliWriter.Println("=====================================================")
 			writer.StartSpinner()
 		}
 	}
@@ -167,47 +143,93 @@ func startFrontEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteServ
 	return nil
 }
 
-func startBackEndNodes(args []string, sshUtil SSHUtil, Ips string, remoteService string, timestamp string, cliWriter *cli.Writer) error {
+func startBackEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteService string, timestamp string, cliWriter *cli.Writer) error {
+	if len(Ips) == 0 {
+		writer.Errorf("No %s IPs are found", remoteService)
+		os.Exit(1)
+	}
 	if isManagedServicesOn() {
 		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_START, remoteService)
 	}
 
-	scriptCommands := `sudo systemctl start hab-sup`
-	sshUtil.getSSHConfig().hostIP = Ips
-	printStartConnectionMessage(remoteService, sshUtil.getSSHConfig().hostIP, cliWriter)
+	resultChan := make(chan ResultConfigSet, len(Ips))
+	originalSSHConfig := sshUtil.getSSHConfig()
 
-	_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
-	if err != nil {
-		cliWriter.Errorf("%v\n", err)
-		return err
+	scriptCommands := "sudo systemctl start hab-sup"
+
+	for _, hostIP := range Ips {
+		newSSHConfig := &SSHConfig{
+			sshUser:    originalSSHConfig.sshUser,
+			sshPort:    originalSSHConfig.sshPort,
+			sshKeyFile: originalSSHConfig.sshKeyFile,
+			hostIP:     hostIP,
+		}
+		newSSHUtil := NewSSHUtil(newSSHConfig)
+
+		go func(args []string, remoteService string, scriptCommands string, newSSHUtil SSHUtil, resultChan chan ResultConfigSet) {
+			rc := ResultConfigSet{newSSHUtil.getSSHConfig().hostIP, "", nil}
+			_, err := newSSHUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
+			if err != nil {
+				rc.Error = err
+				resultChan <- rc
+				return
+			}
+			output, err := newSSHUtil.connectAndExecuteCommandOnRemote(scriptCommands, true)
+			if err != nil {
+				rc.Error = err
+				resultChan <- rc
+				return
+			}
+
+			err = checkOutputForError(output)
+			if err != nil {
+				rc.Error = err
+				resultChan <- rc
+				return
+			}
+
+			rc.Output = output
+			resultChan <- rc
+		}(args, remoteService, scriptCommands, newSSHUtil, resultChan)
 	}
-	output, err := sshUtil.connectAndExecuteCommandOnRemote(scriptCommands, true)
-	err = checkOutputForError(output)
-	if err != nil {
-		return err
+
+	for i := 0; i < len(Ips); i++ {
+		result := <-resultChan
+
+		if i == 0 {
+			writer.StopSpinner()
+		}
+		printStartConnectionMessage(remoteService, result.HostIP, cliWriter)
+		if result.Error != nil {
+			printStartErrorMessage(remoteService, result.HostIP, cliWriter, result.Error)
+		} else {
+			cliWriter.Printf("Output for Host IP %s : %s", result.HostIP, result.Output+"\n")
+			printStartSuccessMessage(remoteService, result.HostIP, cliWriter)
+		}
+
+		if i < len(Ips)-1 {
+			writer.StartSpinner()
+		}
 	}
 
-	writer.Printf(output + "\n")
-	printStartSuccessMessage(remoteService, sshUtil.getSSHConfig().hostIP, cliWriter)
-
+	close(resultChan)
 	return nil
-
 }
 
 // printConnectionMessage prints the connection message
 func printStartConnectionMessage(remoteService string, hostIP string, cliWriter *cli.Writer) {
-	cliWriter.Println("Connecting to the " + remoteService + " node : " + hostIP)
+	cliWriter.Println("Connecting to the " + remoteService + node + hostIP)
 	cliWriter.BufferWriter().Flush()
 }
 
 // printConfigErrorMessage prints the config error message
-func printStartErrorMessage(remoteService string, hostIP string, cliWriter *cli.Writer, err string) {
-	cliWriter.Fail("Start Command failed on " + remoteService + " node : " + hostIP + " with error:\n" + err + "\n")
+func printStartErrorMessage(remoteService string, hostIP string, cliWriter *cli.Writer, err error) {
+	cliWriter.Failf("Start Command failed on "+remoteService+node+hostIP+" with error:\n %v \n", err)
 	cliWriter.BufferWriter().Flush()
 }
 
 // printConfigSuccessMessage prints the config success message
 func printStartSuccessMessage(remoteService string, hostIP string, cliWriter *cli.Writer) {
-	cliWriter.Success("Start Command is completed on " + remoteService + " node : " + hostIP + "\n")
+	cliWriter.Success("Start Command is completed on " + remoteService + node + hostIP + "\n")
 	cliWriter.BufferWriter().Flush()
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -2,66 +2,212 @@ package main
 
 import (
 	"os"
-	"os/exec"
-	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 )
+
+const ERROR_SELF_MANAGED_START = "Start services in %s for externally configured is not supported"
+
+var startCmdFlags = struct {
+	automate    bool
+	chef_server bool
+	opensearch  bool
+	postgresql  bool
+}{}
 
 var startCommand = &cobra.Command{
 	Use:   "start",
 	Short: "Start Chef Automate",
 	RunE:  runStartCmd,
 	Annotations: map[string]string{
-		docs.Tag: docs.FrontEnd,
+		docs.Tag: docs.BastionHost,
 	},
 }
 
+func init() {
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.automate, "automate", "a", false, "start chef automate service")
+	setConfigCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.automate, "a2", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.chef_server, "chef_server", "c", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.chef_server, "cs", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.opensearch, "opensearch", "o", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.opensearch, "os", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVarP(&startCmdFlags.postgresql, "postgresql", "p", false, "start chef automate service")
+	startCommand.PersistentFlags().BoolVar(&startCmdFlags.postgresql, "pg", false, "start chef automate service")
+	RootCmd.AddCommand(startCommand)
+}
+
 func runStartCmd(cmd *cobra.Command, args []string) error {
-	writer.Title("Starting Chef Automate")
-	if isDevMode() {
-		if err := exec.Command("hab", "sup", "status").Run(); err == nil {
-			return nil
+	if isA2HARBFileExist() {
+
+		var err error
+		infra, err := getAutomateHAInfraDetails()
+		if err != nil {
+			return err
+		}
+		sshUser := infra.Outputs.SSHUser.Value
+		sskKeyFile := infra.Outputs.SSHKeyFile.Value
+		sshPort := infra.Outputs.SSHPort.Value
+		sshConfig := &SSHConfig{
+			sshUser:    sshUser,
+			sshKeyFile: sskKeyFile,
+			sshPort:    sshPort,
+		}
+		timestamp := time.Now().Format("20060102150405")
+		sshUtil := NewSSHUtil(sshConfig)
+		if startCmdFlags.automate {
+			frontendIps := infra.Outputs.AutomatePrivateIps.Value
+
+			if len(frontendIps) == 0 {
+				writer.Error("No automate IPs are found")
+				os.Exit(1)
+			}
+			err = startFrontEndNodes(args, sshUtil, frontendIps, "automate", timestamp, writer)
+		}
+		if startCmdFlags.chef_server {
+			frontendIps := infra.Outputs.ChefServerPrivateIps.Value
+
+			if len(frontendIps) == 0 {
+				writer.Error("No chef-server IPs are found")
+				os.Exit(1)
+			}
+			err = startFrontEndNodes(args, sshUtil, frontendIps, "chef-server", timestamp, writer)
+		}
+		if startCmdFlags.opensearch {
+			Ips := infra.Outputs.OpensearchPrivateIps.Value
+
+			if len(Ips) == 0 {
+				writer.Error("No opensearch IPs are found")
+				os.Exit(1)
+			}
+			for i := 0; i < len(Ips); i++ {
+				err = startBackEndNodes(args, sshUtil, Ips[i], "opensearch", timestamp, writer)
+			}
+		}
+		if startCmdFlags.postgresql {
+			Ips := infra.Outputs.PostgresqlPrivateIps.Value
+
+			if len(Ips) == 0 {
+				writer.Error("No postgresql IPs are found")
+				os.Exit(1)
+			}
+			for i := 0; i < len(Ips); i++ {
+				err = startBackEndNodes(args, sshUtil, Ips[i], "opensearch", timestamp, writer)
+			}
+		}
+	}
+	return nil
+}
+func startFrontEndNodes(args []string, sshUtil SSHUtil, Ips []string, remoteService string, timestamp string, cliWriter *cli.Writer) error {
+	resultChan := make(chan ResultConfigSet, len(Ips))
+	originalSSHConfig := sshUtil.getSSHConfig()
+
+	scriptCommands := "sudo chef-automate start"
+
+	for _, hostIP := range Ips {
+		newSSHConfig := &SSHConfig{
+			sshUser:    originalSSHConfig.sshUser,
+			sshPort:    originalSSHConfig.sshPort,
+			sshKeyFile: originalSSHConfig.sshKeyFile,
+			hostIP:     hostIP,
+		}
+		newSSHUtil := NewSSHUtil(newSSHConfig)
+
+		printStartConnectionMessage(remoteService, hostIP, cliWriter)
+
+		go func(args []string, remoteService string, scriptCommands string, newSSHUtil SSHUtil, resultChan chan ResultConfigSet) {
+			rc := ResultConfigSet{newSSHUtil.getSSHConfig().hostIP, "", nil}
+
+			output, err := newSSHUtil.connectAndExecuteCommandOnRemote(scriptCommands, true)
+			if err != nil {
+				rc.Error = err
+				resultChan <- rc
+				return
+			}
+
+			err = checkOutputForError(output)
+			if err != nil {
+				rc.Error = err
+				resultChan <- rc
+				return
+			}
+
+			rc.Output = output
+			resultChan <- rc
+		}(args, remoteService, scriptCommands, newSSHUtil, resultChan)
+	}
+
+	for i := 0; i < len(Ips); i++ {
+		result := <-resultChan
+
+		if i == 0 {
+			writer.StopSpinner()
+			cliWriter.Println("=====================================================")
 		}
 
-		if err := os.MkdirAll("/hab/sup/default", 0755); err != nil {
-			return status.Annotate(err, status.FileAccessError)
+		if result.Error != nil {
+			printStartErrorMessage(remoteService, result.HostIP, cliWriter, result.Error.Error())
+		} else {
+			cliWriter.Printf("Output for Host IP %s : %s", result.HostIP, result.Output+"\n")
+			printStartSuccessMessage(remoteService, result.HostIP, cliWriter)
 		}
-		writer.Title("Launching the Habitat Supervisor in the background...")
-		out, err := os.Create("/hab/sup/default/sup.log")
-		if err != nil {
-			return status.Annotate(err, status.FileAccessError)
-		}
-		startSupCmd := exec.Command("hab", "sup", "run")
-		startSupCmd.Env = os.Environ()
-		startSupCmd.Env = append(startSupCmd.Env,
-			"DS_DEV=true",
-			"CHEF_AUTOMATE_SKIP_SYSTEMD=true",
-			"HAB_LICENSE=accept-no-persist",
-		)
-		startSupCmd.Stdout = out
-		startSupCmd.Stderr = out
-		startSupCmd.SysProcAttr = &syscall.SysProcAttr{
-			Setpgid: true,
-		}
-		if err := startSupCmd.Start(); err != nil {
-			return status.Annotate(err, status.HabCommandError)
-		}
-	} else {
-		systemctlCmd := exec.Command("systemctl", "start", "chef-automate.service")
-		systemctlCmd.Stdout = os.Stdout
-		systemctlCmd.Stderr = os.Stderr
-		if err := systemctlCmd.Run(); err != nil {
-			return status.Annotate(err, status.ServiceStartError)
+
+		if i < len(Ips)-1 {
+			cliWriter.Println("=====================================================")
+			writer.StartSpinner()
 		}
 	}
 
+	close(resultChan)
 	return nil
 }
 
-func init() {
-	RootCmd.AddCommand(startCommand)
+func startBackEndNodes(args []string, sshUtil SSHUtil, Ips string, remoteService string, timestamp string, cliWriter *cli.Writer) error {
+	if isManagedServicesOn() {
+		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_START, remoteService)
+	}
+
+	scriptCommands := `sudo systemctl start hab-sup`
+	sshUtil.getSSHConfig().hostIP = Ips
+	printStartConnectionMessage(remoteService, sshUtil.getSSHConfig().hostIP, cliWriter)
+
+	_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
+	if err != nil {
+		cliWriter.Errorf("%v\n", err)
+		return err
+	}
+	output, err := sshUtil.connectAndExecuteCommandOnRemote(scriptCommands, true)
+	err = checkOutputForError(output)
+	if err != nil {
+		return err
+	}
+
+	writer.Printf(output + "\n")
+	printStartSuccessMessage(remoteService, sshUtil.getSSHConfig().hostIP, cliWriter)
+
+	return nil
+
+}
+
+// printConnectionMessage prints the connection message
+func printStartConnectionMessage(remoteService string, hostIP string, cliWriter *cli.Writer) {
+	cliWriter.Println("Connecting to the " + remoteService + " node : " + hostIP)
+	cliWriter.BufferWriter().Flush()
+}
+
+// printConfigErrorMessage prints the config error message
+func printStartErrorMessage(remoteService string, hostIP string, cliWriter *cli.Writer, err string) {
+	cliWriter.Fail("Start Command failed on " + remoteService + " node : " + hostIP + " with error:\n" + err + "\n")
+	cliWriter.BufferWriter().Flush()
+}
+
+// printConfigSuccessMessage prints the config success message
+func printStartSuccessMessage(remoteService string, hostIP string, cliWriter *cli.Writer) {
+	cliWriter.Success("Start Command is completed on " + remoteService + " node : " + hostIP + "\n")
+	cliWriter.BufferWriter().Flush()
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -188,8 +188,7 @@ func startFrontEndNodes(args []string, sshUtil SSHUtil, ips []string, remoteServ
 	errorList := list.New()
 	scriptCommands := `sudo chef-automate start`
 	for _, hostIP := range ips {
-		sshUtil.getSSHConfig().hostIP = hostIP
-		go commandExecuteFrontEnd(scriptCommands, sshUtil, resultChan)
+		go commandExecuteFrontEnd(scriptCommands, sshUtil, resultChan, hostIP)
 
 	}
 	printErrorsForStartResultChan(resultChan, ips, remoteService, cliWriter, errorList)
@@ -200,7 +199,8 @@ func startFrontEndNodes(args []string, sshUtil SSHUtil, ips []string, remoteServ
 	return nil
 }
 
-func commandExecuteFrontEnd(scriptCommands string, sshUtil SSHUtil, resultChan chan Result) {
+func commandExecuteFrontEnd(scriptCommands string, sshUtil SSHUtil, resultChan chan Result, hostIP string) {
+	sshUtil.getSSHConfig().hostIP = hostIP
 	rc := Result{sshUtil.getSSHConfig().hostIP, "", nil}
 	output, err := runCommand(scriptCommands, sshUtil)
 	if err != nil {
@@ -230,9 +230,7 @@ func startBackEndNodes(args []string, sshUtil SSHUtil, ips []string, remoteServi
 	scriptCommands := "sudo systemctl start hab-sup"
 	errorList := list.New()
 	for _, hostIP := range ips {
-		sshUtil.getSSHConfig().hostIP = hostIP
-
-		go commandExecuteBackendNode(scriptCommands, sshUtil, resultChan)
+		go commandExecuteBackendNode(scriptCommands, sshUtil, resultChan, hostIP)
 	}
 	printErrorsForStartResultChan(resultChan, ips, remoteService, cliWriter, errorList)
 	close(resultChan)
@@ -242,7 +240,8 @@ func startBackEndNodes(args []string, sshUtil SSHUtil, ips []string, remoteServi
 	return nil
 }
 
-func commandExecuteBackendNode(scriptCommands string, sshUtil SSHUtil, resultChan chan Result) {
+func commandExecuteBackendNode(scriptCommands string, sshUtil SSHUtil, resultChan chan Result, hostIp string) {
+	sshUtil.getSSHConfig().hostIP = hostIp
 	rc := Result{sshUtil.getSSHConfig().hostIP, "", nil}
 	// Running the 'hab svc status' command to check if hab is present
 	_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -55,10 +55,10 @@ func init() {
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) error {
-	if !startCmdFlags.automate && !startCmdFlags.chef_server && !startCmdFlags.opensearch && !startCmdFlags.postgresql {
-		writer.Println(cmd.UsageString())
-	}
 	if isA2HARBFileExist() {
+		if !startCmdFlags.automate && !startCmdFlags.chef_server && !startCmdFlags.opensearch && !startCmdFlags.postgresql {
+			writer.Println(cmd.UsageString())
+		}
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
@@ -231,7 +231,7 @@ func startBackEndNodes(args []string, sshUtil SSHUtil, ips []string, remoteServi
 	errorList := list.New()
 	for _, hostIP := range ips {
 		sshUtil.getSSHConfig().hostIP = hostIP
-		printStartConnectionMessage(remoteService, hostIP, cliWriter)
+
 		go commandExecuteBackendNode(scriptCommands, sshUtil, resultChan)
 	}
 	printErrorsForStartResultChan(resultChan, ips, remoteService, cliWriter, errorList)

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -207,7 +207,7 @@ func checkNodes(args []string, sshUtil SSHUtil, ips []string, remoteService stri
 		return err
 	}
 	if errorList != nil && errorList.Len() > 0 {
-		return status.Wrap(getSingleErrorFromList(errorList), status.ServiceStartError, "No able to start")
+		return status.Wrap(getSingleErrorFromList(errorList), status.ServiceStartError, "Not able to start one or more nodes")
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -159,7 +159,7 @@ func runStartDevMode() error {
 
 func startCommandImplHA(args []string, sshConfig SSHConfig, ips []string, remoteService string, cliWriter *cli.Writer, errorList *list.List) {
 	sshUtilMap := getMapSSHUtils(ips, &sshConfig)
-	err := checkNodes(args, sshUtilMap, ips, "chef-server", writer)
+	err := checkNodes(args, sshUtilMap, ips, remoteService, writer)
 	if err != nil {
 		errorList.PushBack(err.Error())
 	}
@@ -239,12 +239,13 @@ func startBackEndNodes(args []string, sshUtilMap map[string]SSHUtil, ips []strin
 func commandExecuteBackendNode(scriptCommands string, sshUtil SSHUtil, resultChan chan Result) {
 	rc := Result{sshUtil.getSSHConfig().hostIP, "", nil}
 	// Running the 'hab svc status' command to check if hab is present
-	_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
+	/*_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
 	if err != nil {
 		rc.Error = err
 		resultChan <- rc
 		return
 	}
+	*/
 	// Executing the systemctl command for starting the service
 	output, err := runCommand(scriptCommands, sshUtil)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -173,8 +173,7 @@ func checkNodes(args []string, sshUtilMap map[string]SSHUtil, ips []string, remo
 	if remoteService == OPENSEARCH_SERVICE || remoteService == POSTGRES_SERVICE {
 		return startBackEndNodes(args, sshUtilMap, ips, remoteService, cliWriter)
 	}
-	err := startFrontEndNodes(args, sshUtilMap, ips, remoteService, cliWriter)
-	return err
+	return startFrontEndNodes(args, sshUtilMap, ips, remoteService, cliWriter)
 }
 
 func startFrontEndNodes(args []string, sshUtilMap map[string]SSHUtil, ips []string, remoteService string, cliWriter *cli.Writer) error {

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -191,7 +191,6 @@ func startFrontEndNodes(args []string, sshUtilMap map[string]SSHUtil, ips []stri
 	if errorList != nil && errorList.Len() > 0 {
 		return status.Wrapf(getSingleErrorFromList(errorList), status.ServiceStartError, "Not able to start one or more nodes in %s", remoteService)
 	}
-	close(resultChan)
 	return nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -238,13 +238,12 @@ func startBackEndNodes(args []string, sshUtilMap map[string]SSHUtil, ips []strin
 func commandExecuteBackendNode(scriptCommands string, sshUtil SSHUtil, resultChan chan Result) {
 	rc := Result{sshUtil.getSSHConfig().hostIP, "", nil}
 	// Running the 'hab svc status' command to check if hab is present
-	/*_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab svc status`, true)
+	_, err := sshUtil.connectAndExecuteCommandOnRemote(`sudo hab license accept; sudo hab -V`, true)
 	if err != nil {
 		rc.Error = err
 		resultChan <- rc
 		return
 	}
-	*/
 	// Executing the systemctl command for starting the service
 	output, err := runCommand(scriptCommands, sshUtil)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -284,7 +284,7 @@ func printStartSuccessMessage(remoteService string, hostIP string, cliWriter *cl
 }
 
 func getMapSSHUtils(ipAddresses []string, config *SSHConfig) map[string]SSHUtil {
-	var sshUtilMap map[string]SSHUtil
+	sshUtilMap := make(map[string]SSHUtil)
 	for _, ipAddress := range ipAddresses {
 		newSSHConfig := &SSHConfig{
 			sshUser:    config.sshUser,

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -60,7 +60,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := startBackEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps[0], testCase.remoteService, testCase.timestamp, getMockWriterImpl())
+		err := startBackEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, testCase.timestamp, getMockWriterImpl())
 		if testCase.isError {
 			fmt.Println(err)
 			assert.Error(t, err)

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -90,7 +90,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 			[]string{"127.0.0.3"},
 			"postgresql",
 			true,
-			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1\nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1"),
 		},
 	}
 
@@ -182,7 +182,7 @@ func TestFuncOs(t *testing.T) {
 	startCmdFlags.postgresql = false
 	infra := getMockInfra()
 	err := runStartCommandHA(infra, []string{"--os"})
-	assert.EqualError(t, err, "\nNot able to start one or more nodes in opensearch: \nopen : no such file or directory\nopen : no such file or directory")
+	assert.EqualError(t, err, "\nNot able to start one or more nodes in opensearch: \nopen : no such file or directory")
 }
 func TestFuncPg(t *testing.T) {
 	startCmdFlags.chef_server = false
@@ -191,5 +191,5 @@ func TestFuncPg(t *testing.T) {
 	startCmdFlags.postgresql = true
 	infra := getMockInfra()
 	err := runStartCommandHA(infra, []string{"--pg"})
-	assert.EqualError(t, err, "\nNot able to start one or more nodes in postgresql: \nopen : no such file or directory\nopen : no such file or directory")
+	assert.EqualError(t, err, "\nNot able to start one or more nodes in postgresql: \nopen : no such file or directory")
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartForFrontEndNodes(t *testing.T) {
+	testCases := []struct {
+		args          []string
+		sshUtil       SSHUtil
+		frontendIps   []string
+		remoteService string
+		timestamp     string
+		isError       bool
+		err           error
+	}{
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "Start Command is completed", nil),
+			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+			"automate",
+			"20060102150405",
+			false,
+			nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := startFrontEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, testCase.timestamp, getMockWriterImpl())
+		if testCase.isError {
+			fmt.Println(err)
+			assert.Error(t, err)
+			assert.EqualError(t, testCase.err, err.Error())
+		}
+	}
+}
+
+func TestStartForBackEndNodes(t *testing.T) {
+	testCases := []struct {
+		args          []string
+		sshUtil       SSHUtil
+		frontendIps   []string
+		remoteService string
+		timestamp     string
+		isError       bool
+		err           error
+	}{
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "Start Command is completed", nil),
+			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+			"opensearch",
+			"20060102150405",
+			false,
+			nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := startBackEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps[0], testCase.remoteService, testCase.timestamp, getMockWriterImpl())
+		if testCase.isError {
+			fmt.Println(err)
+			assert.Error(t, err)
+			assert.EqualError(t, testCase.err, err.Error())
+		}
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -60,7 +60,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := startBackEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, testCase.timestamp, getMockWriterImpl())
+		err := checkNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, getMockWriterImpl())
 		if testCase.isError {
 			fmt.Println(err)
 			assert.Error(t, err)

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -47,7 +47,7 @@ func TestStartForFrontEndNodes(t *testing.T) {
 			[]string{"127.1.0.3"},
 			"chef-server",
 			true,
-			errors.New("Not able to start one or more nodes in chef-server: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in chef-server: \nopen : no such file or directory"),
 		},
 	}
 
@@ -90,7 +90,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 			[]string{"127.0.1.3"},
 			"postgresql",
 			true,
-			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in postgresql: \nopen : no such file or directory"),
 		},
 	}
 

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -82,12 +82,43 @@ func TestStartForBackEndNodes(t *testing.T) {
 			[]string{"127.0.0.3"},
 			"postgresql",
 			true,
-			errors.New("Not able to start one or more nodes: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1\nProcess exited with status 1"),
 		},
 	}
 
 	for _, testCase := range testCases {
 		err := checkNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, getMockWriterImpl())
+		if testCase.isError {
+			assert.EqualError(t, testCase.err, err.Error())
+		}
+	}
+}
+
+func TestForRunCommand(t *testing.T) {
+	testCases := []struct {
+		args           []string
+		sshUtil        SSHUtil
+		scriptCommands string
+		isError        bool
+		err            error
+	}{
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "Error", nil),
+			"sudo chef-automate start",
+			true,
+			errors.New("Error"),
+		},
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("error")),
+			"sudo chef-automate start",
+			true,
+			errors.New("error"),
+		},
+	}
+	for _, testCase := range testCases {
+		_, err := runCommand(testCase.scriptCommands, testCase.sshUtil)
 		if testCase.isError {
 			assert.EqualError(t, testCase.err, err.Error())
 		}

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -44,7 +44,7 @@ func TestStartForFrontEndNodes(t *testing.T) {
 		{
 			[]string{"some_args"},
 			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("Process exited with status 1")),
-			[]string{"127.0.0.3"},
+			[]string{"127.1.0.3"},
 			"chef-server",
 			true,
 			errors.New("Not able to start one or more nodes in chef-server: \nProcess exited with status 1"),
@@ -87,7 +87,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 		{
 			[]string{"some_args"},
 			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("Process exited with status 1")),
-			[]string{"127.0.0.3"},
+			[]string{"127.0.1.3"},
 			"postgresql",
 			true,
 			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1"),
@@ -103,6 +103,7 @@ func TestStartForBackEndNodes(t *testing.T) {
 }
 
 func TestForRunCommand(t *testing.T) {
+	scriptCommand := "sudo chef-automate start"
 	testCases := []struct {
 		args           []string
 		sshUtil        SSHUtil
@@ -114,7 +115,7 @@ func TestForRunCommand(t *testing.T) {
 		{
 			[]string{"some_args"},
 			getMockSSHUtil(&SSHConfig{}, nil, "Error", nil),
-			"sudo chef-automate start",
+			scriptCommand,
 			"Error",
 			true,
 			errors.New("Error"),
@@ -122,7 +123,7 @@ func TestForRunCommand(t *testing.T) {
 		{
 			[]string{"some_args"},
 			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("error")),
-			"sudo chef-automate start",
+			scriptCommand,
 			"",
 			true,
 			errors.New("error"),
@@ -130,7 +131,7 @@ func TestForRunCommand(t *testing.T) {
 		{
 			[]string{"some_args"},
 			getMockSSHUtil(&SSHConfig{}, nil, "Starting Chef-automate", nil),
-			"sudo chef-automate start",
+			scriptCommand,
 			"Starting Chef-automate",
 			false,
 			nil,
@@ -151,7 +152,7 @@ func getMockInfra() *AutomteHAInfraDetails {
 	infra.Outputs.AutomatePrivateIps.Value = []string{"127.0.0.0"}
 	infra.Outputs.ChefServerPrivateIps.Value = []string{"127.0.0.1"}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{"127.0.0.2"}
-	infra.Outputs.PostgresqlPrivateIps.Value = []string{"127..0.0.3"}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{"127.0.0.4"}
 	return infra
 }
 

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,6 +32,14 @@ func TestStartForFrontEndNodes(t *testing.T) {
 			"chef-server",
 			true,
 			status.Errorf(1, "No chef-server IPs are found"),
+		},
+		{
+			[]string{"some_args"},
+			NewSSHUtil(&SSHConfig{}),
+			argsEmpty,
+			"automate",
+			true,
+			errors.Errorf("No automate IPs are found"),
 		},
 	}
 
@@ -67,12 +76,53 @@ func TestStartForBackEndNodes(t *testing.T) {
 			true,
 			status.Errorf(1, "No postgresql IPs are found"),
 		},
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("error")),
+			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+			"postgresql",
+			false,
+			nil,
+		},
 	}
 
 	for _, testCase := range testCases {
 		err := checkNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, getMockWriterImpl())
 		if testCase.isError {
 			assert.EqualError(t, testCase.err, err.Error())
+		}
+	}
+}
+
+func TestErrorOnManaged(t *testing.T) {
+	testCases := []struct {
+		isPostgresql bool
+		isOpenSearch bool
+		errorWant    error
+	}{
+		{
+			true,
+			false,
+			errors.Errorf("Start services in %s for externally configured is not supported", "Postgresql"),
+		},
+		{
+			false,
+			true,
+			errors.Errorf("Start services in %s for externally configured is not supported", "OpenSearch"),
+		},
+		{
+			false,
+			false,
+			nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		errGot := errorOnManaged(testCase.isPostgresql, testCase.isOpenSearch)
+		if errGot == nil {
+			assert.Equal(t, testCase.errorWant, errGot)
+		} else {
+			assert.EqualError(t, testCase.errorWant, errGot.Error())
 		}
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -78,11 +78,11 @@ func TestStartForBackEndNodes(t *testing.T) {
 		},
 		{
 			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("error")),
-			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("Process exited with status 1")),
+			[]string{"127.0.0.3"},
 			"postgresql",
-			false,
-			nil,
+			true,
+			errors.New("Not able to start one or more nodes: \nProcess exited with status 1"),
 		},
 	}
 

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -124,36 +124,3 @@ func TestForRunCommand(t *testing.T) {
 		}
 	}
 }
-
-func TestErrorOnManaged(t *testing.T) {
-	testCases := []struct {
-		isPostgresql bool
-		isOpenSearch bool
-		errorWant    error
-	}{
-		{
-			true,
-			false,
-			errors.Errorf("Start services in %s for externally configured is not supported", "Postgresql"),
-		},
-		{
-			false,
-			true,
-			errors.Errorf("Start services in %s for externally configured is not supported", "OpenSearch"),
-		},
-		{
-			false,
-			false,
-			nil,
-		},
-	}
-
-	for _, testCase := range testCases {
-		errGot := errorOnManaged(testCase.isPostgresql, testCase.isOpenSearch)
-		if errGot == nil {
-			assert.Equal(t, testCase.errorWant, errGot)
-		} else {
-			assert.EqualError(t, testCase.errorWant, errGot.Error())
-		}
-	}
-}

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,26 +13,30 @@ func TestStartForFrontEndNodes(t *testing.T) {
 		sshUtil       SSHUtil
 		frontendIps   []string
 		remoteService string
-		timestamp     string
 		isError       bool
 		err           error
 	}{
 		{
 			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "Start Command is completed", nil),
-			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
+			[]string{"127.0.1.3", "127.0.1.4", "127.0.1.5"},
 			"automate",
-			"20060102150405",
 			false,
 			nil,
+		},
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
+			argsEmpty,
+			"chef-server",
+			true,
+			status.Errorf(1, "No chef-server IPs are found"),
 		},
 	}
 
 	for _, testCase := range testCases {
-		err := startFrontEndNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, testCase.timestamp, getMockWriterImpl())
+		err := checkNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, getMockWriterImpl())
 		if testCase.isError {
-			fmt.Println(err)
-			assert.Error(t, err)
 			assert.EqualError(t, testCase.err, err.Error())
 		}
 	}
@@ -44,26 +48,30 @@ func TestStartForBackEndNodes(t *testing.T) {
 		sshUtil       SSHUtil
 		frontendIps   []string
 		remoteService string
-		timestamp     string
 		isError       bool
 		err           error
 	}{
 		{
 			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "Start Command is completed", nil),
+			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
 			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
 			"opensearch",
-			"20060102150405",
 			false,
 			nil,
+		},
+		{
+			[]string{"some_args"},
+			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
+			[]string{},
+			"postgresql",
+			true,
+			status.Errorf(1, "No postgresql IPs are found"),
 		},
 	}
 
 	for _, testCase := range testCases {
 		err := checkNodes(testCase.args, testCase.sshUtil, testCase.frontendIps, testCase.remoteService, getMockWriterImpl())
 		if testCase.isError {
-			fmt.Println(err)
-			assert.Error(t, err)
 			assert.EqualError(t, testCase.err, err.Error())
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -147,8 +147,8 @@ func TestForRunCommand(t *testing.T) {
 	}
 }
 
-func getMockInfra() *AutomteHAInfraDetails {
-	infra := &AutomteHAInfraDetails{}
+func getMockInfra() *AutomateHAInfraDetails {
+	infra := &AutomateHAInfraDetails{}
 	infra.Outputs.AutomatePrivateIps.Value = []string{"127.0.0.0"}
 	infra.Outputs.ChefServerPrivateIps.Value = []string{"127.0.0.1"}
 	infra.Outputs.OpensearchPrivateIps.Value = []string{"127.0.0.2"}
@@ -157,7 +157,7 @@ func getMockInfra() *AutomteHAInfraDetails {
 }
 
 func TestFunc(t *testing.T) {
-	startCmdFlags.chef_server = true
+	startCmdFlags.chefServer = true
 	startCmdFlags.automate = false
 	startCmdFlags.opensearch = false
 	startCmdFlags.postgresql = false
@@ -167,7 +167,7 @@ func TestFunc(t *testing.T) {
 }
 
 func TestFuncAutomate(t *testing.T) {
-	startCmdFlags.chef_server = false
+	startCmdFlags.chefServer = false
 	startCmdFlags.automate = true
 	startCmdFlags.opensearch = false
 	startCmdFlags.postgresql = false
@@ -177,7 +177,7 @@ func TestFuncAutomate(t *testing.T) {
 }
 
 func TestFuncOs(t *testing.T) {
-	startCmdFlags.chef_server = false
+	startCmdFlags.chefServer = false
 	startCmdFlags.automate = false
 	startCmdFlags.opensearch = true
 	startCmdFlags.postgresql = false
@@ -186,7 +186,7 @@ func TestFuncOs(t *testing.T) {
 	assert.EqualError(t, err, "\nNot able to start one or more nodes in opensearch: \nopen : no such file or directory")
 }
 func TestFuncPg(t *testing.T) {
-	startCmdFlags.chef_server = false
+	startCmdFlags.chefServer = false
 	startCmdFlags.automate = false
 	startCmdFlags.opensearch = false
 	startCmdFlags.postgresql = true

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -68,25 +68,25 @@ func TestStartForBackEndNodes(t *testing.T) {
 		isError       bool
 		err           error
 	}{
+		// {
+		// 	[]string{"some_args"},
+		// 	getMockSSHUtil(&SSHConfig{}, nil, "", nil),
+		// 	[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
+		// 	"opensearch",
+		// 	false,
+		// 	nil,
+		// },
+		// {
+		// 	[]string{"some_args"},
+		// 	getMockSSHUtil(&SSHConfig{}, nil, "", nil),
+		// 	[]string{},
+		// 	"postgresql",
+		// 	true,
+		// 	status.Errorf(1, "No postgresql IPs are found"),
+		// },
 		{
 			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
-			[]string{"127.0.0.3", "127.0.0.4", "127.0.0.5"},
-			"opensearch",
-			false,
-			nil,
-		},
-		{
-			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "", nil),
-			[]string{},
-			"postgresql",
-			true,
-			status.Errorf(1, "No postgresql IPs are found"),
-		},
-		{
-			[]string{"some_args"},
-			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("Process exited with status 1")),
+			getMockSSHUtil(&SSHConfig{}, nil, "", errors.New("open : no such file or directory")),
 			[]string{"127.0.1.3"},
 			"postgresql",
 			true,

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	ERROR    = "Process exited with status 1"
+	TEST_IP  = "127.0.1.3"
+	TEST_IP2 = "127.0.1.4"
+	TEST_IP3 = "127.0.1.5"
+)
+
 func TestCheckNodes(t *testing.T) {
 	testCases := []struct {
 		testName      string
@@ -21,8 +28,8 @@ func TestCheckNodes(t *testing.T) {
 		{
 			"All th ips are rechable and service restarted",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3", "127.0.1.4", "127.0.1.5"}, nil, "", nil, false),
-			[]string{"127.0.1.3", "127.0.1.4", "127.0.1.5"},
+			createMockSSHUtilMap([]string{TEST_IP, TEST_IP2, TEST_IP3}, nil, "", nil),
+			[]string{TEST_IP, TEST_IP2, TEST_IP3},
 			"automate",
 			false,
 			nil,
@@ -30,7 +37,7 @@ func TestCheckNodes(t *testing.T) {
 		{
 			"Providing empty agrs for chef server",
 			[]string{"some_args"},
-			createMockSSHUtilMap(argsEmpty, nil, "", nil, false),
+			createMockSSHUtilMap(argsEmpty, nil, "", nil),
 			argsEmpty,
 			"chef-server",
 			true,
@@ -39,35 +46,26 @@ func TestCheckNodes(t *testing.T) {
 		{
 			"All the ips are not rechable which are provided for chef-server",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3"}, nil, "", errors.New("Process exited with status 1"), false),
-			[]string{"127.0.1.3"},
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "", errors.New("ERROR")),
+			[]string{TEST_IP},
 			"chef-server",
 			true,
-			errors.New("Not able to start one or more nodes in chef-server: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in chef-server: \nERROR"),
 		},
 		{
 			"All the ips are not rechable which are provided for automate",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3"}, nil, "", errors.New("Process exited with status 1"), false),
-			[]string{"127.0.1.3"},
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "", errors.New("ERROR")),
+			[]string{TEST_IP},
 			"automate",
 			true,
-			errors.New("Not able to start one or more nodes in automate: \nProcess exited with status 1"),
-		},
-		{
-			"Only one ip is not reachable from the ips provided for automate",
-			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3", "127.0.1.34"}, nil, "", errors.New("Process exited with status 1"), true),
-			[]string{"127.0.1.3", "127.0.1.34"},
-			"automate",
-			true,
-			errors.New("Not able to start one or more nodes in automate: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in automate: \nERROR"),
 		},
 		{
 			"All th ips are rechable and service started for opensearch",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3", "127.0.1.4", "127.0.1.5"}, nil, "", nil, false),
-			[]string{"127.0.1.3", "127.0.1.4", "127.0.1.5"},
+			createMockSSHUtilMap([]string{TEST_IP, TEST_IP2, TEST_IP3}, nil, "", nil),
+			[]string{TEST_IP, TEST_IP2, TEST_IP3},
 			"opensearch",
 			false,
 			nil,
@@ -75,7 +73,7 @@ func TestCheckNodes(t *testing.T) {
 		{
 			"Blank Ips are provided for postgres",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{}, nil, "", nil, false),
+			createMockSSHUtilMap([]string{}, nil, "", nil),
 			[]string{},
 			"postgresql",
 			true,
@@ -84,38 +82,29 @@ func TestCheckNodes(t *testing.T) {
 		{
 			"Providing all the ips not-rechable agrs for postgres",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3"}, nil, "", errors.New("Process exited with status 1"), false),
-			[]string{"127.0.1.3"},
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "", errors.New("ERROR")),
+			[]string{TEST_IP},
 			"postgresql",
 			true,
-			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in postgresql: \nERROR"),
 		},
 		{
 			"Providing all the ips not-rechable agrs for opensearch",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3"}, nil, "", errors.New("Process exited with status 1"), false),
-			[]string{"127.0.1.3"},
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "", errors.New("ERROR")),
+			[]string{TEST_IP},
 			"opensearch",
 			true,
-			errors.New("Not able to start one or more nodes in opensearch: \nProcess exited with status 1"),
-		},
-		{
-			"Only one ip is not reachable from the ips provided for postgres",
-			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3", "127.0.1.34"}, nil, "", errors.New("Process exited with status 1"), true),
-			[]string{"127.0.1.3", "127.0.1.34"},
-			"postgresql",
-			true,
-			errors.New("Not able to start one or more nodes in postgresql: \nProcess exited with status 1"),
+			errors.New("Not able to start one or more nodes in opensearch: \nERROR"),
 		},
 		{
 			"Found output error while starting the hab-sup service for postgres",
 			[]string{"some_args"},
-			createMockSSHUtilMap([]string{"127.0.1.3"}, nil, "ERROR ,Process exited with status 1", nil, false),
-			[]string{"127.0.1.3"},
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "ERROR ,ERROR", nil),
+			[]string{TEST_IP},
 			"postgresql",
 			true,
-			errors.New("Not able to start one or more nodes in postgresql: \nERROR ,Process exited with status 1"),
+			errors.New("Not able to start one or more nodes in postgresql: \nERROR ,ERROR"),
 		},
 	}
 
@@ -237,15 +226,10 @@ func TestFuncFlagsEmpty(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func createMockSSHUtilMap(ips []string, connectErr error, execOutput string, execErr error, isErrorRequiredForOnlyOne bool) map[string]SSHUtil {
+func createMockSSHUtilMap(ips []string, connectErr error, execOutput string, execErr error) map[string]SSHUtil {
 	sshUtilMap := make(map[string]SSHUtil)
-	start := 0
-	if isErrorRequiredForOnlyOne {
-		sshUtilMap[ips[0]] = getMockSSHUtil(&SSHConfig{}, connectErr, execOutput, nil)
-		start = 1
-	}
-	for i := start; i < len(ips); i++ {
-		sshUtilMap[ips[i]] = getMockSSHUtil(&SSHConfig{}, connectErr, execOutput, execErr)
+	for i := 0; i < len(ips); i++ {
+		sshUtilMap[ips[i]] = getMockSSHUtil(&SSHConfig{hostIP: ips[i]}, connectErr, execOutput, execErr)
 	}
 	return sshUtilMap
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
 Should able to run chef-automate start on bastion system of Automate HA cluster, should see output relevant to Automate HA infrastructure:
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-711
### :+1: Definition of Done
Start services in all nodes with the flags
Start service in a given node
Start services in given type of node (either all OS or PG or Automate Server or Infra Server)
### :athletic_shoe: How to Build and Test the Change
`build components/automate-cli/`
`chef-automate start --a2 --cs`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


https://user-images.githubusercontent.com/98326242/231832973-eb395aac-4dd2-48d1-a8d4-cafaef149f7f.mov


<img width="1088" alt="Screenshot 2023-04-11 at 5 30 12 PM" src="https://user-images.githubusercontent.com/98326242/231157297-cb6c9995-7bcb-49cd-a8d8-a913fd7201d9.png">

