### PR TITLE
Fix the warning in the terrafrom code while add-node,upgrade

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,4 +5,3 @@ This provides the `automate-backend-deployment` package.
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package
-

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -31,7 +31,8 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent frontend .aib files
-  find /var/tmp/ -name frontend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+ # find /var/tmp/ -name frontend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+   find /var/tmp/ -name frontend\*aib -printf '%T+\t%p\n' | sort -r | awk '{print $2}' | tail -n +2 | xargs -I{} bash -c 'truncate_with_timestamp "$@"' bash {}
 }
 
 wait_for_install() {

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -31,7 +31,7 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent frontend .aib files
-  find ${tmp_path} -name frontend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+  find /var/tmp/ -name frontend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
 }
 
 wait_for_install() {

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -17,7 +17,7 @@ failure() {
 # Creating mount path for elasticsearch backup 
 sudo mkdir -p ${nfs_mount_path}
 sudo chown hab:hab -RL ${nfs_mount_path}/
-
+ADMIN_PASSWORD_SET="admin.password.done"
 # When we truncate the file we need to preserve the file permisssions
 truncate_with_timestamp() {
   local TMPFILE=$(mktemp)
@@ -264,7 +264,13 @@ fi
 # actions to perform only on the Automate + bootstrap node
 if [[ "${automate_role}" == "bootstrap_automate" ]]; then
   # reset the admin user password to the one specified in the TF config
-  chef-automate iam admin-access restore '${admin_password}'
+  if [ ! -f ${tmp_path}/$ADMIN_PASSWORD_SET ]; then
+    echo "Applying the password for chef-automate on bootstrap node" 
+    chef-automate iam admin-access restore '${admin_password}'
+    sudo touch ${tmp_path}/$ADMIN_PASSWORD_SET
+  else
+    echo "Escaping the password reset command, this might be upgrade flow"  
+  fi  
   # generate a bootstrap bundle and make it available to scp down
   rm -f ${tmp_path}/bootstrap.abb
   chef-automate bootstrap bundle create ${tmp_path}/bootstrap.abb

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -31,7 +31,6 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent frontend .aib files
- # find /var/tmp/ -name frontend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
    find /var/tmp/ -name frontend\*aib -printf '%T+\t%p\n' | sort -r | awk '{print $2}' | tail -n +2 | xargs -I{} bash -c 'truncate_with_timestamp "$@"' bash {}
 }
 
@@ -264,7 +263,7 @@ fi
 # actions to perform only on the Automate + bootstrap node
 if [[ "${automate_role}" == "bootstrap_automate" ]]; then
   # reset the admin user password to the one specified in the TF config
-  if [ ! -f ${tmp_path}/$ADMIN_PASSWORD_SET ]; then
+  if [ ! -f ${tmp_path}/$ADMIN_PASSWORD_SET ] && [ -n "${admin_password}" ]; then
     echo "Applying the password for chef-automate on bootstrap node" 
     chef-automate iam admin-access restore '${admin_password}'
     sudo touch ${tmp_path}/$ADMIN_PASSWORD_SET

--- a/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
+++ b/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
@@ -31,7 +31,8 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent backend .aib files
-  find /var/tmp/ -name backend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+  #find /var/tmp/ -name backend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+   find /var/tmp/ -name backend\*aib -printf '%T+\t%p\n' | sort -r | awk '{print $2}' | tail -n +2 | xargs -I{} bash -c 'truncate_with_timestamp "$@"' bash {}
 }
 
 user_and_group() {

--- a/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
+++ b/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
@@ -31,7 +31,7 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent backend .aib files
-  find ${tmp_path} -name backend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
+  find /var/tmp/ -name backend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
 }
 
 user_and_group() {

--- a/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
+++ b/terraform/a2ha-terraform/modules/habitat/templates/install_hab.sh.tpl
@@ -31,7 +31,6 @@ export -f truncate_with_timestamp
 
 save_space() {
   # this will truncate all but the most recent backend .aib files
-  #find /var/tmp/ -name backend\*aib -printf "%T+\t%p\n" | sort -r | awk '{print $2}' | tail -n +2 | xargs -n1 -I{} bash -c 'truncate_with_timestamp "$@"' _ {}
    find /var/tmp/ -name backend\*aib -printf '%T+\t%p\n' | sort -r | awk '{print $2}' | tail -n +2 | xargs -I{} bash -c 'truncate_with_timestamp "$@"' bash {}
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
couple of issue in the below PR 
- fix the warnings in the terraform logs 
- save_space function is not freeing up the old airgap bundle 
package link : punitmundra/automate-ha-deployment/0.1.0/20230428071313


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
