### PR TITLE
Chef 2251 remove open search frontend node is not actually removing nodes from cluster

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConfigUtils.go
+++ b/components/automate-cli/cmd/chef-automate/automateConfigUtils.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"path/filepath"
+	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	ptoml "github.com/pelletier/go-toml"
@@ -29,12 +30,12 @@ func getModeFromConfig(configPath string) (string, error) {
 		} else if config.Get("architecture.aws") != nil {
 			return AWS_MODE, nil
 		} else {
-			return AUTOMATE, nil
+			return strings.ToUpper(AUTOMATE), nil
 		}
 	} else if checkIfFileExist(filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "a2ha.rb")) {
 		return HA_MODE, nil
 	} else {
-		return AUTOMATE, nil
+		return strings.ToUpper(AUTOMATE), nil
 	}
 }
 

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -83,6 +83,9 @@ const (
 	  "transient" :{
 		  "cluster.routing.allocation.exclude._ip" : "%s"
 	   }
-	}' -k -u admin:admin
+	}' -k \
+	--cacert /hab/svc/automate-ha-opensearch/config/certificates/root-ca.pem \
+	--key /hab/svc/automate-ha-opensearch/config/certificates/admin-key.pem \
+	--cert /hab/svc/automate-ha-opensearch/config/certificates/admin.pem
 	`
 )

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -72,4 +72,17 @@ const (
 	`
 
 	SUDO_PASSWORD_CMD = `echo "%s" | sudo -S bash -c "`
