### PR TITLE
Code changes to achieve idempotency with node flag in OS

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chef/automate/api/config/deployment"
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/lib/io/fileutils"
@@ -427,8 +428,8 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	if err != nil {
 		return err
 	}
-    
-	if flagsObj.node!="" && stringutils.SliceContains(skipIpsList, flagsObj.node) {
+
+	if flagsObj.node != "" && stringutils.SliceContains(skipIpsList, flagsObj.node) {
 		return nil
 	}
 
@@ -448,15 +449,8 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	if err != nil {
 		return err
 	}
-	oldCn := ""
-	for _, config := range automatesConfig {
-		if config.Global.V1.External.Opensearch != nil && config.Global.V1.External.Opensearch.Ssl != nil {
-			if config.Global.V1.External.Opensearch.Ssl.ServerName != nil {
-				oldCn = config.Global.V1.External.Opensearch.Ssl.ServerName.Value
-				break
-			}
-		}
-	}
+	
+	oldCn:=getOldCn(automatesConfig)
 
 	// Patching root-ca to frontend-nodes for maintaining the connection.
 	cn := nodesCn
@@ -507,6 +501,19 @@ func patchOSNodeDN(flagsObj *certRotateFlags, patchFnParam *patchFnParameters, c
 
 	flagsObj.node = nodeVal
 	return nil
+}
+
+func getOldCn(automatesConfig map[string]*deployment.AutomateConfig) string {
+	oldCn := ""
+	for _, config := range automatesConfig {
+		if config.Global.V1.External.Opensearch != nil && config.Global.V1.External.Opensearch.Ssl != nil {
+			if config.Global.V1.External.Opensearch.Ssl.ServerName != nil {
+				oldCn = config.Global.V1.External.Opensearch.Ssl.ServerName.Value
+				break
+			}
+		}
+	}
+	return oldCn
 }
 
 // patchConfig will patch the configurations to required nodes.

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -4,9 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/chef/automate/api/config/deployment"
+	"github.com/chef/automate/api/config/shared"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -787,7 +790,7 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 		testCaseDescription string
 		newRootCA           string
 		newCn               string
-		oldCn				string
+		oldCn               string
 		node                string
 		currentCertsInfo    *certShowCertificates
 		infra               *AutomateHAInfraDetails
@@ -822,20 +825,18 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 			newCn:               newCn,
 			oldCn:               newCn,
 			node:                ValidIP4,
-			currentCertsInfo: &certShowCertificates{
-			},
-			infra:       infra,
-			skipIpsList: c.getIps("frontend", infra),
+			currentCertsInfo:    &certShowCertificates{},
+			infra:               infra,
+			skipIpsList:         c.getIps("frontend", infra),
 		},
 		{
 			testCaseDescription: "Opensearch root-ca and cn patching | different cn and node flag",
 			newCn:               newCn + "n",
 			oldCn:               newCn,
 			node:                ValidIP4,
-			currentCertsInfo: &certShowCertificates{
-			},
-			infra:       infra,
-			skipIpsList: []string{},
+			currentCertsInfo:    &certShowCertificates{},
+			infra:               infra,
+			skipIpsList:         []string{},
 		},
 		{
 			testCaseDescription: "Opensearch root-ca and cn patching | different root-ca",
@@ -852,7 +853,7 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testCaseDescription, func(t *testing.T) {
-			skipIpsListGot := c.getFrontEndIpsForSkippingCnAndRootCaPatching(testCase.newRootCA, testCase.newCn,testCase.oldCn, testCase.node, testCase.currentCertsInfo, infra)
+			skipIpsListGot := c.getFrontEndIpsForSkippingCnAndRootCaPatching(testCase.newRootCA, testCase.newCn, testCase.oldCn, testCase.node, testCase.currentCertsInfo, infra)
 			assert.Equal(t, testCase.skipIpsList, skipIpsListGot)
 		})
 	}
