### PR TITLE
Fixed waiver control information not showing in details for a control under nodes

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.html
@@ -235,7 +235,7 @@
                         <p>This control was waived.</p>
                         <dl class="waiver-details">
                           <dt>Expires:</dt>
-                          <dd>{{ control.waiver_data.expiration_date | datetime: RFC2822 }}</dd>
+                          <dd>{{ control.waiver_data.expiration_date === "" ? "-" : (control.waiver_data.expiration_date | datetime: RFC2822) }}</dd>
                           <dt>Reason:</dt>
                           <dd>{{ control.waiver_data.justification }}</dd>
                         </dl>

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -103,9 +103,11 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
         const res = this.controlDetails['profiles'][0].controls[0].results;
         const code = this.controlDetails['profiles'][0].controls[0].code;
         const desc = this.controlDetails['profiles'][0].controls[0].desc;
+        const waiver_data = this.controlDetails['profiles'][0].controls[0].waiver_data;
         this.controlList.control_elements[this.index].result = res;
         this.controlList.control_elements[this.index].code = code;
         this.controlList.control_elements[this.index].desc = desc;
+        this.controlList.control_elements[this.index].waiver_data = waiver_data;
       } else if (detailsStatusSt === EntityStatus.loadingFailure) {
         this.isError = true;
         this.reportIdArray = this.reportIdArray.slice(0, -1);
@@ -225,9 +227,11 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
                 const res = this.controlDetails['profiles'][0].controls[0].results;
                 const code = this.controlDetails['profiles'][0].controls[0].code;
                 const desc = this.controlDetails['profiles'][0].controls[0].desc;
+                const waiver_data = this.controlDetails['profiles'][0].controls[0].waiver_data;
                 this.controlList.control_elements[this.index].result = res;
                 this.controlList.control_elements[this.index].code = code;
                 this.controlList.control_elements[this.index].desc = desc;
+                this.controlList.control_elements[this.index].waiver_data = waiver_data;
               }
             });
           });


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When there is a waived control present and we want to get the details of that control, no expire date, and the reason is showing in the UI.

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2782
### :+1: Definition of Done
Added changes to show the expire date, and the reason on waived controls.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

# build components/automate-ui-devproxy/
# start_automate_ui_background
# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab
to test this please add the test data
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1520" alt="Screenshot 2023-04-25 at 5 36 26 PM" src="https://user-images.githubusercontent.com/12297653/234271413-5fe20b2f-514c-4567-8f78-aea2cd5501fb.png">

