### PR TITLE
Modified status api

### DIFF
--- a/components/automate-cli/pkg/verifyserver/models/status.go
+++ b/components/automate-cli/pkg/verifyserver/models/status.go
@@ -9,4 +9,5 @@ type ServiceDetails struct {
 type StatusDetails struct {
 	Status   string            `json:"status"`
 	Services *[]ServiceDetails `json:"services"`
+	Error    string            `json:"error"`
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/status.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/status.go
@@ -10,11 +10,15 @@ import (
 func (h *Handler) GetStatus(c *fiber.Ctx) {
 	services, err := h.StatusService.GetServices()
 	if err != nil {
-		c.Next(err)
-		return
+		c.JSON(response.BuildSuccessResponse(&models.StatusDetails{
+			Status:   constants.OK,
+			Services: &[]models.ServiceDetails{},
+			Error:    err.Error(),
+		}))
+	} else {
+		c.JSON(response.BuildSuccessResponse(&models.StatusDetails{
+			Status:   constants.OK,
+			Services: services,
+		}))
 	}
-	c.JSON(response.BuildSuccessResponse(&models.StatusDetails{
-		Status:   constants.OK,
-		Services: services,
-	}))
 }

--- a/components/automate-cli/pkg/verifyserver/services/statusservice/statusservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/statusservice/statusservice.go
@@ -1,13 +1,13 @@
 package statusservice
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 	"github.com/chef/automate/lib/logger"
-	"github.com/gofiber/fiber"
 )
 
 type IStatusService interface {
@@ -52,7 +52,7 @@ func (ss *StatusService) GetServicesFromHabSvcStatus() (*[]models.ServiceDetails
 	ss.Log.Debug("Output for '"+constants.HABSTATUSCMD+"' command: ", string(output))
 	if err != nil {
 		ss.Log.Error("Error while running '"+constants.HABSTATUSCMD+"' command: ", err)
-		return nil, fiber.NewError(fiber.StatusInternalServerError, "Error getting services from hab svc status")
+		return nil, errors.New("error getting services from hab svc status")
 	}
 	return ss.ParseHabSvcStatus(string(output))
 }
@@ -64,7 +64,7 @@ func (ss *StatusService) ParseHabSvcStatus(output string) (*[]models.ServiceDeta
 
 	tableStart := strings.Index(output, "package")
 	if tableStart == -1 {
-		return nil, fiber.NewError(fiber.StatusInternalServerError, "No table found in output")
+		return nil, errors.New("no table found in output")
 	}
 
 	lines := strings.Split(output[tableStart:], "\n")
@@ -102,7 +102,7 @@ func (ss *StatusService) GetServicesFromAutomateStatus() (*map[string]models.Ser
 		if ss.CheckIfBENode(string(output)) {
 			return &map[string]models.ServiceDetails{}, nil
 		}
-		return nil, fiber.NewError(fiber.StatusInternalServerError, "Error getting services from chef-automate status")
+		return nil, errors.New("error getting services from chef-automate status")
 	}
 	return ss.ParseChefAutomateStatus(string(output))
 }
@@ -114,7 +114,7 @@ func (ss *StatusService) ParseChefAutomateStatus(output string) (*map[string]mod
 
 	tableStart := strings.Index(output, "Service Name")
 	if tableStart == -1 {
-		return nil, fiber.NewError(fiber.StatusInternalServerError, "No table found in output")
+		return nil, errors.New("no table found in output")
 	}
 
 	lines := strings.Split(output[tableStart:], "\n")

--- a/components/automate-cli/pkg/verifyserver/services/statusservice/statusservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/statusservice/statusservice_test.go
@@ -239,7 +239,7 @@ func TestStatusService(t *testing.T) {
 			},
 			expectedOutput: nil,
 			isError:        true,
-			errorMsg:       "Error getting services from hab svc status",
+			errorMsg:       "error getting services from hab svc status",
 		},
 		{
 			testCaseDescription: "Automate Error",
@@ -251,7 +251,7 @@ func TestStatusService(t *testing.T) {
 			},
 			expectedOutput: nil,
 			isError:        true,
-			errorMsg:       "Error getting services from chef-automate status",
+			errorMsg:       "error getting services from chef-automate status",
 		},
 	}
 
@@ -344,14 +344,14 @@ func TestParseChefAutomateStatus(t *testing.T) {
 			input:               constants.AUTOMATESTATUSONBEERROR,
 			expected:            0,
 			isError:             true,
-			errorMsg:            "No table found in output",
+			errorMsg:            "no table found in output",
 		},
 		{
 			testCaseDescription: "Empty Response",
 			input:               "",
 			expected:            0,
 			isError:             true,
-			errorMsg:            "No table found in output",
+			errorMsg:            "no table found in output",
 		},
 		{
 			testCaseDescription: "A2 Node Unhealthy",
@@ -427,7 +427,7 @@ func TestParseHabSvcStatus(t *testing.T) {
 			input:               "",
 			expected:            0,
 			isError:             true,
-			errorMsg:            "No table found in output",
+			errorMsg:            "no table found in output",
 		},
 	}
 
@@ -476,7 +476,7 @@ func TestGetServicesFromHabSvcStatus(t *testing.T) {
 			},
 			expected: 0,
 			isError:  true,
-			errorMsg: "Error getting services from hab svc status",
+			errorMsg: "error getting services from hab svc status",
 		},
 	}
 
@@ -536,7 +536,7 @@ func TestGetServicesFromAutomateStatus(t *testing.T) {
 			},
 			expected: 0,
 			isError:  true,
-			errorMsg: "Error getting services from chef-automate status",
+			errorMsg: "error getting services from chef-automate status",
 		},
 	}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Changed response body for status API.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2127
https://github.com/chef/automate/pull/7868
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

<img width="1143" alt="Screenshot 2023-05-17 at 3 40 39 PM" src="https://github.com/chef/automate/assets/11033984/3fb689e6-7300-4859-a107-fa07bbdfa2e8">

<img width="1125" alt="Screenshot 2023-05-17 at 4 38 41 PM" src="https://github.com/chef/automate/assets/11033984/7e5aa243-a20b-4827-a5c7-ba500d8133d9">

<img width="1134" alt="Screenshot 2023-05-17 at 4 42 44 PM" src="https://github.com/chef/automate/assets/11033984/4d368094-cc1d-473f-8015-9d7ded66fafd">

<img width="1133" alt="Screenshot 2023-05-17 at 4 44 29 PM" src="https://github.com/chef/automate/assets/11033984/2c73d93b-3420-4ecf-9282-6f8988496280">