+
+	STOP_FE_SERVICES_CMD = `sudo chef-automate stop`
+	STOP_BE_SERVICES_CMD = `sudo systemctl stop hab-sup`
+
+	EXCLUDE_OPENSEARCH_NODE_REQUEST = `
+	curl --location --request PUT 'https://localhost:9200/_cluster/settings' \
+	--header 'Content-Type: application/json' \
+	--data-raw '{
+	  "transient" :{
+		  "cluster.routing.allocation.exclude._ip" : "%s"
+	   }
+	}' -k -u admin:admin
+	`
 )

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -76,15 +76,14 @@ const (
 	STOP_BE_SERVICES_CMD = `sudo systemctl stop hab-sup`
 
 	EXCLUDE_OPENSEARCH_NODE_REQUEST = `
-	curl --location --request PUT 'https://localhost:9200/_cluster/settings' \
+	curl --location --request PUT 'http://localhost:10144/_cluster/settings' \
 	--header 'Content-Type: application/json' \
 	--data-raw '{
-	  "transient" :{
+	  "persistent" :{
 		  "cluster.routing.allocation.exclude._ip" : "%s"
 	   }
-	}' -k \
-	--cacert /hab/svc/automate-ha-opensearch/config/certificates/root-ca.pem \
-	--key /hab/svc/automate-ha-opensearch/config/certificates/admin-key.pem \
-	--cert /hab/svc/automate-ha-opensearch/config/certificates/admin.pem
+	}'
 	`
+
+	GET_OPENSEARCH_CLUSTER_SETTINGS = `curl --location --request GET 'http://localhost:10144/_cluster/settings'`
 )

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -3,7 +3,6 @@ package main
 const (
 	AWS_MODE            = "AWS_MODE"
 	EXISTING_INFRA_MODE = "EXISTING_INFRA_MODE"
-	AUTOMATE            = "AUTOMATE"
 	HA_MODE             = "HA_MODE"
 )
 

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -73,7 +73,7 @@ const (
 
 	SUDO_PASSWORD_CMD = `echo "%s" | sudo -S bash -c "`
 
-	STOP_FE_SERVICES_CMD = `sudo chef-automate stop`
+	STOP_FE_SERVICES_CMD = `sudo systemctl stop chef-automate`
 	STOP_BE_SERVICES_CMD = `sudo systemctl stop hab-sup`
 
 	EXCLUDE_OPENSEARCH_NODE_REQUEST = `

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -216,7 +216,7 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 
 		sshConfig := c.getSshDetails(infra)
 		sshUtil := NewSSHUtil(sshConfig)
-		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(), sshUtil, writer)
+		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(&remoteCmdExecutor{}), sshUtil, writer)
 		currentCertsInfo, err := certShowFlow.fetchCurrentCerts()
 
 		if err != nil {
@@ -449,8 +449,8 @@ func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infr
 	if err != nil {
 		return err
 	}
-	
-	oldCn:=getOldCn(automatesConfig)
+
+	oldCn := getOldCn(automatesConfig)
 
 	// Patching root-ca to frontend-nodes for maintaining the connection.
 	cn := nodesCn
@@ -686,7 +686,7 @@ func (c *certRotateFlow) getAllIPs(infra *AutomateHAInfraDetails) []string {
 	return ips
 }
 
-//getFilteredIps will return ips on which cert-rotation need to perform.
+// getFilteredIps will return ips on which cert-rotation need to perform.
 func (c *certRotateFlow) getFilteredIps(serviceIps, skipIpsList []string) []string {
 	filteredIps := []string{}
 	for _, ip := range serviceIps {
@@ -697,7 +697,7 @@ func (c *certRotateFlow) getFilteredIps(serviceIps, skipIpsList []string) []stri
 	return filteredIps
 }
 
-//compareCurrentCertsWithNewCerts compare current certs and new certs and returns ips to skip cert-rotation.
+// compareCurrentCertsWithNewCerts compare current certs and new certs and returns ips to skip cert-rotation.
 func (c *certRotateFlow) compareCurrentCertsWithNewCerts(remoteService string, newCerts *certificates, flagsObj *certRotateFlags, currentCertsInfo *certShowCertificates) []string {
 	skipIpsList := []string{}
 	isCertsSame := true
@@ -734,7 +734,7 @@ func (c *certRotateFlow) compareCurrentCertsWithNewCerts(remoteService string, n
 	return skipIpsList
 }
 
-//comparePublicCertAndPrivateCert compare new public-cert and private cert with current public-cert and private-cert and returns ips to skip cert-rotation.
+// comparePublicCertAndPrivateCert compare new public-cert and private cert with current public-cert and private-cert and returns ips to skip cert-rotation.
 func (c *certRotateFlow) comparePublicCertAndPrivateCert(newCerts *certificates, certByIpList []CertByIP, isCertsSame bool, flagsObj *certRotateFlags) []string {
 	skipIpsList := []string{}
 	for _, currentCerts := range certByIpList {
@@ -753,7 +753,7 @@ func (c *certRotateFlow) comparePublicCertAndPrivateCert(newCerts *certificates,
 	return skipIpsList
 }
 
-//getFrontEndIpsForSkippingRootCAPatching compare new root-ca and current root-ca of remoteService and returns ips to skip root-ca patching.
+// getFrontEndIpsForSkippingRootCAPatching compare new root-ca and current root-ca of remoteService and returns ips to skip root-ca patching.
 func (c *certRotateFlow) getFrontEndIpsForSkippingRootCAPatching(remoteService string, newRootCA string, infra *AutomateHAInfraDetails, currentCertsInfo *certShowCertificates) []string {
 	skipIpsList := []string{}
 
@@ -772,7 +772,7 @@ func (c *certRotateFlow) getFrontEndIpsForSkippingRootCAPatching(remoteService s
 	return skipIpsList
 }
 
-//getFrontEndIpsForSkippingCnAndRootCaPatching compare new root-ca and new cn with current root-ca and cn and returns ips to skip root-ca patching.
+// getFrontEndIpsForSkippingCnAndRootCaPatching compare new root-ca and new cn with current root-ca and cn and returns ips to skip root-ca patching.
 func (c *certRotateFlow) getFrontEndIpsForSkippingCnAndRootCaPatching(newRootCA, newCn, oldCn, node string, currentCertsInfo *certShowCertificates, infra *AutomateHAInfraDetails) []string {
 	isRootCaSame := false
 

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/platform/command"
 	"github.com/chef/automate/lib/stringutils"
 	"github.com/chef/toml"
 	"github.com/pkg/errors"
@@ -216,7 +217,7 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 
 		sshConfig := c.getSshDetails(infra)
 		sshUtil := NewSSHUtil(sshConfig)
-		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), sshUtil, writer)
+		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), sshUtil, writer)
 		currentCertsInfo, err := certShowFlow.fetchCurrentCerts()
 
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -165,13 +165,13 @@ func init() {
 		},
 	}
 
-	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.automate, CONST_AUTOMATE, "a", false, "Automate Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.automate, AUTOMATE, "a", false, "Automate Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&flagsObj.automate, "a2", false, "Automate Certificate Rotation")
-	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.chefserver, CONST_CHEF_SERVER, "c", false, "Chef Infra Server Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.chefserver, CHEF_SERVER, "c", false, "Chef Infra Server Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&flagsObj.chefserver, "cs", false, "Chef Infra Server Certificate Rotation")
-	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.postgres, CONST_POSTGRESQL, "p", false, "Postgres Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.postgres, POSTGRESQL, "p", false, "Postgres Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&flagsObj.postgres, "pg", false, "Postgres Certificate Rotation")
-	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.opensearch, CONST_OPENSEARCH, "o", false, "OS Certificate Rotation")
+	certRotateCmd.PersistentFlags().BoolVarP(&flagsObj.opensearch, OPENSEARCH, "o", false, "OS Certificate Rotation")
 	certRotateCmd.PersistentFlags().BoolVar(&flagsObj.opensearch, "os", false, "OS Certificate Rotation")
 
 	certRotateCmd.PersistentFlags().StringVar(&flagsObj.privateCertPath, "private-cert", "", "Private certificate")
@@ -262,9 +262,9 @@ func (c *certRotateFlow) certRotateFrontend(sshUtil SSHUtil, certs *certificates
 	var remoteService string
 
 	if flagsObj.automate {
-		remoteService = CONST_AUTOMATE
+		remoteService = AUTOMATE
 	} else if flagsObj.chefserver {
-		remoteService = CONST_CHEF_SERVER
+		remoteService = CHEF_SERVER
 	}
 	//get ips to exclude
 	skipIpsList := c.compareCurrentCertsWithNewCerts(remoteService, certs, flagsObj, currentCertsInfo)
@@ -296,8 +296,8 @@ func (c *certRotateFlow) certRotateFrontend(sshUtil SSHUtil, certs *certificates
 
 	// If we pass root-ca flag in automate then we need to update root-ca in the ChefServer to maintain the connection
 	if flagsObj.automate {
-		skipIpsList := c.getFrontEndIpsForSkippingRootCAPatching(CONST_AUTOMATE, certs.rootCA, infra, currentCertsInfo)
-		c.skipMessagePrinter(CONST_CHEF_SERVER, SKIP_FRONT_END_IPS_MSG_A2, "", skipIpsList)
+		skipIpsList := c.getFrontEndIpsForSkippingRootCAPatching(AUTOMATE, certs.rootCA, infra, currentCertsInfo)
+		c.skipMessagePrinter(CHEF_SERVER, SKIP_FRONT_END_IPS_MSG_A2, "", skipIpsList)
 		err = c.patchRootCAinCS(sshUtil, certs.rootCA, timestamp, infra, flagsObj, skipIpsList)
 		if err != nil {
 			return err
@@ -309,11 +309,11 @@ func (c *certRotateFlow) certRotateFrontend(sshUtil SSHUtil, certs *certificates
 // certRotatePG will rotate the certificates of Postgres.
 func (c *certRotateFlow) certRotatePG(sshUtil SSHUtil, certs *certificates, infra *AutomateHAInfraDetails, flagsObj *certRotateFlags, currentCertsInfo *certShowCertificates) error {
 	if isManagedServicesOn() {
-		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_DB_CERT_ROTATE, CONST_POSTGRESQL)
+		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_DB_CERT_ROTATE, POSTGRESQL)
 	}
 	fileName := "cert-rotate-pg.toml"
 	timestamp := time.Now().Format("20060102150405")
-	remoteService := CONST_POSTGRESQL
+	remoteService := POSTGRESQL
 
 	// Creating and patching the required configurations.
 	var config string
@@ -372,11 +372,11 @@ func (c *certRotateFlow) certRotatePG(sshUtil SSHUtil, certs *certificates, infr
 // certRotateOS will rotate the certificates of OpenSearch.
 func (c *certRotateFlow) certRotateOS(sshUtil SSHUtil, certs *certificates, infra *AutomateHAInfraDetails, flagsObj *certRotateFlags, currentCertsInfo *certShowCertificates) error {
 	if isManagedServicesOn() {
-		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_DB_CERT_ROTATE, CONST_OPENSEARCH)
+		return status.Errorf(status.InvalidCommandArgsError, ERROR_SELF_MANAGED_DB_CERT_ROTATE, OPENSEARCH)
 	}
 	fileName := "cert-rotate-os.toml"
 	timestamp := time.Now().Format("20060102150405")
-	remoteService := CONST_OPENSEARCH
+	remoteService := OPENSEARCH
 
 	var adminDn pkix.Name
 	var err error
@@ -548,9 +548,9 @@ func (c *certRotateFlow) patchConfig(param *patchFnParameters) error {
 
 	// Defining set of commands which run on particular remoteservice nodes
 	var scriptCommands string
-	if param.remoteService == CONST_AUTOMATE || param.remoteService == CONST_CHEF_SERVER || param.remoteService == "frontend" {
+	if param.remoteService == AUTOMATE || param.remoteService == CHEF_SERVER || param.remoteService == "frontend" {
 		scriptCommands = fmt.Sprintf(FRONTEND_COMMAND, PATCH, param.remoteService+param.timestamp, dateFormat)
-	} else if param.remoteService == CONST_POSTGRESQL || param.remoteService == CONST_OPENSEARCH {
+	} else if param.remoteService == POSTGRESQL || param.remoteService == OPENSEARCH {
 		scriptCommands = fmt.Sprintf(COPY_USER_CONFIG, param.remoteService+param.timestamp, param.remoteService)
 	}
 	err = c.copyAndExecute(filteredIps, param.sshUtil, param.timestamp, param.remoteService, param.fileName, scriptCommands, param.flagsObj)
@@ -564,7 +564,7 @@ func (c *certRotateFlow) patchConfig(param *patchFnParameters) error {
 func (c *certRotateFlow) patchRootCAinCS(sshUtil SSHUtil, rootCA, timestamp string, infra *AutomateHAInfraDetails, flagsObj *certRotateFlags, skipIpsList []string) error {
 
 	fileName := "rotate-root_CA.toml"
-	remoteService := CONST_CHEF_SERVER
+	remoteService := CHEF_SERVER
 	cmd := `sudo chef-automate config show | grep fqdn | awk '{print $3}' | tr -d '"'`
 	ips := c.getIps(remoteService, infra)
 	if len(ips) == 0 {
@@ -653,13 +653,13 @@ func (c *certRotateFlow) getSshDetails(infra *AutomateHAInfraDetails) *SSHConfig
 
 // getIps will return the Ips based on the given remote service.
 func (c *certRotateFlow) getIps(remoteService string, infra *AutomateHAInfraDetails) []string {
-	if remoteService == CONST_AUTOMATE {
+	if remoteService == AUTOMATE {
 		return infra.Outputs.AutomatePrivateIps.Value
-	} else if remoteService == CONST_CHEF_SERVER {
+	} else if remoteService == CHEF_SERVER {
 		return infra.Outputs.ChefServerPrivateIps.Value
-	} else if remoteService == CONST_POSTGRESQL {
+	} else if remoteService == POSTGRESQL {
 		return infra.Outputs.PostgresqlPrivateIps.Value
-	} else if remoteService == CONST_OPENSEARCH {
+	} else if remoteService == OPENSEARCH {
 		return infra.Outputs.OpensearchPrivateIps.Value
 	} else if remoteService == "frontend" {
 		return append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
@@ -701,7 +701,7 @@ func (c *certRotateFlow) getFilteredIps(serviceIps, skipIpsList []string) []stri
 func (c *certRotateFlow) compareCurrentCertsWithNewCerts(remoteService string, newCerts *certificates, flagsObj *certRotateFlags, currentCertsInfo *certShowCertificates) []string {
 	skipIpsList := []string{}
 	isCertsSame := true
-	if remoteService == CONST_AUTOMATE {
+	if remoteService == AUTOMATE {
 		if flagsObj.node == "" {
 			isCertsSame = strings.TrimSpace(currentCertsInfo.AutomateRootCert) == newCerts.rootCA
 		}
@@ -709,12 +709,12 @@ func (c *certRotateFlow) compareCurrentCertsWithNewCerts(remoteService string, n
 		return skipIpsList
 	}
 
-	if remoteService == CONST_CHEF_SERVER {
+	if remoteService == CHEF_SERVER {
 		skipIpsList = c.comparePublicCertAndPrivateCert(newCerts, currentCertsInfo.ChefServerCertsByIP, isCertsSame, flagsObj)
 		return skipIpsList
 	}
 
-	if remoteService == CONST_OPENSEARCH {
+	if remoteService == OPENSEARCH {
 		if flagsObj.node == "" {
 			isCertsSame = strings.TrimSpace(currentCertsInfo.OpensearchRootCert) == newCerts.rootCA
 			isCertsSame = (strings.TrimSpace(currentCertsInfo.OpensearchAdminCert) == newCerts.adminCert) && isCertsSame
@@ -724,7 +724,7 @@ func (c *certRotateFlow) compareCurrentCertsWithNewCerts(remoteService string, n
 		return skipIpsList
 	}
 
-	if remoteService == CONST_POSTGRESQL {
+	if remoteService == POSTGRESQL {
 		if flagsObj.node == "" {
 			isCertsSame = strings.TrimSpace(currentCertsInfo.PostgresqlRootCert) == newCerts.rootCA
 		}
@@ -757,15 +757,15 @@ func (c *certRotateFlow) comparePublicCertAndPrivateCert(newCerts *certificates,
 func (c *certRotateFlow) getFrontEndIpsForSkippingRootCAPatching(remoteService string, newRootCA string, infra *AutomateHAInfraDetails, currentCertsInfo *certShowCertificates) []string {
 	skipIpsList := []string{}
 
-	if remoteService == CONST_POSTGRESQL {
+	if remoteService == POSTGRESQL {
 		if strings.TrimSpace(currentCertsInfo.PostgresqlRootCert) == newRootCA {
 			skipIpsList = append(skipIpsList, c.getIps("frontend", infra)...)
 		}
 	}
 
-	if remoteService == CONST_AUTOMATE {
+	if remoteService == AUTOMATE {
 		if strings.TrimSpace(currentCertsInfo.AutomateRootCert) == newRootCA {
-			skipIpsList = append(skipIpsList, c.getIps(CONST_CHEF_SERVER, infra)...)
+			skipIpsList = append(skipIpsList, c.getIps(CHEF_SERVER, infra)...)
 		}
 	}
 
@@ -1015,7 +1015,7 @@ func (c *certRotateFlow) getMerger(fileName string, timestamp string, remoteType
 		dest interface{}
 		err1 error
 	)
-	if remoteType == CONST_OPENSEARCH {
+	if remoteType == OPENSEARCH {
 		dest, err1 = getMergedOpensearchInterface(rawOutput, fileName, remoteType)
 	} else {
 		dest, err1 = getMergedPostgresqlInterface(rawOutput, fileName, remoteType)

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -216,7 +216,7 @@ func (c *certRotateFlow) certRotate(cmd *cobra.Command, args []string, flagsObj 
 
 		sshConfig := c.getSshDetails(infra)
 		sshUtil := NewSSHUtil(sshConfig)
-		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(&remoteCmdExecutor{}), sshUtil, writer)
+		certShowFlow := NewCertShowImpl(certShowFlags{}, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), sshUtil, writer)
 		currentCertsInfo, err := certShowFlow.fetchCurrentCerts()
 
 		if err != nil {

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -458,7 +458,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 	testCases := []testCaseInfo{
 		{
 			testCaseDescription: "Automate new certs are equal | No node flag",
-			remoteService:       CONST_AUTOMATE,
+			remoteService:       AUTOMATE,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent,
@@ -484,7 +484,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Automate new certs are different | No node flag",
-			remoteService:       CONST_AUTOMATE,
+			remoteService:       AUTOMATE,
 			newCerts: &certificates{
 				publicCert:  FileContent + "a",
 				privateCert: FileContent,
@@ -510,7 +510,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Automate new certs are eqaul | Node flag",
-			remoteService:       CONST_AUTOMATE,
+			remoteService:       AUTOMATE,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent,
@@ -536,7 +536,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Chef-server new certs are equal | No node flag",
-			remoteService:       CONST_CHEF_SERVER,
+			remoteService:       CHEF_SERVER,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent,
@@ -560,7 +560,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Chef-server new certs are different | No node flag",
-			remoteService:       CONST_CHEF_SERVER,
+			remoteService:       CHEF_SERVER,
 			newCerts: &certificates{
 				publicCert:  FileContent + "a",
 				privateCert: FileContent,
@@ -584,7 +584,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Opensearch new certs are equals | No node flag",
-			remoteService:       CONST_OPENSEARCH,
+			remoteService:       OPENSEARCH,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent,
@@ -619,7 +619,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Opensearch new certs are different | No node flag",
-			remoteService:       CONST_OPENSEARCH,
+			remoteService:       OPENSEARCH,
 			newCerts: &certificates{
 				publicCert:  FileContent + "a",
 				privateCert: FileContent,
@@ -654,7 +654,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Postgresql new certs are eqaul | No node flag",
-			remoteService:       CONST_POSTGRESQL,
+			remoteService:       POSTGRESQL,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent,
@@ -685,7 +685,7 @@ func TestCompareCurrentCertsWithNewCerts(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Postgresql new certs are different | No node flag",
-			remoteService:       CONST_POSTGRESQL,
+			remoteService:       POSTGRESQL,
 			newCerts: &certificates{
 				publicCert:  FileContent,
 				privateCert: FileContent + "a",
@@ -737,16 +737,16 @@ func TestGetFrontEndIpsForSkippingRootCAPatching(t *testing.T) {
 	testCases := []testCaseInfo{
 		{
 			testCaseDescription: "Automate root-ca patching in chef-server | same root-ca",
-			remoteService:       CONST_AUTOMATE,
+			remoteService:       AUTOMATE,
 			newRootCA:           FileContent,
 			currentCertsInfo: &certShowCertificates{
 				AutomateRootCert: FileContent,
 			},
-			skipIpsList: c.getIps(CONST_CHEF_SERVER, infra),
+			skipIpsList: c.getIps(CHEF_SERVER, infra),
 		},
 		{
 			testCaseDescription: "Automate root-ca patching in chef-server | different root-ca",
-			remoteService:       CONST_AUTOMATE,
+			remoteService:       AUTOMATE,
 			newRootCA:           FileContent + "a",
 			currentCertsInfo: &certShowCertificates{
 				AutomateRootCert: FileContent,
@@ -755,7 +755,7 @@ func TestGetFrontEndIpsForSkippingRootCAPatching(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Postgresql root-ca patching in frontend | same root-ca",
-			remoteService:       CONST_POSTGRESQL,
+			remoteService:       POSTGRESQL,
 			newRootCA:           FileContent,
 			currentCertsInfo: &certShowCertificates{
 				PostgresqlRootCert: FileContent,
@@ -764,7 +764,7 @@ func TestGetFrontEndIpsForSkippingRootCAPatching(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Postgresql root-ca patching in frontEnd | different root-ca",
-			remoteService:       CONST_POSTGRESQL,
+			remoteService:       POSTGRESQL,
 			newRootCA:           FileContent + "a",
 			currentCertsInfo: &certShowCertificates{
 				PostgresqlRootCert: FileContent,
@@ -939,8 +939,7 @@ func TestGetOldCn(t *testing.T) {
 					V1: &shared.V1{
 						External: &shared.External{
 							Opensearch: &shared.External_Opensearch{
-								Ssl: &shared.External_Opensearch_SSL{
-								},
+								Ssl: &shared.External_Opensearch_SSL{},
 							},
 						},
 					},
@@ -963,11 +962,11 @@ func TestGetOldCn(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run("GetOldCn", func(t *testing.T) {
-			configMap:= map[string]*deployment.AutomateConfig {
+			configMap := map[string]*deployment.AutomateConfig{
 				ValidIP: testCase.automatesConfig,
 			}
-			oldCn:=getOldCn(configMap)
-			assert.Equal(t, testCase.OldCnExpected,oldCn)
+			oldCn := getOldCn(configMap)
+			assert.Equal(t, testCase.OldCnExpected, oldCn)
 		})
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -106,7 +106,7 @@ func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdR
 
 	switch true {
 	case nodeMap.Frontend.CmdInputs.NodeType:
-		const remoteService string = CONST_FRONTEND
+		const remoteService string = FRONTEND
 		nodeIps, err := preCmdExecCheck(nodeMap.Frontend, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
@@ -114,7 +114,7 @@ func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdR
 		output := c.executeCmdOnGivenNodes(nodeMap.Frontend.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	case nodeMap.Automate.CmdInputs.NodeType:
-		const remoteService string = CONST_AUTOMATE
+		const remoteService string = AUTOMATE
 		nodeIps, err := preCmdExecCheck(nodeMap.Automate, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
@@ -123,7 +123,7 @@ func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdR
 		output := c.executeCmdOnGivenNodes(nodeMap.Automate.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	case nodeMap.ChefServer.CmdInputs.NodeType:
-		const remoteService string = CONST_CHEF_SERVER
+		const remoteService string = CHEF_SERVER
 		nodeIps, err := preCmdExecCheck(nodeMap.ChefServer, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
@@ -132,7 +132,7 @@ func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdR
 		output := c.executeCmdOnGivenNodes(nodeMap.ChefServer.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	case nodeMap.Postgresql.CmdInputs.NodeType:
-		const remoteService string = CONST_POSTGRESQL
+		const remoteService string = POSTGRESQL
 		nodeIps, err := preCmdExecCheck(nodeMap.Postgresql, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
@@ -141,7 +141,7 @@ func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdR
 		output := c.executeCmdOnGivenNodes(nodeMap.Postgresql.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	case nodeMap.Opensearch.CmdInputs.NodeType:
-		const remoteService string = CONST_OPENSEARCH
+		const remoteService string = OPENSEARCH
 		nodeIps, err := preCmdExecCheck(nodeMap.Opensearch, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
@@ -325,15 +325,15 @@ func getSshDetails(infra *AutomateHAInfraDetails) *SSHConfig {
 func getNodeIPs(single bool, ip string, infra *AutomateHAInfraDetails, remoteService string) ([]string, error) {
 	nodeIps := []string{}
 	switch {
-	case remoteService == CONST_OPENSEARCH:
+	case remoteService == OPENSEARCH:
 		nodeIps = infra.Outputs.OpensearchPrivateIps.Value
-	case remoteService == CONST_POSTGRESQL:
+	case remoteService == POSTGRESQL:
 		nodeIps = infra.Outputs.PostgresqlPrivateIps.Value
-	case remoteService == CONST_CHEF_SERVER:
+	case remoteService == CHEF_SERVER:
 		nodeIps = infra.Outputs.ChefServerPrivateIps.Value
-	case remoteService == CONST_AUTOMATE:
+	case remoteService == AUTOMATE:
 		nodeIps = infra.Outputs.AutomatePrivateIps.Value
-	case remoteService == CONST_FRONTEND:
+	case remoteService == FRONTEND:
 		nodeIps = append(infra.Outputs.AutomatePrivateIps.Value, infra.Outputs.ChefServerPrivateIps.Value...)
 	}
 	if ip != "" {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -52,7 +52,7 @@ type CmdResult struct {
 
 type RemoteCmdExecutor interface {
 	Execute() (map[string][]*CmdResult, error)
-	Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer)
+	ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
 }
 
 type remoteCmdExecutor struct {
@@ -62,16 +62,16 @@ type remoteCmdExecutor struct {
 }
 
 type MockRemoteCmdExecutor struct {
-	ExecuteFunc func() (map[string][]*CmdResult, error)
-	SetFunc     func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer)
+	ExecuteFunc            func() (map[string][]*CmdResult, error)
+	ExecuteWithNodeMapFunc func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
 }
 
 func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
 	return m.ExecuteFunc()
 }
 
-func (m *MockRemoteCmdExecutor) Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-	m.SetFunc(nodeMap, sshUtil, writer)
+func (m *MockRemoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+	return m.ExecuteWithNodeMapFunc(nodeMap)
 }
 
 func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) RemoteCmdExecutor {
@@ -82,63 +82,72 @@ func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.
 	}
 }
 
-func (c *remoteCmdExecutor) Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-	c.NodeMap = nodeMap
-	c.SshUtil = sshUtil
-	c.Output = writer
+func NewRemoteCmdExecutorWithoutNodeMap(sshUtil SSHUtil, writer *cli.Writer) RemoteCmdExecutor {
+	return &remoteCmdExecutor{
+		SshUtil: sshUtil,
+		Output:  writer,
+	}
+}
+
+func (c *remoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+	return c.execute(nodeMap)
 }
 
 func (c *remoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
+	return c.execute(c.NodeMap)
+}
+
+func (c *remoteCmdExecutor) execute(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 	timestamp := time.Now().Format("20060102150405")
 	cmdResult := map[string][]*CmdResult{}
 
-	sshConfig := getSshDetails(c.NodeMap.Infra)
+	sshConfig := getSshDetails(nodeMap.Infra)
 	c.SshUtil.setSSHConfig(sshConfig)
 
 	switch true {
-	case c.NodeMap.Frontend.CmdInputs.NodeType:
+	case nodeMap.Frontend.CmdInputs.NodeType:
 		const remoteService string = CONST_FRONTEND
-		nodeIps, err := preCmdExecCheck(c.NodeMap.Frontend, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
+		nodeIps, err := preCmdExecCheck(nodeMap.Frontend, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
 		}
-		output := c.executeCmdOnGivenNodes(c.NodeMap.Frontend.CmdInputs, nodeIps, remoteService, timestamp, writer)
+		output := c.executeCmdOnGivenNodes(nodeMap.Frontend.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
-	case c.NodeMap.Automate.CmdInputs.NodeType:
+	case nodeMap.Automate.CmdInputs.NodeType:
 		const remoteService string = CONST_AUTOMATE
-		nodeIps, err := preCmdExecCheck(c.NodeMap.Automate, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
+		nodeIps, err := preCmdExecCheck(nodeMap.Automate, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
 		}
 
-		output := c.executeCmdOnGivenNodes(c.NodeMap.Automate.CmdInputs, nodeIps, remoteService, timestamp, writer)
+		output := c.executeCmdOnGivenNodes(nodeMap.Automate.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
-	case c.NodeMap.ChefServer.CmdInputs.NodeType:
+	case nodeMap.ChefServer.CmdInputs.NodeType:
 		const remoteService string = CONST_CHEF_SERVER
-		nodeIps, err := preCmdExecCheck(c.NodeMap.ChefServer, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
+		nodeIps, err := preCmdExecCheck(nodeMap.ChefServer, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
 		}
 
-		output := c.executeCmdOnGivenNodes(c.NodeMap.ChefServer.CmdInputs, nodeIps, remoteService, timestamp, writer)
+		output := c.executeCmdOnGivenNodes(nodeMap.ChefServer.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
-	case c.NodeMap.Postgresql.CmdInputs.NodeType:
+	case nodeMap.Postgresql.CmdInputs.NodeType:
 		const remoteService string = CONST_POSTGRESQL
-		nodeIps, err := preCmdExecCheck(c.NodeMap.Postgresql, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
+		nodeIps, err := preCmdExecCheck(nodeMap.Postgresql, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
 		}
 
-		output := c.executeCmdOnGivenNodes(c.NodeMap.Postgresql.CmdInputs, nodeIps, remoteService, timestamp, writer)
+		output := c.executeCmdOnGivenNodes(nodeMap.Postgresql.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
-	case c.NodeMap.Opensearch.CmdInputs.NodeType:
+	case nodeMap.Opensearch.CmdInputs.NodeType:
 		const remoteService string = CONST_OPENSEARCH
-		nodeIps, err := preCmdExecCheck(c.NodeMap.Opensearch, c.SshUtil, c.NodeMap.Infra, remoteService, timestamp, writer)
+		nodeIps, err := preCmdExecCheck(nodeMap.Opensearch, c.SshUtil, nodeMap.Infra, remoteService, timestamp, writer)
 		if err != nil {
 			return cmdResult, err
 		}
 
-		output := c.executeCmdOnGivenNodes(c.NodeMap.Opensearch.CmdInputs, nodeIps, remoteService, timestamp, writer)
+		output := c.executeCmdOnGivenNodes(nodeMap.Opensearch.CmdInputs, nodeIps, remoteService, timestamp, writer)
 		return output, nil
 	default:
 		return cmdResult, errors.New("Missing or Unsupported flag")

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -349,9 +349,7 @@ func GetSingleIp(ips []string) (string, error) {
 
 // isValidIP will check whether the given ip is in the given remoteservice ips set or not.
 func isValidIP(ip string, ips []string) bool {
-	ipv4Regex := `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
-	match, _ := regexp.MatchString(ipv4Regex, ip)
-	if !match {
+	if !isValidIPFormat(ip) {
 		return false
 	}
 	for _, clusterIP := range ips {
@@ -360,6 +358,14 @@ func isValidIP(ip string, ips []string) bool {
 		}
 	}
 	return false
+}
+
+func isValidIPFormat(ip string) bool {
+	if strings.TrimSpace(ip) == "" {
+		return false
+	}
+	match, _ := regexp.MatchString(IPV4REGEX, ip)
+	return match
 }
 
 // printOutput of the remote jobs

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -53,6 +53,7 @@ type CmdResult struct {
 type RemoteCmdExecutor interface {
 	Execute() (map[string][]*CmdResult, error)
 	ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
+	GetSshUtil() SSHUtil
 }
 
 type remoteCmdExecutor struct {
@@ -64,6 +65,7 @@ type remoteCmdExecutor struct {
 type MockRemoteCmdExecutor struct {
 	ExecuteFunc            func() (map[string][]*CmdResult, error)
 	ExecuteWithNodeMapFunc func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
+	GetSshUtilFunc         func() SSHUtil
 }
 
 func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
@@ -72,6 +74,10 @@ func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
 
 func (m *MockRemoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 	return m.ExecuteWithNodeMapFunc(nodeMap)
+}
+
+func (m *MockRemoteCmdExecutor) GetSshUtil() SSHUtil {
+	return m.GetSshUtilFunc()
 }
 
 func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) RemoteCmdExecutor {
@@ -87,6 +93,10 @@ func NewRemoteCmdExecutorWithoutNodeMap(sshUtil SSHUtil, writer *cli.Writer) Rem
 		SshUtil: sshUtil,
 		Output:  writer,
 	}
+}
+
+func (c *remoteCmdExecutor) GetSshUtil() SSHUtil {
+	return c.SshUtil
 }
 
 func (c *remoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -52,6 +52,7 @@ type CmdResult struct {
 
 type RemoteCmdExecutor interface {
 	Execute() (map[string][]*CmdResult, error)
+	Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer)
 }
 
 type remoteCmdExecutor struct {
@@ -60,12 +61,31 @@ type remoteCmdExecutor struct {
 	Output  *cli.Writer
 }
 
+type MockRemoteCmdExecutor struct {
+	ExecuteFunc func() (map[string][]*CmdResult, error)
+	SetFunc     func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer)
+}
+
+func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
+	return m.ExecuteFunc()
+}
+
+func (m *MockRemoteCmdExecutor) Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+	m.SetFunc(nodeMap, sshUtil, writer)
+}
+
 func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) RemoteCmdExecutor {
 	return &remoteCmdExecutor{
 		NodeMap: nodeMap,
 		SshUtil: sshUtil,
 		Output:  writer,
 	}
+}
+
+func (c *remoteCmdExecutor) Set(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+	c.NodeMap = nodeMap
+	c.SshUtil = sshUtil
+	c.Output = writer
 }
 
 func (c *remoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -43,7 +43,7 @@ func TestExecute(t *testing.T) {
 
 	nodeFlagFalse := &Cmd{
 		CmdInputs: &CmdInputs{
-			NodeType: false,
+			NodeType:        false,
 			SkipPrintOutput: true,
 		},
 	}
@@ -52,7 +52,7 @@ func TestExecute(t *testing.T) {
 			return errors.New(errorForPreExec)
 		},
 		CmdInputs: &CmdInputs{
-			NodeType: true,
+			NodeType:        true,
 			SkipPrintOutput: true,
 		},
 	}
@@ -616,7 +616,7 @@ func TestPrintOutput(t *testing.T) {
 		{
 			name: "Print Success message and combine output files in one",
 			args: args{
-				remoteService: CONST_AUTOMATE,
+				remoteService: AUTOMATE,
 				result: CmdResult{
 					HostIP:      ip7,
 					OutputFiles: []string{out},
@@ -630,7 +630,7 @@ func TestPrintOutput(t *testing.T) {
 		{
 			name: "Print Success message and file combinations failed",
 			args: args{
-				remoteService: CONST_AUTOMATE,
+				remoteService: AUTOMATE,
 				result: CmdResult{
 					HostIP:      ip7,
 					OutputFiles: []string{fail},
@@ -644,7 +644,7 @@ func TestPrintOutput(t *testing.T) {
 		{
 			name: "Print Error message",
 			args: args{
-				remoteService: CONST_AUTOMATE,
+				remoteService: AUTOMATE,
 				result: CmdResult{
 					HostIP:      ip7,
 					OutputFiles: []string{},

--- a/components/automate-cli/cmd/chef-automate/constants.go
+++ b/components/automate-cli/cmd/chef-automate/constants.go
@@ -1,13 +1,13 @@
 package main
 
 const (
-	CONST_FRONTEND    = "frontend"
-	CONST_AUTOMATE    = "automate"
-	CONST_CHEF_SERVER = "chef_server"
-	CONST_POSTGRESQL  = "postgresql"
-	CONST_OPENSEARCH  = "opensearch"
-	SET               = "set"
-	PATCH             = "patch"
-	SUDO_PASSWORD     = "sudo_password"
-	IPV4REGEX         = `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
+	FRONTEND      = "frontend"
+	AUTOMATE      = "automate"
+	CHEF_SERVER   = "chef_server"
+	POSTGRESQL    = "postgresql"
+	OPENSEARCH    = "opensearch"
+	SET           = "set"
+	PATCH         = "patch"
+	SUDO_PASSWORD = "sudo_password"
+	IPV4REGEX     = `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
 )

--- a/components/automate-cli/cmd/chef-automate/constants.go
+++ b/components/automate-cli/cmd/chef-automate/constants.go
@@ -9,4 +9,5 @@ const (
 	SET               = "set"
 	PATCH             = "patch"
 	SUDO_PASSWORD     = "sudo_password"
+	IPV4REGEX         = `^(((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4})`
 )

--- a/components/automate-cli/cmd/chef-automate/ha_cert_show.go
+++ b/components/automate-cli/cmd/chef-automate/ha_cert_show.go
@@ -98,7 +98,7 @@ func NewCertShowImpl(flags certShowFlags, nodeUtils NodeOpUtils, sshUtil SSHUtil
 // certShowCmdFunc is the main function for the cert show command
 func certShowCmdFunc(flagsObj *certShowFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(&remoteCmdExecutor{}), NewSSHUtil(&SSHConfig{}), writer)
+		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), NewSSHUtil(&SSHConfig{}), writer)
 		return cs.certShow(cmd, args)
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/ha_cert_show.go
+++ b/components/automate-cli/cmd/chef-automate/ha_cert_show.go
@@ -98,7 +98,7 @@ func NewCertShowImpl(flags certShowFlags, nodeUtils NodeOpUtils, sshUtil SSHUtil
 // certShowCmdFunc is the main function for the cert show command
 func certShowCmdFunc(flagsObj *certShowFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(), NewSSHUtil(&SSHConfig{}), writer)
+		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(&remoteCmdExecutor{}), NewSSHUtil(&SSHConfig{}), writer)
 		return cs.certShow(cmd, args)
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/ha_cert_show.go
+++ b/components/automate-cli/cmd/chef-automate/ha_cert_show.go
@@ -7,6 +7,7 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/chef/automate/lib/platform/command"
 	"github.com/chef/automate/lib/stringutils"
 	"github.com/spf13/cobra"
 )
@@ -98,7 +99,7 @@ func NewCertShowImpl(flags certShowFlags, nodeUtils NodeOpUtils, sshUtil SSHUtil
 // certShowCmdFunc is the main function for the cert show command
 func certShowCmdFunc(flagsObj *certShowFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), NewSSHUtil(&SSHConfig{}), writer)
+		cs := NewCertShowImpl(*flagsObj, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), NewSSHUtil(&SSHConfig{}), writer)
 		return cs.certShow(cmd, args)
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/ha_cert_show.go
+++ b/components/automate-cli/cmd/chef-automate/ha_cert_show.go
@@ -68,16 +68,16 @@ func init() {
 		},
 	}
 
-	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.automate, CONST_AUTOMATE, "a", false, "Show Automate Certificates")
+	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.automate, AUTOMATE, "a", false, "Show Automate Certificates")
 	certShowCmd.PersistentFlags().BoolVar(&flagsObj.automate, "a2", false, "Show Automate Certificates")
 
-	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.chefserver, CONST_CHEF_SERVER, "c", false, "Show Chef Server Certificates")
+	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.chefserver, CHEF_SERVER, "c", false, "Show Chef Server Certificates")
 	certShowCmd.PersistentFlags().BoolVar(&flagsObj.chefserver, "cs", false, "Show Chef Server Certificates")
 
-	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.postgresql, CONST_POSTGRESQL, "p", false, "Show Postgres Certificates")
+	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.postgresql, POSTGRESQL, "p", false, "Show Postgres Certificates")
 	certShowCmd.PersistentFlags().BoolVar(&flagsObj.postgresql, "pg", false, "Show Postgres Certificates")
 
-	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.opensearch, CONST_OPENSEARCH, "o", false, "Show Opensearch Certificates")
+	certShowCmd.PersistentFlags().BoolVarP(&flagsObj.opensearch, OPENSEARCH, "o", false, "Show Opensearch Certificates")
 	certShowCmd.PersistentFlags().BoolVar(&flagsObj.opensearch, "os", false, "Show Opensearch Certificates")
 
 	certShowCmd.PersistentFlags().StringVarP(&flagsObj.node, "node", "n", "", "Service cluster's node IP address to show certificates, if not provided then all nodes certificates will be shown")
@@ -155,32 +155,32 @@ func (c *certShowImpl) fetchCurrentCerts() (*certShowCertificates, error) {
 
 func (c *certShowImpl) validateAndPrintCertificates(remoteService string, certInfo *certShowCertificates) error {
 	switch remoteService {
-	case CONST_AUTOMATE:
-		if err := c.validateNode(certInfo.AutomateCertsByIP, CONST_AUTOMATE); err != nil {
+	case AUTOMATE:
+		if err := c.validateNode(certInfo.AutomateCertsByIP, AUTOMATE); err != nil {
 			return err
 		}
-		c.printAutomateAndCSCertificates(certInfo.AutomateRootCert, certInfo.AutomateCertsByIP, stringutils.Title(CONST_AUTOMATE))
-	case CONST_CHEF_SERVER:
-		if err := c.validateNode(certInfo.ChefServerCertsByIP, CONST_CHEF_SERVER); err != nil {
+		c.printAutomateAndCSCertificates(certInfo.AutomateRootCert, certInfo.AutomateCertsByIP, stringutils.Title(AUTOMATE))
+	case CHEF_SERVER:
+		if err := c.validateNode(certInfo.ChefServerCertsByIP, CHEF_SERVER); err != nil {
 			return err
 		}
-		c.printAutomateAndCSCertificates("", certInfo.ChefServerCertsByIP, stringutils.TitleSplit(CONST_CHEF_SERVER, "_"))
-	case CONST_POSTGRESQL:
+		c.printAutomateAndCSCertificates("", certInfo.ChefServerCertsByIP, stringutils.TitleSplit(CHEF_SERVER, "_"))
+	case POSTGRESQL:
 		if c.nodeUtils.isManagedServicesOn() {
 			return status.New(status.InvalidCommandArgsError, "This command is not supported in Managed Services")
 		}
-		if err := c.validateNode(certInfo.PostgresqlCertsByIP, CONST_POSTGRESQL); err != nil {
+		if err := c.validateNode(certInfo.PostgresqlCertsByIP, POSTGRESQL); err != nil {
 			return err
 		}
-		c.printPostgresqlAndOSCertificates(certInfo.PostgresqlRootCert, "", "", certInfo.PostgresqlCertsByIP, stringutils.Title(CONST_POSTGRESQL))
-	case CONST_OPENSEARCH:
+		c.printPostgresqlAndOSCertificates(certInfo.PostgresqlRootCert, "", "", certInfo.PostgresqlCertsByIP, stringutils.Title(POSTGRESQL))
+	case OPENSEARCH:
 		if c.nodeUtils.isManagedServicesOn() {
 			return status.New(status.InvalidCommandArgsError, "This command is not supported in Managed Services")
 		}
-		if err := c.validateNode(certInfo.OpensearchCertsByIP, CONST_OPENSEARCH); err != nil {
+		if err := c.validateNode(certInfo.OpensearchCertsByIP, OPENSEARCH); err != nil {
 			return err
 		}
-		c.printPostgresqlAndOSCertificates(certInfo.OpensearchRootCert, certInfo.OpensearchAdminKey, certInfo.OpensearchAdminCert, certInfo.OpensearchCertsByIP, stringutils.Title(CONST_OPENSEARCH))
+		c.printPostgresqlAndOSCertificates(certInfo.OpensearchRootCert, certInfo.OpensearchAdminKey, certInfo.OpensearchAdminCert, certInfo.OpensearchCertsByIP, stringutils.Title(OPENSEARCH))
 	default:
 		c.printAllCertificates(certInfo)
 	}
@@ -225,12 +225,12 @@ func (c *certShowImpl) getCerts(config interface{}) (*certShowCertificates, erro
 
 // printAllCertificates prints all certificates
 func (c *certShowImpl) printAllCertificates(certInfo *certShowCertificates) {
-	c.printAutomateAndCSCertificates(certInfo.AutomateRootCert, certInfo.AutomateCertsByIP, stringutils.Title(CONST_AUTOMATE))
-	c.printAutomateAndCSCertificates("", certInfo.ChefServerCertsByIP, stringutils.TitleSplit(CONST_CHEF_SERVER, "_"))
+	c.printAutomateAndCSCertificates(certInfo.AutomateRootCert, certInfo.AutomateCertsByIP, stringutils.Title(AUTOMATE))
+	c.printAutomateAndCSCertificates("", certInfo.ChefServerCertsByIP, stringutils.TitleSplit(CHEF_SERVER, "_"))
 
 	if !c.nodeUtils.isManagedServicesOn() {
-		c.printPostgresqlAndOSCertificates(certInfo.PostgresqlRootCert, "", "", certInfo.PostgresqlCertsByIP, stringutils.Title(CONST_POSTGRESQL))
-		c.printPostgresqlAndOSCertificates(certInfo.OpensearchRootCert, certInfo.OpensearchAdminKey, certInfo.OpensearchAdminCert, certInfo.OpensearchCertsByIP, stringutils.Title(CONST_OPENSEARCH))
+		c.printPostgresqlAndOSCertificates(certInfo.PostgresqlRootCert, "", "", certInfo.PostgresqlCertsByIP, stringutils.Title(POSTGRESQL))
+		c.printPostgresqlAndOSCertificates(certInfo.OpensearchRootCert, certInfo.OpensearchAdminKey, certInfo.OpensearchAdminCert, certInfo.OpensearchCertsByIP, stringutils.Title(OPENSEARCH))
 	}
 }
 
@@ -239,7 +239,7 @@ func (c *certShowImpl) printAutomateAndCSCertificates(rootCA string, certsByIP [
 	c.writer.Title(fmt.Sprintf("%s Certificates", remoteServiceName))
 	c.writer.HR()
 
-	if remoteServiceName == stringutils.Title(CONST_AUTOMATE) {
+	if remoteServiceName == stringutils.Title(AUTOMATE) {
 		c.writer.Println("========================Automate Root CA========================")
 		if len(strings.TrimSpace(rootCA)) == 0 {
 			c.writer.Println("No Automate root certificate found")
@@ -277,7 +277,7 @@ func (c *certShowImpl) printPostgresqlAndOSCertificates(rootCA, adminKey, adminC
 		c.writer.Println(rootCA)
 	}
 
-	if remoteServiceName == stringutils.Title(CONST_OPENSEARCH) {
+	if remoteServiceName == stringutils.Title(OPENSEARCH) {
 		c.writer.Println("\n======================Opensearch Admin Key======================")
 		if len(strings.TrimSpace(adminKey)) == 0 {
 			c.writer.Println("No admin key found")
@@ -372,13 +372,13 @@ func (c *certShowImpl) isCommonCerts(certs []CertByIP) bool {
 // getRemoteService returns the remote service name based on the flags
 func (c *certShowImpl) getRemoteService() string {
 	if c.flags.automate {
-		return CONST_AUTOMATE
+		return AUTOMATE
 	} else if c.flags.chefserver {
-		return CONST_CHEF_SERVER
+		return CHEF_SERVER
 	} else if c.flags.postgresql {
-		return CONST_POSTGRESQL
+		return POSTGRESQL
 	} else if c.flags.opensearch {
-		return CONST_OPENSEARCH
+		return OPENSEARCH
 	} else {
 		return ""
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add.go
@@ -64,13 +64,13 @@ func haAddNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deployer
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/platform/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -64,13 +65,13 @@ func haAddNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deployer
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add.go
@@ -64,13 +64,13 @@ func haAddNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deployer
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewAddNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("Flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
@@ -57,7 +57,7 @@ func TestAddnodeAWSValidate(t *testing.T) {
 	})
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
-	assert.Equal(t, "3", nodeAdd.(*AddNodeAWSImpl).config.Opensearch.Config.InstanceCount)
+	assert.Equal(t, "6", nodeAdd.(*AddNodeAWSImpl).config.Opensearch.Config.InstanceCount)
 }
 
 func TestAddnodeAWSValidateErrorIsManagedServicesOn(t *testing.T) {
@@ -141,15 +141,15 @@ func TestAddAwsnodePrompt(t *testing.T) {
 	assert.Contains(t, w.Output(), `Existing node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 3
+Chef-Server => 2
+OpenSearch => 6
 Postgresql => 4
 
 New node count:
 ================================================
 Automate => 6
-Chef-Server => 1
-OpenSearch => 3
+Chef-Server => 2
+OpenSearch => 6
 Postgresql => 4
 This will add the new nodes to your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 }
@@ -194,22 +194,22 @@ func TestAddnodeDeployWithNewOSNodeInAws(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, "4", nodeAdd.(*AddNodeAWSImpl).config.Opensearch.Config.InstanceCount)
+	assert.Equal(t, "7", nodeAdd.(*AddNodeAWSImpl).config.Opensearch.Config.InstanceCount)
 	res, err := nodeAdd.promptUserConfirmation()
 	assert.Equal(t, true, res)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 3
+Chef-Server => 2
+OpenSearch => 6
 Postgresql => 4
 
 New node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 4
+Chef-Server => 2
+OpenSearch => 7
 Postgresql => 4
 This will add the new nodes to your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	err = nodeAdd.runDeploy()
@@ -282,15 +282,15 @@ func TestAddnodeWithExecuteFuncGenConfigErr(t *testing.T) {
 	assert.Contains(t, w.Output(), `Existing node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 3
+Chef-Server => 2
+OpenSearch => 6
 Postgresql => 4
 
 New node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 4
+Chef-Server => 2
+OpenSearch => 7
 Postgresql => 4
 This will add the new nodes to your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	assert.Equal(t, true, autoFileMoved)
@@ -346,15 +346,15 @@ func TestAddnodeWithExecuteFunc(t *testing.T) {
 	assert.Contains(t, w.Output(), `Existing node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 3
+Chef-Server => 2
+OpenSearch => 6
 Postgresql => 4
 
 New node count:
 ================================================
 Automate => 5
-Chef-Server => 1
-OpenSearch => 4
+Chef-Server => 2
+OpenSearch => 7
 Postgresql => 4
 This will add the new nodes to your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	assert.Equal(t, true, autoFileMoved)

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
@@ -13,7 +13,7 @@ import (
 const CONFIG_TOML_PATH_AWS = "../../pkg/testfiles/aws"
 
 func TestAddnodeAWSValidateError(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{automateCount: 0}
 	nodeAdd := NewAddNodeAWS(w.CliWriter, flags, &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -37,7 +37,7 @@ func TestAddnodeAWSValidateError(t *testing.T) {
 }
 
 func TestAddnodeAWSValidate(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{opensearchCount: 1}
 	nodeAdd := NewAddNodeAWS(w.CliWriter, flags, &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -61,7 +61,7 @@ func TestAddnodeAWSValidate(t *testing.T) {
 }
 
 func TestAddnodeAWSValidateErrorIsManagedServicesOn(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{opensearchCount: 1}
 	nodeAdd := NewAddNodeAWS(w.CliWriter, flags, &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -85,7 +85,7 @@ func TestAddnodeAWSValidateErrorIsManagedServicesOn(t *testing.T) {
 }
 
 func TestAddnodeModifyAws(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		chefServerCount: 1,
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete.go
@@ -51,13 +51,13 @@ func haDeleteNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deplo
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete.go
@@ -51,13 +51,13 @@ func haDeleteNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deplo
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(&remoteCmdExecutor{}), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/platform/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -51,13 +52,13 @@ func haDeleteNodeFactory(addDeleteNodeHACmdFlags *AddDeleteNodeHACmdFlags, deplo
 	switch deployerType {
 	case EXISTING_INFRA_MODE:
 		if !addDeleteNodeHACmdFlags.awsMode {
-			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeOnPrem(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --onprem-mode flag", deployerType)
 		}
 	case AWS_MODE:
 		if !addDeleteNodeHACmdFlags.onPremMode {
-			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer)), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
+			hamd = NewDeleteNodeAWS(writer, *addDeleteNodeHACmdFlags, NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor()), initConfigHabA2HAPathFlag.a2haDirPath, &fileutils.FileSystemUtils{}, NewSSHUtil(&SSHConfig{}))
 		} else {
 			err = fmt.Errorf("flag given does not match with the current deployment type %s. Try with --aws-mode flag", deployerType)
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -119,7 +119,6 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 		}
 	}
 
-	// If the node is successfully remove, delete the machine
 	if err == nil {
 		dna.writer.Println("Node is successfully deleted from the cluster.")
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -109,22 +109,22 @@ func (dna *DeleteNodeAWSImpl) modifyConfig() error {
 	var err error
 
 	switch dna.nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		err = modifyConfigForDeleteNodeForAWS(
 			&dna.config.Automate.Config.InstanceCount,
 			[]string{dna.ipToDelete},
 		)
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		err = modifyConfigForDeleteNodeForAWS(
 			&dna.config.ChefServer.Config.InstanceCount,
 			[]string{dna.ipToDelete},
 		)
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		err = modifyConfigForDeleteNodeForAWS(
 			&dna.config.Postgresql.Config.InstanceCount,
 			[]string{dna.ipToDelete},
 		)
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		err = modifyConfigForDeleteNodeForAWS(
 			&dna.config.Opensearch.Config.InstanceCount,
 			[]string{dna.ipToDelete},
@@ -195,16 +195,16 @@ func (dna *DeleteNodeAWSImpl) runRemoveNodeFromAws() error {
 	var instanceType string
 	var configNodeIpList []string
 	switch dna.nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		instanceType = "chef_automate"
 		configNodeIpList = dna.configAutomateIpList
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		instanceType = "chef_server"
 		configNodeIpList = dna.configChefServerIpList
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		instanceType = "chef_automate_postgresql"
 		configNodeIpList = dna.configPostgresqlIpList
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		instanceType = "chef_automate_opensearch"
 		configNodeIpList = dna.configOpensearchIpList
 	default:
@@ -249,16 +249,16 @@ func (dna *DeleteNodeAWSImpl) validate() error {
 	// Get the node type and ip address of the node to be deleted
 	if len(automateIpList) > 0 {
 		dna.ipToDelete = automateIpList[0]
-		dna.nodeType = CONST_AUTOMATE
+		dna.nodeType = AUTOMATE
 	} else if len(chefServerIpList) > 0 {
 		dna.ipToDelete = chefServerIpList[0]
-		dna.nodeType = CONST_CHEF_SERVER
+		dna.nodeType = CHEF_SERVER
 	} else if len(postgresqlIpList) > 0 {
 		dna.ipToDelete = postgresqlIpList[0]
-		dna.nodeType = CONST_POSTGRESQL
+		dna.nodeType = POSTGRESQL
 	} else if len(opensearchIpList) > 0 {
 		dna.ipToDelete = opensearchIpList[0]
-		dna.nodeType = CONST_OPENSEARCH
+		dna.nodeType = OPENSEARCH
 	} else {
 		return status.New(status.InvalidCommandArgsError, "Please provide service name and ip address of the node which you want to delete")
 	}
@@ -273,7 +273,7 @@ func (dna *DeleteNodeAWSImpl) validate() error {
 	}
 	dna.config = *updatedConfig
 	if dna.nodeUtils.isManagedServicesOn() {
-		if dna.nodeType == CONST_POSTGRESQL || dna.nodeType == CONST_OPENSEARCH {
+		if dna.nodeType == POSTGRESQL || dna.nodeType == OPENSEARCH {
 			return status.New(status.ConfigError, fmt.Sprintf(TYPE_ERROR, "remove"))
 		}
 	}
@@ -292,19 +292,19 @@ func (dna *DeleteNodeAWSImpl) validateCmdArgs() *list.List {
 	var configIpList []string
 
 	switch dna.nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		instanceCount = dna.config.Automate.Config.InstanceCount
 		minCount = AUTOMATE_MIN_INSTANCE_COUNT
 		configIpList = dna.configAutomateIpList
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		instanceCount = dna.config.ChefServer.Config.InstanceCount
 		minCount = CHEF_SERVER_MIN_INSTANCE_COUNT
 		configIpList = dna.configChefServerIpList
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		instanceCount = dna.config.Postgresql.Config.InstanceCount
 		minCount = POSTGRESQL_MIN_INSTANCE_COUNT
 		configIpList = dna.configPostgresqlIpList
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		instanceCount = dna.config.Opensearch.Config.InstanceCount
 		minCount = OPENSEARCH_MIN_INSTANCE_COUNT
 		configIpList = dna.configOpensearchIpList

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -9,30 +9,22 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/stringutils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-type SvcDetails struct {
-	ipList         []string
-	configIpList   []string
-	instanceCount  string
-	minInstanceCnt int
-	name           string
-}
 type DeleteNodeAWSImpl struct {
-	config           AwsConfigToml
-	automateIpList   []string
-	chefServerIpList []string
-	opensearchIpList []string
-	postgresqlIpList []string
-	nodeUtils        NodeOpUtils
-	flags            AddDeleteNodeHACmdFlags
-	configpath       string
-	terraformPath    string
-	writer           *cli.Writer
-	fileUtils        fileutils.FileUtils
-	sshUtil          SSHUtil
+	config        AwsConfigToml
+	ipToDelete    string
+	nodeType      string
+	nodeUtils     NodeOpUtils
+	flags         AddDeleteNodeHACmdFlags
+	configpath    string
+	terraformPath string
+	writer        *cli.Writer
+	fileUtils     fileutils.FileUtils
+	sshUtil       SSHUtil
 	AWSConfigIp
 }
 
@@ -57,18 +49,14 @@ var (
 
 func NewDeleteNodeAWS(writer *cli.Writer, flags AddDeleteNodeHACmdFlags, nodeUtils NodeOpUtils, haDirPath string, fileutils fileutils.FileUtils, sshUtil SSHUtil) HAModifyAndDeploy {
 	return &DeleteNodeAWSImpl{
-		config:           AwsConfigToml{},
-		automateIpList:   []string{},
-		chefServerIpList: []string{},
-		opensearchIpList: []string{},
-		postgresqlIpList: []string{},
-		nodeUtils:        nodeUtils,
-		flags:            flags,
-		configpath:       filepath.Join(haDirPath, "config.toml"),
-		terraformPath:    filepath.Join(haDirPath, "terraform"),
-		writer:           writer,
-		fileUtils:        fileutils,
-		sshUtil:          sshUtil,
+		config:        AwsConfigToml{},
+		nodeUtils:     nodeUtils,
+		flags:         flags,
+		configpath:    filepath.Join(haDirPath, "config.toml"),
+		terraformPath: filepath.Join(haDirPath, "terraform"),
+		writer:        writer,
+		fileUtils:     fileutils,
+		sshUtil:       sshUtil,
 	}
 }
 
@@ -107,53 +95,52 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 		return err
 	}
 
-	return dna.runDeploy()
-}
-func (dna *DeleteNodeAWSImpl) modifyConfig() error {
-	dna.config.Architecture.ConfigInitials.Architecture = "aws"
-	err := modifyConfigForDeleteNodeForAWS(
-		&dna.config.Automate.Config.InstanceCount,
-		dna.automateIpList,
-	)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error modifying automate instance count")
-	}
-	err = modifyConfigForDeleteNodeForAWS(
-		&dna.config.ChefServer.Config.InstanceCount,
-		dna.chefServerIpList,
-	)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error modifying chef-server instance count")
-	}
-	err = modifyConfigForDeleteNodeForAWS(
-		&dna.config.Opensearch.Config.InstanceCount,
-		dna.opensearchIpList,
-	)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error modifying opensearch instance count")
-	}
-	err = modifyConfigForDeleteNodeForAWS(
-		&dna.config.Postgresql.Config.InstanceCount,
-		dna.postgresqlIpList,
-	)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error modifying postgresql instance count")
-	}
-	return nil
-}
-
-func (dna *DeleteNodeAWSImpl) prepare() error {
-	// Stop all services on the node to be deleted
-	infra, _, err := dna.nodeUtils.getHaInfraDetails()
+	err = dna.runDeploy()
 	if err != nil {
 		return err
 	}
 
-	err = dna.nodeUtils.stopServicesOnNode(dna.automateIpList, dna.chefServerIpList, dna.postgresqlIpList, dna.opensearchIpList, infra, dna.sshUtil)
-	if err != nil {
-		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
+	return dna.stopNodes()
+}
+
+func (dna *DeleteNodeAWSImpl) modifyConfig() error {
+	dna.config.Architecture.ConfigInitials.Architecture = "aws"
+
+	var err error
+
+	switch dna.nodeType {
+	case CONST_AUTOMATE:
+		err = modifyConfigForDeleteNodeForAWS(
+			&dna.config.Automate.Config.InstanceCount,
+			[]string{dna.ipToDelete},
+		)
+	case CONST_CHEF_SERVER:
+		err = modifyConfigForDeleteNodeForAWS(
+			&dna.config.ChefServer.Config.InstanceCount,
+			[]string{dna.ipToDelete},
+		)
+	case CONST_POSTGRESQL:
+		err = modifyConfigForDeleteNodeForAWS(
+			&dna.config.Postgresql.Config.InstanceCount,
+			[]string{dna.ipToDelete},
+		)
+	case CONST_OPENSEARCH:
+		err = modifyConfigForDeleteNodeForAWS(
+			&dna.config.Opensearch.Config.InstanceCount,
+			[]string{dna.ipToDelete},
+		)
+	default:
+		return errors.New("Invalid node type")
 	}
 
+	if err != nil {
+		return status.Wrap(err, status.ConfigError, "Error modifying "+stringutils.TitleReplace(dna.nodeType, "_", "-")+" instance count")
+	}
+
+	return nil
+}
+
+func (dna *DeleteNodeAWSImpl) prepare() error {
 	return dna.nodeUtils.taintTerraform(dna.terraformPath)
 }
 
@@ -165,22 +152,13 @@ func (dna *DeleteNodeAWSImpl) promptUserConfirmation() (bool, error) {
 	dna.writer.Println("OpenSearch => " + strings.Join(dna.AWSConfigIp.configOpensearchIpList, ", "))
 	dna.writer.Println("Postgresql => " + strings.Join(dna.AWSConfigIp.configPostgresqlIpList, ", "))
 	dna.writer.Println("")
-	dna.writer.Println("Nodes to be deleted:")
+	dna.writer.Println("Node to be deleted:")
 	dna.writer.Println("================================================")
-	if len(dna.automateIpList) > 0 {
-		dna.writer.Println("Automate => " + strings.Join(dna.automateIpList, ", "))
-	}
-	if len(dna.chefServerIpList) > 0 {
-		dna.writer.Println("Chef-Server => " + strings.Join(dna.chefServerIpList, ", "))
-	}
-	if len(dna.opensearchIpList) > 0 {
-		dna.writer.Println("OpenSearch => " + strings.Join(dna.opensearchIpList, ", "))
-	}
-	if len(dna.postgresqlIpList) > 0 {
-		dna.writer.Println("Postgresql => " + strings.Join(dna.postgresqlIpList, ", "))
-	}
-	dna.writer.Println("Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.")
-	return dna.writer.Confirm("This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue?")
+
+	dna.writer.Println(fmt.Sprintf("%s => %s", stringutils.TitleReplace(dna.nodeType, "_", "-"), dna.ipToDelete))
+
+	dna.writer.Println("Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.")
+	return dna.writer.Confirm("This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue?")
 }
 
 func (dna *DeleteNodeAWSImpl) runDeploy() error {
@@ -213,34 +191,38 @@ func (dna *DeleteNodeAWSImpl) runDeploy() error {
 }
 
 func (dna *DeleteNodeAWSImpl) runRemoveNodeFromAws() error {
-	err := dna.removeNodeIfExists("chef_automate", dna.automateIpList, dna.configAutomateIpList)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error removing automate node")
+
+	var instanceType string
+	var configNodeIpList []string
+	switch dna.nodeType {
+	case CONST_AUTOMATE:
+		instanceType = "chef_automate"
+		configNodeIpList = dna.configAutomateIpList
+	case CONST_CHEF_SERVER:
+		instanceType = "chef_server"
+		configNodeIpList = dna.configChefServerIpList
+	case CONST_POSTGRESQL:
+		instanceType = "chef_automate_postgresql"
+		configNodeIpList = dna.configPostgresqlIpList
+	case CONST_OPENSEARCH:
+		instanceType = "chef_automate_opensearch"
+		configNodeIpList = dna.configOpensearchIpList
+	default:
+		status.New(status.InvalidCommandArgsError, "Invalid node type")
 	}
 
-	err = dna.removeNodeIfExists("chef_server", dna.chefServerIpList, dna.configChefServerIpList)
+	err := dna.removeNodeIfExists(instanceType, dna.ipToDelete, configNodeIpList)
 	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error removing chef server node")
+		return status.Wrap(err, status.ConfigError, "Error removing "+stringutils.TitleReplace(dna.nodeType, "_", "-")+" node")
 	}
 
-	err = dna.removeNodeIfExists("chef_automate_opensearch", dna.opensearchIpList, dna.configOpensearchIpList)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error removing opensearch node")
-	}
-
-	err = dna.removeNodeIfExists("chef_automate_postgresql", dna.postgresqlIpList, dna.configPostgresqlIpList)
-	if err != nil {
-		return status.Wrap(err, status.ConfigError, "Error removing postgresql node")
-	}
 	return nil
 }
 
-func (dna *DeleteNodeAWSImpl) removeNodeIfExists(nodeType string, nodeIpList, configNodeIpList []string) error {
-	if len(nodeIpList) == 1 {
-		for i := 0; i < len(configNodeIpList); i++ {
-			if configNodeIpList[i] == nodeIpList[0] {
-				return dna.removeNodeFromAws(nodeType, i, len(configNodeIpList)-1)
-			}
+func (dna *DeleteNodeAWSImpl) removeNodeIfExists(nodeType, ipToDelete string, configNodeIpList []string) error {
+	for i := 0; i < len(configNodeIpList); i++ {
+		if configNodeIpList[i] == ipToDelete {
+			return dna.removeNodeFromAws(nodeType, i, len(configNodeIpList)-1)
 		}
 	}
 	return nil
@@ -251,25 +233,47 @@ func (dna *DeleteNodeAWSImpl) validate() error {
 	if err != nil {
 		return status.Wrap(err, status.ConfigError, "Error getting AWS instance Ip")
 	}
-	dna.automateIpList, dna.chefServerIpList, dna.opensearchIpList, dna.postgresqlIpList = splitIPCSV(
+
+	automateIpList, chefServerIpList, opensearchIpList, postgresqlIpList := splitIPCSV(
 		dna.flags.automateIp,
 		dna.flags.chefServerIp,
 		dna.flags.opensearchIp,
 		dna.flags.postgresqlIp,
 	)
-	var exceptionIps []string
-	exceptionIps = append(exceptionIps, dna.automateIpList...)
-	exceptionIps = append(exceptionIps, dna.chefServerIpList...)
-	exceptionIps = append(exceptionIps, dna.opensearchIpList...)
-	exceptionIps = append(exceptionIps, dna.postgresqlIpList...)
 
-	updatedConfig, err := dna.nodeUtils.pullAndUpdateConfigAws(&dna.sshUtil, exceptionIps)
+	// Check if only one node is being deleted
+	if (len(automateIpList) + len(chefServerIpList) + len(opensearchIpList) + len(postgresqlIpList)) != 1 {
+		return status.New(status.InvalidCommandArgsError, "Only one node can be deleted at a time")
+	}
+
+	// Get the node type and ip address of the node to be deleted
+	if len(automateIpList) > 0 {
+		dna.ipToDelete = automateIpList[0]
+		dna.nodeType = CONST_AUTOMATE
+	} else if len(chefServerIpList) > 0 {
+		dna.ipToDelete = chefServerIpList[0]
+		dna.nodeType = CONST_CHEF_SERVER
+	} else if len(postgresqlIpList) > 0 {
+		dna.ipToDelete = postgresqlIpList[0]
+		dna.nodeType = CONST_POSTGRESQL
+	} else if len(opensearchIpList) > 0 {
+		dna.ipToDelete = opensearchIpList[0]
+		dna.nodeType = CONST_OPENSEARCH
+	} else {
+		return status.New(status.InvalidCommandArgsError, "Please provide service name and ip address of the node which you want to delete")
+	}
+
+	if !isValidIPFormat(dna.ipToDelete) {
+		return status.New(status.InvalidCommandArgsError, "Invalid IP address "+dna.ipToDelete)
+	}
+
+	updatedConfig, err := dna.nodeUtils.pullAndUpdateConfigAws(&dna.sshUtil, []string{dna.ipToDelete})
 	if err != nil {
 		return err
 	}
 	dna.config = *updatedConfig
 	if dna.nodeUtils.isManagedServicesOn() {
-		if len(dna.opensearchIpList) > 0 || len(dna.postgresqlIpList) > 0 {
+		if dna.nodeType == CONST_POSTGRESQL || dna.nodeType == CONST_OPENSEARCH {
 			return status.New(status.ConfigError, fmt.Sprintf(TYPE_ERROR, "remove"))
 		}
 	}
@@ -282,38 +286,41 @@ func (dna *DeleteNodeAWSImpl) validate() error {
 
 func (dna *DeleteNodeAWSImpl) validateCmdArgs() *list.List {
 	errorList := list.New()
-	services := []SvcDetails{
-		{dna.automateIpList, dna.configAutomateIpList, dna.config.Automate.Config.InstanceCount, AUTOMATE_MIN_INSTANCE_COUNT, "Automate"},
-		{dna.chefServerIpList, dna.configChefServerIpList, dna.config.ChefServer.Config.InstanceCount, CHEF_SERVER_MIN_INSTANCE_COUNT, "Chef-Server"},
-	}
-	if !dna.nodeUtils.isManagedServicesOn() {
-		services = append(services, []SvcDetails{
-			{dna.opensearchIpList, dna.configOpensearchIpList, dna.config.Opensearch.Config.InstanceCount, OPENSEARCH_MIN_INSTANCE_COUNT, "OpenSearch"},
-			{dna.postgresqlIpList, dna.configPostgresqlIpList, dna.config.Postgresql.Config.InstanceCount, POSTGRESQL_MIN_INSTANCE_COUNT, "Postgresql"},
-		}...)
+
+	var minCount int
+	var instanceCount string
+	var configIpList []string
+
+	switch dna.nodeType {
+	case CONST_AUTOMATE:
+		instanceCount = dna.config.Automate.Config.InstanceCount
+		minCount = AUTOMATE_MIN_INSTANCE_COUNT
+		configIpList = dna.configAutomateIpList
+	case CONST_CHEF_SERVER:
+		instanceCount = dna.config.ChefServer.Config.InstanceCount
+		minCount = CHEF_SERVER_MIN_INSTANCE_COUNT
+		configIpList = dna.configChefServerIpList
+	case CONST_POSTGRESQL:
+		instanceCount = dna.config.Postgresql.Config.InstanceCount
+		minCount = POSTGRESQL_MIN_INSTANCE_COUNT
+		configIpList = dna.configPostgresqlIpList
+	case CONST_OPENSEARCH:
+		instanceCount = dna.config.Opensearch.Config.InstanceCount
+		minCount = OPENSEARCH_MIN_INSTANCE_COUNT
+		configIpList = dna.configOpensearchIpList
+	default:
+		errorList.PushBack("Invalid node type")
 	}
 
-	// Check if only one node is being deleted
-	if (len(dna.automateIpList) + len(dna.chefServerIpList) + len(dna.opensearchIpList) + len(dna.postgresqlIpList)) != 1 {
-		errorList.PushBack("Only one node can be deleted at a time")
-		return errorList
+	allowed, finalCount, err := isFinalInstanceCountAllowed(instanceCount, -1, minCount)
+	if err != nil {
+		errorList.PushBack(fmt.Sprintf("Error occurred in calculating %s final instance count", stringutils.TitleReplace(dna.nodeType, "_", "-")))
 	}
+	if !allowed {
+		errorList.PushBack(fmt.Sprintf("Unable to remove node. %s instance count cannot be less than %d. Final count %d not allowed.", stringutils.TitleReplace(dna.nodeType, "_", "-"), minCount, finalCount))
+	}
+	errorList.PushBackList(checkIfPresentInPrivateIPList(configIpList, []string{dna.ipToDelete}, stringutils.TitleReplace(dna.nodeType, "_", "-")))
 
-	for _, service := range services {
-		if len(service.ipList) > 1 {
-			errorList.PushBack(fmt.Sprintf("Only one %s is allowed to delete for AWS deployment type", service.name))
-		} else if len(service.ipList) == 1 {
-			allowed, finalCount, err := isFinalInstanceCountAllowed(service.instanceCount, -len(service.ipList), service.minInstanceCnt)
-			if err != nil {
-				errorList.PushBack(fmt.Sprintf("Error occurred in calculating %s final instance count", service.name))
-				continue
-			}
-			if !allowed {
-				errorList.PushBack(fmt.Sprintf("Unable to remove node. %s instance count cannot be less than %d. Final count %d not allowed.", service.name, service.minInstanceCnt, finalCount))
-			}
-			errorList.PushBackList(checkIfPresentInPrivateIPList(service.configIpList, service.ipList, service.name))
-		}
-	}
 	return errorList
 }
 
@@ -349,5 +356,20 @@ func (dna *DeleteNodeAWSImpl) getAwsHAIp() error {
 		return err
 	}
 	dna.AWSConfigIp = *ConfigIp
+	return nil
+}
+
+// Stop all services on the node to be deleted
+func (dna *DeleteNodeAWSImpl) stopNodes() error {
+
+	infra, _, err := dna.nodeUtils.getHaInfraDetails()
+	if err != nil {
+		return err
+	}
+
+	err = dna.nodeUtils.stopServicesOnNode(dna.ipToDelete, dna.nodeType, infra, dna.sshUtil)
+	if err != nil {
+		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
+	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -117,6 +117,11 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 			}
 			return stopErr
 		}
+	} else {
+		if err != nil {
+			return errors.Wrap(err, "Error in deleting node")
+		}
+		return errors.New("Error in deleting node")
 	}
 
 	if err == nil {

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -144,7 +144,12 @@ func (dna *DeleteNodeAWSImpl) modifyConfig() error {
 
 func (dna *DeleteNodeAWSImpl) prepare() error {
 	// Stop all services on the node to be deleted
-	err := dna.nodeUtils.stopServicesOnNode(dna.automateIpList, dna.chefServerIpList, dna.postgresqlIpList, dna.opensearchIpList)
+	infra, _, err := dna.nodeUtils.getHaInfraDetails()
+	if err != nil {
+		return err
+	}
+
+	err = dna.nodeUtils.stopServicesOnNode(dna.automateIpList, dna.chefServerIpList, dna.postgresqlIpList, dna.opensearchIpList, infra, dna.sshUtil)
 	if err != nil {
 		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -101,17 +101,16 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 	}
 
 	err = dna.runDeploy()
-	if err != nil {
-		fmt.Println("Error occurred while deploying: ", err)
-	}
-
 	currentCount, newErr := dna.nodeUtils.calculateTotalInstanceCount()
 	if newErr != nil {
-		return newErr
+		return errors.Wrap(err, newErr.Error())
 	}
 
 	if currentCount == previousCount-1 {
-		return dna.stopNodes()
+		stopErr := dna.stopNodes()
+		if stopErr != nil {
+			return errors.Wrap(err, stopErr.Error())
+		}
 	}
 
 	return err

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -113,6 +113,11 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 		}
 	}
 
+	// If the node is successfully remove, delete the machine
+	if err == nil {
+		dna.writer.Println("Node is successfully deleted from the cluster.")
+	}
+
 	return err
 }
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -392,7 +392,7 @@ func (dna *DeleteNodeAWSImpl) stopNodes() error {
 
 	err = dna.nodeUtils.stopServicesOnNode(dna.ipToDelete, dna.nodeType, AWS_MODE, infra)
 	if err != nil {
-		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
+		return status.Wrap(err, status.CommandExecutionError, "Error stopping services on node")
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -103,13 +103,19 @@ func (dna *DeleteNodeAWSImpl) Execute(c *cobra.Command, args []string) error {
 	err = dna.runDeploy()
 	currentCount, newErr := dna.nodeUtils.calculateTotalInstanceCount()
 	if newErr != nil {
-		return errors.Wrap(err, newErr.Error())
+		if err != nil {
+			return errors.Wrap(err, newErr.Error())
+		}
+		return newErr
 	}
 
 	if currentCount == previousCount-1 {
 		stopErr := dna.stopNodes()
 		if stopErr != nil {
-			return errors.Wrap(err, stopErr.Error())
+			if err != nil {
+				return errors.Wrap(err, stopErr.Error())
+			}
+			return stopErr
 		}
 	}
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -648,79 +648,94 @@ func TestDeletenodeAWSExecuteWithError(t *testing.T) {
 }
 
 func TestDeletenodeAWSExecuteNoError(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("y")
-	flags := AddDeleteNodeHACmdFlags{
-		automateIp: "192.0.0.1",
-	}
 	var ipAddres, filewritten, executeCommands, autoFileMoved, tfArchModified bool
-
-	nodeDelete := NewDeleteNodeAWS(
-		w.CliWriter,
-		flags,
-		&MockNodeUtilsImpl{
-			getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-				return nil, &SSHConfig{}, nil
-			},
-			executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
-				return nil
-			},
-			writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
-				filewritten = true
-				return nil
-			},
-			getModeFromConfigFunc: func(path string) (string, error) {
-				return EXISTING_INFRA_MODE, nil
-			},
-			isManagedServicesOnFunc: func() bool {
-				return false
-			},
-			pullAndUpdateConfigAwsFunc: PullAwsConfFunc,
-			isA2HARBFileExistFunc: func() bool {
-				return true
-			},
-			taintTerraformFunc: func(path string) error {
-				return nil
-			},
-			getAWSConfigIpFunc: func() (*AWSConfigIp, error) {
-				ipAddres = true
-				return &AWSConfigIp{
-					configAutomateIpList:   []string{"192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4"},
-					configChefServerIpList: []string{"192.0.1.1", "192.0.1.2", "192.0.1.3", "192.0.1.4"},
-					configOpensearchIpList: []string{"192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"},
-					configPostgresqlIpList: []string{"192.0.3.1", "192.0.3.2", "192.0.3.3", "192.0.3.4"},
-				}, nil
-			},
-			executeShellCommandFunc: func() error {
-				executeCommands = true
-				return nil
-			},
-			moveAWSAutoTfvarsFileFunc: func(path string) error {
-				autoFileMoved = true
-				return nil
-			},
-			modifyTfArchFileFunc: func(path string) error {
-				tfArchModified = true
-				return nil
-			},
-			stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
-				return nil
-			},
-			calculateTotalInstanceCountFunc: func() (int, error) {
-				return 0, nil
-			},
+	mnu := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			return nil, &SSHConfig{}, nil
 		},
-		CONFIG_TOML_PATH_AWS,
-		&fileutils.MockFileSystemUtils{},
-		&MockSSHUtilsImpl{
-			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
-				return "", nil
-			},
-		})
-	err := nodeDelete.Execute(nil, nil)
-	assert.NoError(t, err)
-	assert.True(t, tfArchModified)
-	assert.True(t, ipAddres)
-	assert.True(t, filewritten)
-	assert.True(t, executeCommands)
-	assert.True(t, autoFileMoved)
+		executeAutomateClusterCtlCommandAsyncfunc: func(command string, args []string, helpDocs string) error {
+			return nil
+		},
+		writeHAConfigFilesFunc: func(templateName string, data interface{}) error {
+			filewritten = true
+			return nil
+		},
+		getModeFromConfigFunc: func(path string) (string, error) {
+			return EXISTING_INFRA_MODE, nil
+		},
+		isManagedServicesOnFunc: func() bool {
+			return false
+		},
+		pullAndUpdateConfigAwsFunc: PullAwsConfFunc,
+		isA2HARBFileExistFunc: func() bool {
+			return true
+		},
+		taintTerraformFunc: func(path string) error {
+			return nil
+		},
+		getAWSConfigIpFunc: func() (*AWSConfigIp, error) {
+			ipAddres = true
+			return &AWSConfigIp{
+				configAutomateIpList:   []string{"192.0.0.1", "192.0.0.2", "192.0.0.3", "192.0.0.4"},
+				configChefServerIpList: []string{"192.0.1.1", "192.0.1.2", "192.0.1.3", "192.0.1.4"},
+				configOpensearchIpList: []string{"192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"},
+				configPostgresqlIpList: []string{"192.0.3.1", "192.0.3.2", "192.0.3.3", "192.0.3.4"},
+			}, nil
+		},
+		executeShellCommandFunc: func() error {
+			executeCommands = true
+			return nil
+		},
+		moveAWSAutoTfvarsFileFunc: func(path string) error {
+			autoFileMoved = true
+			return nil
+		},
+		modifyTfArchFileFunc: func(path string) error {
+			tfArchModified = true
+			return nil
+		},
+		stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		calculateTotalInstanceCountFunc: func() (int, error) {
+			return 0, nil
+		},
+	}
+	flagsArr := []AddDeleteNodeHACmdFlags{
+		{
+			automateIp: "192.0.0.1",
+		},
+		{
+			chefServerIp: "192.0.1.1",
+		},
+		{
+			postgresqlIp: "192.0.3.1",
+		},
+		{
+			opensearchIp: "192.0.2.1",
+		},
+	}
+
+	for _, flags := range flagsArr {
+		w := majorupgrade_utils.NewCustomWriterWithInputs("y")
+		nodeDelete := NewDeleteNodeAWS(
+			w.CliWriter,
+			flags,
+			mnu,
+			CONFIG_TOML_PATH_AWS,
+			&fileutils.MockFileSystemUtils{},
+			&MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			})
+		err := nodeDelete.Execute(nil, nil)
+		assert.NoError(t, err)
+		assert.True(t, tfArchModified)
+		assert.True(t, ipAddres)
+		assert.True(t, filewritten)
+		assert.True(t, executeCommands)
+		assert.True(t, autoFileMoved)
+	}
+
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -463,7 +463,7 @@ func TestDeletenodeAWSExecuteWithError(t *testing.T) {
 				tfArchModified = true
 				return nil
 			},
-			stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string) error {
+			stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 				return nil
 			},
 		},
@@ -539,7 +539,7 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 				tfArchModified = true
 				return nil
 			},
-			stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string) error {
+			stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 				return nil
 			},
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -648,6 +648,7 @@ func TestDeletenodeAWSExecuteWithError(t *testing.T) {
 }
 
 func TestDeletenodeAWSExecuteNoError(t *testing.T) {
+	count := 10
 	var ipAddres, filewritten, executeCommands, autoFileMoved, tfArchModified bool
 	mnu := &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -698,7 +699,8 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 			return nil
 		},
 		calculateTotalInstanceCountFunc: func() (int, error) {
-			return 0, nil
+			count = count - 1
+			return count, nil
 		},
 	}
 	flagsArr := []AddDeleteNodeHACmdFlags{

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -623,8 +623,11 @@ func TestDeletenodeAWSExecuteWithError(t *testing.T) {
 				tfArchModified = true
 				return nil
 			},
-			stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+			stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
 				return nil
+			},
+			calculateTotalInstanceCountFunc: func() (int, error) {
+				return 0, nil
 			},
 		},
 		CONFIG_TOML_PATH_AWS,
@@ -699,8 +702,11 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 				tfArchModified = true
 				return nil
 			},
-			stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+			stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
 				return nil
+			},
+			calculateTotalInstanceCountFunc: func() (int, error) {
+				return 0, nil
 			},
 		},
 		CONFIG_TOML_PATH_AWS,

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -84,16 +84,23 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 			return nil
 		}
 	}
-	return dni.prepare()
-	//return dni.runDeploy()
+
+	err = dni.prepare()
+	if err != nil {
+		return err
+	}
+
+	return dni.runDeploy()
 }
 
 func (dni *DeleteNodeOnPremImpl) prepare() error {
-
 	// Stop all services on the node to be deleted
-	return dni.nodeUtils.stopServicesOnNode(dni.automateIpList, dni.chefServerIpList, dni.postgresqlIpList, dni.opensearchIpList)
+	err := dni.nodeUtils.stopServicesOnNode(dni.automateIpList, dni.chefServerIpList, dni.postgresqlIpList, dni.opensearchIpList)
+	if err != nil {
+		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
+	}
 
-	//return dni.nodeUtils.taintTerraform(dni.terraformPath)
+	return dni.nodeUtils.taintTerraform(dni.terraformPath)
 }
 
 func (dni *DeleteNodeOnPremImpl) validate() error {
@@ -212,6 +219,7 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 		}...)
 	}
 
+	// Check if only one node is being deleted
 	if (len(dni.automateIpList) + len(dni.chefServerIpList) + len(dni.opensearchIpList) + len(dni.postgresqlIpList)) != 1 {
 		errorList.PushBack("Only one node can be deleted at a time")
 		return errorList

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -95,7 +95,12 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 
 func (dni *DeleteNodeOnPremImpl) prepare() error {
 	// Stop all services on the node to be deleted
-	err := dni.nodeUtils.stopServicesOnNode(dni.automateIpList, dni.chefServerIpList, dni.postgresqlIpList, dni.opensearchIpList)
+	infra, _, err := dni.nodeUtils.getHaInfraDetails()
+	if err != nil {
+		return err
+	}
+
+	err = dni.nodeUtils.stopServicesOnNode(dni.automateIpList, dni.chefServerIpList, dni.postgresqlIpList, dni.opensearchIpList, infra, dni.sshUtil)
 	if err != nil {
 		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -288,7 +288,7 @@ func (dni *DeleteNodeOnPremImpl) stopNodes() error {
 
 	err = dni.nodeUtils.stopServicesOnNode(dni.ipToDelete, dni.nodeType, EXISTING_INFRA_MODE, infra)
 	if err != nil {
-		return status.Wrap(err, status.CommandExecutionError, "Error stoping services on node")
+		return status.Wrap(err, status.CommandExecutionError, "Error stopping services on node")
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -89,13 +89,19 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 	err = dni.runDeploy()
 	currentCount, newErr := dni.nodeUtils.calculateTotalInstanceCount()
 	if newErr != nil {
-		return errors.Wrap(err, newErr.Error())
+		if err != nil {
+			return errors.Wrap(err, newErr.Error())
+		}
+		return newErr
 	}
 
 	if currentCount == previousCount-1 {
 		stopErr := dni.stopNodes()
 		if stopErr != nil {
-			return errors.Wrap(err, stopErr.Error())
+			if err != nil {
+				return errors.Wrap(err, stopErr.Error())
+			}
+			return stopErr
 		}
 	}
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -84,12 +84,16 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 			return nil
 		}
 	}
-	dni.prepare()
-	return dni.runDeploy()
+	return dni.prepare()
+	//return dni.runDeploy()
 }
 
 func (dni *DeleteNodeOnPremImpl) prepare() error {
-	return dni.nodeUtils.taintTerraform(dni.terraformPath)
+
+	// Stop all services on the node to be deleted
+	return dni.nodeUtils.stopServicesOnNode(dni.automateIpList, dni.chefServerIpList, dni.postgresqlIpList, dni.opensearchIpList)
+
+	//return dni.nodeUtils.taintTerraform(dni.terraformPath)
 }
 
 func (dni *DeleteNodeOnPremImpl) validate() error {
@@ -207,6 +211,12 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 			{dni.postgresqlIpList, "Postgresql", POSTGRESQL_MIN_INSTANCE_COUNT, dni.config.Postgresql.Config.InstanceCount, dni.config.ExistingInfra.Config.PostgresqlPrivateIps},
 		}...)
 	}
+
+	if (len(dni.automateIpList) + len(dni.chefServerIpList) + len(dni.opensearchIpList) + len(dni.postgresqlIpList)) != 1 {
+		errorList.PushBack("Only one node can be deleted at a time")
+		return errorList
+	}
+
 	for _, v := range validations {
 		if len(v.ipList) == 0 {
 			continue

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -109,16 +109,16 @@ func (dni *DeleteNodeOnPremImpl) validate() error {
 	// Get the node type and ip address of the node to be deleted
 	if len(automateIpList) > 0 {
 		dni.ipToDelete = automateIpList[0]
-		dni.nodeType = CONST_AUTOMATE
+		dni.nodeType = AUTOMATE
 	} else if len(chefServerIpList) > 0 {
 		dni.ipToDelete = chefServerIpList[0]
-		dni.nodeType = CONST_CHEF_SERVER
+		dni.nodeType = CHEF_SERVER
 	} else if len(postgresqlIpList) > 0 {
 		dni.ipToDelete = postgresqlIpList[0]
-		dni.nodeType = CONST_POSTGRESQL
+		dni.nodeType = POSTGRESQL
 	} else if len(opensearchIpList) > 0 {
 		dni.ipToDelete = opensearchIpList[0]
-		dni.nodeType = CONST_OPENSEARCH
+		dni.nodeType = OPENSEARCH
 	} else {
 		return status.New(status.InvalidCommandArgsError, "Please provide service name and ip address of the node which you want to delete")
 	}
@@ -134,7 +134,7 @@ func (dni *DeleteNodeOnPremImpl) validate() error {
 	dni.config = *updatedConfig
 	dni.copyConfigForUserPrompt = dni.config
 	if dni.nodeUtils.isManagedServicesOn() {
-		if dni.nodeType == CONST_POSTGRESQL || dni.nodeType == CONST_OPENSEARCH {
+		if dni.nodeType == POSTGRESQL || dni.nodeType == OPENSEARCH {
 			return status.New(status.ConfigError, fmt.Sprintf(TYPE_ERROR, "remove"))
 		}
 	}
@@ -149,28 +149,28 @@ func (dni *DeleteNodeOnPremImpl) modifyConfig() error {
 	var err error
 
 	switch dni.nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		err = modifyConfigForDeleteNode(
 			&dni.config.Automate.Config.InstanceCount,
 			&dni.config.ExistingInfra.Config.AutomatePrivateIps,
 			[]string{dni.ipToDelete},
 			&dni.config.Automate.Config.CertsByIP,
 		)
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		err = modifyConfigForDeleteNode(
 			&dni.config.ChefServer.Config.InstanceCount,
 			&dni.config.ExistingInfra.Config.ChefServerPrivateIps,
 			[]string{dni.ipToDelete},
 			&dni.config.ChefServer.Config.CertsByIP,
 		)
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		err = modifyConfigForDeleteNode(
 			&dni.config.Postgresql.Config.InstanceCount,
 			&dni.config.ExistingInfra.Config.PostgresqlPrivateIps,
 			[]string{dni.ipToDelete},
 			&dni.config.Postgresql.Config.CertsByIP,
 		)
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		err = modifyConfigForDeleteNode(
 			&dni.config.Opensearch.Config.InstanceCount,
 			&dni.config.ExistingInfra.Config.OpensearchPrivateIps,
@@ -222,19 +222,19 @@ func (dni *DeleteNodeOnPremImpl) validateCmdArgs() *list.List {
 	var existingIplist []string
 
 	switch dni.nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		instanceCount = dni.config.Automate.Config.InstanceCount
 		minCount = AUTOMATE_MIN_INSTANCE_COUNT
 		existingIplist = dni.config.ExistingInfra.Config.AutomatePrivateIps
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		instanceCount = dni.config.ChefServer.Config.InstanceCount
 		minCount = CHEF_SERVER_MIN_INSTANCE_COUNT
 		existingIplist = dni.config.ExistingInfra.Config.ChefServerPrivateIps
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		instanceCount = dni.config.Postgresql.Config.InstanceCount
 		minCount = POSTGRESQL_MIN_INSTANCE_COUNT
 		existingIplist = dni.config.ExistingInfra.Config.PostgresqlPrivateIps
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		instanceCount = dni.config.Opensearch.Config.InstanceCount
 		minCount = OPENSEARCH_MIN_INSTANCE_COUNT
 		existingIplist = dni.config.ExistingInfra.Config.OpensearchPrivateIps

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -99,6 +99,11 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 		}
 	}
 
+	// If the node is successfully remove, delete the machine
+	if err == nil {
+		dni.writer.Println("Node is successfully removed from the cluster. Please delete the machine manually.")
+	}
+
 	return err
 }
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -103,6 +103,11 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 			}
 			return stopErr
 		}
+	} else {
+		if err != nil {
+			return errors.Wrap(err, "Error in deleting node")
+		}
+		return errors.New("Error in deleting node")
 	}
 
 	if err == nil {

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -87,17 +87,16 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 	}
 
 	err = dni.runDeploy()
-	if err != nil {
-		fmt.Println("Error occurred while deploying: ", err)
-	}
-
 	currentCount, newErr := dni.nodeUtils.calculateTotalInstanceCount()
 	if newErr != nil {
-		return newErr
+		return errors.Wrap(err, newErr.Error())
 	}
 
 	if currentCount == previousCount-1 {
-		return dni.stopNodes()
+		stopErr := dni.stopNodes()
+		if stopErr != nil {
+			return errors.Wrap(err, stopErr.Error())
+		}
 	}
 
 	return err

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem.go
@@ -105,7 +105,6 @@ func (dni *DeleteNodeOnPremImpl) Execute(c *cobra.Command, args []string) error 
 		}
 	}
 
-	// If the node is successfully remove, delete the machine
 	if err == nil {
 		dni.writer.Println("Node is successfully removed from the cluster. Please delete the machine manually.")
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -109,7 +109,7 @@ func TestDeleteNodeModifyAutomate(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.automateIp, nodedelete.(*DeleteNodeOnPremImpl).automateIpList[0])
+	assert.Equal(t, flags.automateIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	assert.Equal(t, "1", nodedelete.(*DeleteNodeOnPremImpl).config.Automate.Config.InstanceCount)
 	assert.Equal(t, 1, len(nodedelete.(*DeleteNodeOnPremImpl).config.Automate.Config.CertsByIP))
 	assert.Equal(t, 1, len(nodedelete.(*DeleteNodeOnPremImpl).config.ExistingInfra.Config.AutomatePrivateIps))
@@ -177,7 +177,7 @@ func TestRemovenodeValidateTypeAwsOrSelfManaged2(t *testing.T) {
 	})
 	err := nodeAdd.validate()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf(TYPE_ERROR, "remove"))
+	assert.Contains(t, err.Error(), multipleNodeError)
 }
 
 func TestDeleteNodeModifyInfra(t *testing.T) {
@@ -207,7 +207,7 @@ func TestDeleteNodeModifyInfra(t *testing.T) {
 	// even though validation will fail still we check if modify config is working as expected or not
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.chefServerIp, nodedelete.(*DeleteNodeOnPremImpl).chefServerIpList[0])
+	assert.Equal(t, flags.chefServerIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	assert.Equal(t, "0", nodedelete.(*DeleteNodeOnPremImpl).config.ChefServer.Config.InstanceCount)
 	assert.Equal(t, 0, len(nodedelete.(*DeleteNodeOnPremImpl).config.ChefServer.Config.CertsByIP))
 	assert.Equal(t, 0, len(nodedelete.(*DeleteNodeOnPremImpl).config.ExistingInfra.Config.ChefServerPrivateIps))
@@ -238,7 +238,7 @@ func TestDeletenodeModifyOpensearch(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).opensearchIpList[0])
+	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	assert.Equal(t, "3", nodedelete.(*DeleteNodeOnPremImpl).config.Opensearch.Config.InstanceCount)
 	assert.Equal(t, 3, len(nodedelete.(*DeleteNodeOnPremImpl).config.Opensearch.Config.CertsByIP))
 	assert.Equal(t, 3, len(nodedelete.(*DeleteNodeOnPremImpl).config.ExistingInfra.Config.OpensearchPrivateIps))
@@ -271,7 +271,7 @@ func TestDeletenodeModifyPostgresql(t *testing.T) {
 	// even though validation will fail still we check if modify config is working as expected or not
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.postgresqlIp, nodedelete.(*DeleteNodeOnPremImpl).postgresqlIpList[0])
+	assert.Equal(t, flags.postgresqlIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	assert.Equal(t, "2", nodedelete.(*DeleteNodeOnPremImpl).config.Postgresql.Config.InstanceCount)
 	assert.Equal(t, 2, len(nodedelete.(*DeleteNodeOnPremImpl).config.Postgresql.Config.CertsByIP))
 	assert.Equal(t, 2, len(nodedelete.(*DeleteNodeOnPremImpl).config.ExistingInfra.Config.PostgresqlPrivateIps))
@@ -302,7 +302,7 @@ func TestDeleteNodePrompt(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.automateIp, nodedelete.(*DeleteNodeOnPremImpl).automateIpList[0])
+	assert.Equal(t, flags.automateIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	res, err := nodedelete.promptUserConfirmation()
 	assert.Equal(t, true, res)
 	assert.NoError(t, err)
@@ -313,11 +313,11 @@ Chef-Server => 192.0.2.2
 OpenSearch => 192.0.2.3, 192.0.2.4, 192.0.2.5, 192.0.2.6
 Postgresql => 192.0.2.7, 192.0.2.8, 192.0.2.9
 
-Nodes to be deleted:
+Node to be deleted:
 ================================================
 Automate => 192.0.2.0
-Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.
-This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
+Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.
+This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 }
 
 func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
@@ -354,7 +354,7 @@ func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).opensearchIpList[0])
+	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	res, err := nodedelete.promptUserConfirmation()
 	assert.Equal(t, true, res)
 	assert.NoError(t, err)
@@ -365,11 +365,11 @@ Chef-Server => 192.0.2.2
 OpenSearch => 192.0.2.3, 192.0.2.4, 192.0.2.5, 192.0.2.6
 Postgresql => 192.0.2.7, 192.0.2.8, 192.0.2.9
 
-Nodes to be deleted:
+Node to be deleted:
 ================================================
-OpenSearch => 192.0.2.3
-Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.
-This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
+Opensearch => 192.0.2.3
+Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.
+This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	err = nodedelete.runDeploy()
 	assert.NoError(t, err)
 	assert.Equal(t, true, filewritten)
@@ -440,7 +440,7 @@ func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).opensearchIpList[0])
+	assert.Equal(t, flags.opensearchIp, nodedelete.(*DeleteNodeOnPremImpl).ipToDelete)
 	res, err := nodedelete.promptUserConfirmation()
 	assert.Equal(t, true, res)
 	assert.NoError(t, err)
@@ -451,11 +451,11 @@ Chef-Server => 192.0.2.2
 OpenSearch => 192.0.2.3, 192.0.2.4, 192.0.2.5, 192.0.2.6
 Postgresql => 192.0.2.7, 192.0.2.8, 192.0.2.9
 
-Nodes to be deleted:
+Node to be deleted:
 ================================================
-OpenSearch => 192.0.2.3
-Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.
-This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
+Opensearch => 192.0.2.3
+Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.
+This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	err = nodedelete.runDeploy()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "random")
@@ -494,7 +494,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+		stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 			return nil
 		},
 		pullAndUpdateConfigFunc: func(sshUtil *SSHUtil, exceptionIps []string) (*ExistingInfraConfigToml, error) {
@@ -522,11 +522,11 @@ Chef-Server => 192.0.2.2
 OpenSearch => 192.0.2.3, 192.0.2.4, 192.0.2.5, 192.0.2.6
 Postgresql => 192.0.2.7, 192.0.2.8, 192.0.2.9
 
-Nodes to be deleted:
+Node to be deleted:
 ================================================
-OpenSearch => 192.0.2.6
-Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.
-This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
+Opensearch => 192.0.2.6
+Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.
+This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	assert.Equal(t, true, filewritten)
 	assert.Equal(t, true, deployed)
 }
@@ -564,7 +564,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+		stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 			return nil
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
@@ -582,11 +582,11 @@ Chef-Server => 192.0.2.2
 OpenSearch => 192.0.2.3, 192.0.2.4, 192.0.2.5, 192.0.2.6
 Postgresql => 192.0.2.7, 192.0.2.8, 192.0.2.9
 
-Nodes to be deleted:
+Node to be deleted:
 ================================================
-OpenSearch => 192.0.2.6
-Removal of nodes for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch nodes.
-This will delete the above nodes from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
+Opensearch => 192.0.2.6
+Removal of node for Postgresql or OpenSearch is at your own risk and may result to data loss. Consult your database administrator before trying to delete Postgresql or OpenSearch node.
+This will delete the above node from your existing setup. It might take a while. Are you sure you want to continue? (y/n)`)
 	assert.Equal(t, true, filewritten)
 	assert.Equal(t, true, deployed)
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -273,7 +273,7 @@ func TestDeletenodeModifyPostgresql(t *testing.T) {
 	// even though validation will fail still we check if modify config is working as expected or not
 	err = nodedelete.modifyConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, flags.postgresqlIp, nodedelete.(*DeleteNodeOnPremImpl).postgresqlIp[0])
+	assert.Equal(t, flags.postgresqlIp, nodedelete.(*DeleteNodeOnPremImpl).postgresqlIpList[0])
 	assert.Equal(t, "2", nodedelete.(*DeleteNodeOnPremImpl).config.Postgresql.Config.InstanceCount)
 	assert.Equal(t, 2, len(nodedelete.(*DeleteNodeOnPremImpl).config.Postgresql.Config.CertsByIP))
 	assert.Equal(t, 2, len(nodedelete.(*DeleteNodeOnPremImpl).config.ExistingInfra.Config.PostgresqlPrivateIps))

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -494,8 +494,11 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+		stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
 			return nil
+		},
+		calculateTotalInstanceCountFunc: func() (int, error) {
+			return 0, nil
 		},
 		pullAndUpdateConfigFunc: func(sshUtil *SSHUtil, exceptionIps []string) (*ExistingInfraConfigToml, error) {
 			cfg, err := readConfig(CONFIG_TOML_PATH + "/config.toml")
@@ -564,8 +567,11 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(ip, nodeType string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
+		stopServicesOnNodeFunc: func(ip, nodeType, deploymentType string, infra *AutomateHAInfraDetails) error {
 			return nil
+		},
+		calculateTotalInstanceCountFunc: func() (int, error) {
+			return 0, nil
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
 	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -31,7 +31,7 @@ func PullAwsConfFunc(sshUtil *SSHUtil, ex []string) (*AwsConfigToml, error) {
 }
 
 func TestDeleteNodeValidateError(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		automateIp: "192.0.2.2",
 	}
@@ -58,7 +58,7 @@ Automate Ip 192.0.2.2 is not present in existing list of ip addresses. Please us
 }
 
 func TestDeleteNodeValidateErrorMultiple(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		automateIp: "10.2.1.67,10.2.1.637",
 	}
@@ -85,7 +85,7 @@ func TestDeleteNodeValidateErrorMultiple(t *testing.T) {
 }
 
 func TestDeleteNodeModifyAutomate(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		automateIp: "192.0.2.0",
 	}
@@ -116,7 +116,7 @@ func TestDeleteNodeModifyAutomate(t *testing.T) {
 }
 
 func TestRemovenodeValidateTypeAwsOrSelfManaged(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		postgresqlIp: TEST_IP_1,
 	}
@@ -148,7 +148,7 @@ func TestRemovenodeValidateTypeAwsOrSelfManaged(t *testing.T) {
 }
 
 func TestRemovenodeValidateTypeAwsOrSelfManaged2(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		opensearchIp: TEST_IP_1,
 		automateIp:   TEST_IP_2,
@@ -181,7 +181,7 @@ func TestRemovenodeValidateTypeAwsOrSelfManaged2(t *testing.T) {
 }
 
 func TestDeleteNodeModifyInfra(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		chefServerIp: "192.0.2.2",
 	}
@@ -214,7 +214,7 @@ func TestDeleteNodeModifyInfra(t *testing.T) {
 }
 
 func TestDeletenodeModifyOpensearch(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		opensearchIp: "192.0.2.6",
 	}
@@ -245,7 +245,7 @@ func TestDeletenodeModifyOpensearch(t *testing.T) {
 }
 
 func TestDeletenodeModifyPostgresql(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("x")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		postgresqlIp: "192.0.2.9",
 	}
@@ -377,7 +377,7 @@ This will delete the above node from your existing setup. It might take a while.
 }
 
 func TestDeleteNodeDeployWithNewOSMinCountError(t *testing.T) {
-	w := majorupgrade_utils.NewCustomWriterWithInputs("y")
+	w := majorupgrade_utils.NewCustomWriter()
 	flags := AddDeleteNodeHACmdFlags{
 		opensearchIp: "192.0.2.3,192.0.2.5",
 	}
@@ -462,6 +462,7 @@ This will delete the above node from your existing setup. It might take a while.
 }
 
 func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
+	count := 10
 	w := majorupgrade_utils.NewCustomWriterWithInputs("y")
 	flags := AddDeleteNodeHACmdFlags{
 		opensearchIp: "192.0.2.6",
@@ -498,7 +499,8 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 			return nil
 		},
 		calculateTotalInstanceCountFunc: func() (int, error) {
-			return 0, nil
+			count = count - 1
+			return count, nil
 		},
 		pullAndUpdateConfigFunc: func(sshUtil *SSHUtil, exceptionIps []string) (*ExistingInfraConfigToml, error) {
 			cfg, err := readConfig(CONFIG_TOML_PATH + "/config.toml")

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -535,6 +535,7 @@ This will delete the above node from your existing setup. It might take a while.
 }
 
 func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
+	count := 10
 	w := majorupgrade_utils.NewCustomWriterWithInputs("y")
 	flags := AddDeleteNodeHACmdFlags{
 		opensearchIp: "192.0.2.6",
@@ -571,7 +572,8 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 			return nil
 		},
 		calculateTotalInstanceCountFunc: func() (int, error) {
-			return 0, nil
+			count = count - 1
+			return count, nil
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,
 	}, CONFIG_TOML_PATH, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -494,7 +494,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string) error {
+		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 			return nil
 		},
 		pullAndUpdateConfigFunc: func(sshUtil *SSHUtil, exceptionIps []string) (*ExistingInfraConfigToml, error) {
@@ -564,7 +564,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
-		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string) error {
+		stopServicesOnNodeFunc: func(automateIpList, chefServerIpList, postgresqlIpList, opensearchIpList []string, infra *AutomateHAInfraDetails, sshUtil SSHUtil) error {
 			return nil
 		},
 		pullAndUpdateConfigFunc: PullConfFunc,

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -437,7 +437,6 @@ func (nu *NodeUtilsImpl) checkExistingExcludedOSNodes(automateIp string, infra *
 		Automate: &Cmd{CmdInputs: &CmdInputs{
 			Cmd:                      GET_OPENSEARCH_CLUSTER_SETTINGS,
 			NodeIps:                  []string{automateIp},
-			Single:                   true,
 			NodeType:                 true,
 			SkipPrintOutput:          true,
 			HideSSHConnectionMessage: true}},
@@ -511,7 +510,6 @@ func createCmdInputs(ip string, cmd string) *Cmd {
 		CmdInputs: &CmdInputs{
 			Cmd:                      cmd,
 			NodeIps:                  []string{ip},
-			Single:                   true,
 			NodeType:                 true,
 			SkipPrintOutput:          true,
 			HideSSHConnectionMessage: true,

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -334,15 +334,14 @@ func (nu *NodeUtilsImpl) stopServicesOnNode(automateIpList, chefServerIpList, po
 	postgresqlCmd := &Cmd{CmdInputs: &CmdInputs{NodeType: false}}
 	opensearchCmd := &Cmd{CmdInputs: &CmdInputs{NodeType: false}}
 
-	cmd := "sudo echo 'hello'"
-
 	if len(automateIpList) > 0 {
-		automateCmd = createCmdInputs(automateIpList, cmd)
+		automateCmd = createCmdInputs(automateIpList, STOP_FE_SERVICES_CMD)
 	} else if len(chefServerIpList) > 0 {
-		chefServerCmd = createCmdInputs(chefServerIpList, cmd)
+		chefServerCmd = createCmdInputs(chefServerIpList, STOP_FE_SERVICES_CMD)
 	} else if len(postgresqlIpList) > 0 {
-		postgresqlCmd = createCmdInputs(postgresqlIpList, cmd)
+		postgresqlCmd = createCmdInputs(postgresqlIpList, STOP_BE_SERVICES_CMD)
 	} else if len(opensearchIpList) > 0 {
+		cmd := fmt.Sprintf(EXCLUDE_OPENSEARCH_NODE_REQUEST, opensearchIpList[0]) + STOP_BE_SERVICES_CMD
 		opensearchCmd = createCmdInputs(opensearchIpList, cmd)
 	}
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -502,7 +502,7 @@ func createCmdInputs(ip string, cmd string) *Cmd {
 			NodeIps:                  []string{ip},
 			Single:                   true,
 			NodeType:                 true,
-			SkipPrintOutput:          false,
+			SkipPrintOutput:          true,
 			HideSSHConnectionMessage: true,
 		},
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -336,13 +336,13 @@ func (nu *NodeUtilsImpl) stopServicesOnNode(ip, nodeType string, infra *Automate
 	opensearchCmd := &Cmd{CmdInputs: &CmdInputs{NodeType: false}}
 
 	switch nodeType {
-	case CONST_AUTOMATE:
+	case AUTOMATE:
 		automateCmd = createCmdInputs(ip, STOP_FE_SERVICES_CMD)
-	case CONST_CHEF_SERVER:
+	case CHEF_SERVER:
 		chefServerCmd = createCmdInputs(ip, STOP_FE_SERVICES_CMD)
-	case CONST_POSTGRESQL:
+	case POSTGRESQL:
 		postgresqlCmd = createCmdInputs(ip, STOP_BE_SERVICES_CMD)
-	case CONST_OPENSEARCH:
+	case OPENSEARCH:
 		cmd := fmt.Sprintf(EXCLUDE_OPENSEARCH_NODE_REQUEST, ip) + STOP_BE_SERVICES_CMD
 		opensearchCmd = createCmdInputs(ip, cmd)
 	default:

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -358,9 +358,7 @@ func (nu *NodeUtilsImpl) stopServicesOnNode(ip, nodeType string, infra *Automate
 		Infra:      infra,
 	}
 
-	nu.cmdUtil.Set(nodeMap, sshUtil, writer)
-
-	_, err := nu.cmdUtil.Execute()
+	_, err := nu.cmdUtil.ExecuteWithNodeMap(nodeMap)
 	if err != nil {
 		return err
 	}

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -243,7 +243,9 @@ func TestModifyTfArchFileNotExist(t *testing.T) {
 func TestStopServicesOnNodeA2(t *testing.T) {
 	mockUtil := &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-			return nil, &SSHConfig{}, nil
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
+			return infra, &SSHConfig{}, nil
 		},
 	}
 
@@ -256,6 +258,13 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 		},
 		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 			return nil, nil
+		},
+		GetSshUtilFunc: func() SSHUtil {
+			return &MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			}
 		},
 	}, command.NewMockExecutor(t))
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, AUTOMATE, EXISTING_INFRA_MODE, infra)
@@ -264,7 +273,9 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 func TestStopServicesOnNodeCS(t *testing.T) {
 	mockUtil := &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-			return nil, &SSHConfig{}, nil
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
+			return infra, &SSHConfig{}, nil
 		},
 	}
 
@@ -277,6 +288,13 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 		},
 		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 			return nil, nil
+		},
+		GetSshUtilFunc: func() SSHUtil {
+			return &MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			}
 		},
 	}, command.NewMockExecutor(t))
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CHEF_SERVER, AWS_MODE, infra)
@@ -285,7 +303,9 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 func TestStopServicesOnNodePG(t *testing.T) {
 	mockUtil := &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-			return nil, &SSHConfig{}, nil
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
+			return infra, &SSHConfig{}, nil
 		},
 	}
 
@@ -298,6 +318,13 @@ func TestStopServicesOnNodePG(t *testing.T) {
 		},
 		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 			return nil, nil
+		},
+		GetSshUtilFunc: func() SSHUtil {
+			return &MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			}
 		},
 	}, command.NewMockExecutor(t))
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, POSTGRESQL, EXISTING_INFRA_MODE, infra)

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -257,7 +257,7 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 			return nil, nil
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_AUTOMATE, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, AUTOMATE, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -282,7 +282,7 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 			return nil, nil
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_CHEF_SERVER, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CHEF_SERVER, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -307,7 +307,7 @@ func TestStopServicesOnNodePG(t *testing.T) {
 			return nil, nil
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_POSTGRESQL, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, POSTGRESQL, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -332,7 +332,7 @@ func TestStopServicesOnNodeOS(t *testing.T) {
 			return nil, nil
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_OPENSEARCH, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, OPENSEARCH, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -184,7 +183,7 @@ func TestIsFinalInstanceCountAllowed(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsFileAllExist(t *testing.T) {
-	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
+	nodeUtil := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer))
 	dir := t.TempDir()
 	_, err := os.Create(filepath.Join(dir, AWS_AUTO_TFVARS))
 	assert.NoError(t, err)
@@ -196,7 +195,7 @@ func TestMoveAWSAutoTfvarsFileAllExist(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsFileNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
+	nodeUtil := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer))
 	dir := t.TempDir()
 
 	err := os.MkdirAll(filepath.Join(dir, DESTROY_AWS_FOLDER), os.ModePerm)
@@ -208,7 +207,7 @@ func TestMoveAWSAutoTfvarsFileNotExist(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsDestroyFolderNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
+	nodeUtil := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer))
 	dir := t.TempDir()
 
 	_, err := os.Create(filepath.Join(dir, AWS_AUTO_TFVARS))
@@ -221,7 +220,7 @@ func TestMoveAWSAutoTfvarsDestroyFolderNotExist(t *testing.T) {
 }
 
 func TestModifyTfArchFile(t *testing.T) {
-	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
+	nodeUtil := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer))
 	dir := t.TempDir()
 	_, err := os.Create(filepath.Join(dir, TF_ARCH_FILE))
 	assert.NoError(t, err)
@@ -234,7 +233,7 @@ func TestModifyTfArchFile(t *testing.T) {
 }
 
 func TestModifyTfArchFileNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
+	nodeUtil := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer))
 	dir := t.TempDir()
 	err := nodeUtil.modifyTfArchFile(dir)
 	assert.Error(t, err)
@@ -254,8 +253,8 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 		ExecuteFunc: func() (map[string][]*CmdResult, error) {
 			return nil, nil
 		},
-		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-			// do nothing
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return nil, nil
 		},
 	})
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_AUTOMATE, infra, &MockSSHUtilsImpl{
@@ -279,8 +278,8 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 		ExecuteFunc: func() (map[string][]*CmdResult, error) {
 			return nil, nil
 		},
-		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-			// do nothing
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return nil, nil
 		},
 	})
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_CHEF_SERVER, infra, &MockSSHUtilsImpl{
@@ -304,8 +303,8 @@ func TestStopServicesOnNodePG(t *testing.T) {
 		ExecuteFunc: func() (map[string][]*CmdResult, error) {
 			return nil, nil
 		},
-		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-			// do nothing
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return nil, nil
 		},
 	})
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_POSTGRESQL, infra, &MockSSHUtilsImpl{
@@ -329,8 +328,8 @@ func TestStopServicesOnNodeOS(t *testing.T) {
 		ExecuteFunc: func() (map[string][]*CmdResult, error) {
 			return nil, nil
 		},
-		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
-			// do nothing
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return nil, nil
 		},
 	})
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_OPENSEARCH, infra, &MockSSHUtilsImpl{

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -183,7 +184,7 @@ func TestIsFinalInstanceCountAllowed(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsFileAllExist(t *testing.T) {
-	nodeUtil := NewNodeUtils()
+	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
 	dir := t.TempDir()
 	_, err := os.Create(filepath.Join(dir, AWS_AUTO_TFVARS))
 	assert.NoError(t, err)
@@ -195,7 +196,7 @@ func TestMoveAWSAutoTfvarsFileAllExist(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsFileNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils()
+	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
 	dir := t.TempDir()
 
 	err := os.MkdirAll(filepath.Join(dir, DESTROY_AWS_FOLDER), os.ModePerm)
@@ -207,7 +208,7 @@ func TestMoveAWSAutoTfvarsFileNotExist(t *testing.T) {
 }
 
 func TestMoveAWSAutoTfvarsDestroyFolderNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils()
+	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
 	dir := t.TempDir()
 
 	_, err := os.Create(filepath.Join(dir, AWS_AUTO_TFVARS))
@@ -220,7 +221,7 @@ func TestMoveAWSAutoTfvarsDestroyFolderNotExist(t *testing.T) {
 }
 
 func TestModifyTfArchFile(t *testing.T) {
-	nodeUtil := NewNodeUtils()
+	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
 	dir := t.TempDir()
 	_, err := os.Create(filepath.Join(dir, TF_ARCH_FILE))
 	assert.NoError(t, err)
@@ -233,8 +234,109 @@ func TestModifyTfArchFile(t *testing.T) {
 }
 
 func TestModifyTfArchFileNotExist(t *testing.T) {
-	nodeUtil := NewNodeUtils()
+	nodeUtil := NewNodeUtils(&remoteCmdExecutor{})
 	dir := t.TempDir()
 	err := nodeUtil.modifyTfArchFile(dir)
 	assert.Error(t, err)
+}
+
+func TestStopServicesOnNodeA2(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			return nil, &SSHConfig{}, nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+			// do nothing
+		},
+	})
+	err = nodeUtil.stopServicesOnNode([]string{TEST_IP_1}, nil, nil, nil, infra, &MockSSHUtilsImpl{
+		getSSHConfigFunc: func() *SSHConfig {
+			return &SSHConfig{}
+		},
+	})
+	assert.NoError(t, err)
+}
+func TestStopServicesOnNodeCS(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			return nil, &SSHConfig{}, nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+			// do nothing
+		},
+	})
+	err = nodeUtil.stopServicesOnNode(nil, []string{TEST_IP_1}, nil, nil, infra, &MockSSHUtilsImpl{
+		getSSHConfigFunc: func() *SSHConfig {
+			return &SSHConfig{}
+		},
+	})
+	assert.NoError(t, err)
+}
+func TestStopServicesOnNodePG(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			return nil, &SSHConfig{}, nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+			// do nothing
+		},
+	})
+	err = nodeUtil.stopServicesOnNode(nil, nil, []string{TEST_IP_1}, nil, infra, &MockSSHUtilsImpl{
+		getSSHConfigFunc: func() *SSHConfig {
+			return &SSHConfig{}
+		},
+	})
+	assert.NoError(t, err)
+}
+func TestStopServicesOnNodeOS(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			return nil, &SSHConfig{}, nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		SetFunc: func(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) {
+			// do nothing
+		},
+	})
+	err = nodeUtil.stopServicesOnNode(nil, nil, nil, []string{TEST_IP_1}, infra, &MockSSHUtilsImpl{
+		getSSHConfigFunc: func() *SSHConfig {
+			return &SSHConfig{}
+		},
+	})
+	assert.NoError(t, err)
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -258,7 +258,7 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 			// do nothing
 		},
 	})
