### PR TITLE
Add nginx status endpoint

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -515,18 +515,9 @@ func executeShellCommand(command string, args []string, workingDir string) error
 	return err
 }
 
-func executeShellCommandAndGet(command string, args []string, workingDir string) error {
-	writer.Printf("\n%s command execution started \n\n\n", command)
-	c := exec.Command(command, args...)
-	c.Stdin = os.Stdin
-	if len(workingDir) > 0 {
-		c.Dir = workingDir
-	}
-	c.Stdout = io.MultiWriter(os.Stdout)
-	c.Stderr = io.MultiWriter(os.Stderr)
-	err := c.Run()
-	writer.Printf("%s command execution done, exiting\n", command)
-	return err
+func executeShellCommandMinLogs(command string) error {
+	cmd := exec.Command("bash", "-c", command)
+	return cmd.Run()
 }
 
 func extarctVersionAndRelease(filename string) (string, string) {

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -2,12 +2,21 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver"
+	"github.com/chef/automate/components/automate-cli/pkg/verifysystemdcreate"
+	"github.com/chef/automate/lib/io/fileutils"
 	verification "github.com/chef/automate/lib/verification"
 	"github.com/spf13/cobra"
+)
+
+const (
+	BINARY_DESTINATION_FOLDER = "/etc/automate-verify"
+	SYSTEMD_PATH              = "/etc/systemd/system"
 )
 
 type verifyCmdFlags struct {
@@ -33,15 +42,34 @@ type verifyServeCmdFlow struct {
 	sshUtil SSHUtil
 }
 
+type verifySystemdCreateFlow struct{}
+
 var verifyServeCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Start verify server",
-	Long:  "Start verify server for running checks",
+	Short: "Start verify server for running checks",
 	Annotations: map[string]string{
 		docs.Compatibility: docs.Compatibility,
 	},
 	Args: cobra.ExactArgs(0),
 	RunE: verifyServeCmdFunc(),
+}
+
+var verifySystemdServiceCmd = &cobra.Command{
+	Use:   "systemd-service COMMAND",
+	Short: "Systemd utilities for verify command",
+	Annotations: map[string]string{
+		docs.Compatibility: docs.Compatibility,
+	},
+}
+
+var verifySystemdServiceCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Start verify server as systemd service",
+	Annotations: map[string]string{
+		docs.Compatibility: docs.Compatibility,
+	},
+	Args: cobra.ExactArgs(0),
+	RunE: verifySystemdCreateFunc(),
 }
 
 func init() {
@@ -110,6 +138,8 @@ func init() {
 		"",
 		"Config file that needs to be verified")
 
+	verifySystemdServiceCmd.AddCommand(verifySystemdServiceCreateCmd)
+	verifyCmd.AddCommand(verifySystemdServiceCmd)
 	verifyCmd.AddCommand(verifyServeCmd)
 	RootCmd.AddCommand(verifyCmd)
 }
