### PR TITLE
Added nil check for sudo password variable

### DIFF
--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -258,7 +258,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     # If the sudo_password is set, store it in the secrets hash
     if sudo_password
       # Set a new secret
-      secrets.set('sudo_password',  sudo_password)
+      secrets.set('sudo_password', sudo_password)
       # Save the updated secrets store to disk
       secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
     end

--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -255,6 +255,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
     sudo_password = ENV['sudo_password']
+    # If the sudo_password is set, store it in the secrets hash
     if sudo_password
       # Set a new secret
       secrets.set('sudo_password',  sudo_password)

--- a/components/automate-cluster-ctl/libexec/cluster-deploy
+++ b/components/automate-cluster-ctl/libexec/cluster-deploy
@@ -254,10 +254,13 @@ class AutomateClusterSetup < AutomateCluster::Command
 
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
-    # Set a new secret
-    secrets.set('sudo_password',  ENV['sudo_password'])
-    # Save the updated secrets store to disk
-    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    sudo_password = ENV['sudo_password']
+    if sudo_password
+      # Set a new secret
+      secrets.set('sudo_password',  sudo_password)
+      # Save the updated secrets store to disk
+      secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    end
   end
 
   def ask_for_action

--- a/components/automate-cluster-ctl/libexec/cluster-provision
+++ b/components/automate-cluster-ctl/libexec/cluster-provision
@@ -91,6 +91,7 @@ class AutomateClusterSetup < AutomateCluster::Command
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
     sudo_password = ENV['sudo_password']
+    # If the sudo_password is set, store it in the secrets hash
     if sudo_password
       # Set a new secret
       secrets.set('sudo_password',  sudo_password)

--- a/components/automate-cluster-ctl/libexec/cluster-provision
+++ b/components/automate-cluster-ctl/libexec/cluster-provision
@@ -94,7 +94,7 @@ class AutomateClusterSetup < AutomateCluster::Command
     # If the sudo_password is set, store it in the secrets hash
     if sudo_password
       # Set a new secret
-      secrets.set('sudo_password',  sudo_password)
+      secrets.set('sudo_password', sudo_password)
       # Save the updated secrets store to disk
       secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
     end

--- a/components/automate-cluster-ctl/libexec/cluster-provision
+++ b/components/automate-cluster-ctl/libexec/cluster-provision
@@ -90,10 +90,13 @@ class AutomateClusterSetup < AutomateCluster::Command
 
   # store the sudo_password from the env variable in the secrets hash
   def store_secret_envs
-    # Set a new secret
-    secrets.set('sudo_password',  ENV['sudo_password'])
-    # Save the updated secrets store to disk
-    secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    sudo_password = ENV['sudo_password']
+    if sudo_password
+      # Set a new secret
+      secrets.set('sudo_password',  sudo_password)
+      # Save the updated secrets store to disk
+      secrets.save(File.expand_path(AutomateCluster::Config.secrets_store_file))
+    end
   end
 
   def ask_for_action


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added nil check for sudo password variable.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/pull/7774
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Rebuild automate-ha-cluster-ctl (rebuild components/automate-cluster-ctl/) or can use (akrishna/automate-ha-cluster-ctl/0.1.0/20230405123959) and automate-ha-deployment(rebuild components/automate-backend-deployment/) or can use (akrishna/automate-ha-deployment/0.1.0/20230405131647).
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![Screenshot 2023-04-05 at 5 53 37 PM](https://user-images.githubusercontent.com/11033984/230079714-f34f9404-81f6-4ead-b341-5fc9f675ac07.png)

