### PR TITLE
Status api should be called for remote checks only

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/batchcheckservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/batchcheckservice.go
@@ -52,10 +52,12 @@ func (ss *BatchCheckService) BatchCheck(checks []string, config *models.Config) 
 		checkTriggerRespMap = getBastionCheckResp(ss, bastionChecks, config)
 	}
 
-	config.DeploymentState, err = ss.getDeploymentState(config)
-	if err != nil {
-		ss.log.Error("Failed to get the Deployment state:", err)
-		return models.BatchCheckResponse{}, err
+	if len(remoteChecks) > 0 {
+		config.DeploymentState, err = ss.getDeploymentState(config)
+		if err != nil {
+			ss.log.Error("Failed to get the Deployment state:", err)
+			return models.BatchCheckResponse{}, err
+		}
 	}
 
 	successfullyStartedMockServers, notStartedMockServers := ss.startMockServerIfNeeded(remoteChecks, config)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The status api was getting called post bastion checks. It should be only called for remote checks.

### :chains: Related Resources

https://chefio.atlassian.net/jira/software/c/projects/CHEF/boards/459?modal=detail&selectedIssue=CHEF-2159

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
1. Build cli with this branch
2. Use this cli to run chef-automate verify --config config.toml

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

<img width="630" alt="Screenshot 2023-06-26 at 4 00 36 PM" src="https://github.com/chef/automate/assets/10796521/15ccc82c-15fd-4397-bfd5-6bc89c964bfe">
