### PR TITLE
[CHEF-3816]: Run either s3config or nfs-mount based on backup_type

### DIFF
--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -291,8 +291,10 @@ func (v *verifyCmdFlow) RunVerify(config string) error {
 	}
 
 	// Get config required for batch-check API call
-	batchCheckConfig := &models.Config{}
-	batchCheckConfig = batchCheckConfig.NewConfig()
+	batchCheckConfig := &models.Config{
+		Hardware: &models.Hardware{},
+		SSHUser:  &models.SSHUser{},
+	}
 
 	err := batchCheckConfig.PopulateWith(v.Config)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -291,10 +291,7 @@ func (v *verifyCmdFlow) RunVerify(config string) error {
 	}
 
 	// Get config required for batch-check API call
-	batchCheckConfig := &models.Config{
-		Hardware: &models.Hardware{},
-		SSHUser:  &models.SSHUser{},
-	}
+	batchCheckConfig := models.NewConfig()
 
 	err := batchCheckConfig.PopulateWith(v.Config)
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -517,8 +517,9 @@ func TestGetHostIPsWithNoLatestCLI(t *testing.T) {
 
 func TestVerifyCmdFunc(t *testing.T) {
 	tests := []struct {
-		test     string
-		flagsObj *verifyCmdFlags
+		test                string
+		flagsObj            *verifyCmdFlags
+		ConvTfvarToJsonFunc func(string) string
 	}{
 		{
 			test: "Existing Infra",
@@ -526,16 +527,23 @@ func TestVerifyCmdFunc(t *testing.T) {
 				config: CONFIG_TOML_PATH + CONFIG_FILE,
 				debug:  true,
 			},
+			ConvTfvarToJsonFunc: func(string) string {
+				return AwsAutoTfvarsJsonStringEmpty
+			},
 		}, {
 			test: "Aws Infra",
 			flagsObj: &verifyCmdFlags{
 				config: CONFIG_AWS_TOML_PATH + AWS_CONFIG_FILE,
 				debug:  true,
 			},
+			ConvTfvarToJsonFunc: func(string) string {
+				return AwsAutoTfvarsJsonStringEmpty
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.test, func(t *testing.T) {
+			ConvTfvarToJsonFunc = tt.ConvTfvarToJsonFunc
 			vf := verifyCmdFunc(tt.flagsObj)
 			assert.NotNil(t, vf, "verifyCmdFunc should not be nil")
 

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -95,17 +95,13 @@ type Config struct {
 	APIToken        string         `json:"api_token"`
 }
 
-func (c *Config) NewConfig() *Config {
+func NewConfig() *Config {
 	return &Config{
 		Hardware:    &Hardware{},
 		Certificate: []*Certificate{},
 		SSHUser:     &SSHUser{},
-		Backup: &Backup{
-			FileSystem:    &FileSystem{},
-			ObjectStorage: &ObjectStorage{},
-		},
-		ExternalOS: &ExternalOS{},
-		ExternalPG: &ExternalPG{},
+		ExternalOS:  &ExternalOS{},
+		ExternalPG:  &ExternalPG{},
 	}
 }
 

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -171,7 +171,15 @@ func (c *Config) PopulateWith(haConfig *config.HaDeployConfig) error {
 		c.populateConfigInitials(haConfig)
 	}
 
-	if haConfig.GetObjectStorageConfig() != nil {
+	if haConfig.GetConfigInitials().BackupConfig == "file_system" && c.Backup == nil {
+		c.Backup = &Backup{
+			FileSystem: &FileSystem{
+				MountLocation: haConfig.GetConfigInitials().BackupMount,
+			},
+		}
+	}
+
+	if haConfig.GetObjectStorageConfig() != nil && haConfig.GetConfigInitials().BackupConfig == "object_storage" && c.Backup == nil {
 		c.populateObjectStorageConfig(haConfig)
 	}
 
@@ -249,11 +257,15 @@ func (c *Config) populateCommonConfig(haConfig *config.HaDeployConfig) error {
 
 func (c *Config) populateObjectStorageConfig(haConfig *config.HaDeployConfig) {
 	objectStorageConfig := haConfig.GetObjectStorageConfig()
-	c.Backup.ObjectStorage.BucketName = objectStorageConfig.BucketName
-	c.Backup.ObjectStorage.AWSRegion = objectStorageConfig.Region
-	c.Backup.ObjectStorage.AccessKey = objectStorageConfig.AccessKey
-	c.Backup.ObjectStorage.SecretKey = objectStorageConfig.SecretKey
-	c.Backup.ObjectStorage.Endpoint = objectStorageConfig.Endpoint
+	c.Backup = &Backup{
+		ObjectStorage: &ObjectStorage{
+			BucketName: objectStorageConfig.BucketName,
+			AWSRegion:  objectStorageConfig.Region,
+			AccessKey:  objectStorageConfig.AccessKey,
+			SecretKey:  objectStorageConfig.SecretKey,
+			Endpoint:   objectStorageConfig.Endpoint,
+		},
+	}
 }
 
 func (c *Config) populateConfigInitials(haConfig *config.HaDeployConfig) {
@@ -263,13 +275,15 @@ func (c *Config) populateConfigInitials(haConfig *config.HaDeployConfig) {
 	c.SSHUser.PrivateKey = configInitials.SSHKeyFile
 	c.SSHUser.SudoPassword = configInitials.SudoPassword
 	c.Arch = configInitials.Architecture
-	c.Backup.FileSystem.MountLocation = configInitials.BackupMount
 }
 
 func (c *Config) populateAwsS3BucketName(haConfig *config.HaDeployConfig) {
 	if haConfig.Architecture.Aws.BackupConfig == "s3" {
-		c.Backup.ObjectStorage.BucketName = haConfig.Architecture.Aws.S3BucketName
-		c.Backup.ObjectStorage.Endpoint = "https://s3.amazonaws.com"
+		c.Backup = &Backup{
+			ObjectStorage: &ObjectStorage{
+				BucketName: haConfig.Architecture.Aws.S3BucketName,
+			},
+		}
 		cred := credentials.NewSharedCredentials("", "")
 		creds, err := cred.Get()
 		if err != nil {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently both s3-config and nfs-mount check are executed, but only one should execute based on backup_type in config. This PR is fixing this issue

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3816

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

1. Build automate-cli with with branch
2. Run chef-automate verify --config config.toml

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

<img width="1125" alt="MicrosoftTeams-image (8)" src="https://github.com/chef/automate/assets/10796521/042c16af-ba99-4d03-b987-0c4d2274c40f">
<img width="961" alt="Screenshot 2023-06-27 at 5 54 06 PM" src="https://github.com/chef/automate/assets/10796521/d2e6442b-5d1f-4e28-9f9a-8bcdad2e87c7">
<img width="955" alt="Screenshot 2023-06-27 at 5 47 59 PM" src="https://github.com/chef/automate/assets/10796521/7a6b65aa-b709-4b85-9ba4-96e4b1d13955">
<img width="963" alt="Screenshot 2023-06-27 at 5 47 39 PM" src="https://github.com/chef/automate/assets/10796521/751a016d-9e6b-4b4f-98f1-1e894bb64935">