-	err = nodeUtil.stopServicesOnNode([]string{TEST_IP_1}, nil, nil, nil, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_AUTOMATE, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -283,7 +283,7 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 			// do nothing
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(nil, []string{TEST_IP_1}, nil, nil, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_CHEF_SERVER, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -308,7 +308,7 @@ func TestStopServicesOnNodePG(t *testing.T) {
 			// do nothing
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(nil, nil, []string{TEST_IP_1}, nil, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_POSTGRESQL, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},
@@ -333,7 +333,7 @@ func TestStopServicesOnNodeOS(t *testing.T) {
 			// do nothing
 		},
 	})
-	err = nodeUtil.stopServicesOnNode(nil, nil, nil, []string{TEST_IP_1}, infra, &MockSSHUtilsImpl{
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CONST_OPENSEARCH, infra, &MockSSHUtilsImpl{
 		getSSHConfigFunc: func() *SSHConfig {
 			return &SSHConfig{}
 		},

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils_test.go
@@ -254,6 +254,12 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
 			return infra, &SSHConfig{}, nil
 		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
+		},
 	}
 
 	infra, _, err := mockUtil.getHaInfraDetails()
@@ -277,12 +283,19 @@ func TestStopServicesOnNodeA2(t *testing.T) {
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, AUTOMATE, EXISTING_INFRA_MODE, infra)
 	assert.NoError(t, err)
 }
-func TestStopServicesOnNodeCS(t *testing.T) {
+
+func TestStopServicesOnNodeA2AWS(t *testing.T) {
 	mockUtil := &MockNodeUtilsImpl{
 		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
 			infra := &AutomateHAInfraDetails{}
 			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
 			return infra, &SSHConfig{}, nil
+		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
 		},
 	}
 
@@ -304,7 +317,44 @@ func TestStopServicesOnNodeCS(t *testing.T) {
 			}
 		},
 	}, command.NewMockExecutor(t), MockWriter.CliWriter)
