### PR TITLE
fetch aws config details from terraform

### DIFF
--- a/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails.go
+++ b/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+)
+
+type configDetails struct {
+	AutomateIps          []string `json:"automate_private_ips"`
+	ChefServerIps        []string `json:"chef_server_private_ips"`
+	PostgresqlIps        []string `json:"postgresql_private_ips"`
+	OpensearchIps        []string `json:"opensearch_private_ips"`
+	AutomateLBFqdn       string   `json:"automate_lb_fqdn"`
+	AutomateFrontendURL  string   `json:"automate_frontend_url"`
+	BucketName           string   `json:"bucket_name"`
+	OsSnapshotRoleArn    string   `json:"aws_os_snapshot_role_arn"`
+	OsSnapshotUserID     string   `json:"os_snapshot_user_access_key_id"`
+	OsSnapshotUserSecret string   `json:"os_snapshot_user_access_key_secret"`
+}
+
+func fetchAwsConfigFromTerraform() (*configDetails, error) {
+	AwsConfigJsonString := convTfvarToJson(filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "terraform", "reference_architectures", "deployment", "output.auto.tfvars"))
+	awsAutoTfvarConfig, err := getJsonFromTerraformOutputAutoTfVarsFile(AwsConfigJsonString)
+	if err != nil {
+		return nil, err
+	}
+	return awsAutoTfvarConfig, nil
+}
+
+func getJsonFromTerraformOutputAutoTfVarsFile(jsonString string) (*configDetails, error) {
+	params := configDetails{}
+	err := json.Unmarshal([]byte(jsonString), &params)
+	if err != nil {
+		writer.Fail(err.Error())
+		return nil, err
+	}
+	return &params, nil
+}

