### PR TITLE
Creating 'tmp_path' and modifying only the SSH User permission

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,3 +5,4 @@ This provides the `automate-backend-deployment` package.
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package
+

--- a/terraform/a2ha-terraform/modules/system/main.tf
+++ b/terraform/a2ha-terraform/modules/system/main.tf
@@ -23,7 +23,7 @@ resource "null_resource" "create_temp_path" {
     inline = [ 
       "echo tmp_path: ${var.tmp_path}", 
       "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S mkdir -p ${var.tmp_path}", 
-      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S chown -R ${var.ssh_user}:${var.ssh_group_name} ${var.tmp_path}" 
+      "echo '${var.ssh_user_sudo_password}' | ${var.sudo_cmd} -S chown -R ${var.ssh_user} ${var.tmp_path}" 
       ]
    }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Automate HA - AWS - While creating `tmp_path`, terraform should only modify the SSH User permission

### :chains: Related Resources
Jira ticket: https://chefio.atlassian.net/browse/CHEF-2852

### :+1: Definition of Done


### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![image](https://user-images.githubusercontent.com/54614142/234554555-c8f60a23-8c2b-4219-a054-f1b0c26d5973.png)