@@ -126,6 +156,30 @@ func verifyServeCmdFunc() func(cmd *cobra.Command, args []string) error {
 func (v *verifyServeCmdFlow) runVerifyServeCmd(cmd *cobra.Command, args []string) error {
 	verifyserver.Start()
 	return nil
+}
+
+func verifySystemdCreateFunc() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		c := verifySystemdCreateFlow{}
+		return c.runVerifySystemdCreateCmd(cmd, args)
+	}
+}
+
+func (v *verifySystemdCreateFlow) runVerifySystemdCreateCmd(cmd *cobra.Command, args []string) error {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return status.Wrap(err, status.UnknownError, "Error getting executable path")
+	}
+	binaryPath, err = filepath.EvalSymlinks(binaryPath)
+	if err != nil {
+		return status.Wrap(err, status.UnknownError, "Error evaluating symlinks in binary path")
+	}
+
+	createSystemdServiceWithBinary, err := verifysystemdcreate.NewCreateSystemdService(os.Executable, os.Create, fileutils.CreateDestinationAndCopy, executeShellCommandMinLogs, BINARY_DESTINATION_FOLDER, SYSTEMD_PATH, writer)
+	if err != nil {
+		return err
+	}
+	return createSystemdServiceWithBinary.Create(binaryPath)
 }
 
 func verifyCmdFunc(flagsObj *verifyCmdFlags) func(cmd *cobra.Command, args []string) error {

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver"
 	verification "github.com/chef/automate/lib/verification"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,21 @@ type verifyCmdFlow struct {
 	Verification      verification.Verification
 	A2HARBFileExist   bool
 	ManagedServicesOn bool
+}
+
+type verifyServeCmdFlow struct {
+	sshUtil SSHUtil
+}
+
+var verifyServeCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start verify server",
+	Long:  "Start verify server for running checks",
+	Annotations: map[string]string{
+		docs.Compatibility: docs.Compatibility,
+	},
+	Args: cobra.ExactArgs(0),
+	RunE: verifyServeCmdFunc(),
 }
 
 func init() {
@@ -93,7 +109,23 @@ func init() {
 		"file",
 		"",
 		"Config file that needs to be verified")
+
+	verifyCmd.AddCommand(verifyServeCmd)
 	RootCmd.AddCommand(verifyCmd)
+}
+
+func verifyServeCmdFunc() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		c := verifyServeCmdFlow{
+			sshUtil: NewSSHUtil(&SSHConfig{}),
+		}
+		return c.runVerifyServeCmd(cmd, args)
+	}
+}
+
+func (v *verifyServeCmdFlow) runVerifyServeCmd(cmd *cobra.Command, args []string) error {
+	verifyserver.Start()
+	return nil
 }
 
 func verifyCmdFunc(flagsObj *verifyCmdFlags) func(cmd *cobra.Command, args []string) error {

--- a/components/automate-cli/pkg/verifyserver/server.go
+++ b/components/automate-cli/pkg/verifyserver/server.go
@@ -1,0 +1,7 @@
+package verifyserver
+
+import "fmt"
+
+func Start() {
+	fmt.Println("Started Verify Server")
+}

--- a/components/automate-cli/pkg/verifyserver/server.go
+++ b/components/automate-cli/pkg/verifyserver/server.go
@@ -1,7 +1,17 @@
 package verifyserver
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/gofiber/fiber"
+	"time"
+)
 
 func Start() {
-	fmt.Println("Started Verify Server")
+	app := fiber.New()
+
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	log.Fatal(app.Listen(":3000"))
 }

