### PR TITLE
Firewall API

### DIFF
--- a/components/automate-cli/pkg/verifyserver/constants/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/constants/firewall.go
@@ -1,0 +1,8 @@
+package constants
+
+const (
+	FIREWALL_TITLE              = "check for reachability of service at destination port from the source node"
+	FIREWALL_SUCCESS_MESSAGE    = "The %s service running at %s:%s is reachable from %s"
+	FIREWALL_ERROR_MESSAGE      = "The %s service running at %s:%s is not reachable from %s"
+	FIREWALL_RESOLUTION_MESSAGE = "Check your firewall settings to provide access to %s port at %s from %s"
+)

--- a/components/automate-cli/pkg/verifyserver/constants/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/constants/firewall.go
@@ -1,8 +1,5 @@
 package constants
 
 const (
-	FIREWALL_TITLE              = "check for reachability of service at destination port from the source node"
-	FIREWALL_SUCCESS_MESSAGE    = "The %s service running at %s:%s is reachable from %s"
-	FIREWALL_ERROR_MESSAGE      = "The %s service running at %s:%s is not reachable from %s"
-	FIREWALL_RESOLUTION_MESSAGE = "Check your firewall settings to provide access to %s port at %s from %s"
+	FIREWALL_TITLE = "check for reachability of service at destination port from the source node"
 )

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -150,8 +150,6 @@ type FirewallRequest struct {
 	DestinationNodeIP          string `json:"destination_node_ip"`
 	DestinationServicePort     string `json:"destination_service_port"`
 	DestinationServiceProtocol string `json:"destination_service_protocol"`
-	Cert                       string `json:"cert"`
-	Key                        string `json:"key"`
 	RootCert                   string `json:"root_cert"`
 }
 

