### PR TITLE
Allowing Restart-Services from bastion

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -55,6 +55,7 @@ type RemoteCmdExecutor interface {
 	Execute() (map[string][]*CmdResult, error)
 	ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
 	GetSshUtil() SSHUtil
+	SetWriter(writer *cli.Writer)
 }
 
 type remoteCmdExecutor struct {
@@ -67,6 +68,7 @@ type MockRemoteCmdExecutor struct {
 	ExecuteFunc            func() (map[string][]*CmdResult, error)
 	ExecuteWithNodeMapFunc func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
 	GetSshUtilFunc         func() SSHUtil
+	SetWriterFunc func(cli *cli.Writer)
 }
 
 func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {
@@ -79,6 +81,10 @@ func (m *MockRemoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map
 
 func (m *MockRemoteCmdExecutor) GetSshUtil() SSHUtil {
 	return m.GetSshUtilFunc()
+}
+
+func (m *MockRemoteCmdExecutor) SetWriter(cli *cli.Writer) {
+	m.SetWriterFunc(cli)
 }
 
 func NewRemoteCmdExecutor(nodeMap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) RemoteCmdExecutor {
@@ -98,6 +104,10 @@ func NewRemoteCmdExecutorWithoutNodeMap(sshUtil SSHUtil, writer *cli.Writer) Rem
 
 func (c *remoteCmdExecutor) GetSshUtil() SSHUtil {
 	return c.SshUtil
+}
+
+func (c *remoteCmdExecutor) SetWriter(writer *cli.Writer) {
+	c.Output = writer
 }
 
 func (c *remoteCmdExecutor) ExecuteWithNodeMap(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils.go
@@ -68,7 +68,7 @@ type MockRemoteCmdExecutor struct {
 	ExecuteFunc            func() (map[string][]*CmdResult, error)
 	ExecuteWithNodeMapFunc func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error)
 	GetSshUtilFunc         func() SSHUtil
-	SetWriterFunc func(cli *cli.Writer)
+	SetWriterFunc          func(cli *cli.Writer)
 }
 
 func (m *MockRemoteCmdExecutor) Execute() (map[string][]*CmdResult, error) {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -267,6 +267,7 @@ func TestExecute(t *testing.T) {
 			c := &remoteCmdExecutor{
 				NodeMap: testCase.fields.NodeMap,
 				SshUtil: testCase.fields.SshUtil,
+				Output: cli.NewWriter(os.Stdout, os.Stderr, os.Stdin),
 			}
 			_, err := c.Execute()
 			if testCase.wantErr {

--- a/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
+++ b/components/automate-cli/cmd/chef-automate/cmdUtils_test.go
@@ -267,7 +267,7 @@ func TestExecute(t *testing.T) {
 			c := &remoteCmdExecutor{
 				NodeMap: testCase.fields.NodeMap,
 				SshUtil: testCase.fields.SshUtil,
-				Output: cli.NewWriter(os.Stdout, os.Stderr, os.Stdin),
+				Output:  cli.NewWriter(os.Stdout, os.Stderr, os.Stdin),
 			}
 			_, err := c.Execute()
 			if testCase.wantErr {

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	api "github.com/chef/automate/api/interservice/deployment"
@@ -10,6 +11,21 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 )
+
+const (
+	RESTART_FRONTEND_COMMAND    = `sudo chef-automate restart-services`
+	RESTART_BACKEND_COMMAND     = `sudo systemctl restart hab-sup`
+	DEFAULT_TIMEOUT_FOR_RESTART = 1500
+)
+
+var restartCmdFlags = struct {
+	automate    bool
+	chefServer  bool
+	opensearch  bool
+	postgresql  bool
+	timeout     int
+	waitTimeout int
+}{}
 
 var restartServicesCmd = &cobra.Command{
 	Use:   "restart-services",
@@ -21,7 +37,105 @@ var restartServicesCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	restartServicesCmd.PersistentFlags().BoolVarP(&restartCmdFlags.automate, "automate", "a", false, "restart chef automate service on automate nodes")
+	restartServicesCmd.PersistentFlags().BoolVar(&restartCmdFlags.automate, "a2", false, "restart chef automate service on automate nodes[DUPLICATE]")
+	restartServicesCmd.PersistentFlags().BoolVarP(&restartCmdFlags.chefServer, "chef_server", "c", false, "restart chef automate service on chef-server nodes")
+	restartServicesCmd.PersistentFlags().BoolVar(&restartCmdFlags.chefServer, "cs", false, "restart chef automate service on chef-server nodes[DUPLICATE]")
+	restartServicesCmd.PersistentFlags().BoolVarP(&restartCmdFlags.opensearch, "opensearch", "o", false, "restart hab-sup service on opensearch nodes")
+	restartServicesCmd.PersistentFlags().BoolVar(&restartCmdFlags.opensearch, "os", false, "restart hab-sup service on opensearch nodes[DUPLICATE]")
+	restartServicesCmd.PersistentFlags().BoolVarP(&restartCmdFlags.postgresql, "postgresql", "p", false, "restart hab-sup service on postgresql nodes")
+	restartServicesCmd.PersistentFlags().BoolVar(&restartCmdFlags.postgresql, "pg", false, "restart hab-sup service on postgresql nodes[DUPLICATE]")
+	restartServicesCmd.PersistentFlags().IntVar(&restartCmdFlags.timeout, "wait-timeout", DEFAULT_TIMEOUT_FOR_RESTART, "This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process")
+	RootCmd.AddCommand(restartServicesCmd)
+}
+
 func runRestartServices(cmd *cobra.Command, args []string) error {
+	if isA2HARBFileExist() {
+		infra, err := getAutomateHAInfraDetails()
+		if err != nil {
+			return err
+		}
+		frontend := &Cmd{
+			CmdInputs: &CmdInputs{
+				NodeType: false,
+			},
+		}
+
+		automate := &Cmd{
+			PreExec: nil,
+			CmdInputs: &CmdInputs{
+				Cmd:                      RESTART_FRONTEND_COMMAND,
+				WaitTimeout:              restartCmdFlags.waitTimeout,
+				Single:                   false,
+				Args:                     args,
+				ErrorCheckEnableInOutput: true,
+				//SkipPrintOutput:          true,
+				NodeType:                 restartCmdFlags.automate,
+			},
+		}
+
+		chefServer := &Cmd{
+			PreExec: nil,
+			CmdInputs: &CmdInputs{
+				Cmd:                      RESTART_FRONTEND_COMMAND,
+				WaitTimeout:              restartCmdFlags.waitTimeout,
+				Single:                   false,
+				Args:                     args,
+				ErrorCheckEnableInOutput: true,
+				//SkipPrintOutput:          true,
+				NodeType:                 restartCmdFlags.chefServer,
+			},
+		}
+
+		postgresql := &Cmd{
+			PreExec: nil,
+			CmdInputs: &CmdInputs{
+				Cmd:                      RESTART_BACKEND_COMMAND,
+				WaitTimeout:              restartCmdFlags.waitTimeout,
+				Single:                   false,
+				Args:                     args,
+				ErrorCheckEnableInOutput: true,
+				NodeType:                 restartCmdFlags.postgresql,
+			},
+		}
+		opensearch := &Cmd{
+			PreExec: nil,
+			CmdInputs: &CmdInputs{
+				Cmd:                      RESTART_BACKEND_COMMAND,
+				WaitTimeout:              restartCmdFlags.waitTimeout,
+				Single:                   false,
+				Args:                     args,
+				ErrorCheckEnableInOutput: true,
+				NodeType:                 restartCmdFlags.opensearch,
+			},
+		}
+		nodeMap := &NodeTypeAndCmd{
+			Frontend:   frontend,
+			Automate:   automate,
+			ChefServer: chefServer,
+			Postgresql: postgresql,
+			Opensearch: opensearch,
+			Infra:      infra,
+		}
+		if restartCmdFlags.timeout < DEFAULT_TIMEOUT_FOR_RESTART {
+			return errors.Errorf("The operation timeout duration for each individual node during the services restart should be set to a value greater than %v seconds.", DEFAULT_TIMEOUT_FOR_RESTART)
+		}
+		sshConfig := getSshDetails(infra)
+		sshConfig.timeout = restartCmdFlags.timeout
+		sshUtil := NewSSHUtil(sshConfig)
+		//sshUtil.setSSHConfig(sshConfig)
+
+		cmdUtil := NewRemoteCmdExecutor(nodeMap, sshUtil, writer)
+
+		if restartCmdFlags.automate || restartCmdFlags.chefServer || restartCmdFlags.postgresql || restartCmdFlags.opensearch {
+			_, err = cmdUtil.Execute()
+		} else {
+			writer.Println(cmd.UsageString())
+		}
+
+		return err
+	}
 	connection, err := client.Connection(client.DefaultClientTimeout)
 	if err != nil {
 		return err
@@ -47,8 +161,4 @@ func runRestartServices(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func init() {
-	RootCmd.AddCommand(restartServicesCmd)
 }

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -165,7 +165,7 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 			cmdResult, err := rs.executeRemoteExecutor(nodeMap, sshUtil, writer)
 			errChan <- err
 			wg.Add(1)
-			go rs.printRestartCmdOutput(cmdResult, AUTOMATE, wg, mutex, writer)
+			rs.printRestartCmdOutput(cmdResult, AUTOMATE, wg, mutex, writer)
 		}(*flags, errChan)
 	} else {
 		errChan <- nil
@@ -180,7 +180,7 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 			cmdResult, err := rs.executeRemoteExecutor(nodeMap, sshUtil, writer)
 			errChan <- err
 			wg.Add(1)
-			go rs.printRestartCmdOutput(cmdResult, CHEF_SERVER, wg, mutex, writer)
+			rs.printRestartCmdOutput(cmdResult, CHEF_SERVER, wg, mutex, writer)
 		}(*flags, errChan)
 	} else {
 		errChan <- nil
@@ -210,7 +210,7 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 			cmdResult, err := rs.executeRemoteExecutor(nodeMap, sshUtil, writer)
 			errChan <- err
 			wg.Add(1)
-			go rs.printRestartCmdOutput(cmdResult, POSTGRESQL, wg, mutex, writer)
+			rs.printRestartCmdOutput(cmdResult, POSTGRESQL, wg, mutex, writer)
 		}(*flags, errChan)
 	} else {
 		errChan <- nil
@@ -227,7 +227,7 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 			cmdResult, err := rs.executeRemoteExecutor(nodeMap, sshUtil, writer)
 			errChan <- err
 			wg.Add(1)
-			go rs.printRestartCmdOutput(cmdResult, OPENSEARCH, wg, mutex, writer)
+			rs.printRestartCmdOutput(cmdResult, OPENSEARCH, wg, mutex, writer)
 		}(*flags, errChan)
 	} else {
 		errChan <- nil

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -68,9 +68,9 @@ func runRestartServicesCmd(flags *RestartCmdFlags) func(cmd *cobra.Command, args
 
 func runRestartServices(cmd *cobra.Command, args []string, flags *RestartCmdFlags) error {
 	if isA2HARBFileExist() {
-		NodeOpUtils := &NodeUtilsImpl{}
+		nodeOpUtils := &NodeUtilsImpl{}
 		remoteExcecutor := NewRemoteCmdExecutorWithoutNodeMap(&SSHUtilImpl{}, cli.NewWriter(os.Stdout, os.Stderr, os.Stdin))
-		return runRestartFromBastion(flags, remoteExcecutor, NodeOpUtils)
+		return runRestartFromBastion(flags, remoteExcecutor, nodeOpUtils)
 	}
 	connection, err := client.Connection(client.DefaultClientTimeout)
 	if err != nil {
@@ -155,17 +155,14 @@ func runRestartCmdForFrontEnd(infra *AutomateHAInfraDetails, flags *RestartCmdFl
 }
 
 func runRestartCmdForBackend(infra *AutomateHAInfraDetails, flags *RestartCmdFlags, rs RemoteCmdExecutor, errChan chan *ResultWithError) {
+	flags.automate = false
+	flags.chefServer = false
 	if flags.postgresql {
-		flags.automate = false
-		flags.chefServer = false
 		restartOnGivenNode(flags, POSTGRESQL, infra, rs, errChan)
 	} else {
 		errChan <- &ResultWithError{}
 	}
-
 	if flags.opensearch {
-		flags.automate = false
-		flags.chefServer = false
 		flags.postgresql = false
 		restartOnGivenNode(flags, OPENSEARCH, infra, rs, errChan)
 	} else {
@@ -177,8 +174,8 @@ func restartOnGivenNode(flags *RestartCmdFlags, nodeType string, infra *Automate
 	go func(flags RestartCmdFlags, resultErrChan chan *ResultWithError) {
 		nodeMap := constructNodeMapForAllNodeTypes(&flags, infra)
 		cmdResult, err := rs.ExecuteWithNodeMap(nodeMap)
-		ResultWithError := &ResultWithError{result: cmdResult, err: err}
-		resultErrChan <- ResultWithError
+		resultWithError := &ResultWithError{result: cmdResult, err: err}
+		resultErrChan <- resultWithError
 	}(*flags, resultErrChan)
 }
 

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -188,6 +188,7 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 
 	if rs.isManagedServicesOn() {
 		errChan <- nil
+		errChan <- nil
 		for i := 0; i < 4; i++ {
 			errVal := <-errChan
 			if errVal != nil {

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -288,8 +288,6 @@ func constructNodeMapForAllNodeTypes(flags *RestartCmdFlags, infra *AutomateHAIn
 		Frontend: &Cmd{
 			CmdInputs: &CmdInputs{
 				Cmd:                      RESTART_FRONTEND_COMMAND,
-				ErrorCheckEnableInOutput: true,
-				WaitTimeout:              int(flags.timeout),
 				Single:                   false,
 				NodeType:                 false,
 				SkipPrintOutput:          true,

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -21,6 +21,13 @@ const (
 	ERROR_ON_MANAGED_SERVICES   = "Restarting services on managed %s is not supported."
 )
 
+type restartFromBastion interface {
+	getAutomateHAInfraDetails() (*AutomateHAInfraDetails, error)
+	isManagedServicesOn() bool
+	executeRemoteExecutor(*NodeTypeAndCmd, SSHUtil, *cli.Writer) (map[string][]*CmdResult, error)
+	printRestartCmdOutput(map[string][]*CmdResult, string, *sync.WaitGroup, *sync.Mutex, *cli.Writer)
+}
+
 type RestartCmdFlags struct {
 	automate   bool
 	chefServer bool
@@ -95,13 +102,6 @@ func runRestartServices(cmd *cobra.Command, args []string, flags *RestartCmdFlag
 	}
 
 	return nil
-}
-
-type restartFromBastion interface {
-	getAutomateHAInfraDetails() (*AutomateHAInfraDetails, error)
-	isManagedServicesOn() bool
-	executeRemoteExecutor(*NodeTypeAndCmd, SSHUtil, *cli.Writer) (map[string][]*CmdResult, error)
-	printRestartCmdOutput(map[string][]*CmdResult, string, *sync.WaitGroup, *sync.Mutex, *cli.Writer)
 }
 
 type restartFromBastionImpl struct{}

--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -136,29 +136,6 @@ func (rs *restartFromBastionImpl) printRestartCmdOutput(cmdResult map[string][]*
 	wg.Done()
 }
 
-type MockrestartFromBastionImpl struct {
-	getAutomateHAInfraDetailsFunc func() (*AutomateHAInfraDetails, error)
-	isManagedServicesOnFunc       func() bool
-	executeRemoteExecutorFunc     func(*NodeTypeAndCmd, SSHUtil, *cli.Writer) (map[string][]*CmdResult, error)
-	printRestartCmdOutputFunc     func(map[string][]*CmdResult, string, *sync.WaitGroup, *sync.Mutex, *cli.Writer)
-}
-
-func (mrs *MockrestartFromBastionImpl) getAutomateHAInfraDetails() (*AutomateHAInfraDetails, error) {
-	return mrs.getAutomateHAInfraDetailsFunc()
-}
-
-func (mrs *MockrestartFromBastionImpl) isManagedServicesOn() bool {
-	return mrs.isManagedServicesOnFunc()
-}
-
-func (mrs *MockrestartFromBastionImpl) executeRemoteExecutor(nodemap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) (map[string][]*CmdResult, error) {
-	return mrs.executeRemoteExecutorFunc(nodemap, sshUtil, writer)
-}
-
-func (mrs *MockrestartFromBastionImpl) printRestartCmdOutput(cmdResult map[string][]*CmdResult, remoteService string, wg *sync.WaitGroup, mutex *sync.Mutex, writer *cli.Writer) {
-	mrs.printRestartCmdOutputFunc(cmdResult, remoteService, wg, mutex, writer)
-}
-
 func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error {
 
 	var wg = &sync.WaitGroup{}
@@ -210,7 +187,6 @@ func runRestartFromBastion(flags *RestartCmdFlags, rs restartFromBastion) error 
 	}
 
 	if rs.isManagedServicesOn() {
-		errChan <- nil
 		errChan <- nil
 		for i := 0; i < 4; i++ {
 			errVal := <-errChan

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstructNodeMapForEachNodeTpe(t *testing.T) {
+	var restartCmdFlags = restartCmdFlags{}
+	restartCmdFlags.automate = true
+	var infra AutomateHAInfraDetails
+
+	type ExpectedOutput struct {
+		automate    bool
+		chef_server bool
+		frontend    bool
+	}
+
+	type testCaseInfo struct {
+		testCaseDescription string
+		Automate            bool
+		ChefServer         bool
+		frontend            bool
+		ExpectedOutput      ExpectedOutput
+	}
+
+	testCases := []testCaseInfo{
+		{
+			testCaseDescription: "should construct nodeMap for automate when automate flag is passed",
+			Automate:            true,
+			ChefServer:         false,
+			frontend:            false,
+			ExpectedOutput: ExpectedOutput{
+				Automate:    true,
+				ChefServer: false,
+
+				frontend:    false,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for chef-server when chef-server flag is passed",
+			Automate:            false,
+			ChefServer:         true,
+			frontend:            false,
+			ExpectedOutput: ExpectedOutput{
+				Automate:    false,
+				ChefServer: true,
+				frontend:    false,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for automate when automate flag is passed",
+			Automate:            true,
+			ChefServer:         false,
+			frontend:            false,
+			ExpectedOutput: ExpectedOutput{
+				automate:    true,
+				chef_server: false,
+				frontend:    false,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for frontend when frontend flag is passed",
+			Automate:            false,
+			ChefServer:         false,
+			frontend:            true,
+			ExpectedOutput: ExpectedOutput{
+				automate:    false,
+				chef_server: false,
+				frontend:    true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testCaseDescription, func(t *testing.T) {
+			preflightCmdFlags.automate = tc.Automate
+			preflightCmdFlags.chef_server = tc.ChefServer
+			preflightCmdFlags.frontend = tc.frontend
+
+			nodeMap := constructAndGetNodeMap(&infra)
+
+			assert.EqualValues(t, nodeMap.Automate.CmdInputs.NodeType, tc.ExpectedOutput.automate)
+			assert.EqualValues(t, nodeMap.ChefServer.CmdInputs.NodeType, tc.ExpectedOutput.chef_server)
+			assert.EqualValues(t, nodeMap.Frontend.CmdInputs.NodeType, tc.ExpectedOutput.frontend)
+		})
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -7,83 +7,221 @@ import (
 )
 
 func TestConstructNodeMapForEachNodeTpe(t *testing.T) {
-	var restartCmdFlags = restartCmdFlags{}
 	restartCmdFlags.automate = true
 	var infra AutomateHAInfraDetails
 
 	type ExpectedOutput struct {
-		automate    bool
-		chef_server bool
-		frontend    bool
+		Automate   bool
+		ChefServer bool
+		Postgresql bool
+		Opensearch bool
+		frontend   bool
 	}
 
 	type testCaseInfo struct {
 		testCaseDescription string
 		Automate            bool
-		ChefServer         bool
+		ChefServer          bool
+		Postgresql          bool
+		Opensearch          bool
 		frontend            bool
 		ExpectedOutput      ExpectedOutput
 	}
 
 	testCases := []testCaseInfo{
 		{
+			testCaseDescription: "should construct nodeMap for frontend when frontend flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			frontend:            true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+				frontend:   true,
+			},
+		},
+		{
 			testCaseDescription: "should construct nodeMap for automate when automate flag is passed",
 			Automate:            true,
-			ChefServer:         false,
-			frontend:            false,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			frontend:            true,
 			ExpectedOutput: ExpectedOutput{
-				Automate:    true,
-				ChefServer: false,
-
-				frontend:    false,
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+				frontend:   true,
 			},
 		},
 		{
 			testCaseDescription: "should construct nodeMap for chef-server when chef-server flag is passed",
-			Automate:            false,
-			ChefServer:         true,
-			frontend:            false,
-			ExpectedOutput: ExpectedOutput{
-				Automate:    false,
-				ChefServer: true,
-				frontend:    false,
-			},
-		},
-		{
-			testCaseDescription: "should construct nodeMap for automate when automate flag is passed",
 			Automate:            true,
-			ChefServer:         false,
-			frontend:            false,
-			ExpectedOutput: ExpectedOutput{
-				automate:    true,
-				chef_server: false,
-				frontend:    false,
-			},
-		},
-		{
-			testCaseDescription: "should construct nodeMap for frontend when frontend flag is passed",
-			Automate:            false,
-			ChefServer:         false,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
 			frontend:            true,
 			ExpectedOutput: ExpectedOutput{
-				automate:    false,
-				chef_server: false,
-				frontend:    true,
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+				frontend:   true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for postgresql when Postgresql flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			frontend:            true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+				frontend:   true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for opensearch when Opensearch flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			frontend:            true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+				frontend:   true,
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testCaseDescription, func(t *testing.T) {
-			preflightCmdFlags.automate = tc.Automate
-			preflightCmdFlags.chef_server = tc.ChefServer
-			preflightCmdFlags.frontend = tc.frontend
+			restartCmdFlags.automate = tc.Automate
+			restartCmdFlags.chefServer = tc.ChefServer
+			restartCmdFlags.postgresql = tc.Postgresql
+			restartCmdFlags.opensearch = tc.Opensearch
+			nodeMap := ConstructNodeMapForEachNodeTpe(&infra,&restartCmdFlags)
 
-			nodeMap := constructAndGetNodeMap(&infra)
+			assert.EqualValues(t, tc.ExpectedOutput.Automate, nodeMap.Automate.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.ChefServer, nodeMap.ChefServer.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.Postgresql, nodeMap.Postgresql.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.Opensearch, nodeMap.Opensearch.CmdInputs.NodeType)
+		})
+	}
+}
 
-			assert.EqualValues(t, nodeMap.Automate.CmdInputs.NodeType, tc.ExpectedOutput.automate)
-			assert.EqualValues(t, nodeMap.ChefServer.CmdInputs.NodeType, tc.ExpectedOutput.chef_server)
-			assert.EqualValues(t, nodeMap.Frontend.CmdInputs.NodeType, tc.ExpectedOutput.frontend)
+func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
+	restartCmdFlags.automate = true
+	var infra AutomateHAInfraDetails
+
+	type ExpectedOutput struct {
+		Automate   bool
+		ChefServer bool
+		Postgresql bool
+		Opensearch bool
+	}
+
+	type testCaseInfo struct {
+		testCaseDescription string
+		Automate            bool
+		ChefServer          bool
+		Postgresql          bool
+		Opensearch          bool
+		ExpectedOutput      ExpectedOutput
+	}
+
+	testCases := []testCaseInfo{
+		{
+			testCaseDescription: "should construct nodeMap for frontend when frontend flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for automate when automate flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for chef-server when chef-server flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for postgresql when Postgresql flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+			},
+		},
+		{
+			testCaseDescription: "should construct nodeMap for opensearch when Opensearch flag is passed",
+			Automate:            true,
+			ChefServer:          true,
+			Postgresql:          true,
+			Opensearch:          true,
+			ExpectedOutput: ExpectedOutput{
+				Automate:   true,
+				ChefServer: true,
+				Postgresql: true,
+				Opensearch: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testCaseDescription, func(t *testing.T) {
+			restartCmdFlags.automate = tc.Automate
+			restartCmdFlags.chefServer = tc.ChefServer
+			restartCmdFlags.postgresql = tc.Postgresql
+			restartCmdFlags.opensearch = tc.Opensearch
+			nodeMap := constructNodeMapForAllNodeTypes(&restartCmdFlags,&infra)
+
+			assert.EqualValues(t, tc.ExpectedOutput.Automate, nodeMap.Automate.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.ChefServer, nodeMap.ChefServer.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.Postgresql, nodeMap.Postgresql.CmdInputs.NodeType)
+			assert.EqualValues(t, tc.ExpectedOutput.Opensearch, nodeMap.Opensearch.CmdInputs.NodeType)
 		})
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -115,7 +115,6 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 	}
 }
 
-
 func TestRunRestartFromBastion(t *testing.T) {
 	type testCase struct {
 		description         string
@@ -206,5 +205,47 @@ func TestRunRestartFromBastion(t *testing.T) {
 				assert.Nil(t, err)
 			}
 		})
+	}
+}
+
+func TestHandleManagedServiceError(t *testing.T) {
+
+	testCases := []struct {
+		flags          *RestartCmdFlags
+		errorExepected error
+	}{
+		{
+			flags: &RestartCmdFlags{
+				postgresql: true,
+			},
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, POSTGRESQL),
+		},
+		{
+			flags: &RestartCmdFlags{
+				opensearch: true,
+			},
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, OPENSEARCH),
+		},
+		{
+			flags:          &RestartCmdFlags{},
+			errorExepected: nil,
+		},
+		{
+			flags: &RestartCmdFlags{
+				postgresql: true,
+				opensearch: true,
+			},
+			errorExepected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := handleManagedServiceError(testCase.flags)
+
+		if testCase.errorExepected != nil {
+			assert.EqualError(t, err, testCase.errorExepected.Error())
+		} else {
+			assert.Nil(t, err)
+		}
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -83,6 +83,29 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 	}
 }
 
+type MockrestartFromBastionImpl struct {
+	getAutomateHAInfraDetailsFunc func() (*AutomateHAInfraDetails, error)
+	isManagedServicesOnFunc       func() bool
+	executeRemoteExecutorFunc     func(*NodeTypeAndCmd, SSHUtil, *cli.Writer) (map[string][]*CmdResult, error)
+	printRestartCmdOutputFunc     func(map[string][]*CmdResult, string, *sync.WaitGroup, *sync.Mutex, *cli.Writer)
+}
+
+func (mrs *MockrestartFromBastionImpl) getAutomateHAInfraDetails() (*AutomateHAInfraDetails, error) {
+	return mrs.getAutomateHAInfraDetailsFunc()
+}
+
+func (mrs *MockrestartFromBastionImpl) isManagedServicesOn() bool {
+	return mrs.isManagedServicesOnFunc()
+}
+
+func (mrs *MockrestartFromBastionImpl) executeRemoteExecutor(nodemap *NodeTypeAndCmd, sshUtil SSHUtil, writer *cli.Writer) (map[string][]*CmdResult, error) {
+	return mrs.executeRemoteExecutorFunc(nodemap, sshUtil, writer)
+}
+
+func (mrs *MockrestartFromBastionImpl) printRestartCmdOutput(cmdResult map[string][]*CmdResult, remoteService string, wg *sync.WaitGroup, mutex *sync.Mutex, writer *cli.Writer) {
+	mrs.printRestartCmdOutputFunc(cmdResult, remoteService, wg, mutex, writer)
+}
+
 func TestRunRestartFromBastion(t *testing.T) {
 	type testCase struct {
 		description         string

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,6 +93,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 		mockRemoteCmdExec    *MockRemoteCmdExecutor
 		errorWant            error
 	}
+	printRestartOutput := func(m map[string][]*CmdResult, s string, w *cli.Writer) {}
 	testCases := []testCase{
 		{
 			description: "Error when wait timeout is less than default timeout",
@@ -145,7 +147,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 			}(),
 			mockRestartCmdHelper: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-					return nil, &SSHConfig{}, nil
+					return nil, &SSHConfig{}, errors.New("Error occured while reading infra details")
 				},
 				isManagedServicesOnFunc: func() bool {
 					return false
@@ -176,6 +178,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 					return map[string][]*CmdResult{}, nil
 				},
+				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: nil,
 		},
@@ -197,6 +200,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 					return map[string][]*CmdResult{}, nil
 				},
+				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: errors.New("Some error occured while remote execution"),
 		},
@@ -218,6 +222,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 					return map[string][]*CmdResult{}, nil
 				},
+				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: nil,
 		},
@@ -240,6 +245,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 					return map[string][]*CmdResult{}, nil
 				},
+				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
@@ -262,6 +268,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
 					return map[string][]*CmdResult{}, nil
 				},
+				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
@@ -269,7 +276,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			err := runRestartFromBastion(testCase.flags, testCase.mockRemoteCmdExec, testCase.mockRestartCmdHelper)
+			err := runRestartFromBastion(testCase.flags, testCase.mockRemoteCmdExec, testCase.mockRestartCmdHelper, printRestartOutput)
 			if err != nil {
 				assert.EqualError(t, testCase.errorWant, err.Error())
 			} else {

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -105,7 +105,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
@@ -127,7 +127,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
@@ -148,7 +148,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
@@ -169,7 +169,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
@@ -190,7 +190,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -93,20 +93,45 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 	}
 }
 
+func newDefaultRestartCmdFlag() *RestartCmdFlags {
+	return &RestartCmdFlags{
+		automate:   false,
+		chefServer: false,
+		postgresql: false,
+		opensearch: false,
+		node:       "",
+		timeout:    DEFAULT_TIMEOUT_FOR_RESTART,
+	}
+}
 func TestRunRestartFromBastion(t *testing.T) {
 	type testCase struct {
-		description         string
-		flags               *RestartCmdFlags
+		description          string
+		flags                *RestartCmdFlags
 		mockRestartCmdHelper *MockrestartFromBastionImpl
-		errorWant           error
+		errorWant            error
 	}
-
 	testCases := []testCase{
 		{
-			description: "No service flag provided and node flag is provided",
-			flags: &RestartCmdFlags{
-				node: "1",
+			description: "Error when wait timeout is less than default timeout",
+			flags: func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				restartCmdFlags.timeout=120
+				return restartCmdFlags
+			  } (),
+			mockRestartCmdHelper: &MockrestartFromBastionImpl{
+				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
+					return &AutomateHAInfraDetails{}, nil
+				},
 			},
+			errorWant: status.Errorf(status.InvalidCommandArgsError, "The operation timeout duration for each individual node during the restart should be set to a value greater than %v seconds.",DEFAULT_TIMEOUT_FOR_RESTART),
+		},
+		{
+			description: "No service flag provided and node flag is provided",
+			flags: func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				restartCmdFlags.node="1"
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil
@@ -116,7 +141,10 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Error while reading infra details",
-			flags:       &RestartCmdFlags{},
+			flags:      func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return nil, errors.New("Error occured while reading infra details")
@@ -126,7 +154,10 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Restart all node-types",
-			flags:       &RestartCmdFlags{},
+			flags:   func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil
@@ -142,7 +173,10 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Error when restarting all node-types with remote execution ",
-			flags:       &RestartCmdFlags{},
+			flags:  func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil
@@ -158,7 +192,10 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Restarting all services with managed Infra",
-			flags:       &RestartCmdFlags{},
+			flags:   func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil
@@ -174,9 +211,11 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Restarting Opensearch with managed services",
-			flags: &RestartCmdFlags{
-				opensearch: true,
-			},
+			flags: func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				restartCmdFlags.opensearch = true
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil
@@ -192,9 +231,11 @@ func TestRunRestartFromBastion(t *testing.T) {
 		},
 		{
 			description: "Restarting Postgresql with managed services",
-			flags: &RestartCmdFlags{
-				postgresql: true,
-			},
+			flags: func ()*RestartCmdFlags{
+				restartCmdFlags := newDefaultRestartCmdFlag()
+				restartCmdFlags.postgresql = true
+				return restartCmdFlags
+			  } (),
 			mockRestartCmdHelper: &MockrestartFromBastionImpl{
 				getAutomateHAInfraDetailsFunc: func() (*AutomateHAInfraDetails, error) {
 					return &AutomateHAInfraDetails{}, nil

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -10,79 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
-	type testCase struct {
-		flags           *RestartCmdFlags
-		nodeMapExpected *NodeTypeAndCmd
-	}
-	infra := &AutomateHAInfraDetails{}
-
-	testCases := []testCase{
-		{
-			flags: &RestartCmdFlags{
-				automate: true,
-			},
-			nodeMapExpected: &NodeTypeAndCmd{
-				Frontend: &Cmd{
-					CmdInputs: &CmdInputs{
-						Cmd:                      "sudo chef-automate restart-services",
-						SkipPrintOutput:          true,
-						HideSSHConnectionMessage: true,
-					},
-				},
-				Automate: &Cmd{
-					CmdInputs: &CmdInputs{
-						Cmd:                      "sudo chef-automate restart-services",
-						ErrorCheckEnableInOutput: true,
-						NodeIps:                  []string{""},
-						NodeType:                 true,
-						SkipPrintOutput:          true,
-						HideSSHConnectionMessage: true,
-					},
-				},
-				ChefServer: &Cmd{
-					CmdInputs: &CmdInputs{
-						Cmd:                      "sudo chef-automate restart-services",
-						ErrorCheckEnableInOutput: true,
-						NodeIps:                  []string{""},
-						NodeType:                 false,
-						SkipPrintOutput:          true,
-						HideSSHConnectionMessage: true,
-					},
-				},
-				Postgresql: &Cmd{
-					CmdInputs: &CmdInputs{
-						Cmd:                      "sudo HAB_LICENSE=accept-no-persist systemctl restart hab-sup",
-						NodeIps:                  []string{""},
-						ErrorCheckEnableInOutput: true,
-						NodeType:                 false,
-
-						SkipPrintOutput:          true,
-						HideSSHConnectionMessage: true,
-					},
-				},
-				Opensearch: &Cmd{
-					CmdInputs: &CmdInputs{
-						Cmd:                      "sudo HAB_LICENSE=accept-no-persist systemctl restart hab-sup",
-						NodeIps:                  []string{""},
-						ErrorCheckEnableInOutput: true,
-						NodeType:                 false,
-
-						SkipPrintOutput:          true,
-						HideSSHConnectionMessage: true,
-					},
-				},
-				Infra: infra,
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		nodeMapGet := constructNodeMapForAllNodeTypes(testCase.flags, infra)
-		assert.Equal(t, testCase.nodeMapExpected, nodeMapGet)
-	}
-}
-
 type MockrestartFromBastionImpl struct {
 	getAutomateHAInfraDetailsFunc func() (*AutomateHAInfraDetails, error)
 	isManagedServicesOnFunc       func() bool
@@ -104,6 +31,76 @@ func (mrs *MockrestartFromBastionImpl) executeRemoteExecutor(nodemap *NodeTypeAn
 
 func (mrs *MockrestartFromBastionImpl) printRestartCmdOutput(cmdResult map[string][]*CmdResult, remoteService string, wg *sync.WaitGroup, mutex *sync.Mutex, writer *cli.Writer) {
 	mrs.printRestartCmdOutputFunc(cmdResult, remoteService, wg, mutex, writer)
+}
+func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
+	type testCase struct {
+		flags           *RestartCmdFlags
+		nodeMapExpected *NodeTypeAndCmd
+	}
+	infra := &AutomateHAInfraDetails{}
+
+	testCases := []testCase{
+		{
+			flags: &RestartCmdFlags{
+				automate: true,
+			},
+			nodeMapExpected: &NodeTypeAndCmd{
+				Frontend: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      RESTART_FRONTEND_COMMAND,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Automate: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      RESTART_FRONTEND_COMMAND,
+						ErrorCheckEnableInOutput: true,
+						NodeIps:                  []string{""},
+						NodeType:                 true,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				ChefServer: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      RESTART_FRONTEND_COMMAND,
+						ErrorCheckEnableInOutput: true,
+						NodeIps:                  []string{""},
+						NodeType:                 false,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Postgresql: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      RESTART_BACKEND_COMMAND,
+						NodeIps:                  []string{""},
+						ErrorCheckEnableInOutput: true,
+						NodeType:                 false,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Opensearch: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      RESTART_BACKEND_COMMAND,
+						NodeIps:                  []string{""},
+						ErrorCheckEnableInOutput: true,
+						NodeType:                 false,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Infra: infra,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		nodeMapGet := constructNodeMapForAllNodeTypes(testCase.flags, infra)
+		assert.Equal(t, testCase.nodeMapExpected, nodeMapGet)
+	}
 }
 
 func TestRunRestartFromBastion(t *testing.T) {

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -34,6 +34,7 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 						ErrorCheckEnableInOutput: true,
 						NodeIps:                  []string{""},
 						NodeType:                 true,
+						SkipPrintOutput:          true,
 						HideSSHConnectionMessage: true,
 					},
 				},
@@ -43,6 +44,7 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 						ErrorCheckEnableInOutput: true,
 						NodeIps:                  []string{""},
 						NodeType:                 false,
+						SkipPrintOutput:          true,
 						HideSSHConnectionMessage: true,
 					},
 				},
@@ -52,6 +54,7 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,
+						SkipPrintOutput:          true,
 						HideSSHConnectionMessage: true,
 					},
 				},
@@ -61,6 +64,7 @@ func TestConstructNodeMapForAllNodeTypes(t *testing.T) {
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,
+						SkipPrintOutput:          true,
 						HideSSHConnectionMessage: true,
 					},
 				},
@@ -247,7 +251,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
+			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, OPENSEARCH),
 		},
 		{
 			description: "Restarting Postgresql with managed services",
@@ -270,7 +274,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
+			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, POSTGRESQL),
 		},
 	}
 
@@ -296,13 +300,13 @@ func TestHandleManagedServiceError(t *testing.T) {
 			flags: &RestartCmdFlags{
 				postgresql: true,
 			},
-			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, POSTGRESQL),
 		},
 		{
 			flags: &RestartCmdFlags{
 				opensearch: true,
 			},
-			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, OPENSEARCH),
 		},
 		{
 			flags:          &RestartCmdFlags{},
@@ -313,7 +317,7 @@ func TestHandleManagedServiceError(t *testing.T) {
 				postgresql: true,
 				opensearch: true,
 			},
-			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, "postgresql and opensearch"),
 		},
 	}
 

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -211,7 +211,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return nil, &SSHConfig{}, nil
 				},
 				isManagedServicesOnFunc: func() bool {
-					return true
+					return false
 				},
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
@@ -241,7 +241,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return map[string][]*CmdResult{}, nil
 				},
 			},
-			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, OPENSEARCH),
+			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
 		{
 			description: "Restarting Postgresql with managed services",
@@ -263,7 +263,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return map[string][]*CmdResult{}, nil
 				},
 			},
-			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, POSTGRESQL),
+			errorWant: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
 	}
 
@@ -289,13 +289,13 @@ func TestHandleManagedServiceError(t *testing.T) {
 			flags: &RestartCmdFlags{
 				postgresql: true,
 			},
-			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, POSTGRESQL),
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
 		{
 			flags: &RestartCmdFlags{
 				opensearch: true,
 			},
-			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES, OPENSEARCH),
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
 		{
 			flags:          &RestartCmdFlags{},
@@ -306,7 +306,7 @@ func TestHandleManagedServiceError(t *testing.T) {
 				postgresql: true,
 				opensearch: true,
 			},
-			errorExepected: nil,
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICES),
 		},
 	}
 

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_restart-services.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_restart-services.yaml
@@ -3,50 +3,10 @@ synopsis: restart deployment services
 usage: chef-automate restart-services [flags]
 description: Restart services for a deployment
 options:
-'- name: a2
-  default_value: "false"
-  usage: restart chef automate service on automate nodes[DUPLICATE]
-- name: automate
-  shorthand: a
-  default_value: "false"
-  usage: restart chef automate service on automate nodes
-  compatible_with_options: AutomateHA
-- name: chef_server
-  shorthand: c
-  default_value: "false"
-  usage: restart chef automate service on chef-server nodes
-  compatible_with_options: AutomateHA
-- name: cs
-  default_value: "false"
-  usage: |
-    restart chef automate service on chef-server nodes[DUPLICATE]
 - name: help
   shorthand: h
   default_value: "false"
   usage: help for restart-services
-- name: node
-  usage: Node Ip address
-  compatible_with_options: AutomateHA
-- name: opensearch
-  shorthand: o
-  default_value: "false"
-  usage: restart hab-sup service on opensearch nodes
-  compatible_with_options: AutomateHA
-- name: os
-  default_value: "false"
-  usage: restart hab-sup service on opensearch nodes[DUPLICATE]
-- name: pg
-  default_value: "false"
-  usage: restart hab-sup service on postgresql nodes[DUPLICATE]
-  compatible_with_options: AutomateHA
-- name: postgresql
-  shorthand: p
-  default_value: "false"
-  usage: restart hab-sup service on postgresql nodes
-- name: wait-timeout
-  default_value: "1200"
-  usage: |
-    This flag sets the operation timeout duration (in seconds) for each individual node during the restart services
 inherited_options:
 - name: debug
   shorthand: d
@@ -59,4 +19,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate - Chef Automate CLI
-supported_on: Bastion
+supported_on: FrontEnd

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_restart-services.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_restart-services.yaml
@@ -3,10 +3,50 @@ synopsis: restart deployment services
 usage: chef-automate restart-services [flags]
 description: Restart services for a deployment
 options:
+'- name: a2
+  default_value: "false"
+  usage: restart chef automate service on automate nodes[DUPLICATE]
+- name: automate
+  shorthand: a
+  default_value: "false"
+  usage: restart chef automate service on automate nodes
+  compatible_with_options: AutomateHA
+- name: chef_server
+  shorthand: c
+  default_value: "false"
+  usage: restart chef automate service on chef-server nodes
+  compatible_with_options: AutomateHA
+- name: cs
+  default_value: "false"
+  usage: |
+    restart chef automate service on chef-server nodes[DUPLICATE]
 - name: help
   shorthand: h
   default_value: "false"
   usage: help for restart-services
+- name: node
+  usage: Node Ip address
+  compatible_with_options: AutomateHA
+- name: opensearch
+  shorthand: o
+  default_value: "false"
+  usage: restart hab-sup service on opensearch nodes
+  compatible_with_options: AutomateHA
+- name: os
+  default_value: "false"
+  usage: restart hab-sup service on opensearch nodes[DUPLICATE]
+- name: pg
+  default_value: "false"
+  usage: restart hab-sup service on postgresql nodes[DUPLICATE]
+  compatible_with_options: AutomateHA
+- name: postgresql
+  shorthand: p
+  default_value: "false"
+  usage: restart hab-sup service on postgresql nodes
+- name: wait-timeout
+  default_value: "1200"
+  usage: |
+    This flag sets the operation timeout duration (in seconds) for each individual node during the restart services
 inherited_options:
 - name: debug
   shorthand: d
@@ -19,4 +59,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate - Chef Automate CLI
-supported_on: FrontEnd
+supported_on: Bastion


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As a user of Automate HA, when I run following commands on bastion system of Automate HA cluster, I should see output relevant to Automate HA infrastructure:

chef-automate restart-services

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-720
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

1. git checkout this branch
2. rebuild components/automate-cli and upload it to you origin
3. Install automate-cli on bastion\
5. Run chef-automate restart-services 
 ### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[Demo-video](https://progresssoftware-my.sharepoint.com/:v:/g/personal/btejaswi_progress_com/EdKhNQR7zadEqV_85PUb7nYB0_7AuvS-LJVS3KJzI_j_aA?e=VoBRud)
