### PR TITLE
ssh_group_name added

### DIFF
--- a/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/genA2haRbTmpl.go
@@ -6,8 +6,10 @@ secrets_store_file "{{ .Architecture.ConfigInitials.SecretsStoreFile }}"
 architecture "{{ .Architecture.ConfigInitials.Architecture }}"
 workspace_path "{{ .Architecture.ConfigInitials.WorkspacePath }}"
 ssh_user "{{ .Architecture.ConfigInitials.SSHUser }}"
+ssh_group_name "{{ .Architecture.ConfigInitials.SSHGroupName }}"
 ssh_key_file "{{ .Architecture.ConfigInitials.SSHKeyFile }}"
 {{ if .Architecture.ConfigInitials.SSHPort }} ssh_port "{{ .Architecture.ConfigInitials.SSHPort }}" {{ else }} ssh_port "22" {{ end }}
+{{ if .Architecture.ConfigInitials.SSHGroupName }} ssh_group_name "{{ .Architecture.ConfigInitials.SSHGroupName }}" {{ else }} ssh_group_name "{{ .Architecture.ConfigInitials.SSHUser }}" {{ end }}
 
 # logging_monitoring_management "true"
 # ew_elk "false"
@@ -130,11 +132,13 @@ secrets_store_file "{{ .Architecture.ConfigInitials.SecretsStoreFile }}"
 architecture "{{ .Architecture.ConfigInitials.Architecture }}"
 workspace_path "{{ .Architecture.ConfigInitials.WorkspacePath }}"
 ssh_user "{{ .Architecture.ConfigInitials.SSHUser }}"
+ssh_group_name "{{ .Architecture.ConfigInitials.SSHGroupName }}"
 ssh_key_file "{{ .Architecture.ConfigInitials.SSHKeyFile }}"
 ssh_port "{{ .Architecture.ConfigInitials.SSHPort }}"
 backup_mount "{{ .Architecture.ConfigInitials.BackupMount }}"
 backup_config "{{ .Architecture.ConfigInitials.BackupConfig }}"
 {{ if  .Architecture.ConfigInitials.S3BucketName }} s3_bucketName "{{ .Architecture.ConfigInitials.S3BucketName }}" {{ else }} # s3_bucketName "{{ .Architecture.ConfigInitials.S3BucketName }}" {{ end }}
+{{ if .Architecture.ConfigInitials.SSHGroupName }} ssh_group_name "{{ .Architecture.ConfigInitials.SSHGroupName }}" {{ else }} ssh_group_name "{{ .Architecture.ConfigInitials.SSHUser }}" {{ end }}
 # logging_monitoring_management "true"
 # new_elk "false"
 # existing_elk "false"

