### PR TITLE
Add missing config change for opensearch snapshot path

### DIFF
--- a/components/docs-chef-io/content/automate/ha_automate_to_automate_ha.md
+++ b/components/docs-chef-io/content/automate/ha_automate_to_automate_ha.md
@@ -78,6 +78,13 @@ minimum version of Chef Automate: [20201230192246](https://docs.chef.io/release_
     {{% automate/char-warn %}}
     {{< /warning >}}
 
+    Update the backup paths to match the elasticsearch snapshot location from the A2HA:
+
+    ```bash
+    [global.v1.external.opensearch.backup.fs]
+    path = "/mnt/automate_backups/elasticsearch"
+    ```
+
 1. Unpack the `bootstrap.abb` file on all the Frontend nodes:
 
     Login to Each Frontend Node and then run after copying the `bootstrap.abb` file.


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Need to update the config path for the opensearch/elasticsearch snapshots to match the path from the backups. 

Otherwise, we'll get errors about being unable to create the appropriate snapshot repositories.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
