### PR TITLE
CHEF-3217 - Patch with file path 

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -31,6 +31,8 @@ type CmdInputs struct {
 	SkipPrintOutput          bool
 	HideSSHConnectionMessage bool
 	MutipleCmdWithArgs       map[string]string
+	SourceConfig             string
+	DestinationConfig        string
 }
 
 type NodeTypeAndCmd struct {
@@ -140,14 +142,19 @@ func (c *remoteCmdExecutor) executeCmdOnGivenNodes(input *CmdInputs, nodeIps []s
 	}
 	timeout := input.WaitTimeout
 	inputFileToOutputFileMap := map[string]string{}
-	for _, file := range inputFiles {
-		destinationFile := remoteService + "_" + timestamp + "_" + file
-		if strings.Contains(file, "/") {
-			filePath := strings.Split(file, "/")
-			lastFileidx := len(filePath) - 1
-			destinationFile = filePath[lastFileidx]
+
+	if input.SourceConfig != "" && input.DestinationConfig != "" {
+		inputFileToOutputFileMap[input.SourceConfig] = input.DestinationConfig
+	} else {
+		for _, file := range inputFiles {
+			destinationFile := remoteService + "_" + timestamp + "_" + file
+			if strings.Contains(file, "/") {
+				filePath := strings.Split(file, "/")
+				lastFileidx := len(filePath) - 1
+				destinationFile = filePath[lastFileidx]
+			}
+			inputFileToOutputFileMap[file] = destinationFile
 		}
-		inputFileToOutputFileMap[file] = destinationFile
 	}
 
 	for _, hostIP := range nodeIps {

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -220,7 +220,7 @@ func runShowCmd(cmd *cobra.Command, args []string) error {
 
 		chefServer := &Cmd{
 			CmdInputs: &CmdInputs{
-				Cmd:        frontendCommand,
+				Cmd:         frontendCommand,
 				WaitTimeout: configCmdFlags.waitTimeout,
 				Single:      false,
 				InputFiles:  []string{},
@@ -357,7 +357,14 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		configFile := args[0]
-		frontendCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "frontend"+"_"+timestamp+"_"+configFile, dateFormat)
+		configFileRenamed := configFile
+		if strings.Contains(configFile, "/") {
+			filePath := strings.Split(configFile, "/")
+			lastFileidx := len(filePath) - 1
+			configFileRenamed = filePath[lastFileidx]
+		}
+
+		frontendCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "frontend"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
 		frontend := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -368,9 +375,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				InputFiles:               []string{configFile},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.frontend,
+				SourceConfig:             configFile,
+				DestinationConfig:        "frontend" + "_" + timestamp + "_" + configFileRenamed,
 			},
 		}
-		automateCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "automate"+"_"+timestamp+"_"+configFile, dateFormat)
+		automateCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "automate"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
 		automate := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -381,10 +390,12 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				InputFiles:               []string{configFile},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.automate,
+				SourceConfig:             configFile,
+				DestinationConfig:        "automate" + "_" + timestamp + "_" + configFileRenamed,
 			},
 		}
 
-		chefServerCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "chef_server"+"_"+timestamp+"_"+configFile, dateFormat)
+		chefServerCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "chef_server"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
 		chefServer := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -395,10 +406,12 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				InputFiles:               []string{configFile},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.chef_server,
+				SourceConfig:             configFile,
+				DestinationConfig:        "chef_server" + "_" + timestamp + "_" + configFileRenamed,
 			},
 		}
 
-		postgresqlCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", "postgresql"+"_"+timestamp+"_"+configFile)
+		postgresqlCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", "postgresql"+"_"+timestamp+"_"+configFileRenamed)
 		postgresql := &Cmd{
 			PreExec: prePatchCheckForPostgresqlNodes,
 			CmdInputs: &CmdInputs{
@@ -409,9 +422,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				InputFiles:               []string{configFile},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.postgresql,
+				SourceConfig:             configFile,
+				DestinationConfig:        "postgresql" + "_" + timestamp + "_" + configFileRenamed,
 			},
 		}
-		opensearchCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", "opensearch"+"_"+timestamp+"_"+configFile)
+		opensearchCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", "opensearch"+"_"+timestamp+"_"+configFileRenamed)
 		opensearch := &Cmd{
 			PreExec: prePatchCheckForOpensearch,
 			CmdInputs: &CmdInputs{
@@ -422,6 +437,8 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				InputFiles:               []string{configFile},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.opensearch,
+				SourceConfig:             configFile,
+				DestinationConfig:        "opensearch" + "_" + timestamp + "_" + configFileRenamed,
 			},
 		}
 

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -357,14 +357,15 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		configFile := args[0]
-		configFileRenamed := configFile
+		sourceConfigFileName := configFile
 		if strings.Contains(configFile, "/") {
 			filePath := strings.Split(configFile, "/")
 			lastFileidx := len(filePath) - 1
-			configFileRenamed = filePath[lastFileidx]
+			sourceConfigFileName = filePath[lastFileidx]
 		}
 
-		frontendCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "frontend"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
+		frontendConfigFileName := fmt.Sprintf("frontend_%s_%s", timestamp, sourceConfigFileName)
+		frontendCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, frontendConfigFileName, dateFormat)
 		frontend := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -372,14 +373,15 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
-				InputFiles:               []string{configFile},
+				InputFiles:               []string{},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.frontend,
 				SourceConfig:             configFile,
-				DestinationConfig:        "frontend" + "_" + timestamp + "_" + configFileRenamed,
+				DestinationConfig:        frontendConfigFileName,
 			},
 		}
