### PR TITLE
NFS_Mount_API

### DIFF
--- a/components/automate-cli/pkg/verifyserver/constants/apiurlconstant.go
+++ b/components/automate-cli/pkg/verifyserver/constants/apiurlconstant.go
@@ -5,4 +5,6 @@ const (
 	CONTENT_TYPE                     = "Content-Type"
 	TYPE_JSON                        = "application/json"
 	HARDWARE_RESOURCE_CHECK_API_PATH = "/api/v1/checks/hardware-resource-count"
+	NFS_MOUNT_API_PATH               = "/api/v1/checks/nfs-mount"
+	NFS_MOUNT_LOC_API_PATH           = "/api/v1/fetch/nfs-mount-loc"
 )

--- a/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
+++ b/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
@@ -1,0 +1,11 @@
+package constants
+
+const (
+	MOUNT_SUCCESS_MSG    = "NFS mount location found"
+	MOUNT_ERROR_MSG      = "NFS mount location not found"
+	MOUNT_RESOLUTION_MSG = "NFS volume should be mounted on %s"
+
+	SHARE_SUCCESS_MSG    = "NFS mount location is shared across given nodes"
+	SHARE_ERROR_MSG      = "NFS mount location %s is not shared across all given nodes"
+	SHARE_RESOLUTION_MSG = "NFS volume should be common across all given nodes at mount location: %s"
+)

