### PR TITLE
Fixed mock server 409 conflict error

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/mockserverservice/mockserverservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/mockserverservice/mockserverservice.go
@@ -39,13 +39,13 @@ func (s *MockServersServiceImp) Start(cfg *models.StartMockServerRequestBody) er
 	var err error
 	switch cfg.Protocol {
 	case constants.TCP:
-		err = s.StartTCPServer(cfg.Port)
+		err = s.StartTCPServer(cfg.Port, cfg.Protocol)
 	case constants.UDP:
-		err = s.StartUDPServer(cfg.Port)
+		err = s.StartUDPServer(cfg.Port, cfg.Protocol)
 	case constants.HTTP:
-		err = s.StartHTTPServer(cfg.Port)
+		err = s.StartHTTPServer(cfg.Port, cfg.Protocol)
 	case constants.HTTPS:
-		err = s.StartHTTPSServer(cfg.Port, cfg.Cert, cfg.Key)
+		err = s.StartHTTPSServer(cfg.Port, cfg.Protocol, cfg.Cert, cfg.Key)
 	default:
 		err = errors.New("unsupported protocol")
 	}
@@ -77,23 +77,12 @@ func (s *MockServersServiceImp) Stop(cfg *models.StopMockServerRequestBody) erro
 }
 
 // IsMockServerRunning returns true if on given port and protocol any server is running.
-func (s *MockServersServiceImp) IsMockServerRunningOnGivenPort(port int) bool {
-	servers := s.mockServers
-
-	for _, server := range servers {
-		if server.Port == port {
-			s.logger.Debug("Mock server is already running on port: ", port)
-			return true
-		}
-	}
-	return false
-}
-
 func (s *MockServersServiceImp) IsMockServerRunningOnGivenPortAndProctocol(port int, protocol string) bool {
 	servers := s.mockServers
 
 	for _, server := range servers {
 		if server.Port == port && server.Protocol == protocol {
+			s.logger.Debug("Mock server is already running on port: ", port)
 			return true
 		}
 	}
@@ -101,11 +90,11 @@ func (s *MockServersServiceImp) IsMockServerRunningOnGivenPortAndProctocol(port 
 	return false
 }
 
-func (s *MockServersServiceImp) StartTCPServer(port int) error {
+func (s *MockServersServiceImp) StartTCPServer(port int, protocol string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.IsMockServerRunningOnGivenPort(port) {
+	if s.IsMockServerRunningOnGivenPortAndProctocol(port, protocol) {
 		return errors.New("port unavailable")
 	}
 
@@ -153,11 +142,11 @@ func (s *MockServersServiceImp) StartTCPServer(port int) error {
 	return nil
 }
 
-func (s *MockServersServiceImp) StartUDPServer(port int) error {
+func (s *MockServersServiceImp) StartUDPServer(port int, protocol string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.IsMockServerRunningOnGivenPort(port) {
+	if s.IsMockServerRunningOnGivenPortAndProctocol(port, protocol) {
 		return errors.New("port unavailable")
 	}
 
@@ -204,11 +193,11 @@ func (s *MockServersServiceImp) StartUDPServer(port int) error {
 	return nil
 }
 
-func (s *MockServersServiceImp) StartHTTPServer(port int) error {
+func (s *MockServersServiceImp) StartHTTPServer(port int, protocol string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.IsMockServerRunningOnGivenPort(port) {
+	if s.IsMockServerRunningOnGivenPortAndProctocol(port, protocol) {
 		return errors.New("port unavailable")
 	}
 
@@ -266,11 +255,11 @@ func (s *MockServersServiceImp) StartHTTPServer(port int) error {
 	}
 }
 
-func (s *MockServersServiceImp) StartHTTPSServer(port int, cert string, key string) error {
+func (s *MockServersServiceImp) StartHTTPSServer(port int, protocol string, cert string, key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.IsMockServerRunningOnGivenPort(port) {
+	if s.IsMockServerRunningOnGivenPortAndProctocol(port, protocol) {
 		return errors.New("port unavailable")
 	}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
We were getting `409 Conflict` when the mock server tried to start TCP and UDP servers on the common port 9638 of Postgresql Node.
Postgresql needs port 9638 for TCP and UDP.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://docs.chef.io/automate/ha_on_premises_deployment_prerequisites/#firewall-checks
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Before:
![Screenshot 2023-06-20 at 6 05 32 PM](https://github.com/chef/automate/assets/11033984/a5b5e69d-5e1f-441f-b02b-f0b5bb1bf5d7)
After:
![Screenshot 2023-06-20 at 6 07 24 PM](https://github.com/chef/automate/assets/11033984/61425500-afce-4d45-a338-ea6e67ff4720)