-		automateCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "automate"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
+		automateConfigFileName := fmt.Sprintf("automate%s_%s", timestamp, sourceConfigFileName)
+		automateCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, automateConfigFileName, dateFormat)
 		automate := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -387,15 +389,15 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
-				InputFiles:               []string{configFile},
+				InputFiles:               []string{},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.automate,
 				SourceConfig:             configFile,
-				DestinationConfig:        "automate" + "_" + timestamp + "_" + configFileRenamed,
+				DestinationConfig:        automateConfigFileName,
 			},
 		}
-
-		chefServerCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, "chef_server"+"_"+timestamp+"_"+configFileRenamed, dateFormat)
+		chefserverConfigFileName := fmt.Sprintf("chef_server%s_%s", timestamp, sourceConfigFileName)
+		chefServerCmd := fmt.Sprintf(FRONTEND_COMMAND, PATCH, chefserverConfigFileName, dateFormat)
 		chefServer := &Cmd{
 			PreExec: prePatchCheckForFrontendNodes,
 			CmdInputs: &CmdInputs{
@@ -403,15 +405,15 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   false,
 				Args:                     args,
-				InputFiles:               []string{configFile},
+				InputFiles:               []string{},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.chef_server,
 				SourceConfig:             configFile,
-				DestinationConfig:        "chef_server" + "_" + timestamp + "_" + configFileRenamed,
+				DestinationConfig:        chefserverConfigFileName,
 			},
 		}
-
-		postgresqlCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", "postgresql"+"_"+timestamp+"_"+configFileRenamed)
+		postgresqlConfigFileName := fmt.Sprintf("postgresql%s_%s", timestamp, sourceConfigFileName)
+		postgresqlCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "postgresql", "%s", postgresqlConfigFileName)
 		postgresql := &Cmd{
 			PreExec: prePatchCheckForPostgresqlNodes,
 			CmdInputs: &CmdInputs{
@@ -419,14 +421,15 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				Args:                     args,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   true,
-				InputFiles:               []string{configFile},
+				InputFiles:               []string{},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.postgresql,
 				SourceConfig:             configFile,
-				DestinationConfig:        "postgresql" + "_" + timestamp + "_" + configFileRenamed,
+				DestinationConfig:        postgresqlConfigFileName,
 			},
 		}
-		opensearchCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", "opensearch"+"_"+timestamp+"_"+configFileRenamed)
+		opensearchConfigFileName := fmt.Sprintf("postgresql%s_%s", timestamp, sourceConfigFileName)
+		opensearchCmd := fmt.Sprintf(BACKEND_COMMAND, dateFormat, "opensearch", "%s", opensearchConfigFileName)
 		opensearch := &Cmd{
 			PreExec: prePatchCheckForOpensearch,
 			CmdInputs: &CmdInputs{
@@ -434,11 +437,11 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 				Args:                     args,
 				WaitTimeout:              configCmdFlags.waitTimeout,
 				Single:                   true,
-				InputFiles:               []string{configFile},
+				InputFiles:               []string{},
 				ErrorCheckEnableInOutput: true,
 				NodeType:                 configCmdFlags.opensearch,
 				SourceConfig:             configFile,
-				DestinationConfig:        "opensearch" + "_" + timestamp + "_" + configFileRenamed,
+				DestinationConfig:        opensearchConfigFileName,
 			},
 		}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Introduced two variables in Command input : SourceConfig and DestinationConfig. 
SourceConfig holds the entire config file path provided by the user. DestinationConfig holds the timestamp formatted file name that will be copied on the nodes. 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3217

### :+1: Definition of Done
User should be able to patch config present in any folder path

### :athletic_shoe: How to Build and Test the Change
Checkout the branch
rebuild components/automate-cli

use the package to test changes

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1792" alt="Screenshot 2023-06-01 at 2 38 57 PM" src="https://github.com/chef/automate/assets/86220713/b5f1b1f9-e947-4650-afd0-aa7dc3f26eba">
<img width="1792" alt="Screenshot 2023-06-01 at 2 39 17 PM" src="https://github.com/chef/automate/assets/86220713/1c10e8da-05de-42c9-8ffc-cc5f2324ce58">
<img width="1792" alt="Screenshot 2023-06-01 at 2 38 08 PM" src="https://github.com/chef/automate/assets/86220713/f6a4941e-bbdf-489a-afbf-2f0057f220b7">
<img width="1792" alt="Screenshot 2023-06-01 at 2 36 30 PM" src="https://github.com/chef/automate/assets/86220713/cf7bb788-502b-482c-97b4-76b7bdced29c">

<img width="1792" alt="Screenshot 2023-06-01 at 2 35 44 PM" src="https://github.com/chef/automate/assets/86220713/d0e070db-a7a2-46a6-b7c4-f9b2c2500de0">
<img width="1792" alt="Screenshot 2023-06-01 at 2 35 35 PM" src="https://github.com/chef/automate/assets/86220713/564eff96-4315-4abd-869d-f59dd9538f35">
<img width="1792" alt="Screenshot 2023-06-01 at 2 35 23 PM" src="https://github.com/chef/automate/assets/86220713/8b8cc385-4430-4837-a54b-3911f17ef84f">

<img width="1904" alt="Screenshot 2023-06-01 at 2 34 16 PM" src="https://github.com/chef/automate/assets/86220713/43dd8d95-76d3-41ba-9af7-10fd864a8301">
<img width="1904" alt="Screenshot 2023-06-01 at 2 33 40 PM" src="https://github.com/chef/automate/assets/86220713/0be23ea8-928b-48f0-90bf-06b007237ef3">