--- a/components/automate-cli/cmd/chef-automate/haValidationScriptTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/haValidationScriptTmpl.go
@@ -29,6 +29,9 @@ SSH_KEY=$(grep -E '(^|\s)ssh_key_file($|\s)' $CONFIG | cut -c13- | sed 's/"//g' 
 #Taking and filtering ssh_user from config.toml file
 SSH_USER=$(grep -E '(^|\s)ssh_user($|\s)' $CONFIG | cut -c10- | sed 's/"//g' | sed 's/=//g')
 
+#Taking and filtering ssh_group_name from config.toml file
+SSH_GROUP_NAME=$(grep -E '(^|\s)ssh_group_name($|\s)' $CONFIG | cut -c10- | sed 's/"//g' | sed 's/=//g')
+
 #Taking and filtering ssh_port from config.toml file
 SSH_PORT=$(grep -E '(^|\s)ssh_port($|\s)' $CONFIG | cut -c10- | sed 's/"//g' | sed 's/=//g')
 

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -33,6 +33,7 @@ type AwsConfigToml struct {
 			Architecture                string `toml:"architecture"`
 			WorkspacePath               string `toml:"workspace_path"`
 			SSHUser                     string `toml:"ssh_user"`
+			SSHGroupName                string `toml:"ssh_group_name"`
 			SSHKeyFile                  string `toml:"ssh_key_file"`
 			SSHPort                     string `toml:"ssh_port"`
 			LoggingMonitoringManagement string `toml:"logging_monitoring_management"`
@@ -170,6 +171,7 @@ type ExistingInfraConfigToml struct {
 			Architecture                string `toml:"architecture,omitempty"`
 			WorkspacePath               string `toml:"workspace_path,omitempty"`
 			SSHUser                     string `toml:"ssh_user,omitempty"`
+			SSHGroupName                string `toml:"ssh_group_name,omitempty"`
 			SSHKeyFile                  string `toml:"ssh_key_file,omitempty"`
 			SSHPort                     string `toml:"ssh_port,omitempty"`
 			LoggingMonitoringManagement string `toml:"logging_monitoring_management,omitempty"`

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -10,7 +10,11 @@ const haAwsConfigTemplate = `
 # Eg.: ssh_user = "ubuntu"
 ssh_user = ""
 
-# custome ssh port no to connect instances, default will be 22
+# custom ssh group name, it will be defaulted to ssh_user
+# Eg.: ssh_group_name = "ubuntu"
+ssh_group_name = ""
+
+# custom ssh port no to connect instances, default will be 22
 # Eg.: ssh_port = "22"
 ssh_port = ""
 
@@ -304,6 +308,10 @@ const haExistingNodesConfigTemplate = `
 ## === INPUT NEEDED ===
 # Eg.: ssh_user = "ubuntu"
 ssh_user = ""
+
+# custom ssh group name, it will be defaulted to ssh_user
+# Eg.: ssh_group_name = "ubuntu"
+ssh_group_name = ""
 
 # private ssh key file path to access instances
 # Eg.: ssh_user = "~/.ssh/A2HA.pem"

--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -45,6 +45,7 @@ type HAAwsAutoTfvars struct {
 	AwsSshKeyFile                      string      `json:"ssh_key_file"`
 	SshPort                            string      `json:"ssh_port"`
 	SshUser                            string      `json:"ssh_user"`
+	SSHGroupName                       string      `json:"ssh_group_name"`
 	HabitatUidGid                      string      `json:"habitat_uid_gid"`
 	PostgresqlArchiveDiskFsPath        string      `json:"postgresql_archive_disk_fs_path"`
 	PostgresqlInstanceCount            int         `json:"postgresql_instance_count"`
@@ -137,6 +138,7 @@ type HATfvars struct {
 	SshKeyFile                      string      `json:"ssh_key_file"`
 	SshPort                         string      `json:"ssh_port"`
 	SshUser                         string      `json:"ssh_user"`
+	SSHGroupName                    string      `json:"ssh_group_name"`
 	HabitatUidGid                   string      `json:"habitat_uid_gid"`
 	PostgresqlArchiveDiskFsPath     string      `json:"postgresql_archive_disk_fs_path"`
 	PostgresqlInstanceCount         int         `json:"postgresql_instance_count"`
@@ -735,6 +737,7 @@ func getExistingHAConfigFromTFVars(tfvarConfig *HATfvars) (*ExistingInfraConfigT
 	sharedConfigToml.Architecture.ConfigInitials.SSHKeyFile = strings.TrimSpace(tfvarConfig.SshKeyFile)
 	sharedConfigToml.Architecture.ConfigInitials.SSHPort = strings.TrimSpace(tfvarConfig.SshPort)
 	sharedConfigToml.Architecture.ConfigInitials.SSHUser = strings.TrimSpace(tfvarConfig.SshUser)
+	sharedConfigToml.Architecture.ConfigInitials.SSHGroupName = strings.TrimSpace(tfvarConfig.SSHGroupName)
 	sharedConfigToml.Architecture.ConfigInitials.WorkspacePath = AUTOMATE_HA_WORKSPACE_DIR
 	sharedConfigToml.Automate.Config.Fqdn = strings.TrimSpace(tfvarConfig.AutomateFqdn)
 	sharedConfigToml.Automate.Config.InstanceCount = strconv.Itoa(tfvarConfig.AutomateInstanceCount)
@@ -819,6 +822,7 @@ func getAwsHAConfigFromTFVars(tfvarConfig *HATfvars, awsAutoTfvarConfig *HAAwsAu
 	sharedConfigToml.Architecture.ConfigInitials.SSHKeyFile = strings.TrimSpace(awsAutoTfvarConfig.AwsSshKeyFile)
 	sharedConfigToml.Architecture.ConfigInitials.SSHPort = strings.TrimSpace(awsAutoTfvarConfig.SshPort)
 	sharedConfigToml.Architecture.ConfigInitials.SSHUser = strings.TrimSpace(awsAutoTfvarConfig.SshUser)
+	sharedConfigToml.Architecture.ConfigInitials.SSHGroupName = strings.TrimSpace(awsAutoTfvarConfig.SSHGroupName)
 	sharedConfigToml.Architecture.ConfigInitials.WorkspacePath = AUTOMATE_HA_WORKSPACE_DIR
 	sharedConfigToml.Automate.Config.InstanceCount = strconv.Itoa(awsAutoTfvarConfig.AutomateInstanceCount)
 	sharedConfigToml.Automate.Config.ConfigFile = strings.TrimSpace(awsAutoTfvarConfig.AutomateConfigFile)

--- a/components/automate-cluster-ctl/lib/cluster/config.rb
+++ b/components/automate-cluster-ctl/lib/cluster/config.rb
@@ -46,6 +46,7 @@ module AutomateCluster
     default :architecture
 
     default :ssh_user, 'centos'
+    default :ssh_group_name, 'centos'
     default :ssh_port, '22'
     default(:ssh_key_file, '~/.ssh/id_rsa').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
     default(:workspace_path, '/hab/a2_deploy_workspace').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }

--- a/components/automate-cluster-ctl/lib/cluster/config.rb
+++ b/components/automate-cluster-ctl/lib/cluster/config.rb
@@ -46,7 +46,7 @@ module AutomateCluster
     default :architecture
 
     default :ssh_user, 'centos'
-    default :ssh_group_name, 'centos'
+    default :ssh_group_name, :ssh_user
     default :ssh_port, '22'
     default(:ssh_key_file, '~/.ssh/id_rsa').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
     default(:workspace_path, '/hab/a2_deploy_workspace').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }

--- a/components/automate-cluster-ctl/lib/cluster/config.rb
+++ b/components/automate-cluster-ctl/lib/cluster/config.rb
@@ -46,7 +46,7 @@ module AutomateCluster
     default :architecture
 
     default :ssh_user, 'centos'
-    default :ssh_group_name, :ssh_user
+    default :ssh_group_name, 'centos'
     default :ssh_port, '22'
     default(:ssh_key_file, '~/.ssh/id_rsa').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }
     default(:workspace_path, '/hab/a2_deploy_workspace').writes_value { |path| AutomateCluster::Config.expand_relative_paths(path) }

--- a/components/automate-cluster-ctl/templates/terraform.tfvars.erb
+++ b/components/automate-cluster-ctl/templates/terraform.tfvars.erb
@@ -276,6 +276,7 @@ postgresql_archive_disk_fs_path = "<%= config.backup_mount %>/postgresql"
 
 habitat_uid_gid = "<%= config.habitat_uid_gid %>"
 ssh_user = "<%= config.ssh_user %>"
+ssh_group_name = "<%= config.ssh_group_name %>"
 ssh_port = "<%= config.ssh_port %>"
 ssh_key_file = "<%= config.ssh_key_file %>"
 

--- a/terraform/a2ha-terraform/modules/system/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system/inputs.tf
@@ -29,6 +29,9 @@ variable "ssh_user" {
   default = "centos"
 }
 
+variable "ssh_group_name" {
+}
+
 variable "ssh_user_sudo_password" {
 }
 

--- a/terraform/a2ha-terraform/modules/system/inputs.tf
+++ b/terraform/a2ha-terraform/modules/system/inputs.tf
@@ -18,6 +18,9 @@ variable "public_ips" {
   default = []
 }
 
+variable "ssh_group_name" {
+}
+
 variable "ssh_key_file" {
 }
 
@@ -27,9 +30,6 @@ variable "ssh_port" {
 
 variable "ssh_user" {
   default = "centos"
-}
-
-variable "ssh_group_name" {
 }
 
 variable "ssh_user_sudo_password" {

--- a/terraform/a2ha-terraform/modules/system/main.tf
+++ b/terraform/a2ha-terraform/modules/system/main.tf
@@ -23,7 +23,7 @@ resource "null_resource" "create_temp_path" {
     inline = [ 
       "echo tmp_path: ${var.tmp_path}", 
       "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S mkdir -p ${var.tmp_path}", 
-      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S chown -R ${var.ssh_user}:${var.ssh_user} ${var.tmp_path}" 
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S chown -R ${var.ssh_user}:${var.ssh_group_name} ${var.tmp_path}" 
       ]
    }
 }

--- a/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
@@ -11,6 +11,7 @@ module "system-tuning-automate" {
   private_ips                     = var.automate_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
@@ -25,6 +26,7 @@ module "system-tuning-chef_server" {
   private_ips                     = var.chef_server_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
@@ -40,6 +42,7 @@ module "system-tuning-opensearch" {
   private_ips                     = var.opensearch_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd
@@ -55,6 +58,7 @@ module "system-tuning-postgresql" {
   private_ips                     = var.postgresql_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd

--- a/terraform/a2ha-terraform/reference_architectures/deployment/outputs.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/outputs.tf
@@ -10,6 +10,10 @@ output "ssh_user" {
   value = var.ssh_user
 }
 
+output "ssh_group_name" {
+  value = var.ssh_group_name
+}
+
 output "ssh_port" {
   value = var.ssh_port
 }

--- a/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
@@ -224,6 +224,8 @@ variable "ssh_port" {
 variable "ssh_user" {
   default = "centos"
 }
+variable "ssh_group_name" {
+}
 
 variable "sudo_cmd" {
   default = "sudo"

--- a/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/variables.tf
@@ -214,6 +214,9 @@ variable "setup_self_managed_services" {
   default = false
 }
 
+variable "ssh_group_name" {
+}
+
 variable "ssh_key_file" {
 }
 
@@ -223,8 +226,6 @@ variable "ssh_port" {
 
 variable "ssh_user" {
   default = "centos"
-}
-variable "ssh_group_name" {
 }
 
 variable "sudo_cmd" {

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -18,6 +18,7 @@ module "system-tuning-frontend" {
   private_ips                     = local.frontend_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.fe_sudo_password
   sudo_cmd                        = var.sudo_cmd
@@ -33,6 +34,7 @@ module "system-tuning-backend" {
   private_ips                     = local.backend_private_ips
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
+  ssh_group_name                  = var.ssh_group_name
   ssh_port                        = var.ssh_port
   ssh_user_sudo_password          = local.be_sudo_password
   sudo_cmd                        = var.sudo_cmd

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/outputs.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/outputs.tf
@@ -10,6 +10,10 @@ output "ssh_user" {
   value = var.ssh_user
 }
 
+output "ssh_group_name" {
+  value = var.ssh_group_name
+}
+
 output "ssh_port" {
   value = var.ssh_port
 }

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/variables.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/variables.tf
@@ -161,6 +161,9 @@ variable "ssh_port" {
 variable "ssh_user" {
 }
 
+variable "ssh_group_name" {
+}
+
 variable "sudo_cmd" {
   default = "sudo"
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
https://chefio.atlassian.net/browse/CHEF-2054

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Initialised Automate HA On Prem infra
added custom groupname on all the automate HA nodes

`sudo groupadd aazeez`
`sudo usermod -a -G aazeez ec2-user`

<img width="529" alt="Screenshot 2023-04-14 at 4 34 37 PM" src="https://user-images.githubusercontent.com/38317160/232032635-82a9bc4c-7294-460b-a948-d9867a1dca92.png">
<img width="679" alt="Screenshot 2023-04-14 at 4 35 03 PM" src="https://user-images.githubusercontent.com/38317160/232032644-7a9a3d66-0017-466d-a0e2-376198a6281f.png">
<img width="727" alt="Screenshot 2023-04-14 at 4 36 43 PM" src="https://user-images.githubusercontent.com/38317160/232032649-3fa8ab16-486e-44ce-b11f-272ead2f3178.png">


### :athletic_shoe: How to Build and Test the Change

- Rebuild automate-cli (`rebuild components/automate-cli`/) or can use (`aazeez/automate-cli/0.1.0/20230414122935`), automate-ha-cluster-ctl (`rebuild components/automate-cluster-ctl`/) or can use (aazeez/automate-ha-cluster-ctl/0.1.0/20230413171357`), and automate-ha-deployment(`rebuild components/automate-backend-deployment`/) or can use (`aazeez/automate-ha-deployment/0.1.0/20230413175551`).
- Upload the above packages hab pkg upload <PATH_TO_PACKAGE_HART_FILE>.
- Create an airgap bundle with new packages sudo ./chef-automate airgap bundle create -m latest_semver.json --channel dev. Update this [latest_semver.json](https://packages.chef.io/manifests/dev/automate/latest_semver.json) manifest file with your origins.
- Note: Do not update the automate-cli origin in the manifest file, just install the new automate-cli on Bastion.

`hab pkg install -bf aazeez/automate-cli/0.1.0/20230414122935`

Create custom group name in all Automate HA nodes
To create custom group
`sudo groupadd groupname`

To add ec2-user to custom group
`sudo usermod -a -G groupname ec2-user`

Modify `config.toml` `ssh_group_name` value with same `groupname` added in HA nodes and deploy 

Note: if `ssh_group_name` is not provided it will be defaulted to ssh_user

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