--- a/components/automate-cli/pkg/verifyserver/models/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/models/firewall.go
@@ -1,0 +1,6 @@
+package models
+
+type FirewallResponse struct {
+	Passed bool     `json:"passed"`
+	Checks []Checks `json:"checks"`
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
+	"github.com/gofiber/fiber/v2"
+)
+
+func (h *Handler) FirewallCheck(c *fiber.Ctx) error {
+	reqBody := models.FirewallRequest{}
+	if err := c.BodyParser(&reqBody); err != nil {
+		h.Logger.Error(err.Error())
+		return fiber.NewError(http.StatusBadRequest, "Invalid Body Request")
+	}
+	if strings.TrimSpace(reqBody.SourceNodeIP) == "" ||
+		strings.TrimSpace(reqBody.DestinationNodeIP) == "" ||
+		strings.TrimSpace(reqBody.DestinationServicePort) == "" ||
+		strings.TrimSpace(reqBody.DestinationServiceProtocol) == "" {
+		return fiber.NewError(http.StatusBadRequest, "source_node_ip, destination_node_ip, destination_service_port, destination_service_protocol, cert, key or root_cert cannot be empty")
+	}
+
+	port, err := strconv.Atoi(reqBody.DestinationServicePort)
+	if err != nil {
+		h.Logger.Error(err)
+		return fiber.NewError(http.StatusBadRequest, "Invalid port number")
+	}
+
+	// If port number is invalid
+	err = validatePortRange(port, h)
+	if err != nil {
+		h.Logger.Error(err)
+		return fiber.NewError(http.StatusBadRequest, "Invalid port range")
+	}
+
+	if reqBody.DestinationServiceProtocol == constants.HTTPS && reqBody.RootCert == "" {
+		return fiber.NewError(http.StatusBadRequest, "RootCA value is mandatory for protocol HTTPS")
+	}
+	if reqBody.DestinationServiceProtocol != constants.TCP && reqBody.DestinationServiceProtocol != constants.UDP && reqBody.DestinationServiceProtocol != constants.HTTPS {
+		return fiber.NewError(http.StatusBadRequest, "Please Give Valid Protocol i.e tcp, udp or https")
+	}
+	firewallDetails := h.FirewallService.GetFirewallDetails(reqBody)
+	return c.JSON(response.BuildSuccessResponse(firewallDetails))
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
@@ -47,7 +47,7 @@ func (h *Handler) FirewallCheck(c *fiber.Ctx) error {
 
 	// For https protocol root_ca is mandatory
 	if strings.TrimSpace(reqBody.DestinationServiceProtocol) == constants.HTTPS && strings.TrimSpace(reqBody.RootCert) == "" {
-		return fiber.NewError(http.StatusBadRequest, "root_cert value is mandatory for protocol destination_service_protocol")
+		return fiber.NewError(http.StatusBadRequest, "root_cert value is mandatory for protocol https")
 	}
 
 	// Supported protocol check

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall.go
@@ -46,12 +46,15 @@ func (h *Handler) FirewallCheck(c *fiber.Ctx) error {
 	}
 
 	// For https protocol root_ca is mandatory
-	if strings.TrimSpace(reqBody.DestinationServiceProtocol) == constants.HTTPS && strings.TrimSpace(reqBody.RootCert) == "" {
+	if strings.TrimSpace(reqBody.DestinationServiceProtocol) == constants.HTTPS &&
+		strings.TrimSpace(reqBody.RootCert) == "" {
 		return fiber.NewError(http.StatusBadRequest, "root_cert value is mandatory for protocol https")
 	}
 
 	// Supported protocol check
-	if strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.TCP && strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.UDP && strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.HTTPS {
+	if strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.TCP &&
+		strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.UDP &&
+		strings.TrimSpace(reqBody.DestinationServiceProtocol) != constants.HTTPS {
 		return fiber.NewError(http.StatusBadRequest, "Please Give Valid Protocol i.e tcp, udp or https")
 	}
 

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
@@ -1,0 +1,1 @@
+package v1_test

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
@@ -1,1 +1,252 @@
 package v1_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/server"
+	v1 "github.com/chef/automate/components/automate-cli/pkg/verifyserver/server/api/v1"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/firewallservice"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/utils/fiberutils"
+	"github.com/chef/automate/lib/logger"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func SetupFirewallHandler(fw firewallservice.IFirewallService) (*fiber.App, error) {
+	log, err := logger.NewLogger("text", "debug")
+	if err != nil {
+		return nil, err
+	}
+	fconf := fiber.Config{
+		ServerHeader: server.SERVICE,
+		ErrorHandler: fiberutils.CustomErrorHandler,
+	}
+	app := fiber.New(fconf)
+	handler := v1.NewHandler(log).
+		AddFirewallService(fw)
+	vs := &server.VerifyServer{
+		Port:    server.DEFAULT_PORT,
+		Log:     log,
+		App:     app,
+		Handler: handler,
+	}
+	vs.SetupRoutes()
+	return vs.App, nil
+}
+
+func SetupMockFirewallService() firewallservice.IFirewallService {
+	return &firewallservice.MockFirewallService{
+		GetFirewallDetailsFunc: func(reqBody models.FirewallRequest) models.FirewallResponse {
+			return models.FirewallResponse{
+				Passed: true,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        true,
+						SuccessMsg:    fmt.Sprintf(constants.FIREWALL_SUCCESS_MESSAGE, constants.TCP, "13.39.148.115", "7432", "15.237.128.20"),
+						ErrorMsg:      "",
+						ResolutionMsg: "",
+					},
+				},
+			}
+		},
+	}
+}
+
+func TestFirewallCheck(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		ExpectedCode int
+		ExpectedBody string
+		RequestBody  string
+	}{
+		{
+			TestName: "Valid Body Request",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "7432",
+				"destination_service_protocol": "tcp"
+			  }`,
+			ExpectedCode: 200,
+			ExpectedBody: `{
+				"status": "SUCCESS",
+				"result": {
+					"passed": true,
+					"checks": [
+						{
+							"title": "check for reachability of service at destination port from the source node",
+							"passed": true,
+							"success_msg": "The tcp service running at 13.39.148.115:7432 is reachable from 15.237.128.20",
+							"error_msg": "",
+							"resolution_msg": ""
+						}
+					]
+				}
+			}`,
+		},
+		{
+			TestName:     "Invalid Body Request",
+			RequestBody:  "Invalid Body",
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Invalid Body Request"
+				}
+			}`,
+		},
+		{
+			TestName: "Not Given all the required Fields",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "7432"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "source_node_ip, destination_node_ip, destination_service_port or destination_service_protocol cannot be empty"
+				}
+			}`,
+		},
+		{
+			TestName: "Giving Space instead of actual Values",
+			RequestBody: `{
+				"source_node_ip": "",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "7432",
+				"destination_service_protocol": "   "
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "source_node_ip, destination_node_ip, destination_service_port or destination_service_protocol cannot be empty"
+				}
+			}`,
+		},
+		{
+			TestName: "Port Number is not a integer",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "abcd",
+				"destination_service_protocol": "tcp"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Invalid destination_service_port number"
+				}
+			}`,
+		},
+		{
+			TestName: "Port Number is not a valid number",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "-1234",
+				"destination_service_protocol": "tcp"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Invalid destination_service_port range"
+				}
+			}`,
+		},
+		{
+			TestName: "Source IP is same as Destination IP",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "15.237.128.20",
+				"destination_service_port": "7432",
+				"destination_service_protocol": "tcp"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "source_node_ip and destination_node_ip cannot be same"
+				}
+			}`,
+		},
+		{
+			TestName: "Using HTTPS protocol but not giving root_ca",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "7432",
+				"destination_service_protocol": "https"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "root_cert value is mandatory for protocol destination_service_protocol"
+				}
+			}`,
+		},
+		{
+			TestName: "Giving Invalid Protocol",
+			RequestBody: `{
+				"source_node_ip": "15.237.128.20",
+				"destination_node_ip": "13.39.148.115",
+				"destination_service_port": "7432",
+				"destination_service_protocol": "udp4"
+			  }`,
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "Please Give Valid Protocol i.e tcp, udp or https"
+				}
+			}`,
+		},
+	}
+
+	FirewallEndpoint := constants.FIREWALL_API_PATH
+
+	app, err := SetupFirewallHandler(SetupMockFirewallService())
+	assert.NoError(t, err)
+
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			bodyReader := strings.NewReader(test.RequestBody)
+			req := httptest.NewRequest("POST", FirewallEndpoint, bodyReader)
+			req.Header.Add("Content-Type", "application/json")
+			res, err := app.Test(req, -1)
+			assert.NoError(t, err)
+			body, err := ioutil.ReadAll(res.Body) //nosemgrep
+			assert.NoError(t, err, test.TestName)
+			assert.JSONEq(t, test.ExpectedBody, string(body))
+			assert.Equal(t, test.ExpectedCode, res.StatusCode)
+		})
+	}
+}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
@@ -207,7 +207,7 @@ func TestFirewallCheck(t *testing.T) {
 				"result": null,
 				"error": {
 					"code": 400,
-					"message": "root_cert value is mandatory for protocol destination_service_protocol"
+					"message": "root_cert value is mandatory for protocol https"
 				}
 			}`,
 		},

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
@@ -1,7 +1,6 @@
 package v1_test
 
 import (
-	"fmt"
 	"io"
 	"net/http/httptest"
 	"strings"
@@ -49,7 +48,7 @@ func SetupMockFirewallService() firewallservice.IFirewallService {
 					{
 						Title:         constants.FIREWALL_TITLE,
 						Passed:        true,
-						SuccessMsg:    fmt.Sprintf(constants.FIREWALL_SUCCESS_MESSAGE, constants.TCP, "13.39.148.115", "7432", "15.237.128.20"),
+						SuccessMsg:    firewallservice.GetFirewallSuccessMsg(constants.TCP, "13.39.148.115", "7432", "15.237.128.20"),
 						ErrorMsg:      "",
 						ResolutionMsg: "",
 					},

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/firewall_test.go
@@ -2,7 +2,7 @@ package v1_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -243,7 +243,7 @@ func TestFirewallCheck(t *testing.T) {
 			req.Header.Add("Content-Type", "application/json")
 			res, err := app.Test(req, -1)
 			assert.NoError(t, err)
-			body, err := ioutil.ReadAll(res.Body) //nosemgrep
+			body, err := io.ReadAll(res.Body)
 			assert.NoError(t, err, test.TestName)
 			assert.JSONEq(t, test.ExpectedBody, string(body))
 			assert.Equal(t, test.ExpectedCode, res.StatusCode)

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/handler.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/externalopensearchservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/externalpostgresqlservice"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/firewallservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/fqdnservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/hardwareresourcecount"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
@@ -36,6 +37,7 @@ type Handler struct {
 	SystemResourceService        systemresourceservice.SystemResourcesService
 	ExternalOpensearchService    externalopensearchservice.IExternalOpensearchService
 	FqdnService                  fqdnservice.IFqdnService
+	FirewallService              firewallservice.IFirewallService
 }
 
 func NewHandler(logger logger.Logger) *Handler {
@@ -113,5 +115,10 @@ func (h *Handler) AddSystemResourceService(srs systemresourceservice.SystemResou
 
 func (h *Handler) AddExternalOpensearchService(eos externalopensearchservice.IExternalOpensearchService) *Handler {
 	h.ExternalOpensearchService = eos
+	return h
+}
+
+func (h *Handler) AddFirewallService(fw firewallservice.IFirewallService) *Handler {
+	h.FirewallService = fw
 	return h
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/startMockServer.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/startMockServer.go
@@ -48,7 +48,7 @@ func (h *Handler) StartMockServer(c *fiber.Ctx) error {
 func validatePortRange(requestBodyPort int, h *Handler) error {
 	if requestBodyPort < 0 || requestBodyPort > 65535 {
 		errString := "start mock-server request body contains invalid port number"
-		fmt.Print(errString)
+		h.Logger.Error(errString)
 		return errors.New(errString)
 	}
 	return nil

--- a/components/automate-cli/pkg/verifyserver/server/routes.go
+++ b/components/automate-cli/pkg/verifyserver/server/routes.go
@@ -22,6 +22,7 @@ func (vs *VerifyServer) SetupRoutes() {
 	apiChecksGroup.Get("/system-user", vs.Handler.CheckSystemUser)
 	apiChecksGroup.Get("/system-resource", vs.Handler.GetSystemResource)
 	apiChecksGroup.Post("/external-opensearch", vs.Handler.ExternalOpensearch)
+	apiChecksGroup.Post("/firewall", vs.Handler.FirewallCheck)
 
 	apiStartGroup := apiV1Group.Group("/start")
 	apiStartGroup.Post("/mock-server", vs.Handler.StartMockServer)

--- a/components/automate-cli/pkg/verifyserver/server/server.go
+++ b/components/automate-cli/pkg/verifyserver/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/systemuserchecktrigger"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/externalopensearchservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/externalpostgresqlservice"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/firewallservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/hardwareresourcecount"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/nfsmountservice"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/opensearchbackupservice"
@@ -118,7 +119,8 @@ func NewVerifyServer(port string, debug bool) (*VerifyServer, error) {
 		AddExternalPostgresqlService(externalpostgresqlservice.NewExternalPostgresqlService(db.NewDBImpl(), fileutils.NewFileSystemUtils(), l)).
 		AddSystemUserService(systemuserservice.NewSystemUserService(l, executil.NewExecCmdServiceImp(), userutils.NewUserUtilImp())).
 		AddExternalOpensearchService(externalopensearchservice.NewExternalOpensearchService(l, constants.TIMEOUT)).
-		AddFqdnService(fqdnservice.NewFqdnService(l, constants.TIMEOUT))
+		AddFqdnService(fqdnservice.NewFqdnService(l, constants.TIMEOUT)).
+		AddFirewallService(firewallservice.NewFirewallService(l, constants.TIMEOUT, port))
 
 	vs := &VerifyServer{
 		Port:    port,

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/batchcheckservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/batchcheckservice_test.go
@@ -2,7 +2,6 @@ package batchcheckservice
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
@@ -580,13 +579,12 @@ func TestBatchCheckService(t *testing.T) {
 			res3 := getResponseForIp(resp.Result, "1.2.3.8", "postgresql")
 			res4 := getResponseForIp(resp.Result, "1.2.3.5", "opensearch")
 			res5 := getResponseForIp(resp.Result, "1.2.3.6", "opensearch")
-			fmt.Println(res, res1, res2, res3, res4, res5)
-			assert.Equal(t, test.expectedResponseForAutomateIp, getResponseForIp(resp.Result, "1.2.3.4", "automate"))
-			assert.Equal(t, test.expectedResponseFromChefServerIp, getResponseForIp(resp.Result, test.chefServerIpArray[0], "chef-infra-server"))
-			assert.Equal(t, test.expectedResponseForPostgresIp1, getResponseForIp(resp.Result, "1.2.3.7", "postgresql"))
-			assert.Equal(t, test.expectedResponseForPostgresIp2, getResponseForIp(resp.Result, "1.2.3.8", "postgresql"))
-			assert.Equal(t, test.expectedResponseForOpenSearchIp1, getResponseForIp(resp.Result, "1.2.3.5", "opensearch"))
-			assert.Equal(t, test.expectedResponseForOpenSearchIp2, getResponseForIp(resp.Result, "1.2.3.6", "opensearch"))
+			assert.Equal(t, test.expectedResponseForAutomateIp, res)
+			assert.Equal(t, test.expectedResponseFromChefServerIp, res1)
+			assert.Equal(t, test.expectedResponseForPostgresIp1, res2)
+			assert.Equal(t, test.expectedResponseForPostgresIp2, res3)
+			assert.Equal(t, test.expectedResponseForOpenSearchIp1, res4)
+			assert.Equal(t, test.expectedResponseForOpenSearchIp2, res5)
 		})
 	}
 

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger.go
@@ -46,18 +46,6 @@ func makeRequests(config models.Config, reqMap map[string][]models.FirewallReque
 	reqMap[constants.BASTION] = getRequestAsBastionSource(config)
 }
 
-func getCertForNodeFromConfig(config models.Config, ip string) models.NodeCert {
-	var nodeCert models.NodeCert
-	for _, node := range config.Certificate.Nodes {
-		if node.IP == ip {
-			nodeCert = node
-			break
-		}
-	}
-	return nodeCert
-
-}
-
 // getRequestsForAutomateAsSource gives the requests for all the ports and types automate as source
 func getRequestsForAutomateAsSource(config models.Config) []models.FirewallRequest {
 	var reqBodies []models.FirewallRequest
@@ -96,14 +84,11 @@ func getRequestsForChefServerAsSource(config models.Config) []models.FirewallReq
 	for _, sourceNodeIP := range config.Hardware.ChefInfraServerNodeIps {
 		//Dest Automate
 		for _, destNodeIP := range config.Hardware.AutomateNodeIps {
-			nodeCert := getCertForNodeFromConfig(config, destNodeIP)
 			reqBody := models.FirewallRequest{
 				SourceNodeIP:               sourceNodeIP,
 				DestinationNodeIP:          destNodeIP,
 				DestinationServicePort:     "443",
 				DestinationServiceProtocol: "https",
-				Cert:                       nodeCert.Cert,
-				Key:                        nodeCert.Key,
 				RootCert:                   config.Certificate.RootCert,
 			}
 			reqBodies = append(reqBodies, reqBody)
@@ -230,8 +215,6 @@ func getRequestAsBastionSource(config models.Config) []models.FirewallRequest {
 				DestinationNodeIP:          destNodeIP,
 				DestinationServicePort:     port,
 				DestinationServiceProtocol: "tcp",
-				Cert:                       config.Certificate.Nodes[0].Cert,
-				Key:                        config.Certificate.Nodes[0].Key,
 				RootCert:                   config.Certificate.RootCert,
 			}
 			reqBodies = append(reqBodies, reqBody)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger.go
@@ -47,7 +47,6 @@ func (ss *SshUserAccessCheck) Run(config models.Config) []models.CheckTriggerRes
 		finalResult = append(finalResult, resp)
 	}
 	close(outputCh)
-	fmt.Println(finalResult)
 
 	return finalResult
 }

--- a/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice.go
@@ -1,0 +1,149 @@
+package firewallservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
+	"github.com/chef/automate/lib/logger"
+)
+
+type IFirewallService interface {
+	GetFirewallDetails(models.FirewallRequest) models.FirewallResponse
+}
+
+type FirewallService struct {
+	log     logger.Logger
+	timeout time.Duration
+	port    string
+}
+
+func NewFirewallService(log logger.Logger, timeout time.Duration, port string) IFirewallService {
+	return &FirewallService{
+		log:     log,
+		timeout: timeout,
+		port:    port,
+	}
+}
+
+func (fw *FirewallService) triggerRequest(req models.FirewallRequest, client *http.Client) (*models.Checks, error) {
+	fw.log.Debug("triggerRequest Called...")
+	url := fmt.Sprintf("http://%s:%s%s", req.SourceNodeIP, fw.port, constants.PORT_REACHABLE_API_PATH)
+	fw.log.Debug("URL: ", url)
+
+	destinationPort, err := strconv.Atoi(req.DestinationServicePort)
+	if err != nil {
+		return nil, errors.New("Failed to convert string ip into int: " + err.Error())
+	}
+	httpReqBody := models.PortReachableRequest{
+		DestinationNodeIp:              req.DestinationNodeIP,
+		DestinationNodePort:            destinationPort,
+		DestinationNodeServiceProtocol: req.DestinationServiceProtocol,
+		RootCA:                         req.RootCert,
+	}
+	httpReqBodyJSON, err := json.Marshal(httpReqBody)
+	if err != nil {
+		return nil, errors.New("Failed to Marshal: " + err.Error())
+	}
+	httpReq, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte(httpReqBodyJSON)))
+	if err != nil {
+		return nil, errors.New("Error creating request: " + err.Error())
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, errors.New("Error sending request: " + err.Error())
+	}
+
+	return fw.getResultStructFromRespBody(resp.Body)
+}
+
+func (fw *FirewallService) getResultStructFromRespBody(respBody io.Reader) (*models.Checks, error) {
+	fw.log.Debug("getResultStructFromRespBody called...")
+	body, err := io.ReadAll(respBody)
+	if err != nil {
+		return nil, errors.New("Cannot able to read data from response body: " + err.Error())
+	}
+
+	// Converting API Response Body into Generic Response Struct.
+	apiRespStruct := response.ResponseBody{}
+	err = json.Unmarshal(body, &apiRespStruct)
+	if err != nil {
+		return nil, errors.New("Failed to Unmarshal: " + err.Error())
+	}
+
+	// If API(/port-reachable) is itself failing.
+	if apiRespStruct.Error != nil {
+		return nil, apiRespStruct.Error
+	}
+
+	// Converting interface into JSON encoding. apiResp.Result is a interface and for accessing the values we are converting that into json.
+	resultByte, err := json.Marshal(apiRespStruct.Result)
+	if err != nil {
+		return nil, errors.New("Failed to Marshal: " + err.Error())
+	}
+
+	resultField := new(models.Checks)
+	// converting JSON into struct.
+	err = json.Unmarshal(resultByte, &resultField)
+	if err != nil {
+		return nil, errors.New("Failed to Unmarshal: " + err.Error())
+	}
+
+	return resultField, nil
+}
+
+func (fw *FirewallService) checkReachability(req models.FirewallRequest) models.Checks {
+	client := &http.Client{
+		Timeout: fw.timeout * time.Second,
+	}
+	respBody, err := fw.triggerRequest(req, client)
+	if err != nil || !respBody.Passed {
+		if err != nil {
+			fw.log.Error("Error: ", err)
+		} else {
+			fw.log.Error("port-reachable api result: ", respBody.Passed)
+		}
+		return models.Checks{
+			Title:         constants.FIREWALL_TITLE,
+			Passed:        false,
+			SuccessMsg:    "",
+			ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, req.DestinationServiceProtocol, req.DestinationNodeIP, req.DestinationServicePort, req.SourceNodeIP),
+			ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, req.DestinationServicePort, req.DestinationNodeIP, req.SourceNodeIP),
+		}
+	}
+	fw.log.Debug("Response From port-reachable API: ", respBody)
+	return models.Checks{
+		Title:         constants.FIREWALL_TITLE,
+		Passed:        true,
+		SuccessMsg:    fmt.Sprintf(constants.FIREWALL_SUCCESS_MESSAGE, req.DestinationServiceProtocol, req.DestinationNodeIP, req.DestinationServicePort, req.SourceNodeIP),
+		ErrorMsg:      "",
+		ResolutionMsg: "",
+	}
+
+}
+func (fw *FirewallService) GetFirewallDetails(reqBody models.FirewallRequest) models.FirewallResponse {
+	resp := models.FirewallResponse{}
+
+	reachableCheck := fw.checkReachability(reqBody)
+	resp.Checks = append(resp.Checks, reachableCheck)
+
+	resp.Passed = true
+	for _, check := range resp.Checks {
+		if !check.Passed {
+			resp.Passed = false
+			break
+		}
+	}
+
+	return resp
+}

--- a/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice.go
@@ -26,7 +26,7 @@ type FirewallService struct {
 	port    string
 }
 
-func NewFirewallService(log logger.Logger, timeout time.Duration, port string) IFirewallService {
+func NewFirewallService(log logger.Logger, timeout time.Duration, port string) *FirewallService {
 	return &FirewallService{
 		log:     log,
 		timeout: timeout,

--- a/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice_test.go
@@ -1,0 +1,1 @@
+package firewallservice_test

--- a/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservice_test.go
@@ -1,1 +1,331 @@
 package firewallservice_test
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/firewallservice"
+	"github.com/chef/automate/lib/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TIMEOUT                         = 1
+	LOCALHOST                       = "localhost"
+	VALID_IP                        = "192.165.54.34"
+	INVALID_PORT_NUMBER             = "abcd"
+	PORT_REACHABLE_SUCCESS_RESPONSE = `{
+		"status": "SUCCESS",
+		"result": {
+			"title": "Check for reachability of service at destination port",
+			"passed": true,
+			"success_msg": "The tcp service running at ANY_IP:7432 is reachable",
+			"error_msg": "",
+			"resolution_msg": ""
+		}
+	}
+`
+
+	PORT_REACHABLE_FAILED_RESPONSE = `{
+    "status": "SUCCESS",
+    "result": {
+        "title": "Check for reachability of service at destination port",
+        "passed": false,
+        "success_msg": "",
+        "error_msg": "The tcp service running at ANY_IP:7433 is not reachable",
+        "resolution_msg": "Check your firewall settings to provide access to 7433 port at 13.39.148.115"
+    }
+}
+`
+
+	PORT_REACHABLE_ERROR_RESPONSE = `{
+	"status": "FAILED",
+	"result": null,
+	"error": {
+		"code": 400,
+		"message": "For Some reasons Port-reachable API got failed"
+	}
+}
+`
+	PORT_REACHABLE_INVALID_RESPONSE = "HELLO"
+
+	PORT_REACHABLE_UNEXPECTED_RESULT_STRUCT_RESPONSE = `{
+		"status": "SUCCESS",
+		"result": {
+		}
+	}
+	`
+)
+
+func TestNewFirewallService(t *testing.T) {
+	testPort := "3073"
+	fw := firewallservice.NewFirewallService(logger.NewTestLogger(), time.Duration(TIMEOUT), testPort)
+	assert.NotNil(t, fw)
+}
+
+func startMockServerOnCustomPort(mockServer *httptest.Server, port string) error {
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
+	if err != nil {
+		return err
+	}
+	mockServer.Listener = l
+	mockServer.Start()
+	return nil
+}
+
+func TestGetFirewallDetails(t *testing.T) {
+	PortReachablePassServerPort := "3074"
+	PortReachableFailedResponseServerPort := "3075"
+	PortReachableErrorResponseServerPort := "3076"
+	PortReachableInvalidResponseServerPort := "3077"
+	PortReachableUnexpectedResultStructResponseServerPort := "3078"
+	VerifyServerNotRunningPort := "3079"
+	httpsTestPort := "3080"
+
+	PortReachablePassMockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(PORT_REACHABLE_SUCCESS_RESPONSE))
+	}))
+	err := startMockServerOnCustomPort(PortReachablePassMockServer, PortReachablePassServerPort)
+	assert.NoError(t, err)
+	defer PortReachablePassMockServer.Close()
+
+	portReachableFailedMockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(PORT_REACHABLE_FAILED_RESPONSE))
+	}))
+	err = startMockServerOnCustomPort(portReachableFailedMockServer, PortReachableFailedResponseServerPort)
+	assert.NoError(t, err)
+	defer portReachableFailedMockServer.Close()
+
+	portReachableInvalidMockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(PORT_REACHABLE_INVALID_RESPONSE))
+	}))
+	err = startMockServerOnCustomPort(portReachableInvalidMockServer, PortReachableInvalidResponseServerPort)
+	assert.NoError(t, err)
+	defer portReachableInvalidMockServer.Close()
+
+	portReachableUnexpectedResultStructMockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(PORT_REACHABLE_UNEXPECTED_RESULT_STRUCT_RESPONSE))
+	}))
+	err = startMockServerOnCustomPort(portReachableUnexpectedResultStructMockServer, PortReachableUnexpectedResultStructResponseServerPort)
+	assert.NoError(t, err)
+	defer portReachableUnexpectedResultStructMockServer.Close()
+
+	portReachableErrorMockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(PORT_REACHABLE_ERROR_RESPONSE))
+	}))
+	err = startMockServerOnCustomPort(portReachableErrorMockServer, PortReachableErrorResponseServerPort)
+	assert.NoError(t, err)
+	defer portReachableErrorMockServer.Close()
+
+	tests := []struct {
+		TestName         string
+		ReqBody          models.FirewallRequest
+		VerifyServerPort string
+		ExpectedRespBody models.FirewallResponse
+	}{
+		{
+			TestName: "Destination IP is reachable from source Node for given port",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachablePassServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: true,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        true,
+						SuccessMsg:    fmt.Sprintf(constants.FIREWALL_SUCCESS_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ErrorMsg:      "",
+						ResolutionMsg: "",
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because verify server not running there",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: VerifyServerNotRunningPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because port-reachable API giving Failed Response",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableFailedResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because port-reachable API giving Error Response",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableErrorResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because port-reachable API giving Invalid Response",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableInvalidResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because port-reachable API giving Unexpected Result Struct Value Response",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableUnexpectedResultStructResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because Source Node IP is not correct",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               "%%",
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     httpsTestPort,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableUnexpectedResultStructResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, httpsTestPort, "%%"),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, httpsTestPort, VALID_IP, "%%"),
+					},
+				},
+			},
+		},
+		{
+			TestName: "Destination IP is not reachable from source Node for given port because Giving Invalid Port Number",
+			ReqBody: models.FirewallRequest{
+				SourceNodeIP:               LOCALHOST,
+				DestinationNodeIP:          VALID_IP,
+				DestinationServicePort:     INVALID_PORT_NUMBER,
+				DestinationServiceProtocol: constants.HTTPS,
+				RootCert:                   "CA_CERT",
+			},
+			VerifyServerPort: PortReachableUnexpectedResultStructResponseServerPort,
+			ExpectedRespBody: models.FirewallResponse{
+				Passed: false,
+				Checks: []models.Checks{
+					{
+						Title:         constants.FIREWALL_TITLE,
+						Passed:        false,
+						SuccessMsg:    "",
+						ErrorMsg:      fmt.Sprintf(constants.FIREWALL_ERROR_MESSAGE, constants.HTTPS, VALID_IP, INVALID_PORT_NUMBER, LOCALHOST),
+						ResolutionMsg: fmt.Sprintf(constants.FIREWALL_RESOLUTION_MESSAGE, INVALID_PORT_NUMBER, VALID_IP, LOCALHOST),
+					},
+				},
+			},
+		},
+	}
+
+	for _, e := range tests {
+		t.Run(e.TestName, func(t *testing.T) {
+			fw := firewallservice.NewFirewallService(logger.NewTestLogger(), time.Duration(TIMEOUT), e.VerifyServerPort)
+			assert.NotNil(t, fw)
+			resp := fw.GetFirewallDetails(e.ReqBody)
+			assert.Equal(t, e.ExpectedRespBody, resp)
+		})
+	}
+}

--- a/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/firewallservice/firewallservicemock.go
@@ -1,0 +1,13 @@
+package firewallservice
+
+import (
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
+)
+
+type MockFirewallService struct {
+	GetFirewallDetailsFunc func(reqBody models.FirewallRequest) models.FirewallResponse
+}
+
+func (mnm *MockFirewallService) GetFirewallDetails(reqBody models.FirewallRequest) models.FirewallResponse {
+	return mnm.GetFirewallDetailsFunc(reqBody)
+}

--- a/components/automate-cli/pkg/verifyserver/services/startmockserverservice/startmockserverservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/startmockserverservice/startmockserverservice.go
@@ -184,7 +184,6 @@ func (s *MockServerService) StartHTTPSServer(port int, cert string, key string) 
 	m.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
 		privateIP := GetPrivateIP()
 
-		// fmt.Println(privateIP)
 		rw.Header().Set("x-server-ip", privateIP)
 		response := models.HTTPSServerResponse{
 			Status: "ok",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As a user I need to check the port reachability between two nodes on given port and using a protocol from Bastion, so that I do not face any issues while doing Automate HA deployment regarding firewall setup and my set up is as per the Automate HA requirements.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2296

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
- Install the following version of automate-cli or create a new automate-cli with this branch and install it
- `ssanju/automate-cli/0.1.0/20230605104431`
- start go-fiber server with `chef-automate verify server`
- From postman make the following request to the endpoint `http://localhost:7799/api/v1/checks/firewall`
- **POST Request**:
```
{
  "source_node_ip": "",
  "destination_node_ip": "",
  "destination_service_port": "",
  "destination_service_protocol": "",
  "root_cert": ""
}
```
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1585" alt="Screenshot 2023-06-05 at 4 16 42 PM" src="https://github.com/chef/automate/assets/101255220/618afcaa-871e-4d4d-9acc-c309292f211e">
<img width="1706" alt="Screenshot 2023-06-05 at 4 17 16 PM" src="https://github.com/chef/automate/assets/101255220/4d0d6b4a-6a90-4309-ad5b-75a6a7e7e26d">
<img width="1702" alt="Screenshot 2023-06-05 at 4 17 38 PM" src="https://github.com/chef/automate/assets/101255220/d28927e9-e14e-4e0b-9ddb-6a55b88409b5">
<img width="1626" alt="Screenshot 2023-06-05 at 4 06 00 PM" src="https://github.com/chef/automate/assets/101255220/24551616-2b52-4383-9550-33bfa71c2c4c">
<img width="1634" alt="Screenshot 2023-06-05 at 4 06 24 PM" src="https://github.com/chef/automate/assets/101255220/57558ea3-6656-461c-9d3d-1a6a5ee69902">
<img width="1636" alt="Screenshot 2023-06-05 at 4 06 43 PM" src="https://github.com/chef/automate/assets/101255220/24743a41-164c-4eb9-aa81-6d94e90f1853">
<img width="1629" alt="Screenshot 2023-06-05 at 4 07 07 PM" src="https://github.com/chef/automate/assets/101255220/2fb509c3-0d67-4f52-87c5-108f45ee6a9c">
<img width="1629" alt="Screenshot 2023-06-05 at 4 07 41 PM" src="https://github.com/chef/automate/assets/101255220/246038ee-588d-4121-86c8-7c04ff79f154">
<img width="1627" alt="Screenshot 2023-06-05 at 4 07 59 PM" src="https://github.com/chef/automate/assets/101255220/cc8939f8-2f8c-49d3-bc7e-b1eb92a5bc0f">
<img width="1635" alt="Screenshot 2023-06-05 at 4 08 39 PM" src="https://github.com/chef/automate/assets/101255220/cf0626d1-ff44-41d1-83bb-cc300586b19c">
<img width="1641" alt="Screenshot 2023-06-05 at 4 09 43 PM" src="https://github.com/chef/automate/assets/101255220/19e92c30-8bc8-4a08-ae5e-5d31a3d3889e">
<img width="1628" alt="Screenshot 2023-06-05 at 4 10 10 PM" src="https://github.com/chef/automate/assets/101255220/9690da3a-5833-4561-aa41-39a3c9935ea2">
