### PR TITLE
Make es-sidecar-service config respect cfg.backups.backend

### DIFF
--- a/components/es-sidecar-service/habitat/config/config.toml
+++ b/components/es-sidecar-service/habitat/config/config.toml
@@ -29,10 +29,14 @@ elasticsearch_url = "http://127.0.0.1:{{gwmember.cfg.http-port}}"
     {{~/if}}
   {{~/eachAlive}}
 {{~else}}
-  {{~#if cfg.backups.s3.bucket}}  
-  backend = "s3"
-  {{~else}}
-  backend = "fs"
+  {{~#if cfg.backups.backend}}
+  backend = "{{cfg.backups.backend}}"
+  {{else}}
+    {{~#if cfg.backups.s3.bucket}}  
+    backend = "s3"
+    {{~else}}
+    backend = "fs"
+    {{~/if}}
   {{~/if}}
 {{~/if}}
 {{~#if cfg.backups.verify_repo}}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

I added a check for `cfg.backups.backend` in the  es-sidecar-service config template so that if we have that configuration set globally it will respect it. Currently the conditional statement checks only checks for this configuration IF we are using the internal `automate-opensearch` service.

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
