### PR TITLE
Added chages for nil pointer error due to uninitialized Config fields

### DIFF
--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -137,6 +137,19 @@ func appendCertsByIpToNodeCerts(certsByIP *[]config.CertByIP, ipList []string, p
 
 }
 
+func NewConfig() *Config {
+	return &Config{
+		SSHUser: &SSHUser{},
+		Backup: &Backup{
+			FileSystem:    &FileSystem{},
+			ObjectStorage: &ObjectStorage{},
+		},
+		Hardware:   &Hardware{},
+		ExternalOS: &ExternalOS{},
+		ExternalPG: &ExternalPG{},
+	}
+}
+
 func createMapforCertByIp(certsByIP *[]config.CertByIP) map[string]*config.CertByIP {
 	certByIPMap := make(map[string]*config.CertByIP)
 	if certsByIP != nil {

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -144,7 +144,12 @@ func NewConfig() *Config {
 			FileSystem:    &FileSystem{},
 			ObjectStorage: &ObjectStorage{},
 		},
-		Hardware:   &Hardware{},
+		Hardware: &Hardware{},
+		Certificate: []*Certificate{
+			{
+				Nodes: []*NodeCert{},
+			},
+		},
 		ExternalOS: &ExternalOS{},
 		ExternalPG: &ExternalPG{},
 	}

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck_test.go
@@ -586,6 +586,14 @@ func TestNewConfig(t *testing.T) {
 	assert.NotNil(t, config.Hardware)
 	assert.Equal(t, reflect.TypeOf(&Hardware{}), reflect.TypeOf(config.Hardware))
 
+	// Verify Certificate is initialized correctly
+	assert.NotNil(t, config.Certificate)
+	assert.Equal(t, reflect.TypeOf([]*Certificate{}), reflect.TypeOf(config.Certificate))
+	assert.NotNil(t, config.Certificate[0])
+	assert.Equal(t, reflect.TypeOf(&Certificate{}), reflect.TypeOf(config.Certificate[0]))
+	assert.NotNil(t, config.Certificate[0].Nodes)
+	assert.Equal(t, reflect.TypeOf([]*NodeCert{}), reflect.TypeOf(config.Certificate[0].Nodes))
+
 	// Verify ExternalOS is initialized correctly
 	assert.NotNil(t, config.ExternalOS)
 	assert.Equal(t, reflect.TypeOf(&ExternalOS{}), reflect.TypeOf(config.ExternalOS))

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck_test.go
@@ -566,3 +566,31 @@ func TestPopulateWith(t *testing.T) {
 		})
 	}
 }
+
+func TestNewConfig(t *testing.T) {
+	config := NewConfig()
+
+	// Verify SSHUser is initialized correctly
+	assert.NotNil(t, config.SSHUser)
+	assert.Equal(t, reflect.TypeOf(&SSHUser{}), reflect.TypeOf(config.SSHUser))
+
+	// Verify Backup is initialized correctly
+	assert.NotNil(t, config.Backup)
+	assert.Equal(t, reflect.TypeOf(&Backup{}), reflect.TypeOf(config.Backup))
+	assert.NotNil(t, config.Backup.FileSystem)
+	assert.Equal(t, reflect.TypeOf(&FileSystem{}), reflect.TypeOf(config.Backup.FileSystem))
+	assert.NotNil(t, config.Backup.ObjectStorage)
+	assert.Equal(t, reflect.TypeOf(&ObjectStorage{}), reflect.TypeOf(config.Backup.ObjectStorage))
+
+	// Verify Hardware is initialized correctly
+	assert.NotNil(t, config.Hardware)
+	assert.Equal(t, reflect.TypeOf(&Hardware{}), reflect.TypeOf(config.Hardware))
+
+	// Verify ExternalOS is initialized correctly
+	assert.NotNil(t, config.ExternalOS)
+	assert.Equal(t, reflect.TypeOf(&ExternalOS{}), reflect.TypeOf(config.ExternalOS))
+
+	// Verify ExternalPG is initialized correctly
+	assert.NotNil(t, config.ExternalPG)
+	assert.Equal(t, reflect.TypeOf(&ExternalPG{}), reflect.TypeOf(config.ExternalPG))
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Config struct was being called with some uninitialised fields which was causing nil pointer error. 
<img width="1207" alt="MicrosoftTeams-image8a8a976ac2328997e8ae761641c2e0bf8717337b9ce934fdfe3a49ed25703038" src="https://github.com/chef/automate/assets/36985548/00043992-4d7e-4a38-9a4e-af61310960a9">

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
- All pointer fields should be initialised 
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