--- a/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
+++ b/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
@@ -1,6 +1,8 @@
 package constants
 
 const (
+	NFS_MOUNT = "NFS Mount"
+
 	MOUNT_SUCCESS_MSG    = "NFS mount location found"
 	MOUNT_ERROR_MSG      = "NFS mount location not found"
 	MOUNT_RESOLUTION_MSG = "NFS volume should be mounted on %s"
@@ -11,5 +13,5 @@ const (
 	SHARE_RESOLUTION_MSG               = "NFS volume %s should be common across all given nodes at mount location: %s"
 	SHARE_RESOLUTION_MSG_WITHOUT_MOUNT = "NFS volume should be mounted and common across all given nodes at mount location: %s"
 
-	NFS_MOUNT_ENDPOINT = "/api/v1/checks/nfs-mount"
+	TIMEOUT = 30
 )

--- a/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
+++ b/components/automate-cli/pkg/verifyserver/constants/nfsmountconstant.go
@@ -5,7 +5,11 @@ const (
 	MOUNT_ERROR_MSG      = "NFS mount location not found"
 	MOUNT_RESOLUTION_MSG = "NFS volume should be mounted on %s"
 
-	SHARE_SUCCESS_MSG    = "NFS mount location is shared across given nodes"
-	SHARE_ERROR_MSG      = "NFS mount location %s is not shared across all given nodes"
-	SHARE_RESOLUTION_MSG = "NFS volume should be common across all given nodes at mount location: %s"
+	SHARE_SUCCESS_MSG                  = "NFS mount location is shared across given nodes"
+	SHARE_ERROR_MSG                    = "NFS mount location %s is not shared across all given nodes"
+	SHARE_ERROR_MSG_WITHOUT_MOUNT      = "No NFS Volume found at mount location: %s"
+	SHARE_RESOLUTION_MSG               = "NFS volume %s should be common across all given nodes at mount location: %s"
+	SHARE_RESOLUTION_MSG_WITHOUT_MOUNT = "NFS volume should be mounted and common across all given nodes at mount location: %s"
+
+	NFS_MOUNT_ENDPOINT = "/api/v1/checks/nfs-mount"
 )

--- a/components/automate-cli/pkg/verifyserver/models/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/models/nfsmount.go
@@ -1,0 +1,26 @@
+package models
+
+type NFSMountRequest struct {
+	AutomateNodeIPs        []string `json:"automate_node_ips"`
+	ChefInfraServerNodeIPs []string `json:"chef_infra_server_node_ips"`
+	PostgresqlNodeIPs      []string `json:"postgresql_node_ips"`
+	OpensearchNodeIPs      []string `json:"opensearch_node_ips"`
+	MountLocation          string   `json:"mount_location"`
+}
+
+type NFSMountResponse struct {
+	IP        string   `json:"ip"`
+	NodeType  string   `json:"node_type"`
+	CheckList []Checks `json:"checks"`
+	Error     error    `json:"error"`
+}
+
+type NFSMountLocRequest struct {
+	MountLocation string `json:"mount_location"`
+}
+
+type NFSMountLocResponse struct {
+	Address       string `json:"address"`
+	MountLocation string `json:"mount_location"`
+	Nfs           string `json:"nfs"`
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/handler.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/handler.go
@@ -2,14 +2,16 @@ package v1
 
 import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/statusservice"
 	"github.com/chef/automate/lib/logger"
 )
 
 type Handler struct {
-	Logger        logger.Logger
-	StatusService statusservice.IStatusService
+	Logger            logger.Logger
+	StatusService     statusservice.IStatusService
 	BatchCheckService batchcheckservice.IBatchCheckService
+	NFSMountService   nfsmountservice.INFSService
 }
 
 func NewHandler(logger logger.Logger) *Handler {
@@ -23,5 +25,10 @@ func (h *Handler) AddStatusService(ss statusservice.IStatusService) *Handler {
 
 func (h *Handler) AddBatchCheckService(bc batchcheckservice.IBatchCheckService) *Handler {
 	h.BatchCheckService = bc
+	return h
+}
+
+func (h *Handler) AddNFSMountService(nm nfsmountservice.INFSService) *Handler {
+	h.NFSMountService = nm
 	return h
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -24,6 +24,7 @@ func (h *Handler) NFSMount(c *fiber.Ctx) {
 		c.Next(&fiber.Error{Code: http.StatusBadRequest, Message: "Mount Location cannot be empty"})
 		return
 	}
+	h.Logger.Debug("Mount Location Recieved: ", reqBody.MountLocation)
 
 	NFSMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
 	c.JSON(response.BuildSuccessResponse(NFSMountDetails))

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -26,6 +26,6 @@ func (h *Handler) NFSMount(c *fiber.Ctx) {
 	}
 	h.Logger.Debug("Mount Location Recieved: ", reqBody.MountLocation)
 
-	NfsMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
-	c.JSON(response.BuildSuccessResponse(NfsMountDetails))
+	nfsMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
+	c.JSON(response.BuildSuccessResponse(nfsMountDetails))
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -26,6 +26,6 @@ func (h *Handler) NFSMount(c *fiber.Ctx) {
 	}
 	h.Logger.Debug("Mount Location Recieved: ", reqBody.MountLocation)
 
-	NFSMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
-	c.JSON(response.BuildSuccessResponse(NFSMountDetails))
+	NfsMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
+	c.JSON(response.BuildSuccessResponse(NfsMountDetails))
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -1,0 +1,25 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
+	"github.com/gofiber/fiber"
+)
+
+func (h *Handler) NFSMount(c *fiber.Ctx) {
+	reqBody := models.NFSMountRequest{}
+	if err := c.BodyParser(&reqBody); err != nil {
+		h.Logger.Error(err.Error())
+		c.JSON(response.BuildFailedResponse(&fiber.Error{Code: http.StatusBadRequest, Message: "Invalid Body Request"}))
+		return
+	}
+	if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 || len(reqBody.PostgresqlNodeIPs) == 0 || len(reqBody.OpensearchNodeIPs) == 0 || reqBody.MountLocation == "" {
+		c.JSON(response.BuildFailedResponse(&fiber.Error{Code: http.StatusBadRequest, Message: "Give all the required body parameters"}))
+		return
+	}
+
+	NFSMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody, false)
+	c.JSON(response.BuildSuccessResponse(NFSMountDetails))
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -12,11 +12,16 @@ func (h *Handler) NFSMount(c *fiber.Ctx) {
 	reqBody := models.NFSMountRequest{}
 	if err := c.BodyParser(&reqBody); err != nil {
 		h.Logger.Error(err.Error())
-		c.JSON(response.BuildFailedResponse(&fiber.Error{Code: http.StatusBadRequest, Message: "Invalid Body Request"}))
+		c.Next(&fiber.Error{Code: http.StatusBadRequest, Message: "Invalid Body Request"})
 		return
 	}
-	if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 || len(reqBody.PostgresqlNodeIPs) == 0 || len(reqBody.OpensearchNodeIPs) == 0 || reqBody.MountLocation == "" {
-		c.JSON(response.BuildFailedResponse(&fiber.Error{Code: http.StatusBadRequest, Message: "Give all the required body parameters"}))
+	if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 || len(reqBody.PostgresqlNodeIPs) == 0 || len(reqBody.OpensearchNodeIPs) == 0 {
+		c.Next(&fiber.Error{Code: http.StatusBadRequest, Message: "AutomateNodeIPs, ChefInfraServerNodeIPs, PostgresqlNodeIPs or OpensearchNodeIPs cannot be empty"})
+		return
+	}
+
+	if reqBody.MountLocation == "" {
+		c.Next(&fiber.Error{Code: http.StatusBadRequest, Message: "Mount Location cannot be empty"})
 		return
 	}
 

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -20,6 +20,6 @@ func (h *Handler) NFSMount(c *fiber.Ctx) {
 		return
 	}
 
-	NFSMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody, false)
+	NFSMountDetails := h.NFSMountService.GetNFSMountDetails(reqBody)
 	c.JSON(response.BuildSuccessResponse(NFSMountDetails))
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
@@ -1,0 +1,336 @@
+package v1_test
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/server"
+	v1 "github.com/chef/automate/components/automate-cli/pkg/verifyserver/server/api/v1"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/utils/fiberutils"
+	"github.com/chef/automate/lib/logger"
+	"github.com/gofiber/fiber"
+	"github.com/stretchr/testify/assert"
+)
+
+func SetupNFSMountHandler(nm nfsmountservice.INFSService) (*fiber.App, error) {
+	log, err := logger.NewLogger("text", "debug")
+	if err != nil {
+		return nil, err
+	}
+	fconf := &fiber.Settings{
+		ServerHeader: server.SERVICE,
+		ErrorHandler: fiberutils.CustomErrorHandler,
+	}
+	app := fiber.New(fconf)
+	handler := v1.NewHandler(log).
+		AddNFSMountService(nm)
+	vs := &server.VerifyServer{
+		Port:    server.DEFAULT_PORT,
+		Log:     log,
+		App:     app,
+		Handler: handler,
+	}
+	vs.SetupRoutes()
+	return vs.App, nil
+}
+
+func SetupMockNFSMountService() nfsmountservice.INFSService {
+	return &nfsmountservice.MockNFSMountService{
+		GetNFSMountDetailsFunc: func(reqBody models.NFSMountRequest) *[]models.NFSMountResponse {
+			return &[]models.NFSMountResponse{
+				{
+					IP:       "localhost",
+					NodeType: "automate",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "automate",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "chef-infra-server",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "chef-infra-server",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "postgresql",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "postgresql",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "postgresql",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "opensearch",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "opensearch",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+				{
+					IP:       "localhost",
+					NodeType: "opensearch",
+					CheckList: []models.Checks{
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location found",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+						{
+							Title:         "NFS Mount",
+							Passed:        true,
+							SuccessMsg:    "NFS mount location is shared across given nodes",
+							ErrorMsg:      "",
+							ResolutionMsg: "",
+						},
+					},
+					Error: nil,
+				},
+			}
+		},
+		DoAPICallFunc: func(ip, NodeType, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse {
+			return models.NFSMountResponse{}
+		},
+		MakeConcurrentCallFunc: func(ip, NodeType, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
+		},
+	}
+}
+
+func TestNFSMount(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		ExpectedCode int
+		ExpectedBody string
+		RequestBody  string
+	}{
+		{
+			TestName:     "Valid Body Request",
+			ExpectedCode: 200,
+			ExpectedBody: `{"status":"SUCCESS","result":[{"ip":"localhost","node_type":"automate","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"automate","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"chef-infra-server","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"chef-infra-server","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null}]}`,
+			RequestBody: `{
+				"automate_node_ips": [
+					"localhost",
+					"localhost"
+				],
+				"chef_infra_server_node_ips": [
+					"localhost",
+					"localhost"
+				],
+				"postgresql_node_ips": [
+					"localhost",
+					"localhost",
+					"localhost"
+				],
+				"opensearch_node_ips": [
+					"localhost",
+					"localhost",
+					"localhost"
+				],
+				"mount_location": "/mnt/automate_backups"
+			}`,
+		},
+		{
+			TestName:     "Invalid Body Request",
+			ExpectedCode: 200,
+			ExpectedBody: `{"status":"FAILED","result":null,"error":{"code":400,"message":"Invalid Body Request"}}`,
+			RequestBody: `{
+				"automate_node_ip": [
+					"localhost",
+					"localhost"
+				],
+			}`,
+		},
+		{
+			TestName:     "Not Given all the required body parameters",
+			ExpectedCode: 200,
+			ExpectedBody: `{"status":"FAILED","result":null,"error":{"code":400,"message":"Give all the required body parameters"}}`,
+			RequestBody: `{
+				"automate_node_ips": []
+			}`,
+		},
+	}
+
+	NFSMountEndpoint := "/api/v1/checks/nfs-mount"
+	app, err := SetupNFSMountHandler(SetupMockNFSMountService())
+	assert.NoError(t, err)
+
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			bodyReader := strings.NewReader(test.RequestBody)
+			req := httptest.NewRequest("POST", NFSMountEndpoint, bodyReader)
+			req.Header.Add("Content-Type", "application/json")
+			res, err := app.Test(req, -1)
+			assert.NoError(t, err)
+			body, err := ioutil.ReadAll(res.Body)
+			assert.NoError(t, err, test.TestName)
+			assert.Contains(t, string(body), test.ExpectedBody)
+			assert.Equal(t, test.ExpectedCode, res.StatusCode)
+		})
+	}
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
@@ -332,7 +332,7 @@ func TestNFSMount(t *testing.T) {
 		},
 	}
 