--- a/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc.go
+++ b/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc.go
@@ -1,0 +1,143 @@
+package verifysystemdcreate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/pkg/errors"
+)
+
+const (
+	SERVICE_NAME          = "automate-verify"
+	SERVICE_DESCRIPTION   = "Service for automating verification"
+	SERVICE_COMMAND       = "chef-automate verify serve"
+	SYSTEMD_FILE          = "%s.service"
+	ENABLE_SYSTEMD_SCRIPT = "systemctl daemon-reload && systemctl enable %[1]v.service && systemctl start %[1]v.service"
+	TEMPLATE_NAME         = "systemd-service"
+	TEMPLATE_TEXT         = `[Unit]
+Description={{.ServiceDescription}}
+After=network.target
+
+[Service]
+ExecStart={{.ServiceCommand}}
+Restart=always
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+`
+)
+
+type systemdInput struct {
+	ServiceName        string
+	ServiceDescription string
+	ServiceCommand     string
+}
+
+type CreateSystemdService struct {
+	ExecutableFunc               func() (string, error)
+	CreateFileFunc               func(name string) (*os.File, error)
+	CreateDestinationAndCopyFunc func(binarySrcPath, binaryDestPath string) error
+	ExecuteShellCommandFunc      func(command string) error
+	BinaryDestinationFolder      string
+	SystemdLocation              string
+	Writer                       *cli.Writer
+}
+
+func NewCreateSystemdService(
+	executable func() (string, error),
+	CreateFile func(name string) (*os.File, error),
+	CreateDestinationAndCopy func(binarySrcPath, binaryDestPath string) error,
+	ExecuteShellCommand func(command string) error,
+	binaryDestinationFolder string,
+	systemdLocation string,
+	writer *cli.Writer) (*CreateSystemdService, error) {
+	if binaryDestinationFolder == "" {
+		return nil, errors.New("binary destination folder cannot be empty")
+	}
+	if systemdLocation == "" {
+		return nil, errors.New("systemd location cannot be empty")
+	}
+	return &CreateSystemdService{
+		ExecutableFunc:               executable,
+		CreateFileFunc:               CreateFile,
+		CreateDestinationAndCopyFunc: CreateDestinationAndCopy,
+		ExecuteShellCommandFunc:      ExecuteShellCommand,
+		BinaryDestinationFolder:      binaryDestinationFolder,
+		SystemdLocation:              systemdLocation,
+		Writer:                       writer,
+	}, nil
+}
+
+// type CreateSystemdService struct{}
+
+// Create the systemd service file.
+func (css *CreateSystemdService) createSystemdServiceFile() error {
+	// Create the template.
+	tmpl, err := template.New(TEMPLATE_NAME).Parse(TEMPLATE_TEXT)
+	if err != nil {
+		return errors.Wrap(err, "Error parsing template")
+	}
+
+	// Prepare the template data.
+	data := systemdInput{
+		ServiceName:        SERVICE_NAME,
+		ServiceDescription: SERVICE_DESCRIPTION,
+		ServiceCommand:     css.BinaryDestinationFolder + "/" + SERVICE_COMMAND,
+	}
+
+	// Execute the template to generate the service file.
+	serviceFilePath := fmt.Sprintf(css.SystemdLocation+"/"+SYSTEMD_FILE, SERVICE_NAME)
+	serviceFile, err := css.CreateFileFunc(serviceFilePath)
+	if err != nil {
+		return errors.Wrap(err, "Error creating service file")
+	}
+	defer serviceFile.Close()
+
+	err = tmpl.Execute(serviceFile, data)
+	if err != nil {
+		return errors.Wrap(err, "Error executing template")
+	}
+
+	return nil
+}
+
+// Enable and start the systemd service.
+func (css *CreateSystemdService) enableSystemdService() error {
+	systemctlCmd := fmt.Sprintf(ENABLE_SYSTEMD_SCRIPT, SERVICE_NAME)
+	err := css.ExecuteShellCommandFunc(systemctlCmd)
+	if err != nil {
+		return errors.Wrap(err, "Error enabling service")
+	}
+	return nil
+}
+
+// Create the systemd service.
+func (css *CreateSystemdService) Create(binaryPath string) error {
+	fullBinaryDestination := filepath.Join(css.BinaryDestinationFolder, filepath.Base(binaryPath))
+
+	err := css.CreateDestinationAndCopyFunc(binaryPath, fullBinaryDestination)
+	if err != nil {
+		return err
+	}
+
+	css.Writer.Printf("Binary copied to %s\n", fullBinaryDestination)
+
+	err = css.createSystemdServiceFile()
+	if err != nil {
+		return err
+	}
+
+	err = css.enableSystemdService()
+	if err != nil {
+		return err
+	}
+
+	css.Writer.Printf("Service %s created successfully\n", SERVICE_NAME)
+
+	return nil
+}

--- a/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc_test.go
+++ b/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc_test.go
@@ -1,0 +1,7 @@
+package verifysystemdcreate
+
+import "testing"
+
+func TestCreateDestinationAndCopyFunc(t *testing.T) {
+
+}

--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -324,6 +324,14 @@ http {
       add_header X-Content-Type-Options "nosniff" always;
     }
 
