### PR TITLE
Check for automate-verify service in remote nodes before adding it to systemd in all remote nodes

### DIFF
--- a/components/automate-backend-deployment/habitat/plan.sh
+++ b/components/automate-backend-deployment/habitat/plan.sh
@@ -110,7 +110,6 @@ do_install() {
   rm -f $pkg_prefix/workspace/backups
 }
 
-
 do_strip() {
   return 0
 }

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -448,7 +448,6 @@ func (v *verifyCmdFlow) getHostIPsWithNoLatestCLI(hostIPs []string) ([]string, e
 		}
 
 		if result.CliVersion < version.BuildTime {
-			// fmt.Printf("Hosyt IP: %s, resultVersion: %s, buildVersion: %s\n", hostIPsWithoutLatestCLI, result.CliVersion, version.BuildTime)
 			hostIPsWithoutLatestCLI = append(hostIPsWithoutLatestCLI, hostIP)
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -210,40 +210,6 @@ func TestGetHostIPsWithNoLatestCLI(t *testing.T) {
 			expectedIpsListLength: 1,
 			wantErr:               nil,
 		},
-		// {
-		// 	description: "remote with old cli version",
-		// 	mockHttputils: &httputils.MockHTTPClient{
-		// 		MakeRequestFunc: func(requestMethod, url string, body interface{}) (*http.Response, []byte, error) {
-		// 			if strings.Contains(url, "10.0.0.2") {
-		// 				return &http.Response{
-		// 						StatusCode: http.StatusOK,
-		// 					}, []byte(`{
-		// 					"status": "SUCCESS",
-		// 					"result": {
-		// 							"status": "OK",
-		// 							"services": [],
-		// 							"cli_version": "w",
-		// 							"error": "error getting services from hab svc status"
-		// 					}
-		// 			}`), nil
-		// 			}
-		// 			return &http.Response{
-		// 					StatusCode: http.StatusOK,
-		// 				}, []byte(`{
-		// 					"status": "SUCCESS",
-		// 					"result": {
-		// 							"status": "OK",
-		// 							"services": [],
-		// 							"cli_version": "unknown",
-		// 							"error": "error getting services from hab svc status"
-		// 					}
-		// 			}`), nil
-		// 		},
-		// 	},
-		// 	mockHostIPs:           []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"},
-		// 	expectedIpsListLength: 1,
-		// 	wantErr:               nil,
-		// },
 	}
 
 	for _, tt := range tests {

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -154,6 +154,116 @@ func TestRunVerifyCmd(t *testing.T) {
 
 }
 
+func TestGetHostIPsWithNoLatestCLI(t *testing.T) {
+	tests := []struct {
+		description           string
+		mockHttputils         *httputils.MockHTTPClient
+		mockHostIPs           []string
+		expectedIpsListLength int
+		wantErr               error
+	}{
+
+		{
+			description: "remote with existing automate-verify - success",
+			mockHttputils: &httputils.MockHTTPClient{
+				MakeRequestFunc: func(requestMethod, url string, body interface{}) (*http.Response, []byte, error) {
+					return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}, []byte(`{
+							"status": "SUCCESS",
+							"result": {
+									"status": "OK",
+									"services": [],
+									"cli_version": "unknown",
+									"error": "error getting services from hab svc status"
+							}
+					}`), nil
+				},
+			},
+			mockHostIPs:           []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"},
+			expectedIpsListLength: 0,
+			wantErr:               nil,
+		},
+		{
+			description: "remote with some unreachable IP",
+			mockHttputils: &httputils.MockHTTPClient{
+				MakeRequestFunc: func(requestMethod, url string, body interface{}) (*http.Response, []byte, error) {
+					if strings.Contains(url, "10.0.0.2") {
+						return nil, nil, errors.New("failed to make HTTP request")
+					}
+					return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       nil,
+						}, []byte(`{
+							"status": "SUCCESS",
+							"result": {
+									"status": "OK",
+									"services": [],
+									"cli_version": "unknown",
+									"error": "error getting services from hab svc status"
+							}
+					}`), nil
+				},
+			},
+			mockHostIPs:           []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"},
+			expectedIpsListLength: 1,
+			wantErr:               nil,
+		},
+		// {
+		// 	description: "remote with old cli version",
+		// 	mockHttputils: &httputils.MockHTTPClient{
+		// 		MakeRequestFunc: func(requestMethod, url string, body interface{}) (*http.Response, []byte, error) {
+		// 			if strings.Contains(url, "10.0.0.2") {
+		// 				return &http.Response{
+		// 						StatusCode: http.StatusOK,
+		// 					}, []byte(`{
+		// 					"status": "SUCCESS",
+		// 					"result": {
+		// 							"status": "OK",
+		// 							"services": [],
+		// 							"cli_version": "w",
+		// 							"error": "error getting services from hab svc status"
+		// 					}
+		// 			}`), nil
+		// 			}
+		// 			return &http.Response{
+		// 					StatusCode: http.StatusOK,
+		// 				}, []byte(`{
+		// 					"status": "SUCCESS",
+		// 					"result": {
+		// 							"status": "OK",
+		// 							"services": [],
+		// 							"cli_version": "unknown",
+		// 							"error": "error getting services from hab svc status"
+		// 					}
+		// 			}`), nil
+		// 		},
+		// 	},
+		// 	mockHostIPs:           []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"},
+		// 	expectedIpsListLength: 1,
+		// 	wantErr:               nil,
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cw := majorupgrade_utils.NewCustomWriter()
+
+			vc := newMockVerifyCmdFlow(tt.mockHttputils, cw)
+
+			hostIpsList, err := vc.getHostIPsWithNoLatestCLI(tt.mockHostIPs)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedIpsListLength, len(hostIpsList))
+			}
+		})
+	}
+}
+
 func TestVerifyCmdFunc(t *testing.T) {
 	flagsObj := &verifyCmdFlags{
 		config: CONFIG_TOML_PATH + CONFIG_FILE,
@@ -166,4 +276,44 @@ func TestVerifyCmdFunc(t *testing.T) {
 	err := vf(nil, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "Cannot create automate-verify service since systemd is not present on this machine")
+}
+
+func newMockVerifyCmdFlow(mockHttputils *httputils.MockHTTPClient, cw *majorupgrade_utils.CustomWriter) *verifyCmdFlow {
+
+	mockCreateSystemdService := &verifysystemdcreate.MockCreateSystemdService{
+		CreateFun: func() error {
+			return nil
+		},
+	}
+	mockSystemdCreateUtils := &verifysystemdcreate.MockSystemdCreateUtils{
+		GetBinaryPathFunc: func() (string, error) {
+			return "", nil
+		},
+	}
+	mockSSHUtil := &sshutils.MockSSHUtilsImpl{
+		ExecuteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, cmd string, hostIPs []string) []sshutils.Result {
+			return []sshutils.Result{
+				{
+					HostIP: "",
+					Error:  nil,
+					Output: "",
+				},
+			}
+		},
+		CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, removeFile bool, hostIPs []string) []sshutils.Result {
+			return []sshutils.Result{
+				{
+					HostIP: "",
+					Error:  nil,
+					Output: "",
+				},
+			}
+		},
+	}
+	return NewVerifyCmdFlow(mockHttputils,
+		mockCreateSystemdService,
+		mockSystemdCreateUtils,
+		config.NewHaDeployConfig(),
+		mockSSHUtil,
+		cw.CliWriter)
 }

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -134,7 +134,7 @@
     [cs_nginx.v1.sys.ngx.http]
       ssl_verify_depth = 6
     [global.v1.external.automate.ssl]
-      server_name = "https://<%= overrides[:automate_fqdn] %>"
+      server_name = "<%= overrides[:automate_fqdn] %>"
       root_cert = """<%= overrides[:automate_root_ca] %>"""
   <% end %>
 <% else %>


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Check if the automate-verify service is already running on Each Node, else add the automate-verify service to the systemd, and start the automate-verify service on each node, upgrading if needed.


### :chains: Related Resources
Jira ticket: https://chefio.atlassian.net/browse/CHEF-3588

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
