### PR TITLE
Adding Nginx Status API end point in automate loadbalancer nginx config

### DIFF
--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -324,6 +324,14 @@ http {
       add_header X-Content-Type-Options "nosniff" always;
     }
 
+    location /nginx_status {
+      stub_status;
+
+      access_log off;
+      allow 127.0.0.1;
+      deny all;
+    }
+
     include {{../pkg.svc_config_path}}/*location.conf;
     {{/if}}
   }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Automate Load Balancer does not have any endpoint to get the Nginx stats although the corresponding module http_status is already added in the configuration.
This PR adds the api end point `/nginx_status` endpoint to the automate load balancer which can now expose the API metrics of Automate nodes.
The output can be:
```
Active connections: 1
server accepts handled requests
 9 9 8
Reading: 0 Writing: 1 Waiting: 0
```

The data can be utilised by other metrics collector like Datadog and prometheus and show it in the dashboard

### :chains: Related Resources
- No Issue created. An add hoc idea as part of this 

### :+1: Definition of Done
- The api should be reachable and should respond back when called in the Automate Node
- The api should not be reachable remotely
 
### :athletic_shoe: How to Build and Test the Change
- `rebuild components/automate-load-balancer`
- `start_all_services`
- `curl -k https://localhost/nginx_status`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![image](https://user-images.githubusercontent.com/7055118/234606547-75fb9439-e0bc-408f-af9d-4db030444225.png)