+    location /nginx_status {
+      stub_status;
+
+      access_log off;
+      allow 127.0.0.1;
+      deny all;
+    }
+
     include {{../pkg.svc_config_path}}/*location.conf;
     {{/if}}
   }

--- a/lib/io/fileutils/copy_file.go
+++ b/lib/io/fileutils/copy_file.go
@@ -76,3 +76,10 @@ func copyFile(srcPath, dstPath string, opts *copyOpts) error {
 
 	return AtomicWrite(dstPath, src, WithAtomicWriteFileMode(srcInfo.Mode()))
 }
+
+func CreateDestinationAndCopy(binarySrcPath, binaryDestPath string) error {
+	if err := os.MkdirAll(filepath.Dir(binaryDestPath), 0755); err != nil {
+		return errors.Wrap(err, "Error creating destination folder")
+	}
+	return CopyFile(binarySrcPath, binaryDestPath, Overwrite())
+}

--- a/lib/io/fileutils/copy_file_test.go
+++ b/lib/io/fileutils/copy_file_test.go
@@ -2,7 +2,9 @@ package fileutils_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,4 +59,70 @@ func setupCopy(t *testing.T) (string, string) {
 	tmpDir2 := t.TempDir()
 
 	return tmpDir, tmpDir2
+}
+
+func TestCreateDestinationAndCopy(t *testing.T) {
+	t.Run("it copies the file and creates destination", func(t *testing.T) {
+		d1, d2 := setupCopy(t)
+
+		srcData := []byte("test data")
+		srcPath := path.Join(d1, "src")
+		dstPath := path.Join(d2, "testpath/one/dst")
+		require.NoError(t, ioutil.WriteFile(srcPath, srcData, 0700))
+		require.NoError(t, fileutils.CreateDestinationAndCopy(srcPath, dstPath))
+		dstData, err := ioutil.ReadFile(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, srcData, dstData)
+	})
+
+	t.Run("it copies even when file exists", func(t *testing.T) {
+		d1, d2 := setupCopy(t)
+
+		srcData := []byte("src data")
+		srcPath := path.Join(d1, "src")
+		dstPath := path.Join(d2, "testpath/one/dst")
+		dstData := []byte("dst data")
+		require.NoError(t, ioutil.WriteFile(srcPath, srcData, 0700))
+		require.NoError(t, os.MkdirAll(filepath.Dir(dstPath), 0755))
+		require.NoError(t, ioutil.WriteFile(dstPath, dstData, 0700))
+		require.NoError(t, fileutils.CreateDestinationAndCopy(srcPath, dstPath))
+		dstData, err := ioutil.ReadFile(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, srcData, dstData)
+	})
+
+	t.Run("it make sure that the destination file has same permissions as the source file", func(t *testing.T) {
+		d1, d2 := setupCopy(t)
+
+		srcData := []byte("src data")
+		srcPath := path.Join(d1, "src")
+		dstPath := path.Join(d2, "testpath/one/dst")
+		dstData := []byte("dst data")
+		require.NoError(t, ioutil.WriteFile(srcPath, srcData, 0755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(dstPath), 0755))
+		require.NoError(t, fileutils.CreateDestinationAndCopy(srcPath, dstPath))
+		dstData, err := ioutil.ReadFile(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, srcData, dstData)
+		srcInfo, err := os.Stat(srcPath)
+		require.NoError(t, err)
+		destInfo, err := os.Stat(dstPath)
+		require.NoError(t, err)
+		require.Equal(t, srcInfo.Mode(), destInfo.Mode())
+	})
+
+	// t.Run("it copies over existing file when overwrite is set", func(t *testing.T) {
+	// 	d1, d2 := setupCopy(t)
+
+	// 	srcData := []byte("src data")
+	// 	srcPath := path.Join(d1, "src")
+	// 	dstPath := path.Join(d2, "dst")
+	// 	dstData := []byte("dst data")
+	// 	require.NoError(t, ioutil.WriteFile(srcPath, srcData, 0700))
+	// 	require.NoError(t, ioutil.WriteFile(dstPath, dstData, 0700))
+	// 	require.NoError(t, fileutils.CopyFile(srcPath, dstPath, fileutils.Overwrite()))
+	// 	dstData, err := ioutil.ReadFile(dstPath)
+	// 	require.NoError(t, err)
+	// 	require.Equal(t, srcData, dstData)
+	// })
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Automate Load Balancer does not have any endpoint to get the Nginx stats although the corresponding module http_status is already added in the configuration.
This PR adds the api end point `/nginx_status` endpoint to the automate load balancer which can now expose the API metrics of Automate nodes.
The output can be:
```
Active connections: 1
server accepts handled requests
 9 9 8
Reading: 0 Writing: 1 Waiting: 0
```

The data can be utilised by other metrics collector like Datadog and prometheus and show it in the dashboard

### :chains: Related Resources
- No Issue created. An add hoc idea as part of this 

### :+1: Definition of Done
- The api should be reachable and should respond back when called in the Automate Node
- The api should not be reachable remotely
 
### :athletic_shoe: How to Build and Test the Change
- `rebuild components/automate-load-balancer`
- `start_all_services`
- `curl -k https://localhost/nginx_status`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