-	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CHEF_SERVER, AWS_MODE, infra)
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, AUTOMATE, AWS_MODE, infra)
+	assert.NoError(t, err)
+}
+
+func TestStopServicesOnNodeCS(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
+			return infra, &SSHConfig{}, nil
+		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		GetSshUtilFunc: func() SSHUtil {
+			return &MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			}
+		},
+	}, command.NewMockExecutor(t), MockWriter.CliWriter)
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, CHEF_SERVER, EXISTING_INFRA_MODE, infra)
 	assert.NoError(t, err)
 }
 func TestStopServicesOnNodePG(t *testing.T) {
@@ -313,6 +363,12 @@ func TestStopServicesOnNodePG(t *testing.T) {
 			infra := &AutomateHAInfraDetails{}
 			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
 			return infra, &SSHConfig{}, nil
+		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
 		},
 	}
 
@@ -344,6 +400,60 @@ func TestStopServicesOnNodeOS(t *testing.T) {
 			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
 			return infra, &SSHConfig{}, nil
 		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
+		},
+	}
+
+	infra, _, err := mockUtil.getHaInfraDetails()
+	assert.NoError(t, err)
+
+	nodeUtil := NewNodeUtils(&MockRemoteCmdExecutor{
+		ExecuteFunc: func() (map[string][]*CmdResult, error) {
+			return nil, nil
+		},
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			//return dummy result
+			return map[string][]*CmdResult{
+				TEST_IP_1: {
+					{
+						ScriptName:  "",
+						HostIP:      "",
+						OutputFiles: []string{},
+						Output:      "",
+						Error:       nil,
+					},
+				},
+			}, nil
+		},
+		GetSshUtilFunc: func() SSHUtil {
+			return &MockSSHUtilsImpl{
+				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
+					return "", nil
+				},
+			}
+		},
+	}, command.NewMockExecutor(t), MockWriter.CliWriter)
+	err = nodeUtil.stopServicesOnNode(TEST_IP_1, OPENSEARCH, EXISTING_INFRA_MODE, infra)
+	assert.NoError(t, err)
+}
+
+func TestStopServicesOnNodeOSAWS(t *testing.T) {
+	mockUtil := &MockNodeUtilsImpl{
+		getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.AutomatePrivateIps.Value = []string{TEST_IP_1}
+			return infra, &SSHConfig{}, nil
+		},
+		excludeOpenSearchNodeFunc: func(ipToDelete string, infra *AutomateHAInfraDetails) error {
+			return nil
+		},
+		checkExistingExcludedOSNodesFunc: func(automateIp string, infra *AutomateHAInfraDetails) (string, error) {
+			return "", nil
+		},
 	}
 
 	infra, _, err := mockUtil.getHaInfraDetails()
