### PR TITLE
Changes for env var for req body in logs

### DIFF
--- a/components/automate-cli/pkg/verifyserver/utils/fiberutils/logconfig.go
+++ b/components/automate-cli/pkg/verifyserver/utils/fiberutils/logconfig.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/chef/automate/lib/logger"
 	fiberlogger "github.com/gofiber/fiber/v2/middleware/logger"
-	"github.com/sirupsen/logrus"
 )
 
 const (
 	VERIFY_SERVER_TIMEZONE = "VERIFY_SERVER_TIMEZONE"
 	DEFAULT_TIMEZONE       = "UTC"
+	LOG_REQ_BODY           = "LOG_REQ_BODY"
 )
 
 func CfgLogTimeZone() string {
@@ -34,7 +34,8 @@ func GetLogConfig(log logger.Logger) (lc fiberlogger.Config) {
 	lc = fiberlogger.Config{
 		TimeFormat: time.RFC3339,
 	}
-	if log.NewEntry().Logger.GetLevel() <= logrus.DebugLevel {
+
+	if isLogReqBodyEnabled() {
 		lc.Format = generateLogFormat(
 			"${magenta}"+strings.ToUpper(log.NewEntry().Logger.GetLevel().String())+"${reset}",
 			"time", "pid", "status", "method", "path", "latency", "error", "bytesReceived", "bytesSent", "body",
@@ -59,4 +60,9 @@ func generateLogFormat(prefix string, fields ...string) string {
 	}
 	logFormat += "\n"
 	return logFormat
+}
+
+func isLogReqBodyEnabled() bool {
+	logReqBody := strings.ToUpper(strings.TrimSpace(os.Getenv(LOG_REQ_BODY))) == "TRUE"
+	return logReqBody
 }

--- a/components/automate-cli/pkg/verifyserver/utils/fiberutils/logconfig_test.go
+++ b/components/automate-cli/pkg/verifyserver/utils/fiberutils/logconfig_test.go
@@ -14,6 +14,8 @@ func TestLogUtils(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("It should create the debug format in case of debug level", func(t *testing.T) {
+		os.Setenv(fiberutils.LOG_REQ_BODY, "True")
+		defer os.Unsetenv(fiberutils.LOG_REQ_BODY)
 		lc := fiberutils.GetLogConfig(l)
 		assert.Contains(t, lc.Format, "| ${magenta}DEBUG${reset} | ${red}${time}${reset}  |  ${green}${pid}${reset}  |"+
 			"  ${yellow}${status}${reset}  |  ${blue}${method}${reset}  |  ${magenta}${path}${reset}  |"+


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Initially req body for api's was printed in the log of the verify server.Now there is condition if an env variable "LOG_REQ_BODY" is set it true or not. 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
- Checkout this branch and rebuild cli
- start verify server using command `chef-automate verify serve`
- Trigger any post api and see the logs

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[Screenshot-1](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EVAOGf6cqTNFkVTQy2CW3kMBUa0vS7KACeD8fRlfud09BQ?e=lHG78x)
[Screenshot-2](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/Eb0yKDzCbQdFvkEr5QVnfkcBQZd7ykIVmsqPpS_VmnAj0g?e=uEvP9p)
[Demo](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EXHyTYwtX31Lg8Lf6S_Q1SkB5da5O-SfLdc-CYdf_kdLUQ?e=7PBSWg)