### PR TITLE
Fixing Info command with empty `Automate URL` value

### DIFF
--- a/terraform/a2ha-terraform/reference_architectures/deployment/outputs_common.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/outputs_common.tf
@@ -1,5 +1,5 @@
 output "automate_url" {
-  value = "https://${var.automate_fqdn}"
+  value = "https://${length(var.automate_fqdn) > 0 ? var.automate_fqdn : var.automate_lb_fqdn}"
 }
 
 output "automate_admin_user" {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When user set fqdn value as empty in config.toml, `chef-automate info` command is not should the URL for automate properly

### :chains: Related Resources
Jira Ticket: https://chefio.atlassian.net/browse/CHEF-2690

### :+1: Definition of Done

**It is dev done and tested in:**
- [x] AWS fresh deployment in the latest
- [x] AWS fresh deployment in the latest (AWS Managed)
- [x] On-Prem: Fresh deployment



### :athletic_shoe: How to Build and Test the Change
- Do a fresh deployment
- and use the pkg `arvinth/automate-ha-deployment/0.1.0/20230421075459`
### :white_check_mark: Checklist


**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/54614142/233600640-b78052a2-4543-45c1-8460-1bd7da801e3e.png)