-	NFSMountEndpoint := constants.NFS_MOUNT_ENDPOINT
+	NFSMountEndpoint := constants.NFS_MOUNT_API_PATH
 
 	app, err := SetupNFSMountHandler(SetupMockNFSMountService())
 	assert.NoError(t, err)

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
@@ -257,7 +257,7 @@ func SetupMockNFSMountService() nfsmountservice.INFSService {
 		DoAPICallFunc: func(ip, NodeType, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse {
 			return models.NFSMountResponse{}
 		},
-		MakeConcurrentCallFunc: func(ip, NodeType, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
+		MakeConcurrentCallFunc: func(ip, NodeType, mountLocation string, ch chan string, nfsMountResultMap map[string]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
 		},
 	}
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
@@ -268,7 +268,221 @@ func TestNFSMount(t *testing.T) {
 		{
 			TestName:     "Valid Body Request",
 			ExpectedCode: 200,
-			ExpectedBody: `{"status":"SUCCESS","result":[{"ip":"localhost","node_type":"automate","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"automate","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"chef-infra-server","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"chef-infra-server","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"postgresql","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null},{"ip":"localhost","node_type":"opensearch","checks":[{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location found","error_msg":"","resolution_msg":""},{"title":"NFS Mount","passed":true,"success_msg":"NFS mount location is shared across given nodes","error_msg":"","resolution_msg":""}],"error":null}]}`,
+			ExpectedBody: `{
+				"status": "SUCCESS",
+				"result": [
+					{
+						"ip": "localhost",
+						"node_type": "automate",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "automate",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "chef-infra-server",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "chef-infra-server",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "postgresql",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "postgresql",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "postgresql",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "opensearch",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "opensearch",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					},
+					{
+						"ip": "localhost",
+						"node_type": "opensearch",
+						"checks": [
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location found",
+								"error_msg": "",
+								"resolution_msg": ""
+							},
+							{
+								"title": "NFS Mount",
+								"passed": true,
+								"success_msg": "NFS mount location is shared across given nodes",
+								"error_msg": "",
+								"resolution_msg": ""
+							}
+						],
+						"error": null
+					}
+				]
+			}`,
 			RequestBody: `{
 				"automate_node_ips": [
 					"localhost",
@@ -294,13 +508,27 @@ func TestNFSMount(t *testing.T) {
 		{
 			TestName:     "Invalid Body Request",
 			ExpectedCode: 400,
-			ExpectedBody: `{"status":"FAILED","result":null,"error":{"code":400,"message":"Invalid Body Request"}}`,
-			RequestBody:  "Invalid Body",
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Invalid Body Request"
+				}
+			}`,
+			RequestBody: "Invalid Body",
 		},
 		{
 			TestName:     "Not Given all the required IPs",
 			ExpectedCode: 400,
-			ExpectedBody: `{"status":"FAILED","result":null,"error":{"code":400,"message":"AutomateNodeIPs, ChefInfraServerNodeIPs, PostgresqlNodeIPs or OpensearchNodeIPs cannot be empty"}}`,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "AutomateNodeIPs, ChefInfraServerNodeIPs, PostgresqlNodeIPs or OpensearchNodeIPs cannot be empty"
+				}
+			}`,
 			RequestBody: `{
 				"automate_node_ips": []
 			}`,
@@ -308,7 +536,14 @@ func TestNFSMount(t *testing.T) {
 		{
 			TestName:     "Not Given the mount location",
 			ExpectedCode: 400,
-			ExpectedBody: `{"status":"FAILED","result":null,"error":{"code":400,"message":"Mount Location cannot be empty"}}`,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Mount Location cannot be empty"
+				}
+			}`,
 			RequestBody: `{
 				"automate_node_ips": [
 					"localhost",
@@ -346,7 +581,7 @@ func TestNFSMount(t *testing.T) {
 			assert.NoError(t, err)
 			body, err := ioutil.ReadAll(res.Body)
 			assert.NoError(t, err, test.TestName)
-			assert.Contains(t, string(body), test.ExpectedBody)
+			assert.JSONEq(t, string(body), test.ExpectedBody)
 			assert.Equal(t, test.ExpectedCode, res.StatusCode)
 		})
 	}

--- a/components/automate-cli/pkg/verifyserver/server/routes.go
+++ b/components/automate-cli/pkg/verifyserver/server/routes.go
@@ -13,6 +13,7 @@ func (vs *VerifyServer) SetupRoutes() {
 	apiChecksGroup := apiV1Group.Group("/checks")
 	apiChecksGroup.Get("/fqdn", vs.Handler.CheckFqdn)
 	apiChecksGroup.Post("/batch-checks", vs.Handler.BatchCheck)
+	apiChecksGroup.Post("/nfs-mount", vs.Handler.NFSMount)
 
 	fiberutils.LogResgisteredRoutes(vs.App.Stack(), vs.Log)
 }

--- a/components/automate-cli/pkg/verifyserver/server/server.go
+++ b/components/automate-cli/pkg/verifyserver/server/server.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/chef/automate/components/automate-cli/pkg/verifyserver/server/api/v1"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/statusservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/utils/fiberutils"
 	"github.com/chef/automate/lib/logger"
@@ -62,7 +63,9 @@ func NewVerifyServer(port string, debug bool) (*VerifyServer, error) {
 				trigger.NewSoftwareVersionCheck(),
 				trigger.NewSystemResourceCheck(),
 				trigger.NewSshUserAccessCheck(),
-			)))
+			))).
+		AddNFSMountService(nfsmountservice.NewNFSMountService())
+
 	vs := &VerifyServer{
 		Port:    port,
 		Log:     l,

--- a/components/automate-cli/pkg/verifyserver/server/server.go
+++ b/components/automate-cli/pkg/verifyserver/server/server.go
@@ -1,8 +1,9 @@
 package server
 
 import (
-	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger"
 	"strings"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger"
 
 	"github.com/ansrivas/fiberprometheus"
 	v1 "github.com/chef/automate/components/automate-cli/pkg/verifyserver/server/api/v1"
@@ -64,7 +65,7 @@ func NewVerifyServer(port string, debug bool) (*VerifyServer, error) {
 				trigger.NewSystemResourceCheck(),
 				trigger.NewSshUserAccessCheck(),
 			))).
-		AddNFSMountService(nfsmountservice.NewNFSMountService())
+		AddNFSMountService(nfsmountservice.NewNFSMountService(l, port))
 
 	vs := &VerifyServer{
 		Port:    port,

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
@@ -194,7 +194,7 @@ func triggerAPI(url, mountLocation string) (*http.Response, error) {
 }
 
 func getResultStructFromRespBody(respBody io.Reader) (*models.NFSMountLocResponse, error) {
-	body, err := ioutil.ReadAll(respBody)
+	body, err := ioutil.ReadAll(respBody) // nosemgrep
 	if err != nil {
 		return nil, errors.New("Cannot able to read data from response body: " + err.Error())
 	}

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
@@ -50,7 +50,7 @@ func (nm *NFSMountService) GetNFSMountDetails(reqBody models.NFSMountRequest) *[
 	// So that we don't need to again call the API for checking the shareability
 	shareMap := make(map[string]models.NFSMountLocResponse)
 	countMap := make(map[models.NFSMountLocResponse]int)
-	// using orderList to store the order. so we can generate the same reponse order which create response.
+	// using orderList to store the order. so we can generate the same response order which create response.
 	var orderList []string
 
 	for index, ip := range reqBody.AutomateNodeIPs {
@@ -145,20 +145,20 @@ func (nm *NFSMountService) getResultStructFromRespBody(respBody io.Reader) (*mod
 	}
 
 	// Converting API Response Body into Generic Response Struct.
-	ApiRespStruct := response.ResponseBody{}
-	err = json.Unmarshal(body, &ApiRespStruct)
+	apiRespStruct := response.ResponseBody{}
+	err = json.Unmarshal(body, &apiRespStruct)
 	if err != nil {
 		return nil, errors.New("Failed to Unmarshal: " + err.Error())
 	}
 
 	// If API(/nfs-mount-loc) is itself failing.
-	if ApiRespStruct.Error != nil {
-		nm.log.Error(ApiRespStruct.Error)
-		return nil, ApiRespStruct.Error
+	if apiRespStruct.Error != nil {
+		nm.log.Error(apiRespStruct.Error)
+		return nil, apiRespStruct.Error
 	}
 
-	// Converting interface into JSON encoding. ApiResp.Result is a interface and for accessing the values we are converting that into json.
-	resultByte, err := json.Marshal(ApiRespStruct.Result)
+	// Converting interface into JSON encoding. apiResp.Result is a interface and for accessing the values we are converting that into json.
+	resultByte, err := json.Marshal(apiRespStruct.Result)
 	if err != nil {
 		return nil, errors.New("Failed to Marshal: " + err.Error())
 	}

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
@@ -1,0 +1,260 @@
+package nfsmountservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
+	"github.com/gofiber/fiber"
+)
+
+type INFSService interface {
+	GetNFSMountDetails(models.NFSMountRequest, bool) *[]models.NFSMountResponse
+}
+
+type NFSMountService struct {
+}
+
+func NewNFSMountService() INFSService {
+	return &NFSMountService{}
+}
+
+var mut *sync.Mutex = &sync.Mutex{}
+
+func makeConcurrentCall(ip string, test bool, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
+	res := doAPICall(ip, test, node_type, mountLocation, shareMap, key, countMap)
+	// Mutex Lock is Mandatory. What if two routines tries to write at same time.
+	mut.Lock()
+	nfsMountResultMap[key] = append(nfsMountResultMap[key], res)
+	mut.Unlock()
+	ch <- "done"
+}
+
+func makeRespBody(respBody *[]models.NFSMountResponse, countMap map[models.NFSMountLocResponse]int, orderList []string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse) {
+	compareWith := models.NFSMountLocResponse{}
+	currMax := 0
+	// Finding the Majority element and putting in the compareWith variable for the later comparisons
+	for k, v := range countMap {
+		// fmt.Println(k, v)
+		if v > currMax {
+			currMax = v
+			compareWith = k
+		}
+	}
+
+	for _, key := range orderList {
+		for _, val := range nfsMountResultMap[key] {
+			// Need to check error first. Because while making call to the API if something get wrong
+			// then we are storing checkList as nil and putting the error in Error field.
+			if val.Error == nil {
+				// if nfs is mounted then in our first check for the particular node it will be true. hence we are passing that which checking shareability
+				// Test2 - Check for NFS Volume is Shared among all nodes or not
+				if val.CheckList[0].Passed {
+					checkShare(shareMap[key], compareWith, &val, true)
+				} else {
+					checkShare(shareMap[key], compareWith, &val, false)
+				}
+			}
+			*respBody = append(*respBody, val)
+		}
+	}
+}
+
+func (nm *NFSMountService) GetNFSMountDetails(reqBody models.NFSMountRequest, test bool) *[]models.NFSMountResponse {
+	respBody := new([]models.NFSMountResponse)
+	// For storing the output of go routine temporary in nfsMountResultMap
+	nfsMountResultMap := make(map[string][]models.NFSMountResponse)
+	ch := make(chan string)
+	// Will use these both the maps in checking the shareability
+	// countMap will help us to find the Majority element.
+	// we are storing each node response in share map corresponds to unique key.
+	// So that we don't need to again call the API for checking the shareability
+	shareMap := make(map[string]models.NFSMountLocResponse)
+	countMap := make(map[models.NFSMountLocResponse]int)
+	// using orderList to store the order. so we can generate the same reponse order which create response.
+	var orderList []string
+
+	for index, ip := range reqBody.AutomateNodeIPs {
+		key := "automate" + ip + strconv.Itoa(index)
+		go makeConcurrentCall(ip, test, "automate", reqBody.MountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
+		orderList = append(orderList, key)
+	}
+
+	for index, ip := range reqBody.ChefInfraServerNodeIPs {
+		key := "chef-infra-server" + ip + strconv.Itoa(index)
+		go makeConcurrentCall(ip, test, "chef-infra-server", reqBody.MountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
+		orderList = append(orderList, key)
+	}
+
+	for index, ip := range reqBody.PostgresqlNodeIPs {
+		key := "postgresql" + ip + strconv.Itoa(index)
+		go makeConcurrentCall(ip, test, "postgresql", reqBody.MountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
+		orderList = append(orderList, key)
+	}
+
+	for index, ip := range reqBody.OpensearchNodeIPs {
+		key := "opensearch" + ip + strconv.Itoa(index)
+		go makeConcurrentCall(ip, test, "opensearch", reqBody.MountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
+		orderList = append(orderList, key)
+	}
+
+	// it will help us to hold the program until all triggered go routines cameback
+	for i := 0; i < len(orderList); i++ {
+		<-ch
+	}
+
+	makeRespBody(respBody, countMap, orderList, nfsMountResultMap, shareMap)
+
+	close(ch)
+	return respBody
+}
+
+func doAPICall(ip string, test bool, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse {
+	node := models.NFSMountResponse{}
+	node.IP = ip
+	node.NodeType = node_type
+	var url string
+	// If test is true that means we are running the unit test cases
+	// And there we are passing using testserver and we are passing it's URL
+	// ts.URL contains protocol+URL+portnumber hence we directly need to pass that
+	if test {
+		url = ip
+	} else {
+		url = fmt.Sprintf("http://%s:7799", ip)
+	}
+
+	// It will trigger /nfs-mount-loc API
+	resp, err := triggerAPI(url, mountLocation)
+	if err != nil {
+		node.Error = fiber.NewError(http.StatusBadRequest, err.Error())
+		return node
+	}
+
+	// Getting the result struct from whole response
+	result, err := getResultStructFromRespBody(resp.Body)
+	if err != nil {
+		node.Error = fiber.NewError(http.StatusBadRequest, err.Error())
+		return node
+	}
+	// if address is empty then we are not storing it. Because it's of no use while doing the comparisons
+	if result.Address != "" {
+		mut.Lock()
+		countMap[*result] = countMap[*result] + 1
+		shareMap[key] = *result
+		mut.Unlock()
+	}
+	// fmt.Println(result)
+
+	// Test1 - Check for NFS Volume is mounted at correct Mount Location or not
+	checkMount(mountLocation, &node, result)
+
+	return node
+}
+
+func triggerAPI(url, mountLocation string) (*http.Response, error) {
+	// Request Body for /nfs-mount-loc API
+	reqBody := models.NFSMountLocRequest{
+		MountLocation: mountLocation,
+	}
+
+	// Converting Body into json encoding for passing into request
+	reqBodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, errors.New("Failed to Marshal: " + err.Error())
+	}
+
+	reqURL := url + "/api/v1/fetch/nfs-mount-loc"
+	// fmt.Println(reqURL)
+	httpReq, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewBuffer(reqBodyJSON))
+	if err != nil {
+		return nil, errors.New("Failed to Create HTTP request: " + err.Error())
+	}
+
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	// Making the actual call
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, errors.New("Failed to send the HTTP request: " + err.Error())
+	}
+
+	return resp, nil
+}
+
+func getResultStructFromRespBody(respBody io.Reader) (*models.NFSMountLocResponse, error) {
+	body, err := ioutil.ReadAll(respBody)
+	if err != nil {
+		return nil, errors.New("Cannot able to read data from response body: " + err.Error())
+	}
+
+	// Converting API Response Body into Generic Response Struct.
+	APIRespStruct := response.ResponseBody{}
+	err = json.Unmarshal(body, &APIRespStruct)
+	if err != nil {
+		return nil, errors.New("Failed to Unmarshal: " + err.Error())
+	}
+
+	// If API(/nfs-mount-loc) is itself failing.
+	if APIRespStruct.Error != nil {
+		return nil, APIRespStruct.Error
+	}
+
+	// Converting interface into JSON encoding. APIResp.Result is a interface and for accessing the values we are converting that into json.
+	resultByte, err := json.Marshal(APIRespStruct.Result)
+	if err != nil {
+		return nil, errors.New("Failed to Marshal: " + err.Error())
+	}
+
+	resultField := new(models.NFSMountLocResponse)
+	// converting JSON into struct.
+	err = json.Unmarshal(resultByte, &resultField)
+	if err != nil {
+		return nil, errors.New("Failed to Unmarshal: " + err.Error())
+	}
+	// fmt.Println(resultField)
+
+	return resultField, nil
+}
+
+func checkMount(mountLocation string, node *models.NFSMountResponse, data *models.NFSMountLocResponse) {
+	if data.Address != "" {
+		check := createCheck("NFS Mount", true, constants.MOUNT_SUCCESS_MSG, "", "")
+		node.CheckList = append(node.CheckList, check)
+	} else {
+		check := createCheck("NFS Mount", false, "", constants.MOUNT_ERROR_MSG, fmt.Sprintf(constants.MOUNT_RESOLUTION_MSG, mountLocation))
+		node.CheckList = append(node.CheckList, check)
+	}
+}
+
+func checkShare(data models.NFSMountLocResponse, compareWith models.NFSMountLocResponse, node *models.NFSMountResponse, nfsMounted bool) {
+	// nfsMounted is holding volume is mounted or not. If volume is not mounted then how we can check it's shareability
+	if nfsMounted && data.Address == compareWith.Address && data.Nfs == compareWith.Nfs && data.MountLocation == compareWith.MountLocation {
+		check := createCheck("NFS Mount", true, constants.SHARE_SUCCESS_MSG, "", "")
+		node.CheckList = append(node.CheckList, check)
+	} else {
+		check := createCheck("NFS Mount", false, "", fmt.Sprintf(constants.SHARE_ERROR_MSG, compareWith.MountLocation), fmt.Sprintf(constants.SHARE_RESOLUTION_MSG, compareWith.MountLocation))
+		node.CheckList = append(node.CheckList, check)
+	}
+}
+
+func createCheck(title string, passed bool, successMsg, errorMsg, resolutionMsg string) models.Checks {
+	return models.Checks{
+		Title:         title,
+		Passed:        passed,
+		SuccessMsg:    successMsg,
+		ErrorMsg:      errorMsg,
+		ResolutionMsg: resolutionMsg,
+	}
+}

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
@@ -1,4 +1,4 @@
-package nfsmountservice_test
+package nfsmountservice
 
 import (
 	"bytes"
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
-	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
 	"github.com/chef/automate/lib/logger"
 	"github.com/stretchr/testify/assert"
 )
@@ -90,7 +89,7 @@ var (
 
 func TestNFSMountService(t *testing.T) {
 	testPort := "1234"
-	nm := nfsmountservice.NewNFSMountService(logger.NewTestLogger(), testPort)
+	nm := NewNFSMountService(logger.NewTestLogger(), testPort)
 	assert.NotNil(t, nm)
 	nmDetails := nm.GetNFSMountDetails(models.NFSMountRequest{})
 	assert.Equal(t, new([]models.NFSMountResponse), nmDetails)
@@ -119,7 +118,7 @@ func TestCheckMount(t *testing.T) {
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
 			nodeData := &models.NFSMountResponse{}
-			nfsmountservice.CheckMount("/mnt/automate_backups", nodeData, e.ResultBody)
+			checkMount("/mnt/automate_backups", nodeData, e.ResultBody)
 			assert.Equal(t, e.ExpectedRes, nodeData.CheckList[0].Passed)
 		})
 	}
@@ -170,7 +169,7 @@ func TestCheckShare(t *testing.T) {
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
 			node := new(models.NFSMountResponse)
-			nfsmountservice.CheckShare(e.NfsMounted, e.NfsShared, "/mnt/automate", e.Data, node)
+			checkShare(e.NfsMounted, e.NfsShared, "/mnt/automate", e.Data, node)
 			// checkShare function will append check result in node object.
 			isPassed := node.CheckList[0].Passed
 			assert.Equal(t, e.ExpectedCheckRes, isPassed)
@@ -213,7 +212,7 @@ func TestGetResultStructFromRespBody(t *testing.T) {
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
 			testPort := "1234"
-			res, err := nfsmountservice.NewNFSMountService(logger.NewTestLogger(), testPort).GetResultStructFromRespBody(e.Body)
+			res, err := NewNFSMountService(logger.NewTestLogger(), testPort).getResultStructFromRespBody(e.Body)
 			if e.ExpectedErr != nil {
 				assert.Error(t, err)
 			} else {
@@ -276,8 +275,8 @@ func TestDoAPICall(t *testing.T) {
 			if e.InvalidURLResponse {
 				testPort = "1235"
 			}
-			nm := nfsmountservice.NewNFSMountService(logger.NewTestLogger(), testPort)
-			resp, err := nm.DoAPICall(e.URL, "/mount-location")
+			nm := NewNFSMountService(logger.NewTestLogger(), testPort)
+			resp, err := nm.doAPICall(e.URL, "/mount-location")
 			if e.ExpectedError != nil {
 				assert.Error(t, err)
 			} else {
@@ -372,7 +371,7 @@ func TestGetNFSMountDetails(t *testing.T) {
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
 			testPort := "1234"
-			nm := nfsmountservice.NewNFSMountService(logger.NewTestLogger(), testPort)
+			nm := NewNFSMountService(logger.NewTestLogger(), testPort)
 			resp := nm.GetNFSMountDetails(e.ReqBody)
 			for index, te := range *resp {
 				if e.Response[index].Error != nil {
@@ -459,7 +458,7 @@ func TestMakeRespBody(t *testing.T) {
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
 			respBody := []models.NFSMountResponse{}
-			nfsmountservice.MakeRespBody(&respBody, e.CountMap, e.OrderList, e.NfsMountResultMap, e.ShareMap, "/mnt/automate_backpus")
+			makeRespBody(&respBody, e.CountMap, e.OrderList, e.NfsMountResultMap, e.ShareMap, "/mnt/automate_backpus")
 			assert.Equal(t, len(respBody), e.RespBodyLen)
 			if e.ExpectedError != nil {
 				assert.Error(t, respBody[0].Error)

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
@@ -212,7 +212,8 @@ func TestGetResultStructFromRespBody(t *testing.T) {
 	}
 	for _, e := range tests {
 		t.Run(e.TestName, func(t *testing.T) {
-			res, err := nfsmountservice.GetResultStructFromRespBody(e.Body)
+			testPort := "1234"
+			res, err := nfsmountservice.NewNFSMountService(logger.NewTestLogger(), testPort).GetResultStructFromRespBody(e.Body)
 			if e.ExpectedErr != nil {
 				assert.Error(t, err)
 			} else {

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
@@ -1,0 +1,464 @@
+package nfsmountservice
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/lib/mockserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT = `{
+		"status": "SUCCESS",
+		"result": {
+			"address": "10.0.0.11",
+			"mount_location": "/mnt/automate_backups",
+			"nfs": "10.0.0.11:/automate_backups"
+		}
+	}`
+
+	SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT = models.NFSMountLocResponse{
+		Address:       "10.0.0.11",
+		Nfs:           "10.0.0.11:/automate_backups",
+		MountLocation: "/mnt/automate_backups",
+	}
+
+	SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT2 = models.NFSMountLocResponse{
+		Address:       "10.0.0.12",
+		Nfs:           "10.0.0.12:/automate_backups",
+		MountLocation: "/mnt/automate_backups",
+	}
+
+	NFS_NOT_MOUNTED_STRUCT = models.NFSMountLocResponse{
+		Address:       "",
+		Nfs:           "",
+		MountLocation: "/mnt/automate_backups",
+	}
+
+	FAILED_NFS_MOUNT_LOC_RESPONSE_BODY = `{
+		"status": "FAILED",
+		"result": null,
+		"error": {
+			"code": 400,
+			"message": "Bad Response"
+		}
+	}`
+
+	SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITHOUT_RESULT_STRUCT = `{
+		"status": "SUCCESS",
+		"result": ""
+	}`
+
+	VALID_NFS_MOUNT_RESPONSE = models.NFSMountResponse{
+		IP:       "whatever",
+		NodeType: "automate",
+		CheckList: []models.Checks{
+			{
+				Title:         "NFS Mount",
+				Passed:        true,
+				SuccessMsg:    "NFS mount location found",
+				ErrorMsg:      "",
+				ResolutionMsg: "",
+			},
+		},
+		Error: nil,
+	}
+	VALID_NFS_MOUNT_BUT_NOT_SHARED_RESPONSE = models.NFSMountResponse{
+		IP:       "whatever",
+		NodeType: "automate",
+		CheckList: []models.Checks{
+			{
+				Title:         "NFS Mount",
+				Passed:        false,
+				SuccessMsg:    "",
+				ErrorMsg:      "NFS mount location not found",
+				ResolutionMsg: "NFS volume should be mounted on /mnt/automate_backups",
+			},
+		},
+		Error: nil,
+	}
+)
+
+func TestNFSMountService(t *testing.T) {
+	nm := NewNFSMountService()
+	nmDetails := nm.GetNFSMountDetails(models.NFSMountRequest{}, true)
+	assert.Equal(t, new([]models.NFSMountResponse), nmDetails)
+}
+
+func TestCheckMount(t *testing.T) {
+	tests := []struct {
+		TestName    string
+		ResultBody  *models.NFSMountLocResponse
+		ExpectedRes bool
+	}{
+		{"NFS is Mounted", &models.NFSMountLocResponse{Address: "anything"}, true},
+		{"NFS is not Mounted", &models.NFSMountLocResponse{}, false},
+	}
+
+	for _, e := range tests {
+		nodeData := &models.NFSMountResponse{}
+		checkMount("/mnt/automate_backups", nodeData, e.ResultBody)
+		assert.Equal(t, e.ExpectedRes, nodeData.CheckList[0].Passed)
+	}
+}
+
+func TestCheckShare(t *testing.T) {
+	compareWith := models.NFSMountLocResponse{
+		Address:       "10.0.0.11",
+		Nfs:           "10.0.0.11:/backup_share",
+		MountLocation: "/mnt/automate_backups",
+	}
+	tests := []struct {
+		TestName         string
+		Data             models.NFSMountLocResponse
+		NfsMounted       bool
+		ExpectedCheckRes bool
+	}{
+		{
+			TestName: "NFS is mounted and Shared",
+			Data: models.NFSMountLocResponse{
+				Address:       "10.0.0.11",
+				Nfs:           "10.0.0.11:/backup_share",
+				MountLocation: "/mnt/automate_backups",
+			},
+			NfsMounted:       true,
+			ExpectedCheckRes: true,
+		},
+		{
+			TestName: "NFS is not mounted",
+			Data: models.NFSMountLocResponse{
+				Address:       "",
+				Nfs:           "",
+				MountLocation: "/mnt/automate_backups",
+			},
+			NfsMounted:       false,
+			ExpectedCheckRes: false,
+		},
+		{
+			TestName: "NFS is mounted but not shared",
+			Data: models.NFSMountLocResponse{
+				Address:       "10.0.0.11",
+				Nfs:           "10.0.0.11:/backup_share",
+				MountLocation: "/mnt/automate",
+			},
+			NfsMounted:       true,
+			ExpectedCheckRes: false,
+		},
+	}
+	for _, e := range tests {
+		node := new(models.NFSMountResponse)
+		checkShare(e.Data, compareWith, node, e.NfsMounted)
+		// checkShare function will append check result in node object.
+		isPassed := node.CheckList[0].Passed
+		assert.Equal(t, e.ExpectedCheckRes, isPassed)
+	}
+}
+
+func TestGetResultStructFromRespBody(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		Body         io.Reader
+		ExpectedResp *models.NFSMountLocResponse
+		ExpectedErr  error
+	}{
+		{
+			TestName:     "Success Response Body",
+			Body:         bytes.NewBufferString(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT),
+			ExpectedResp: &SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT,
+			ExpectedErr:  nil,
+		},
+		{
+			TestName:     "Failure Response Body",
+			Body:         bytes.NewBufferString(FAILED_NFS_MOUNT_LOC_RESPONSE_BODY),
+			ExpectedResp: nil,
+			ExpectedErr:  errors.New(""),
+		},
+		{
+			TestName:     "Success Response Body (Response Returning string instead of SuccessResponse Object)",
+			Body:         bytes.NewBufferString(""),
+			ExpectedResp: nil,
+			ExpectedErr:  errors.New(""),
+		},
+		{
+			TestName:     "Success Response Body (Doesn’t Contain Result Struct. Instead some other string)",
+			Body:         bytes.NewBufferString(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITHOUT_RESULT_STRUCT),
+			ExpectedResp: nil,
+			ExpectedErr:  errors.New(""),
+		},
+	}
+	for _, e := range tests {
+		res, err := getResultStructFromRespBody(e.Body)
+		if e.ExpectedErr != nil {
+			assert.Error(t, err)
+		}
+		assert.Equal(t, res, e.ExpectedResp)
+
+	}
+}
+
+func TestTriggerAPI(t *testing.T) {
+	ts := mockserver.NewAPI(t).HttpReqMock("/api/v1/fetch/nfs-mount-loc", 200, []byte(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT), 1*time.Second).Build()
+	tests := []struct {
+		TestName         string
+		URL              string
+		ExpectedResponse string
+		ExpectedError    error
+	}{
+		{
+			TestName:         "Valid URL with running server",
+			URL:              ts.URL,
+			ExpectedResponse: SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT,
+			ExpectedError:    nil,
+		},
+		{
+			TestName:         "Invalid URL",
+			URL:              "http:/whatever.com/",
+			ExpectedResponse: "",
+			ExpectedError:    errors.New(""),
+		},
+		{
+			TestName:         "Valid URL but no server running there",
+			URL:              "http://whatever.com/",
+			ExpectedResponse: "",
+			ExpectedError:    nil,
+		},
+	}
+	for _, e := range tests {
+		resp, err := triggerAPI(e.URL, "/mnt")
+		if e.ExpectedError != nil {
+			require.Error(t, err)
+		} else {
+			body, _ := ioutil.ReadAll(resp.Body)
+			require.Equal(t, e.ExpectedResponse, string(body))
+		}
+	}
+}
+
+func TestDoAPICall(t *testing.T) {
+	ts := mockserver.NewAPI(t).HttpReqMock("/api/v1/fetch/nfs-mount-loc", 200, []byte(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT), 1*time.Second).Build()
+	tests := []struct {
+		TestName                     string
+		URL                          string
+		ChangeURLResponse            bool
+		ExpectedCheckListReponsePass bool
+		ExpectedError                error
+	}{
+		{
+			TestName:                     "Valid URL with running Server",
+			URL:                          ts.URL,
+			ChangeURLResponse:            false,
+			ExpectedCheckListReponsePass: true,
+			ExpectedError:                nil,
+		},
+		{
+			TestName:                     "Invalid URL",
+			URL:                          "http:/anything.com",
+			ChangeURLResponse:            false,
+			ExpectedCheckListReponsePass: false,
+			ExpectedError:                errors.New(""),
+		},
+		{
+			TestName:                     "Valid URL but Some Different Response",
+			URL:                          ts.URL,
+			ChangeURLResponse:            true,
+			ExpectedCheckListReponsePass: false,
+			ExpectedError:                errors.New(""),
+		},
+	}
+
+	for index, e := range tests {
+		if e.ChangeURLResponse {
+			e.URL = mockserver.NewAPI(t).HttpReqMock("/api/v1/fetch/nfs-mount-loc", 200, []byte("Anything Wrong For failing the getResultStructFromRespBody fn call"), 1*time.Second).Build().URL
+		}
+		shareMap := make(map[string]models.NFSMountLocResponse)
+		countMap := make(map[models.NFSMountLocResponse]int)
+
+		resp := doAPICall(e.URL, true, "node_type", "/mount-location", shareMap, "key"+strconv.Itoa(index), countMap)
+		if e.ExpectedError != nil {
+			assert.Error(t, resp.Error)
+		} else {
+			assert.Equal(t, resp.CheckList[0].Passed, e.ExpectedCheckListReponsePass)
+		}
+	}
+}
+
+func TestGetNFSMountDetails(t *testing.T) {
+	ts := mockserver.NewAPI(t).HttpReqMock("/api/v1/fetch/nfs-mount-loc", 200, []byte(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT), 1*time.Second).Build()
+	ts2 := mockserver.NewAPI(t).HttpReqMock("/api/v1/fetch/nfs-mount-loc", 200, []byte(SUCCESS_NFS_MOUNT_LOC_RESPONSE_BODY_WITH_RESULT_STRUCT), 1*time.Second).Build()
+
+	tests := []struct {
+		TestName string
+		ReqBody  models.NFSMountRequest
+		Response []models.NFSMountResponse
+	}{
+		{
+			TestName: "Giving all services Valid IPs",
+			ReqBody: models.NFSMountRequest{
+				AutomateNodeIPs:        []string{ts.URL, ts2.URL},
+				ChefInfraServerNodeIPs: []string{ts.URL},
+				PostgresqlNodeIPs:      []string{ts.URL, ts2.URL},
+				OpensearchNodeIPs:      []string{ts.URL},
+			},
+			Response: []models.NFSMountResponse{
+				{IP: ts.URL, NodeType: "automate", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts2.URL, NodeType: "automate", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts.URL, NodeType: "chef-infra-server", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts.URL, NodeType: "postgresql", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts2.URL, NodeType: "postgresql", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts.URL, NodeType: "opensearch", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+			},
+		},
+		{
+			TestName: "Giving some Valid And Invalid Ips",
+			ReqBody: models.NFSMountRequest{
+				AutomateNodeIPs:        []string{ts.URL, "192.168.54.34"},
+				ChefInfraServerNodeIPs: []string{ts.URL},
+				PostgresqlNodeIPs:      []string{"anything.com", ts2.URL},
+				OpensearchNodeIPs:      []string{ts.URL},
+			},
+			Response: []models.NFSMountResponse{
+				{IP: ts.URL, NodeType: "automate", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: "192.168.54.34", NodeType: "automate", CheckList: nil, Error: errors.New("")},
+				{IP: ts.URL, NodeType: "chef-infra-server", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: "anything.com", NodeType: "postgresql", CheckList: nil, Error: errors.New("")},
+				{IP: ts2.URL, NodeType: "postgresql", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+				{IP: ts.URL, NodeType: "opensearch", CheckList: []models.Checks{
+					{Passed: true},
+					{Passed: true},
+				}, Error: nil},
+			},
+		},
+	}
+
+	for _, e := range tests {
+		nm := NewNFSMountService()
+		resp := nm.GetNFSMountDetails(e.ReqBody, true)
+		for index, te := range *resp {
+			if e.Response[index].Error != nil {
+				assert.Error(t, te.Error)
+			} else {
+				assert.Equal(t, te.CheckList[0].Passed, e.Response[index].CheckList[0].Passed)
+				assert.Equal(t, te.CheckList[1].Passed, e.Response[index].CheckList[1].Passed)
+			}
+			assert.Equal(t, e.Response[index].IP, te.IP)
+			assert.Equal(t, e.Response[index].NodeType, te.NodeType)
+		}
+	}
+}
+
+func TestMakeRespBody(t *testing.T) {
+	tests := []struct {
+		TestName          string
+		CountMap          map[models.NFSMountLocResponse]int
+		OrderList         []string
+		NfsMountResultMap map[string][]models.NFSMountResponse
+		ShareMap          map[string]models.NFSMountLocResponse
+		RespBodyLen       int
+		NfsMounted        bool
+		NfsShared         bool
+		ExpectedError     error
+	}{
+		{
+			TestName: "NFS is mounted and Shared",
+			CountMap: map[models.NFSMountLocResponse]int{
+				SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT: 5,
+			},
+			OrderList: []string{"my-own-key"},
+			NfsMountResultMap: map[string][]models.NFSMountResponse{
+				"my-own-key": {VALID_NFS_MOUNT_RESPONSE},
+			},
+			ShareMap: map[string]models.NFSMountLocResponse{
+				"my-own-key": SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT,
+			},
+			RespBodyLen:   1,
+			NfsMounted:    true,
+			NfsShared:     true,
+			ExpectedError: nil,
+		},
+		{
+			TestName: "NFS is mounted but not shared",
+			CountMap: map[models.NFSMountLocResponse]int{
+				SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT:  5,
+				SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT2: 4,
+			},
+			OrderList: []string{"my-own-key"},
+			NfsMountResultMap: map[string][]models.NFSMountResponse{
+				"my-own-key": {VALID_NFS_MOUNT_RESPONSE},
+			},
+			ShareMap: map[string]models.NFSMountLocResponse{
+				"my-own-key": SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT2,
+			},
+			RespBodyLen:   1,
+			NfsMounted:    true,
+			NfsShared:     false,
+			ExpectedError: nil,
+		},
+		{
+			TestName: "NFS is not mounted",
+			CountMap: map[models.NFSMountLocResponse]int{
+				SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT:  5,
+				SUCCESS_NFS_MOUNT_LOC_RESULT_STRUCT2: 4,
+				NFS_NOT_MOUNTED_STRUCT:               1,
+			},
+			OrderList: []string{"my-own-key"},
+			NfsMountResultMap: map[string][]models.NFSMountResponse{
+				"my-own-key": {VALID_NFS_MOUNT_BUT_NOT_SHARED_RESPONSE},
+			},
+			ShareMap: map[string]models.NFSMountLocResponse{
+				"my-own-key": NFS_NOT_MOUNTED_STRUCT,
+			},
+			RespBodyLen:   1,
+			NfsMounted:    false,
+			NfsShared:     false,
+			ExpectedError: nil,
+		},
+	}
+	// mp := map[string][]models.NFSMountResponse{"my": {VALID_NFS_MOUNT_BUT_NOT_SHARED_RESPONSE, VALID_NFS_MOUNT_BUT_NOT_SHARED_RESPONSE}}
+	// fmt.Println(mp)
+	for _, e := range tests {
+		respBody := []models.NFSMountResponse{}
+		makeRespBody(&respBody, e.CountMap, e.OrderList, e.NfsMountResultMap, e.ShareMap)
+		assert.Equal(t, len(respBody), e.RespBodyLen)
+		if e.ExpectedError != nil {
+			assert.Error(t, respBody[0].Error)
+		} else {
+			assert.Equal(t, e.NfsMounted, respBody[0].CheckList[0].Passed)
+			assert.Equal(t, e.NfsShared, respBody[0].CheckList[1].Passed)
+		}
+	}
+}

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
@@ -1,0 +1,14 @@
+package nfsmountservice
+
+import (
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/gofiber/fiber"
+)
+
+type MockNFSMountService struct {
+	GetNFSMountDetailsFunc func() (*[]*models.NFSMountResponse, *fiber.Error)
+}
+
+func (mnm *MockNFSMountService) GetServices() (*[]*models.NFSMountResponse, *fiber.Error) {
+	return mnm.GetNFSMountDetailsFunc()
+}

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
@@ -6,7 +6,7 @@ import (
 
 type MockNFSMountService struct {
 	GetNFSMountDetailsFunc func(reqBody models.NFSMountRequest) *[]models.NFSMountResponse
-	MakeConcurrentCallFunc func(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int)
+	MakeConcurrentCallFunc func(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int)
 	DoAPICallFunc          func(ip string, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse
 }
 
@@ -14,7 +14,7 @@ func (mnm *MockNFSMountService) GetNFSMountDetails(reqBody models.NFSMountReques
 	return mnm.GetNFSMountDetailsFunc(reqBody)
 }
 
-func (mnm *MockNFSMountService) MakeConcurrentCall(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
+func (mnm *MockNFSMountService) MakeConcurrentCall(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
 	mnm.MakeConcurrentCallFunc(ip, node_type, mountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
 }
 

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
@@ -6,18 +6,8 @@ import (
 
 type MockNFSMountService struct {
 	GetNFSMountDetailsFunc func(reqBody models.NFSMountRequest) *[]models.NFSMountResponse
-	MakeConcurrentCallFunc func(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int)
-	DoAPICallFunc          func(ip string, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse
 }
 
 func (mnm *MockNFSMountService) GetNFSMountDetails(reqBody models.NFSMountRequest) *[]models.NFSMountResponse {
 	return mnm.GetNFSMountDetailsFunc(reqBody)
-}
-
-func (mnm *MockNFSMountService) MakeConcurrentCall(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
-	mnm.MakeConcurrentCallFunc(ip, node_type, mountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
-}
-
-func (mnm *MockNFSMountService) DoAPICall(ip string, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse {
-	return mnm.DoAPICallFunc(ip, node_type, mountLocation, shareMap, key, countMap)
 }

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservicemock.go
@@ -2,13 +2,22 @@ package nfsmountservice
 
 import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
-	"github.com/gofiber/fiber"
 )
 
 type MockNFSMountService struct {
-	GetNFSMountDetailsFunc func() (*[]*models.NFSMountResponse, *fiber.Error)
+	GetNFSMountDetailsFunc func(reqBody models.NFSMountRequest) *[]models.NFSMountResponse
+	MakeConcurrentCallFunc func(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int)
+	DoAPICallFunc          func(ip string, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse
 }
 
-func (mnm *MockNFSMountService) GetServices() (*[]*models.NFSMountResponse, *fiber.Error) {
-	return mnm.GetNFSMountDetailsFunc()
+func (mnm *MockNFSMountService) GetNFSMountDetails(reqBody models.NFSMountRequest) *[]models.NFSMountResponse {
+	return mnm.GetNFSMountDetailsFunc(reqBody)
+}
+
+func (mnm *MockNFSMountService) MakeConcurrentCall(ip string, node_type string, mountLocation string, ch chan string, nfsMountResultMap map[string][]models.NFSMountResponse, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) {
+	mnm.MakeConcurrentCallFunc(ip, node_type, mountLocation, ch, nfsMountResultMap, shareMap, key, countMap)
+}
+
+func (mnm *MockNFSMountService) DoAPICall(ip string, node_type string, mountLocation string, shareMap map[string]models.NFSMountLocResponse, key string, countMap map[models.NFSMountLocResponse]int) models.NFSMountResponse {
+	return mnm.DoAPICallFunc(ip, node_type, mountLocation, shareMap, key, countMap)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Created  API  /api/v1/checks/nfs-mount. It will check for the given IPs NFS is mounted and shared for the given location or not.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2272

### :+1: Definition of Done
Implemented this API as mentioned in the ticket and also followed the swagger.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1728" alt="Screenshot 2023-05-08 at 7 40 16 PM" src="https://user-images.githubusercontent.com/101255220/236849168-4ba9029f-910d-4839-9ddb-cc57d8d3ae8d.png">
<img width="1728" alt="Screenshot 2023-05-08 at 7 40 56 PM" src="https://user-images.githubusercontent.com/101255220/236849198-e58792bb-c9ac-4499-ad34-9a576c6a3f30.png">
<img width="1346" alt="Screenshot 2023-05-08 at 7 42 16 PM" src="https://user-images.githubusercontent.com/101255220/236849212-7350a1b7-2ed1-4305-8685-233b50bb5b30.png">
<img width="1715" alt="Screenshot 2023-05-08 at 7 45 10 PM" src="https://user-images.githubusercontent.com/101255220/236849219-36a69603-317b-46ad-a6ab-97f60295ed3f.png">
<img width="1728" alt="Screenshot 2023-05-09 at 10 38 32 PM" src="https://github.com/chef/automate/assets/101255220/116c90e9-acff-405b-9134-01307bdedb57">
