### PR TITLE
Doc update

### DIFF
--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -64,7 +64,9 @@ Ensure access for the backup type used:
 
 {{< note >}}
 
-- If you are restoring the backup from an older version, then you need to provide the `--airgap-bundle </path/to/current/bundle>`.
+- If you are restoring the backup taken from an older version of Automate, then you need to provide the `--airgap-bundle </path/to/current/bundle>` with your restore command.
+
+In non-airgapped or Internet-connected environment, user can create airgap-bundle using `chef-automate airgap-bundle create --version <CURRENT_INSTALLED_VERSION>` command.
 
 {{< /note >}}
 
@@ -148,6 +150,7 @@ sudo chef-automate backup fix-repo-permissions <path>
 {{< note >}}
 
 - If you have not configured S3 access and secret keys during deployment or if you have taken backup on a different bucket, then you need to provide the `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` flags.
+- In somecase, the restore might not recognise the secret and access key provided in configuration. In such case, provide `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` with the restore command
 
 {{< /note >}}
 

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -71,6 +71,8 @@ Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before
 If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`), you must supply the backup directory.
 Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
+{{< note >}} If restoring a backup from different version, make sure to pass `--airgap-bundle` flag alone with the pathe to latest airgap bundle for a seemless restore {{< /note >}}
+
 To restore on a new host, run:
 
 ```shell

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -147,7 +147,7 @@ sudo chef-automate backup fix-repo-permissions <path>
 
 {{< note >}}
 
-- If you have not configured S3 access and secret keys during deployment or if you have taken backup on a diffrent bucket, then you need to provide the `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` flags.
+- If you have not configured S3 access and secret keys during deployment or if you have taken backup on a different bucket, then you need to provide the `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` flags.
 
 {{< /note >}}
 

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -62,6 +62,13 @@ Ensure access for the backup type used:
          # Use "m" for megabytes and "g" for gigabytes
      ```
 
+{{< note >}}
+
+- If you are restoring the backup from an older version, then you need to provide the `--airgap-bundle </path/to/current/bundle>`.
+
+{{< /note >}}
+
+
 ## Restore From a Filesystem Backup
 
 Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
@@ -71,7 +78,6 @@ Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before
 If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`), you must supply the backup directory.
 Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
-{{< warning >}} If restoring a backup from different version, make sure to passing `--airgap-bundle` flag alone with the path to latest airgap is mandatory {{< /warning >}}
 
 To restore on a new host, run:
 
@@ -138,6 +144,12 @@ sudo chef-automate backup fix-repo-permissions <path>
 ```
 
 ## Restore From an AWS S3 Backup
+
+{{< note >}}
+
+- If you have not configured S3 access and secret keys during deployment or if you have taken backup on a diffrent bucket, then you need to provide the `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` flags.
+
+{{< /note >}}
 
 Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
 

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -147,13 +147,6 @@ sudo chef-automate backup fix-repo-permissions <path>
 
 ## Restore From an AWS S3 Backup
 
-{{< note >}}
-
-- If you have not configured S3 access and secret keys during deployment or if you have taken backup on a different bucket, then you need to provide the `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` flags.
-- In somecase, the restore might not recognise the secret and access key provided in configuration. In such case, provide `--s3-access-key <Access_Key>` and `--s3-secret-key <Secret_Key>` with the restore command
-
-{{< /note >}}
-
 Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before beginning your restore process.
 
 See how to [back up to AWS S3]({{< ref "backup/#backup-to-aws-s3" >}}).
@@ -161,19 +154,19 @@ See how to [back up to AWS S3]({{< ref "backup/#backup-to-aws-s3" >}}).
 To restore from an AWS S3 bucket backup on a new host, run:
 
 ```shell
-chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID
+chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --s3-access-key <access_key> --s3-secret-key <secret_key>
 ```
 
 To restore from an AWS S3 bucket backup on an existing Chef Automate host, run:
 
 ```shell
-chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --skip-preflight
+chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --skip-preflight --s3-access-key <access_key> --s3-secret-key <secret_key>
 ```
 
 Use the `--patch-config` option with a [configuration patch file]({{< relref "restore.md#prerequisites" >}}) to restore to a host with a different FQDN than that of the backup host:
 
 ```shell
-chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --patch-config </path/to/patch.toml> --skip-preflight
+chef-automate backup restore s3://bucket_name/path/to/backups/BACKUP_ID --patch-config </path/to/patch.toml> --skip-preflight --s3-access-key <access_key> --s3-secret-key <secret_key>
 ```
 
 A successful restore shows the timestamp of the backup used at the end of the status output:

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -64,9 +64,9 @@ Ensure access for the backup type used:
 
 {{< note >}}
 
-- If you are restoring the backup taken from an older version of Automate, then you need to provide the `--airgap-bundle </path/to/current/bundle>` with your restore command.
+- If restoring the backup from an older version of Automate, you must provide the `--airgap-bundle </path/to/current/bundle>` with your restore command.
 
-In non-airgapped or Internet-connected environment, user can create airgap-bundle using `chef-automate airgap-bundle create --version <CURRENT_INSTALLED_VERSION>` command.
+- In a non-airgapped or Internet-connected environment, the user can create an airgap-bundle using the `chef-automate airgap-bundle create --version <CURRENT_INSTALLED_VERSION>` command.
 
 {{< /note >}}
 

--- a/components/docs-chef-io/content/automate/restore.md
+++ b/components/docs-chef-io/content/automate/restore.md
@@ -71,7 +71,7 @@ Meet the required [prerequisites]({{< ref "restore.md#prerequisites" >}}) before
 If you have [configured the backup directory]({{< relref "backup.md#backup-to-a-filesystem" >}}) to a directory other than the default directory (`/var/opt/chef-automate/backups`), you must supply the backup directory.
 Without a backup ID, Chef Automate uses the most recent backup in the backup directory.
 
-{{< note >}} If restoring a backup from different version, make sure to pass `--airgap-bundle` flag alone with the pathe to latest airgap bundle for a seemless restore {{< /note >}}
+{{< warning >}} If restoring a backup from different version, make sure to passing `--airgap-bundle` flag alone with the path to latest airgap is mandatory {{< /warning >}}
 
 To restore on a new host, run:
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

As an Automate user, when the user is restoring a backup taken from a different (older) version on Automate, he should be able to restore without errors or terminating the services. As per the older documentation, when the user restores without the `--airgap-bundle`  flag, the command tries to restore the application along with its data, which breaks the application. 


### :chains: Related Resources
Jira ticket(s):
1. https://chefio.atlassian.net/browse/CHEF-2597

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
