### PR TITLE
Rotate certs on OS nodes with different CN

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -468,13 +468,13 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 
 func patchOSNodeDN(flagsObj *certRotateFlags, patchFnParam *patchFnParameters, c *certRotateFlow, nodesDn string) error {
 
-	peerconfig := fmt.Sprintf(OPENSEARCH_DN_CONFIG_FOR_PEERS, fmt.Sprintf("%v", nodesDn))
+	peerConfig := fmt.Sprintf(OPENSEARCH_DN_CONFIG_FOR_PEERS, fmt.Sprintf("%v", nodesDn))
 
 	nodeVal := flagsObj.node
 	flagsObj.node = ""
 
 	patchFnParam.fileName = "cert-rotate-os-peer.toml"
-	patchFnParam.config = peerconfig
+	patchFnParam.config = peerConfig
 	patchFnParam.timestamp = time.Now().Format("20060102150405")
 	patchFnParam.skipIpsList = []string{flagsObj.node}
 

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -98,12 +98,6 @@ const (
 	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-%s/config/user.toml
 	sudo systemctl start hab-sup.service`
 
-	ROTATE_CERT_ON_OS = `
-	echo "y" | sudo cp /tmp/%s /hab/user/automate-ha-opensearch/config/user.toml
-	export TIMESTAMP=$(date +"%s");
-	echo "yes" | sudo hab config apply automate-ha-opemsearch.default  $(date '+%s') /tmp/%s;
-	`
-
 	IP_V4_REGEX = `(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`
 
 	ERROR_SELF_MANAGED_DB_CERT_ROTATE = "Certificate rotation for externally configured %s is not supported."


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

In the HA cluster, custom certs can be enabled on the OS nodes where different certs can be set for each node with a different CN. To preserve the behaviour after cert rotation as well, the certs should be rotated node wise and all the nodes should be aware of each other's new CN.

PR contains the changes to ensure that all the OS are aware of each others CN post cert-rotation as well.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-1024

### :+1: Definition of Done
- Should be able to rotate the Root cert, the admin cert and the respective nodes cert.
- Should be able to rotate the certs with different CN on each node

### :athletic_shoe: How to Build and Test the Change
- Checkout this branch
- rebuild components/automate-ci and upload the hab pkg
- Install the new cli in the bastion machine
- Execute the cert-rotate commands as per the doc

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

<img width="1536" alt="image" src="https://user-images.githubusercontent.com/33195661/231530453-53225983-864b-4cd8-b2b8-2ffd55e7385b.png">

https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EdLDtGycikVOv_YHuj3CT-ABLecYXhQf1Y_aMXi0mhETeQ?e=btGtEh