@@ -369,6 +479,13 @@ func TestStopServicesOnNodeOS(t *testing.T) {
 		}}, command.NewMockExecutor(t), MockWriter.CliWriter)
 	err = nodeUtil.stopServicesOnNode(TEST_IP_1, OPENSEARCH, AWS_MODE, infra)
 	assert.NoError(t, err)
+}
+
+func TestStopServicesOnNodeInvalidNodeType(t *testing.T) {
+	nodeUtil := NewNodeUtils(nil, command.NewMockExecutor(t), MockWriter.CliWriter)
+	err := nodeUtil.stopServicesOnNode(TEST_IP_1, "invalid", EXISTING_INFRA_MODE, &AutomateHAInfraDetails{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid node type")
 }
 
 func TestCalculateTotalInstanceCount(t *testing.T) {

--- a/components/automate-cli/pkg/testfiles/aws/config.toml
+++ b/components/automate-cli/pkg/testfiles/aws/config.toml
@@ -44,7 +44,7 @@ private_key = "test_pri_key"
 [chef_server.config]
 ## === INPUT NEEDED ===
 # No. of Chef Server Frontend Machine or VM eg.: instance_count = "2"
-instance_count = "1"
+instance_count = "2"
 # Add Chef Server load balancer root-ca and keys
 enable_custom_certs = true
 public_key = "test_pub_key"
@@ -56,7 +56,7 @@ private_key = "test_pri_key"
 [opensearch.config]
 ## === INPUT NEEDED ===
 # No. of OpenSearch DB Backend Machine or VM eg.: instance_count = "3"
-instance_count = "3"
+instance_count = "6"
 # Add OpenSearch load balancer root-ca and keys
 enable_custom_certs = true
 root_ca = "test_root_ca"

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -391,7 +391,7 @@ For example, if you have patched any external configurations like SAML or LDAP, 
 
 {{< /warning >}}
 
-The commands require some arguments so that it can determine which types of node you want to remove to your HA setup from your bastion host. It needs the ip address of the node you want to remove as as argument when you run the command.
+The command requires some arguments so that it can determine which types of nodes you want to remove from your HA setup from your bastion host. It needs the IP address of the node you want to remove as an argument when you run the command.
 For example,
 
 - If you want to remove node of automate, you have to run the:

--- a/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deploy_steps.md
@@ -379,7 +379,7 @@ For example, if you have patched any external configurations like SAML or LDAP, 
   Downgrading the number of instance_count for the backend nodes will result in data loss. We do not recommend downgrading the backend nodes.
 {{< /warning >}}
 
-## Delete single node In AWS Deployment post deployment
+## Remove Single Node From Cluster on AWS Deployment
 
 {{< warning >}}
 
@@ -391,10 +391,10 @@ For example, if you have patched any external configurations like SAML or LDAP, 
 
 {{< /warning >}}
 
-The commands require some arguments so that it can determine which types of nodes you want to remove to your HA setup from your bastion host. It needs the ip address of the node you want to remove as as argument when you run the command.
+The commands require some arguments so that it can determine which types of node you want to remove to your HA setup from your bastion host. It needs the ip address of the node you want to remove as as argument when you run the command.
 For example,
 
-- if you want to remove node of automate, you have to run the:
+- If you want to remove node of automate, you have to run the:
 
     ```sh
     chef-automate node remove --automate-ip "<automate-ip-address>"
@@ -418,7 +418,7 @@ For example,
     chef-automate node remove --postgresql-ip "<postgresql-ip-address>"
     ```
 
-Once the command executes, it will remove nodes to your HA setup
+Once the command executes, it will remove the supplied node from your HA setup. The changes might take a while.
 
 ## Uninstall chef automate HA
 

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -493,7 +493,7 @@ For example, if you have patched any external configurations like SAML or LDAP, 
 It's essential to ensure that the IP address of the nodes you are trying to add has sufficient resources and is reachable from the bastion host.
 {{< /warning >}}
 
-## Remove Any Nodes From Frontend Cluster OnPrem Deployment
+## Remove Single Node From Cluster on OnPrem Deployment
 
 {{< warning >}}
 
@@ -503,51 +503,39 @@ It's essential to ensure that the IP address of the nodes you are trying to add 
 
 - Below process can be done for `chef-server` and `automate`.
 
+- Only one node can be removed at a time irrespective of node type.
+
 {{< /warning >}}
 
-The commands require some arguments so that it can determine which types of nodes you want to remove from your HA setup from your bastion host. It needs the IP addresses of the nodes you want to remove as comma-separate values with no spaces in between.
+The commands require some arguments so that it can determine which types of nodes you want to remove from your HA setup from your bastion host. It needs the IP address of the node you want to remove.
 
 For example,
 
-- if you want to remove nodes with IP 10.1.2.23 to automate, you have to run the:
+- If you want to remove node of automate, you have to run the:
 
     ```sh
-    chef-automate node remove --automate-ip 10.1.2.23
+    chef-automate node remove --automate-ip "<automate-ip-address>"
     ```
 
-- If you want to remove nodes with IP 10.1.2.23 and 10.0.1.42 to chef-server you have to run the:
+- If you want to remove node of chef-server, you have to run the:
 
     ```sh
-    chef-automate node remove --chef-server-ip 10.1.2.23,10.0.1.42
+    chef-automate node remove --chef-server-ip "<chef-server-ip-address>"
     ```
 
-- If you want to remove nodes with IP 10.1.2.23 and 10.0.1.42 to OpenSearch, you have to run:
+- If you want to remove node of OpenSearch, you have to run the:
 
     ```sh
-    chef-automate node remove --opensearch-ip 10.1.2.23,10.0.1.42
+    chef-automate node remove --opensearch-ip "<opensearch-ip-address>"
     ```
 
-  - If you want to remove nodes with IP 10.1.2.23, 10.0.1.54 and 10.0.1.42 to PostgreSQL you have to run:
+- If you want to remove node of PostgreSQL you have to run:
 
     ```sh
-    chef-automate node remove --postgresql-ip 10.1.2.23,10.0.1.42,10.0.1.54
+    chef-automate node remove --postgresql-ip "<postgresql-ip-address>"
     ```
 
-You can mix and match different services to remove nodes across various services.
-
-- If you want to remove nodes with IP 10.1.2.23 to automate and nodes with IP 10.0.1.54 and 10.0.1.42 to PostgreSQL, you have to run:
-
-    ```sh
-    chef-automate node remove --automate-ip 10.1.2.23 --postgresql-ip 10.0.1.42,10.0.1.54
-    ```
-
-- If you want to remove nodes with IP 10.1.2.23 to automate, nodes with IP 10.1.0.36 and 10.0.1.233 to chef-server, and nodes with IP 10.0.1.54 and 10.0.1.42 to PostgreSQL you have to run:
-
-    ```sh
-    chef-automate node remove --automate-ip 10.1.2.23 --chef-server-ip 10.1.0.36,10.0.1.233  --postgresql-ip 10.0.1.42,10.0.1.54
-    ```
-
-Once the command executes, it will remove the supplied nodes from your automate setup. The changes might take a while.
+Once the command executes, it will remove the supplied node from your HA setup. The changes might take a while.
 
 - Make sure to remove the ip address of the deleted node from your loadbalancer configuration. For reference check [Load Balancer Configuration page](/automate/loadbalancer_configuration/)
 
@@ -565,7 +553,7 @@ Once the command executes, it will remove the supplied nodes from your automate 
 - First Add a New Node follow [this](#add-more-nodes-to-the-onprem-deployment).
 - Stop the Habitat Supervisior on the node .i.e going to be removed, use `systemctl stop hab-sup` command to stop the
   habitat supervisior.
-- Remove a Existing Node follow [this](#remove-any-nodes-from-frontend-cluster-onprem-deployment).
+- Remove a Existing Node follow [this](#remove-single-node-from-cluster-on-onprem-deployment).
 
 ## Uninstall chef automate HA
 

--- a/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
+++ b/components/docs-chef-io/content/automate/ha_onprim_deployment_procedure.md
@@ -507,7 +507,7 @@ It's essential to ensure that the IP address of the nodes you are trying to add 
 
 {{< /warning >}}
 
-The commands require some arguments so that it can determine which types of nodes you want to remove from your HA setup from your bastion host. It needs the IP address of the node you want to remove.
+The command requires some arguments so that it can determine which types of nodes you want to remove from your HA setup from your bastion host. It needs the IP address of the node you want to remove.
 
 For example,
 

--- a/lib/platform/command/mock.go
+++ b/lib/platform/command/mock.go
@@ -49,6 +49,29 @@ type ExpectedCommand struct {
 	Stdout           io.Writer
 }
 
+type MockExecutorImpl struct {
+	RunFunc            func(string, ...Opt) error
+	StartFunc          func(string, ...Opt) (WaitFunc, error)
+	OutputFunc         func(string, ...Opt) (string, error)
+	CombinedOutputFunc func(string, ...Opt) (string, error)
+}
+
+func (m *MockExecutorImpl) Run(cmd string, opts ...Opt) error {
+	return m.RunFunc(cmd, opts...)
+}
+
+func (m *MockExecutorImpl) Start(cmd string, opts ...Opt) (WaitFunc, error) {
+	return m.StartFunc(cmd, opts...)
+}
+
+func (m *MockExecutorImpl) Output(cmd string, opts ...Opt) (string, error) {
+	return m.OutputFunc(cmd, opts...)
+}
+
+func (m *MockExecutorImpl) CombinedOutput(cmd string, opts ...Opt) (string, error) {
+	return m.CombinedOutputFunc(cmd, opts...)
+}
+
 // Return sets the return value for an expectation
 func (e *Expectation) Return(vals ...interface{}) *Expectation {
 	e.retVals = vals

--- a/lib/stringutils/strings.go
+++ b/lib/stringutils/strings.go
@@ -14,11 +14,15 @@ func Title(s string) string {
 
 // TitleSplit splits the string s by sep and returns a copy of the string s with all Unicode letters that begin words mapped to their title case.
 func TitleSplit(s string, sep string) string {
+	return TitleReplace(s, sep, " ")
+}
+
+func TitleReplace(s string, sep string, rep string) string {
 	split := strings.Split(s, sep)
 	for i, v := range split {
 		split[i] = Title(v)
 	}
-	return strings.Join(split, " ")
+	return strings.Join(split, rep)
 }
 
 func IsNumeric(word string) bool {

--- a/lib/stringutils/strings_test.go
+++ b/lib/stringutils/strings_test.go
@@ -25,3 +25,11 @@ func TestTitleSplit(t *testing.T) {
 	assert.Equal(t, "Foo Bar", stringutils.TitleSplit("foo-bar", "-"))
 	assert.Equal(t, "Foo", stringutils.TitleSplit("foo", "-"))
 }
+
+func TestTitleReplace(t *testing.T) {
+	assert.Equal(t, "Hello World", stringutils.TitleReplace("hello_world", "_", " "))
+	assert.Equal(t, "Hello-World", stringutils.TitleReplace("hello_world", "_", "-"))
+	assert.Equal(t, "Helloworld", stringutils.TitleReplace("helloworld", "_", "-"))
+	assert.Equal(t, "Helloworld", stringutils.TitleReplace("helloworld", "-", " "))
+	assert.Equal(t, "Hello Chef", stringutils.TitleReplace("hello chef", "_", "-"))
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Remove OpenSearch/Frontend node is not actually removing nodes from the cluster.

Document Change Preview: https://deploy-preview-7922--chef-automate.netlify.app/automate/ha_onprim_deployment_procedure/ and https://deploy-preview-7922--chef-automate.netlify.app/automate/ha_aws_deploy_steps/
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2251
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![Screenshot 2023-06-02 at 2 54 54 AM](https://github.com/chef/automate/assets/11033984/39cf88ed-90e9-483e-91f3-f6ad232c8e08)

![Screenshot 2023-06-02 at 3 07 07 AM](https://github.com/chef/automate/assets/11033984/b9e42f2f-d500-4fa1-8b5a-a7bf49a0444b)

![Screenshot 2023-06-02 at 3 07 41 AM](https://github.com/chef/automate/assets/11033984/31961b50-f71e-444e-8c75-7d78cd244e41)

![Screenshot 2023-06-02 at 3 08 44 AM](https://github.com/chef/automate/assets/11033984/420cc6b4-6298-43a2-88a0-3480ebb9f6f0)

![Screenshot 2023-06-02 at 3 17 27 AM](https://github.com/chef/automate/assets/11033984/733d0e84-e305-41b0-b68a-7ad97aebd84a)

![Screenshot 2023-06-02 at 3 18 27 AM](https://github.com/chef/automate/assets/11033984/ee1fcd95-5d74-4a64-82fe-bd093e2e22b6)

![Screenshot 2023-06-02 at 3 20 34 AM](https://github.com/chef/automate/assets/11033984/0a83d5db-1418-47d9-9d69-fe1b5253a277)