@@ -889,6 +890,73 @@ func TestGetFilteredIps(t *testing.T) {
 		t.Run("TestingGetFilteredIps", func(t *testing.T) {
 			filteredIpsGot := c.getFilteredIps(testCase.serviceIps, testCase.skipIpsList)
 			assert.Equal(t, testCase.filteredIpsExpected, filteredIpsGot)
+		})
+	}
+}
+
+func TestGetOldCn(t *testing.T) {
+	type testCaseInfo struct {
+		testCaseDescription string
+		automatesConfig     *deployment.AutomateConfig
+		OldCnExpected       string
+	}
+
+	testCases := []testCaseInfo{
+		{
+			testCaseDescription: "Getting cn value",
+			automatesConfig: &deployment.AutomateConfig{
+				Global: &shared.GlobalConfig{
+					V1: &shared.V1{
+						External: &shared.External{
+							Opensearch: &shared.External_Opensearch{
+								Ssl: &shared.External_Opensearch_SSL{
+									ServerName: &wrapperspb.StringValue{
+										Value: "chefnode",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			OldCnExpected: "chefnode",
+		},
+		{
+			testCaseDescription: "Getting cn value with field are nil",
+			automatesConfig: &deployment.AutomateConfig{
+				Global: &shared.GlobalConfig{
+					V1: &shared.V1{
+						External: &shared.External{},
+					},
+				},
+			},
+			OldCnExpected: "",
+		},
+		{
+			testCaseDescription: "Getting cn value server name as nil",
+			automatesConfig: &deployment.AutomateConfig{
+				Global: &shared.GlobalConfig{
+					V1: &shared.V1{
+						External: &shared.External{
+							Opensearch: &shared.External_Opensearch{
+								Ssl: &shared.External_Opensearch_SSL{
+								},
+							},
+						},
+					},
+				},
+			},
+			OldCnExpected: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("GetOldCn", func(t *testing.T) {
+			configMap:= map[string]*deployment.AutomateConfig {
+				ValidIP: testCase.automatesConfig,
+			}
+			oldCn:=getOldCn(configMap)
+			assert.Equal(t, testCase.OldCnExpected,oldCn)
 		})
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -948,6 +948,17 @@ func TestGetOldCn(t *testing.T) {
 			},
 			OldCnExpected: "",
 		},
+		{
+			testCaseDescription: "Getting cn value server name as nil",
+			automatesConfig: &deployment.AutomateConfig{
+				Global: &shared.GlobalConfig{
+					V1: &shared.V1{
+						External: &shared.External{},
+					},
+				},
+			},
+			OldCnExpected: "",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -787,6 +787,7 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 		testCaseDescription string
 		newRootCA           string
 		newCn               string
+		oldCn				string
 		node                string
 		currentCertsInfo    *certShowCertificates
 		infra               *AutomateHAInfraDetails
@@ -798,25 +799,9 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 			testCaseDescription: "Opensearch root-ca and cn patching | same cn and root-ca",
 			newRootCA:           FileContent,
 			newCn:               newCn,
+			oldCn:               newCn,
 			currentCertsInfo: &certShowCertificates{
 				OpensearchRootCert: FileContent,
-				OpensearchCertsByIP: []CertByIP{
-					{
-						IP:         ValidIP4,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP5,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP6,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-				},
 			},
 			infra:       infra,
 			skipIpsList: c.getIps("frontend", infra),
@@ -825,25 +810,9 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 			testCaseDescription: "Opensearch root-ca and cn patching | same root-ca different cn",
 			newRootCA:           FileContent,
 			newCn:               newCn + "n",
+			oldCn:               "",
 			currentCertsInfo: &certShowCertificates{
 				OpensearchRootCert: FileContent,
-				OpensearchCertsByIP: []CertByIP{
-					{
-						IP:         ValidIP4,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP5,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP6,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-				},
 			},
 			infra:       infra,
 			skipIpsList: []string{},
@@ -851,25 +820,9 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 		{
 			testCaseDescription: "Opensearch root-ca and cn patching | same cn and node flag",
 			newCn:               newCn,
+			oldCn:               newCn,
 			node:                ValidIP4,
 			currentCertsInfo: &certShowCertificates{
-				OpensearchCertsByIP: []CertByIP{
-					{
-						IP:         ValidIP4,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP5,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP6,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-				},
 			},
 			infra:       infra,
 			skipIpsList: c.getIps("frontend", infra),
@@ -877,25 +830,9 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 		{
 			testCaseDescription: "Opensearch root-ca and cn patching | different cn and node flag",
 			newCn:               newCn + "n",
+			oldCn:               newCn,
 			node:                ValidIP4,
 			currentCertsInfo: &certShowCertificates{
-				OpensearchCertsByIP: []CertByIP{
-					{
-						IP:         ValidIP4,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP5,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP6,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-				},
 			},
 			infra:       infra,
 			skipIpsList: []string{},
@@ -904,25 +841,9 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 			testCaseDescription: "Opensearch root-ca and cn patching | different root-ca",
 			newRootCA:           FileContent + "a",
 			newCn:               newCn,
+			oldCn:               newCn,
 			currentCertsInfo: &certShowCertificates{
 				OpensearchRootCert: FileContent,
-				OpensearchCertsByIP: []CertByIP{
-					{
-						IP:         ValidIP4,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP5,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-					{
-						IP:         ValidIP6,
-						PublicKey:  FileContent,
-						PrivateKey: FileContent,
-					},
-				},
 			},
 			infra:       infra,
 			skipIpsList: []string{},
@@ -931,7 +852,7 @@ func TestGetFrontEndIpsForSkippingCnAndRootCaPatching(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testCaseDescription, func(t *testing.T) {
-			skipIpsListGot := c.getFrontEndIpsForSkippingCnAndRootCaPatching(testCase.newRootCA, testCase.newCn, testCase.node, testCase.currentCertsInfo, infra)
+			skipIpsListGot := c.getFrontEndIpsForSkippingCnAndRootCaPatching(testCase.newRootCA, testCase.newCn,testCase.oldCn, testCase.node, testCase.currentCertsInfo, infra)
 			assert.Equal(t, testCase.skipIpsList, skipIpsListGot)
 		})
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Please refer following tickets.


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2704
https://chefio.atlassian.net/browse/CHEF-2705
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change


### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
For Cluster
https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EZu4jGaSyaRJiNMHjoB3N_8BR0ECysbYveh9ObAQU1i8FQ?e=7l2Crg
Node specific command for first time in cluster
https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EfM60O9s5HpBjuIpCOJarREBw7nXEtRKfXIYMI5ZXVwnSA?e=ec6y8B

Node specific command for second time in cluster
https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/Efzv0zGyLcBBsVmMV0UBeX0B6ztbFEpkWAV6E04DjMVDzw?e=VsdWVo