--- a/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails.go
+++ b/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails.go
@@ -31,7 +31,6 @@ func getJsonFromTerraformOutputAutoTfVarsFile(jsonString string) (*configDetails
 	params := configDetails{}
 	err := json.Unmarshal([]byte(jsonString), &params)
 	if err != nil {
-		writer.Fail(err.Error())
 		return nil, err
 	}
 	return &params, nil

--- a/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
+++ b/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+var AwsAutoTfvarsJsonString = `
+{"automate_private_ips":["10.0.130.162", "10.0.153.152"], "chef_server_private_ips":["10.0.136.84", "10.0.149.79"], "postgresql_private_ips":["10.0.135.82", "10.0.159.64", "10.0.161.255"], "opensearch_private_ips":["10.0.133.254", "10.0.144.64", "10.0.163.250"], "automate_lb_fqdn":"A2-df60949d-automate-lb-1317318119.eu-west-2.elb.amazonaws.com", "automate_frontend_url":"https://A2-df60949d-automate-lb-1317318119.eu-west-2.elb.amazonaws.com", "bucket_name":"test", "aws_os_snapshot_role_arn":" ", "os_snapshot_user_access_key_id":" ", "os_snapshot_user_access_key_secret":" "}
+`
+
+var OutputAutoTfvarsFileContent = `automate_private_ips         = ["10.0.130.162", "10.0.153.152"]
+chef_server_private_ips      = ["10.0.136.84", "10.0.149.79"]
+postgresql_private_ips       = ["10.0.135.82", "10.0.159.64", "10.0.161.255"]
+opensearch_private_ips    = ["10.0.133.254", "10.0.144.64", "10.0.163.250"]
+automate_lb_fqdn                = "A2-df60949d-automate-lb-1317318119.eu-west-2.elb.amazonaws.com"
+automate_frontend_url       = "https://A2-df60949d-automate-lb-1317318119.eu-west-2.elb.amazonaws.com"
+bucket_name                  = "test"
+aws_os_snapshot_role_arn     = " "
+os_snapshot_user_access_key_id = " "
+os_snapshot_user_access_key_secret = " "`
+
+func Test_fetchAwsConfigFromTerraform(t *testing.T) {
+	params := new(configDetails)
+	err := json.Unmarshal([]byte(AwsAutoTfvarsJsonString), &params)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	dirPath := filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "terraform", "reference_architectures", "deployment")
+	filePath := dirPath + "/output.auto.tfvars"
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		fmt.Println("Error creating directories:", err)
+		return
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		fmt.Println("Error creating file:", err)
+		return
+	}
+	defer os.Remove(file.Name())
+
+	tests := []struct {
+		TestName       string
+		ExpectedOutput *configDetails
+		WriteString    string
+		ExpectedError  error
+	}{
+		{
+			TestName:       "Valid Content",
+			ExpectedOutput: params,
+			WriteString:    OutputAutoTfvarsFileContent,
+			ExpectedError:  nil,
+		},
+		{
+			TestName:       "Invalid Content",
+			ExpectedOutput: nil,
+			WriteString:    "test",
+			ExpectedError:  errors.New(""),
+		},
+	}
+
+	for _, e := range tests {
+		_, err = file.WriteString(e.WriteString)
+		assert.NoError(t, err)
+		t.Run(e.TestName, func(t *testing.T) {
+			res, err := fetchAwsConfigFromTerraform()
+			if e.ExpectedError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, e.ExpectedOutput, res)
+		})
+	}
+
+	err = file.Close()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
+++ b/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,24 +28,16 @@ os_snapshot_user_access_key_secret = " "`
 func Test_fetchAwsConfigFromTerraform(t *testing.T) {
 	params := new(configDetails)
 	err := json.Unmarshal([]byte(AwsAutoTfvarsJsonString), &params)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	assert.NoError(t, err)
 
 	dirPath := filepath.Join(initConfigHabA2HAPathFlag.a2haDirPath, "terraform", "reference_architectures", "deployment")
 	filePath := dirPath + "/output.auto.tfvars"
+
 	err = os.MkdirAll(dirPath, os.ModePerm)
-	if err != nil {
-		fmt.Println("Error creating directories:", err)
-		return
-	}
+	assert.NoError(t, err, "Error creating directories")
 
 	file, err := os.Create(filePath)
-	if err != nil {
-		fmt.Println("Error creating file:", err)
-		return
-	}
+	assert.NoError(t, err, "Error creating file")
 	defer os.Remove(file.Name())
 
 	tests := []struct {
@@ -84,8 +75,5 @@ func Test_fetchAwsConfigFromTerraform(t *testing.T) {
 	}
 
 	err = file.Close()
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
+	assert.NoError(t, err)
 }

--- a/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
+++ b/components/automate-cli/cmd/chef-automate/fetchAwsConfigDetails_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -26,6 +27,11 @@ os_snapshot_user_access_key_id = " "
 os_snapshot_user_access_key_secret = " "`
 
 func Test_fetchAwsConfigFromTerraform(t *testing.T) {
+	// In mac we can't create directory at root level, but for this test we need directory at root level.
+	// So we are omitting the test in case of Mac OS.
+	if runtime.GOOS == "darwin" {
+		return
+	}
 	params := new(configDetails)
 	err := json.Unmarshal([]byte(AwsAutoTfvarsJsonString), &params)
 	assert.NoError(t, err)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
For AWS deployment, the config file doesn’t have the node's IP address. 
So the config validator should fetch the required details before validating the config and pass the required config to batch check API.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3505
### :+1: Definition of Done
Fetch the Aws config Details like Private ips of Automate, Chef server, Pg, Os, Automate LB fqdn, Bucket name if we have used s3 as backup config from terraform file.
### :athletic_shoe: How to Build and Test the Change
Invoke this fetchAwsConfigFromTerraform() method, it will return the config fetched from terraform file i.e. output.auto.tfvars
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1758" alt="Screenshot 2023-06-20 at 6 20 40 PM" src="https://github.com/chef/automate/assets/108404805/e9b6dcb6-e42b-4170-9756-449f525cc220">
