### PR TITLE
CHEF-2700-issue-changes-required-in-ui-to-revert-unintended-pr-conflict-changes

### DIFF
--- a/components/automate-ui/src/app/helpers/datetime/datetime.ts
+++ b/components/automate-ui/src/app/helpers/datetime/datetime.ts
@@ -23,7 +23,8 @@ export class DateTime {
 
   // Format for date labels in event feed graph
   // Tue, 24 Sept
-  public static readonly EVENT_GRAPH_DATE_LABEL: string = 'ddd, DD MMM';
+  // We are using @angular/common DatePipe. Ref: https://angular.io/api/common/DatePipe
+  public static readonly EVENT_GRAPH_DATE_LABEL: string = 'EEE, dd LLL';
 
   // Format for time labels in event feed table
   // 09:59

--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
@@ -8,12 +8,12 @@
           [attr.x]="zoomButtonPosition(i)"
           y="0"
           tabindex="0"
-          [attr.aria-label]="date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL"
+          [attr.aria-label]="date | date: DateTime.EVENT_GRAPH_DATE_LABEL"
           (click)="dateSelected(date, i)"
           (keydown.enter)="dateSelected(date, i)"/>
         <text class="guitar-string-zoom-date"
           [attr.x]="zoomTextPosition(i)" y="18">
-            {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
+            {{date | date: DateTime.EVENT_GRAPH_DATE_LABEL}}
         </text>
       </ng-container>
       <rect class="slider-overlay start" x="0" y="0" width="0" height="100%"/>
@@ -73,7 +73,7 @@
       [width]="graphicProportions.sectionWidth"
       [index]="i"
       *ngFor="let date of guitarStringDataContainer.sectionDates; let i = index">
-      {{date | datetime: DateTime.EVENT_GRAPH_DATE_LABEL}}
+      {{date | date: DateTime.EVENT_GRAPH_DATE_LABEL}}
     </svg:g>
 
   </chef-guitar-string-collection>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Reverted unintended UI changes that were merged as a part of https://github.com/chef/automate/commit/272dd6ec53864591fb3329f0d807a1a75894cc37#diff-cd389b43fc737de0cac38b967ad6dedc5fb1d223c7ec03a4c018a8fc35fe353a 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/CHEF-2700?atlOrigin=eyJpIjoiNGVkNjU4N2Y0NzkwNGIzNWE1YTM2M2RlZjY0MzdhMTAiLCJwIjoiaiJ9

https://github.com/chef/automate/pull/7756/files#diff-2534e18e2d525aa3852d64f7187519153738ff3bbac56885875fa3eb2c8281a9

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
