### PR TITLE
add stop command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -75,6 +75,8 @@ const (
 	STOP_FE_SERVICES_CMD = `sudo systemctl stop chef-automate`
 	STOP_BE_SERVICES_CMD = `sudo systemctl stop hab-sup`
 
+	CHEF_AUTOMATE_STOP_FE_CMD = `sudo chef-automate stop`
+
 	EXCLUDE_OPENSEARCH_NODE_REQUEST = `
 	curl --location --request PUT 'http://localhost:10144/_cluster/settings' \
 	--header 'Content-Type: application/json' \

--- a/components/automate-cli/cmd/chef-automate/stop.go
+++ b/components/automate-cli/cmd/chef-automate/stop.go
@@ -65,14 +65,9 @@ func init() {
 
 func runStopCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
-		if !stopCmdFlags.automate && !stopCmdFlags.chef_server && !stopCmdFlags.opensearch && !stopCmdFlags.postgresql {
-			if stopCmdFlags.node != "" {
-				writer.Println("Please Provide service flag")
-			}
-			writer.Println(cmd.UsageString())
-			return nil
+		if err := isFlagEnabled(cmd); err != nil {
+			return err
 		}
-
 		infra, err := getAutomateHAInfraDetails()
 		if err != nil {
 			return err
@@ -296,4 +291,16 @@ func getFlagCount() int {
 		count++
 	}
 	return count
+}
+
+func isFlagEnabled(cmd *cobra.Command) error {
+	if !stopCmdFlags.automate && !stopCmdFlags.chef_server && !stopCmdFlags.opensearch && !stopCmdFlags.postgresql {
+		if stopCmdFlags.node != "" {
+			writer.Println("Please Provide service flag")
+			return errors.New("Please provide service flag")
+		}
+		writer.Println(cmd.UsageString())
+		return errors.New("No flag is enabled. Please provide any flag")
+	}
+	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/stop.go
+++ b/components/automate-cli/cmd/chef-automate/stop.go
@@ -37,28 +37,29 @@ func init() {
 		Long:  "Stop a running deployment of Automate.",
 		RunE:  runStopCmd,
 		Annotations: map[string]string{
-			docs.Tag: docs.FrontEnd,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 
-	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.automate, "automate", "a", false, "Stop services of automate node")
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.automate, "automate", "a", false, "Stop chef automate services of automate nodes")
 	stopCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.automate, "a2", false, "Stop services of automate node")
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.automate, "a2", false, "Stop chef automate services of automate nodes")
 	stopCmd.PersistentFlags().SetAnnotation("a2", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.chef_server, "chef_server", "c", false, "Stop services of chef_server node")
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.chef_server, "chef_server", "c", false, "Stop chef automate services of chef_server nodes")
 	stopCmd.PersistentFlags().SetAnnotation("chef_server", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.chef_server, "cs", false, "Stop services of chef_server node")
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.chef_server, "cs", false, "Stop chef automate services of chef_server nodes")
 	stopCmd.PersistentFlags().SetAnnotation("cs", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.opensearch, "opensearch", "o", false, "Stop services of opensearch node")
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.opensearch, "opensearch", "o", false, "Stop hab-sup service of opensearch nodes")
 	stopCmd.PersistentFlags().SetAnnotation("opensearch", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.opensearch, "os", false, "Stop services of opensearch node")
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.opensearch, "os", false, "Stop hab-sup service of opensearch nodes")
 	stopCmd.PersistentFlags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.postgresql, "postgresql", "p", false, "Stop services of postgresql node")
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.postgresql, "postgresql", "p", false, "Stop hab-sup service of postgresql nodes")
 	stopCmd.PersistentFlags().SetAnnotation("postgresql", docs.Compatibility, []string{docs.CompatiblewithHA})
-	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.postgresql, "pg", false, "Stop services of postgresql node")
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.postgresql, "pg", false, "Stop hab-sup service of postgresql nodes")
 	stopCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
 
 	stopCmd.PersistentFlags().StringVar(&stopCmdFlags.node, "node", "", "Node Ip address")
+	stopCmd.PersistentFlags().SetAnnotation("node", docs.Compatibility, []string{docs.CompatiblewithHA})
 	RootCmd.AddCommand(stopCmd)
 }
 

--- a/components/automate-cli/cmd/chef-automate/stop.go
+++ b/components/automate-cli/cmd/chef-automate/stop.go
@@ -3,58 +3,296 @@
 package main
 
 import (
+	"container/list"
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
-	"github.com/chef/automate/components/automate-deployment/pkg/target"
 )
 
-var stopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop deployment",
-	Long:  "Stop a running deployment of Automate.",
-	RunE:  runStopCmd,
-	Annotations: map[string]string{
-		docs.Tag: docs.FrontEnd,
-	},
+const (
+	ERROR_ON_MANAGED_SERVICE_STOP = "Stopping the service for externally configured %s is not supported"
+)
+
+var stopCmdFlags = struct {
+	automate    bool
+	chef_server bool
+	opensearch  bool
+	postgresql  bool
+	node        string
+}{}
+
+func init() {
+	var stopCmd = &cobra.Command{
+		Use:   "stop",
+		Short: "Stop deployment",
+		Long:  "Stop a running deployment of Automate.",
+		RunE:  runStopCmd,
+		Annotations: map[string]string{
+			docs.Tag: docs.FrontEnd,
+		},
+	}
+
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.automate, "automate", "a", false, "Stop services of automate node")
+	stopCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.automate, "a2", false, "Stop services of automate node")
+	stopCmd.PersistentFlags().SetAnnotation("a2", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.chef_server, "chef_server", "c", false, "Stop services of chef_server node")
+	stopCmd.PersistentFlags().SetAnnotation("chef_server", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.chef_server, "cs", false, "Stop services of chef_server node")
+	stopCmd.PersistentFlags().SetAnnotation("cs", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.opensearch, "opensearch", "o", false, "Stop services of opensearch node")
+	stopCmd.PersistentFlags().SetAnnotation("opensearch", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.opensearch, "os", false, "Stop services of opensearch node")
+	stopCmd.PersistentFlags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVarP(&stopCmdFlags.postgresql, "postgresql", "p", false, "Stop services of postgresql node")
+	stopCmd.PersistentFlags().SetAnnotation("postgresql", docs.Compatibility, []string{docs.CompatiblewithHA})
+	stopCmd.PersistentFlags().BoolVar(&stopCmdFlags.postgresql, "pg", false, "Stop services of postgresql node")
+	stopCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
+
+	stopCmd.PersistentFlags().StringVar(&stopCmdFlags.node, "node", "", "Node Ip address")
+	RootCmd.AddCommand(stopCmd)
 }
 
 func runStopCmd(cmd *cobra.Command, args []string) error {
-	connection, err := client.Connection(client.DefaultClientTimeout)
-	if err != nil {
-		return err
+	if isA2HARBFileExist() {
+		if !stopCmdFlags.automate && !stopCmdFlags.chef_server && !stopCmdFlags.opensearch && !stopCmdFlags.postgresql {
+			if stopCmdFlags.node != "" {
+				writer.Println("Please Provide service flag")
+			}
+			writer.Println(cmd.UsageString())
+			return nil
+		}
+
+		infra, err := getAutomateHAInfraDetails()
+		if err != nil {
+			return err
+		}
+
+		if err = runStopCommandHA(infra, isManagedServicesOn()); err != nil {
+			return err
+		}
+
+	} else if isDevMode() {
+		if err := runStopDevMode(); err != nil {
+			return err
+		}
+
+	} else {
+		if err := runStopStandalone(); err != nil {
+			return err
+		}
 	}
 
-	if isDevMode() {
-		_, err = connection.Stop(context.Background(), &api.StopRequest{})
-		if err != nil {
-			return status.Wrap(
-				err,
-				status.DeploymentServiceCallError,
-				"Request to stop services failed",
-			)
-		}
-	} else {
-		// In the non studio case, it is important to ask systemd to perform the stop.
-		// There is currently a bug in habitat where it's possible for hab-launch to
-		// stay alive: https://github.com/habitat-sh/habitat/issues/5783
-		// The deployment-service converger does its best to work around this issue,
-		// but for extra safety, trigger the stop through systemctl.
-		t := target.NewLocalTarget(true)
-		if err := t.EnsureStopped(); err != nil {
-			return status.Wrap(err, status.UnknownError, "Failed to stop Automate")
-		}
+	return nil
+}
+
+func runStopStandalone() error {
+	writer.Title("Stopping Chef Automate")
+	systemctlCmd := exec.Command("systemctl", "stop", "chef-automate.service")
+	systemctlCmd.Stdout = os.Stdout
+	systemctlCmd.Stderr = os.Stderr
+	if err := systemctlCmd.Run(); err != nil {
+		return status.Annotate(err, status.ServiceUnloadError)
 	}
 
 	writer.Title("Chef Automate Stopped")
 	return nil
 }
 
-func init() {
-	RootCmd.AddCommand(stopCmd)
+func runStopDevMode() error {
+	writer.Title("Stopping Chef Automate")
+	connection, err := client.Connection(client.DefaultClientTimeout)
+	if err != nil {
+		return err
+	}
+
+	_, err = connection.Stop(context.Background(), &api.StopRequest{})
+	if err != nil {
+		return status.Wrap(
+			err,
+			status.DeploymentServiceCallError,
+			"Request to stop services failed",
+		)
+	}
+
+	writer.Title("Chef Automate Stopped")
+	return nil
+}
+
+func runStopCommandHA(infra *AutomateHAInfraDetails, isManagedServices bool) error {
+	errorList := list.New()
+	count := getFlagCount()
+
+	if count > 1 && stopCmdFlags.node != "" {
+		return errors.New("Please remove node flag if you have given multiple service flags.")
+	}
+	if stopCmdFlags.automate {
+		getAndStopHaNodes(AUTOMATE, infra, errorList)
+	}
+	if stopCmdFlags.chef_server {
+		getAndStopHaNodes(CHEF_SERVER, infra, errorList)
+	}
+	if stopCmdFlags.opensearch {
+		if isManagedServices {
+			return status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICE_STOP, OPENSEARCH)
+		}
+		getAndStopHaNodes(OPENSEARCH, infra, errorList)
+	}
+	if stopCmdFlags.postgresql {
+		if isManagedServices {
+			return status.Errorf(status.InvalidCommandArgsError, ERROR_ON_MANAGED_SERVICE_STOP, POSTGRESQL)
+		}
+		getAndStopHaNodes(POSTGRESQL, infra, errorList)
+	}
+
+	if errorList.Len() > 0 {
+		return status.New(status.ServiceUnloadError, getSingleErrorFromList(errorList).Error())
+	}
+	return nil
+}
+
+func getAndStopHaNodes(remoteService string, infra *AutomateHAInfraDetails, errorList *list.List) {
+	sshConfig := getSshDetails(infra)
+	var ips []string
+
+	if stopCmdFlags.node != "" {
+		isValid := validateEachIp(remoteService, infra, stopCmdFlags.node)
+		if !isValid {
+			errorList.PushBack(fmt.Sprintf("Please Enter Valid %s IP", remoteService))
+			return
+		}
+		ips = append(ips, stopCmdFlags.node)
+	} else {
+		ips = getIps(remoteService, infra)
+	}
+	stopCommandImplHA(*sshConfig, ips, remoteService, errorList)
+}
+
+func stopCommandImplHA(sshConfig SSHConfig, ips []string, remoteService string, errorList *list.List) {
+	sshUtilMap := getMapSSHUtils(ips, &sshConfig)
+	err := checkNodeType(sshUtilMap, ips, remoteService)
+	if err != nil {
+		errorList.PushBack(err.Error())
+	}
+}
+
+func checkNodeType(sshUtilMap map[string]SSHUtil, ips []string, remoteService string) error {
+	if len(ips) == 0 {
+		writer.Errorf("No %s IPs are found", remoteService)
+		return status.Errorf(1, "No %s IPs are found", remoteService)
+	}
+	if remoteService == OPENSEARCH || remoteService == POSTGRESQL {
+		return stopBackEndNodes(sshUtilMap, ips, remoteService)
+	}
+	return stopFrontEndNodes(sshUtilMap, ips, remoteService)
+}
+
+func stopFrontEndNodes(sshUtilMap map[string]SSHUtil, ips []string, remoteService string) error {
+	resultChan := make(chan Result, len(ips))
+	errorList := list.New()
+	scriptCommands := `sudo chef-automate stop`
+	for _, hostIP := range ips {
+		sshUtil := sshUtilMap[hostIP]
+		go commandExecuteFrontEnd(scriptCommands, sshUtil, resultChan)
+	}
+	printMessageForStopResultChan(resultChan, ips, remoteService, errorList)
+	close(resultChan)
+	if errorList != nil && errorList.Len() > 0 {
+		return status.Wrapf(getSingleErrorFromList(errorList), status.ServiceUnloadError, "Not able to stop one or more nodes in %s", remoteService)
+	}
+	return nil
+}
+
+func stopBackEndNodes(sshUtilMap map[string]SSHUtil, ips []string, remoteService string) error {
+	resultChan := make(chan Result, len(ips))
+	scriptCommands := "sudo systemctl stop hab-sup"
+	errorList := list.New()
+	for _, hostIP := range ips {
+		sshUtil := sshUtilMap[hostIP]
+		go commandExecuteBackendNode(scriptCommands, sshUtil, resultChan)
+	}
+	printMessageForStopResultChan(resultChan, ips, remoteService, errorList)
+	close(resultChan)
+	if errorList != nil && errorList.Len() > 0 {
+		return status.Wrapf(getSingleErrorFromList(errorList), status.ServiceUnloadError, "Not able to stop one or more nodes in %s", remoteService)
+	}
+	return nil
+}
+
+func printMessageForStopResultChan(resultChan chan Result, ips []string, remoteService string, errorList *list.List) {
+	for i := 0; i < len(ips); i++ {
+		result := <-resultChan
+		printStopConnectionMessage(remoteService, result.HostIP)
+		if result.Error != nil {
+			printStopErrorMessage(remoteService, result.HostIP, result.Error)
+			errorList.PushBack(result.Error.Error())
+		} else {
+			writer.Printf("Output for Host IP %s : %s", result.HostIP, result.Output+"\n")
+			printStopSuccessMessage(remoteService, result.HostIP)
+		}
+	}
+}
+
+func printStopConnectionMessage(remoteService string, hostIP string) {
+	writer.Println("Connecting to the " + remoteService + NODE + hostIP)
+	writer.BufferWriter().Flush()
+}
+
+func printStopErrorMessage(remoteService string, hostIP string, err error) {
+	writer.Failf("Stop Command failed on "+remoteService+NODE+hostIP+" with error:\n%v \n", err)
+	writer.BufferWriter().Flush()
+}
+
+func printStopSuccessMessage(remoteService string, hostIP string) {
+	writer.Success("Stop Command is completed on " + remoteService + NODE + hostIP + "\n")
+	writer.BufferWriter().Flush()
+}
+
+func validateEachIp(remoteService string, infra *AutomateHAInfraDetails, ip string) bool {
+	ips := getIps(remoteService, infra)
+	for i := 0; i < len(ips); i++ {
+		if ips[i] == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func getIps(remoteService string, infra *AutomateHAInfraDetails) []string {
+	if remoteService == AUTOMATE {
+		return infra.Outputs.AutomatePrivateIps.Value
+	} else if remoteService == CHEF_SERVER {
+		return infra.Outputs.ChefServerPrivateIps.Value
+	} else if remoteService == POSTGRESQL {
+		return infra.Outputs.PostgresqlPrivateIps.Value
+	} else if remoteService == OPENSEARCH {
+		return infra.Outputs.OpensearchPrivateIps.Value
+	}
+	return []string{}
+}
+
+func getFlagCount() int {
+	count := 0
+	if stopCmdFlags.automate {
+		count++
+	}
+	if stopCmdFlags.chef_server {
+		count++
+	}
+	if stopCmdFlags.opensearch {
+		count++
+	}
+	if stopCmdFlags.postgresql {
+		count++
+	}
+	return count
 }

--- a/components/automate-cli/cmd/chef-automate/stop.go
+++ b/components/automate-cli/cmd/chef-automate/stop.go
@@ -195,7 +195,7 @@ func checkNodeType(sshUtilMap map[string]SSHUtil, ips []string, remoteService st
 func stopFrontEndNodes(sshUtilMap map[string]SSHUtil, ips []string, remoteService string) error {
 	resultChan := make(chan Result, len(ips))
 	errorList := list.New()
-	scriptCommands := `sudo chef-automate stop`
+	scriptCommands := CHEF_AUTOMATE_STOP_FE_CMD
 	for _, hostIP := range ips {
 		sshUtil := sshUtilMap[hostIP]
 		go commandExecuteFrontEnd(scriptCommands, sshUtil, resultChan)
@@ -210,7 +210,7 @@ func stopFrontEndNodes(sshUtilMap map[string]SSHUtil, ips []string, remoteServic
 
 func stopBackEndNodes(sshUtilMap map[string]SSHUtil, ips []string, remoteService string) error {
 	resultChan := make(chan Result, len(ips))
-	scriptCommands := "sudo systemctl stop hab-sup"
+	scriptCommands := STOP_BE_SERVICES_CMD
 	errorList := list.New()
 	for _, hostIP := range ips {
 		sshUtil := sshUtilMap[hostIP]

--- a/components/automate-cli/cmd/chef-automate/stop_test.go
+++ b/components/automate-cli/cmd/chef-automate/stop_test.go
@@ -240,7 +240,6 @@ func TestStopCmd(t *testing.T) {
 			err := runStopCmd(&cobra.Command{}, []string{})
 			if tc.isExpectedError {
 				assert.Error(t, err)
-				assert.EqualError(t, err, tc.errorMessage)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/components/automate-cli/cmd/chef-automate/stop_test.go
+++ b/components/automate-cli/cmd/chef-automate/stop_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckNodeType(t *testing.T) {
+	testCases := []struct {
+		testName      string
+		sshUtilMap    map[string]SSHUtil
+		Ips           []string
+		remoteService string
+		isError       bool
+		err           error
+	}{
+		{
+			"All the ips are reachable and stopped the services of automate",
+			createMockSSHUtilMap([]string{TEST_IP, TEST_IP2, TEST_IP3}, nil, "", nil),
+			[]string{TEST_IP, TEST_IP2, TEST_IP3},
+			"automate",
+			false,
+			nil,
+		},
+		{
+			"Some of the ips are not reachable which are provided for chef-server",
+			createMockSSHUtilMap([]string{TEST_IP}, nil, "", errors.New("ERROR")),
+			[]string{TEST_IP},
+			"chef_server",
+			true,
+			errors.New("Not able to stop one or more nodes in chef_server: \nERROR"),
+		},
+		{
+			"All th ips are reachable and stopped the services of opensearch",
+			createMockSSHUtilMap([]string{TEST_IP, TEST_IP2, TEST_IP3}, nil, "", nil),
+			[]string{TEST_IP, TEST_IP2, TEST_IP3},
+			"opensearch",
+			false,
+			nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			err := checkNodeType(testCase.sshUtilMap, testCase.Ips, testCase.remoteService)
+			if testCase.isError {
+				assert.EqualError(t, err, testCase.err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestStopCommandHA(t *testing.T) {
+	tests := []struct {
+		name            string
+		isForAutomate   bool
+		isForChefServer bool
+		isForPG         bool
+		isForOS         bool
+		isManaged       bool
+		isInfraEmpty    bool
+		node            string
+		isErrorExpected bool
+		errorMessage    string
+	}{
+		{
+			name:            "test_Empty_Flags",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "",
+			isErrorExpected: false,
+			errorMessage:    "",
+		},
+		{
+			name:            "test_Automate",
+			isForAutomate:   true,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "\nNot able to stop one or more nodes in automate: \nopen : no such file or directory",
+		},
+		{
+			name:            "test_InfraServer",
+			isForAutomate:   false,
+			isForChefServer: true,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "\nNot able to stop one or more nodes in chef_server: \nopen : no such file or directory",
+		},
+		{
+			name:            "test_Postgres",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         true,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "\nNot able to stop one or more nodes in postgresql: \nopen : no such file or directory",
+		},
+		{
+			name:            "test_Postgres_with_ManagedServices",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         true,
+			isForOS:         false,
+			isManaged:       true,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "Stopping the service for externally configured postgresql is not supported",
+		},
+		{
+			name:            "test_OpenSearch",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         true,
+			isManaged:       false,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "\nNot able to stop one or more nodes in opensearch: \nopen : no such file or directory",
+		},
+		{
+			name:            "test_OpenSearch_with_ManagedServices",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         true,
+			isManaged:       true,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "Stopping the service for externally configured opensearch is not supported",
+		},
+		{
+			name:            "test_node_with_MultipleServiceFlags",
+			isForAutomate:   true,
+			isForChefServer: true,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "1.2.3.4",
+			isErrorExpected: true,
+			errorMessage:    "Please remove node flag if you have given multiple service flags.",
+		},
+		{
+			name:            "test_valid_node_with_Automate",
+			isForAutomate:   true,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "127.0.0.0",
+			isErrorExpected: true,
+			errorMessage:    "\nNot able to stop one or more nodes in automate: \nopen : no such file or directory",
+		},
+		{
+			name:            "test_invalid_node_with_Automate",
+			isForAutomate:   true,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			node:            "127.0.0.5",
+			isErrorExpected: true,
+			errorMessage:    "\nPlease Enter Valid automate IP",
+		},
+		{
+			name:            "test_empty_infra",
+			isForAutomate:   true,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			isManaged:       false,
+			isInfraEmpty:    true,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "\nNo automate IPs are found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var infra *AutomateHAInfraDetails
+			stopCmdFlags.automate = tc.isForAutomate
+			stopCmdFlags.chef_server = tc.isForChefServer
+			stopCmdFlags.opensearch = tc.isForOS
+			stopCmdFlags.postgresql = tc.isForPG
+			stopCmdFlags.node = tc.node
+			if tc.isInfraEmpty {
+				infra = &AutomateHAInfraDetails{}
+			} else {
+				infra = getMockInfra()
+			}
+			err := runStopCommandHA(infra, tc.isManaged)
+			if tc.isErrorExpected {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.errorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStopCmd(t *testing.T) {
+	tests := []struct {
+		testName        string
+		isHA            bool
+		isDevMode       bool
+		isStandalone    bool
+		isExpectedError bool
+		errorMessage    string
+	}{
+		{"Dev Mode", false, true, false, true, "Failed to read deployment-service TLS certificates: Could not read the service cert: open /hab/svc/deployment-service/data/deployment-service.crt: no such file or directory"},
+		{"Standalone Mode", false, false, true, true, "exec: \"systemctl\": executable file not found in $PATH"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			if tc.isDevMode {
+				os.Setenv("CHEF_DEV_ENVIRONMENT", "true")
+			} else {
+				os.Setenv("CHEF_DEV_ENVIRONMENT", "false")
+			}
+			err := runStopCmd(&cobra.Command{}, []string{})
+			if tc.isExpectedError {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.errorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/stop_test.go
+++ b/components/automate-cli/cmd/chef-automate/stop_test.go
@@ -247,3 +247,64 @@ func TestStopCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestFlagEnabled(t *testing.T) {
+	tests := []struct {
+		testName        string
+		isForAutomate   bool
+		isForChefServer bool
+		isForPG         bool
+		isForOS         bool
+		node            string
+		isErrorExpected bool
+		errorMessage    string
+	}{
+		{
+			testName:        "test_valid_Flags",
+			isForAutomate:   true,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			node:            "",
+			isErrorExpected: false,
+			errorMessage:    "",
+		},
+		{
+			testName:        "test_empty_service_and_node_flag",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			node:            "",
+			isErrorExpected: true,
+			errorMessage:    "No flag is enabled. Please provide any flag",
+		},
+		{
+			testName:        "test_empty_service_but_given_node_flag",
+			isForAutomate:   false,
+			isForChefServer: false,
+			isForPG:         false,
+			isForOS:         false,
+			node:            "1.2.3.4",
+			isErrorExpected: true,
+			errorMessage:    "Please provide service flag",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			stopCmdFlags.automate = tc.isForAutomate
+			stopCmdFlags.chef_server = tc.isForChefServer
+			stopCmdFlags.opensearch = tc.isForOS
+			stopCmdFlags.postgresql = tc.isForPG
+			stopCmdFlags.node = tc.node
+			err := isFlagEnabled(&cobra.Command{})
+			if tc.isErrorExpected {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tc.errorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_stop.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_stop.yaml
@@ -3,10 +3,49 @@ synopsis: Stop deployment
 usage: chef-automate stop [flags]
 description: Stop a running deployment of Automate.
 options:
+- name: a2
+  default_value: "false"
+  usage: Stop chef automate services of automate nodes
+  compatible_with_options: AutomateHA
+- name: automate
+  shorthand: a
+  default_value: "false"
+  usage: Stop chef automate services of automate nodes
+  compatible_with_options: AutomateHA
+- name: chef_server
+  shorthand: c
+  default_value: "false"
+  usage: Stop chef automate services of chef_server nodes
+  compatible_with_options: AutomateHA
+- name: cs
+  default_value: "false"
+  usage: Stop chef automate services of chef_server nodes
+  compatible_with_options: AutomateHA
 - name: help
   shorthand: h
   default_value: "false"
   usage: help for stop
+- name: node
+  usage: Node Ip address
+  compatible_with_options: AutomateHA
+- name: opensearch
+  shorthand: o
+  default_value: "false"
+  usage: Stop hab-sup service of opensearch nodes
+  compatible_with_options: AutomateHA
+- name: os
+  default_value: "false"
+  usage: Stop hab-sup service of opensearch nodes
+  compatible_with_options: AutomateHA
+- name: pg
+  default_value: "false"
+  usage: Stop hab-sup service of postgresql nodes
+  compatible_with_options: AutomateHA
+- name: postgresql
+  shorthand: p
+  default_value: "false"
+  usage: Stop hab-sup service of postgresql nodes
+  compatible_with_options: AutomateHA
 inherited_options:
 - name: debug
   shorthand: d
@@ -19,4 +58,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate - Chef Automate CLI
-supported_on: FrontEnd
+supported_on: Bastion


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added stop command for HA which can be run from bastion node to stop the services of automate, chef_server, postgresql, opensearch.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-712
### :+1: Definition of Done
Added stop command for HA which can be run from bastion node to stop the services of automate, chef_server, postgresql, opensearch. You can also provide any particular ip of which you want to stop the services.

Tested on Standalone Automate, Dev Mode and HA deployments.
### :athletic_shoe: How to Build and Test the Change
Install this cli package: sahiba3108/automate-cli/0.1.0/20230615120402
Then you can run stop command. Some of the examples are:

- chef-automate stop --automate (This will stop the services of entire automate cluster)
- chef-automate stop --a2 --node 1.2.3.4 (This will stop the services of particular node of automate cluster)
- chef-automate stop --a2 -- cs (This will stop the services of entire automate and chef_server cluster)
You can run the same for PG and OS as well.
Doc Link: [https://deploy-preview-7966--chef-automate.netlify.app/automate/cli_chef_automate_ha/#chef-automate-stop](url)
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="702" alt="Screenshot 2023-06-15 at 5 38 06 PM" src="https://github.com/chef/automate/assets/108404805/df6fd31b-c168-4245-991c-108d4f50a7ad">
<img width="594" alt="Screenshot 2023-06-15 at 3 12 15 PM" src="https://github.com/chef/automate/assets/108404805/ae234bc8-2edf-4ed7-aa48-bba7dc41ca2d">
<img width="717" alt="Screenshot 2023-06-15 at 3 12 28 PM" src="https://github.com/chef/automate/assets/108404805/b7dda817-b164-4ec2-a96e-eaa048b3b72a">
<img width="729" alt="Screenshot 2023-06-15 at 3 12 45 PM" src="https://github.com/chef/automate/assets/108404805/251f8cc5-ab66-4b29-9abb-115af5bf91e8">
<img width="619" alt="Screenshot 2023-06-15 at 3 12 56 PM" src="https://github.com/chef/automate/assets/108404805/540f02fd-3cda-4d7b-8a35-cdbecafc214b">
<img width="615" alt="Screenshot 2023-06-15 at 3 13 12 PM" src="https://github.com/chef/automate/assets/108404805/4ba3a2df-77cb-4007-82f7-9d5eaf293141">
<img width="604" alt="Screenshot 2023-06-15 at 3 13 34 PM" src="https://github.com/chef/automate/assets/108404805/1493480e-7287-42a8-9a9a-0414606de415">
<img width="1302" alt="Screenshot 2023-06-15 at 5 40 32 PM" src="https://github.com/chef/automate/assets/108404805/b0cd5d0d-9e89-4ad7-bb83-5bf67793f47b">
<img width="631" alt="Screenshot 2023-06-15 at 3 14 58 PM" src="https://github.com/chef/automate/assets/108404805/11fbbbf7-0ac2-4bf3-8f98-ffc08e3b5827">
<img width="647" alt="Screenshot 2023-06-15 at 3 17 50 PM" src="https://github.com/chef/automate/assets/108404805/00dcf045-f468-4c15-a138-a61a12554175">
<img width="1225" alt="Screenshot 2023-06-15 at 4 10 11 PM" src="https://github.com/chef/automate/assets/108404805/d22c9868-92d6-4a44-b1ad-368ccdf6d9c0">
<img width="1226" alt="Screenshot 2023-06-15 at 4 09 58 PM" src="https://github.com/chef/automate/assets/108404805/82ac6ca5-7874-4efd-bae1-623064adc111">
<img width="630" alt="Screenshot 2023-06-15 at 5 37 32 PM" src="https://github.com/chef/automate/assets/108404805/7815da82-f125-48cd-9dbb-5b49fcfae4d0">
