### PR TITLE
UI Fix to give the resolution message

### DIFF
--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -654,10 +654,6 @@ func buildReports(batchCheckResults []models.BatchCheckResult) []reporting.Verif
 			var errorMsgs, resolutionMsgs []string
 			var successfulCount, failedCount int
 
-			if test.Skipped {
-				continue
-			}
-
 			if test.Checks == nil {
 				resolutionMsgs = append(resolutionMsgs, test.Error.Message)
 				failedCount++

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -654,7 +654,7 @@ func buildReports(batchCheckResults []models.BatchCheckResult) []reporting.Verif
 			var errorMsgs, resolutionMsgs []string
 			var successfulCount, failedCount int
 
-			if test.Checks == nil {
+			if test.Error != nil {
 				resolutionMsgs = append(resolutionMsgs, test.Error.Message)
 				failedCount++
 			}

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -650,6 +650,18 @@ func buildReports(batchCheckResults []models.BatchCheckResult) []reporting.Verif
 	for _, batchCheckResult := range batchCheckResults {
 
 		for _, test := range batchCheckResult.Tests {
+
+			var errorMsgs, resolutionMsgs []string
+			var successfulCount, failedCount int
+
+			if test.Skipped {
+				continue
+			}
+
+			if test.Checks == nil {
+				resolutionMsgs = append(resolutionMsgs, test.Error.Message)
+				failedCount++
+			}
 			report := reporting.VerificationReport{}
 			report.TableKey = batchCheckResult.NodeType
 			info := reporting.Info{}
@@ -665,8 +677,6 @@ func buildReports(batchCheckResults []models.BatchCheckResult) []reporting.Verif
 				info.Status = "Failed"
 			}
 
-			var errorMsgs, resolutionMsgs []string
-			var successfulCount, failedCount int
 			for _, check := range test.Checks {
 				if check.Passed {
 					successfulCount++
@@ -694,7 +704,6 @@ func buildReports(batchCheckResults []models.BatchCheckResult) []reporting.Verif
 		}
 
 	}
-
 	return reports
 }
 

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chef/automate/lib/reporting"
 	"github.com/chef/automate/lib/sshutils"
 	"github.com/chef/automate/lib/version"
+	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -664,6 +665,49 @@ func TestBuildReports(t *testing.T) {
 							SuccessfulCount: 2,
 							FailedCount:     0,
 							ToResolve:       nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Error was there form the handler or Trigger response",
+			args: args{
+				batchCheckResults: []models.BatchCheckResult{
+					{
+						NodeType: "automate",
+						Ip: "1.1.1.1",
+						Tests: []models.ApiResult{
+							{
+								Passed: false,
+								Message: "SSH User Access Check",
+								Check: "ssh-user",
+								Checks: nil,
+								Error: &fiber.Error{
+									Code: 400,
+									Message: "Permissions on the ssh key file do not satisfy the requirement",
+								},
+								Skipped: false,
+							},
+						},
+					},
+				},
+			},
+			want: []reporting.VerificationReport{
+				{
+					TableKey: "automate",
+					Report: reporting.Info{
+						Hostip:    "1.1.1.1",
+						Parameter: "ssh-user",
+						Status:    "Failed",
+						StatusMessage: &reporting.StatusMessage{
+							MainMessage: "SSH User Access Check - Failed",
+							SubMessage: nil,
+						},
+						SummaryInfo: &reporting.SummaryInfo{
+							SuccessfulCount: 0,
+							FailedCount: 1,
+							ToResolve: []string{"Permissions on the ssh key file do not satisfy the requirement"},
 						},
 					},
 				},

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 	"github.com/chef/automate/components/automate-cli/pkg/verifysystemdcreate"
 	"github.com/chef/automate/lib/config"
 	"github.com/chef/automate/lib/httputils"
 	"github.com/chef/automate/lib/majorupgrade_utils"
+	"github.com/chef/automate/lib/reporting"
 	"github.com/chef/automate/lib/sshutils"
 	"github.com/chef/automate/lib/version"
 	"github.com/stretchr/testify/assert"
@@ -602,4 +604,77 @@ func newMockVerifyCmdFlow(mockHttputils *httputils.MockHTTPClient, cw *majorupgr
 		cw.CliWriter,
 		mockVerifyCmdDeps,
 	)
+}
+
+func TestBuildReports(t *testing.T) {
+	type args struct {
+		batchCheckResults []models.BatchCheckResult
+	}
+	tests := []struct {
+		name string
+		args args
+		want []reporting.VerificationReport
+	}{
+		{
+			name: "If Report is successfully created",
+			args: args{
+				batchCheckResults: []models.BatchCheckResult{
+					{
+						NodeType: "automate",
+						Ip:       "1.1.1.1",
+						Tests: []models.ApiResult{
+							{
+								Passed:  true,
+								Message: "SSH User Access Check",
+								Check:   "ssh-user",
+								Checks: []models.Checks{
+									{
+										Title:         "SSH user accessible",
+										Passed:        true,
+										SuccessMsg:    "SSH user is accessible for the node: 1.1.1.1",
+										ErrorMsg:      "",
+										ResolutionMsg: "",
+									},
+									{
+										Title:         "Sudo password valid",
+										Passed:        true,
+										SuccessMsg:    "SSH user sudo password is valid for the node: 1.1.1.1",
+										ErrorMsg:      "",
+										ResolutionMsg: "",
+									},
+								},
+								Skipped: false,
+							},
+						},
+					},
+				},
+			},
+			want: []reporting.VerificationReport{
+				{
+					TableKey: "automate",
+					Report: reporting.Info{
+						Hostip:    "1.1.1.1",
+						Parameter: "ssh-user",
+						Status:    "Success",
+						StatusMessage: &reporting.StatusMessage{
+							MainMessage: "SSH User Access Check - Success",
+							SubMessage:  nil,
+						},
+						SummaryInfo: &reporting.SummaryInfo{
+							SuccessfulCount: 2,
+							FailedCount:     0,
+							ToResolve:       nil,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReports(tt.args.batchCheckResults)
+			assert.Equal(t, got, tt.want)
+
+		})
+	}
 }

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -471,6 +471,7 @@ type NodeCert struct {
 type HardwareResourceCheckResponse struct {
 	Status string                           `json:"status"`
 	Result []HardwareResourceCountApiResult `json:"result"`
+	Error  fiber.Error                      `json:"error"`
 }
 
 type HardwareResourceCountApiResult struct {
@@ -506,6 +507,7 @@ type FirewallRequest struct {
 type NFSMountCheckResponse struct {
 	Status string             `json:"status"`
 	Result []NFSMountResponse `json:"result"`
+	Error  fiber.Error        `json:"error"`
 }
 
 type FqdnRequest struct {

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger.go
@@ -2,6 +2,7 @@ package hardwareresourcechecktrigger
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,10 +40,16 @@ func (ss *HardwareResourceCountCheck) Run(config *models.Config) []models.CheckT
 	// for each and every IP to make the processing simple at the caller end
 
 	if err != nil {
+		statusCode := 503
+		errMessage := err.Error()
+		if resp != nil {
+			statusCode = resp.Error.Code
+			errMessage = resp.Error.Message
+		}
 		hostMap := configutils.GetNodeTypeMap(config.Hardware)
 		for ip, types := range hostMap {
 			for i := 0; i < len(types); i++ {
-				finalResult = append(finalResult, checkutils.PrepareTriggerResponse(nil, ip, types[i], err.Error(), constants.HARDWARE_RESOURCE_COUNT, constants.HARDWARE_RESOURCE_COUNT_MSG, true))
+				finalResult = append(finalResult, checkutils.PrepareTriggerResponse(nil, ip, types[i], errMessage, constants.HARDWARE_RESOURCE_COUNT, constants.HARDWARE_RESOURCE_COUNT_MSG, true, statusCode))
 			}
 		}
 		return finalResult
@@ -82,8 +89,13 @@ func (ss *HardwareResourceCountCheck) TriggerHardwareResourceCountCheck(body int
 	response := models.HardwareResourceCheckResponse{}
 	err = json.Unmarshal(respBody, &response)
 	if err != nil {
-		ss.log.Error("Error while reading unmarshalling response of Hardware resource count check from batch Check API : ", err)
+		ss.log.Error("Error while reading unmarshalling response of Hardware resource count check from batch Check API : ", response.Error.Message)
 		return nil, err
+	}
+	
+	if response.Error.Message != "" {
+		ss.log.Error("Error while calling the Hardware Resource Count: ", response.Error.Message)
+		return &response, errors.New(response.Error.Message) 
 	}
 	return &response, nil
 }

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger.go
@@ -40,7 +40,7 @@ func (ss *HardwareResourceCountCheck) Run(config *models.Config) []models.CheckT
 	// for each and every IP to make the processing simple at the caller end
 
 	if err != nil {
-		statusCode := 503
+		statusCode := 500
 		errMessage := err.Error()
 		if resp != nil {
 			statusCode = resp.Error.Code
@@ -89,7 +89,7 @@ func (ss *HardwareResourceCountCheck) TriggerHardwareResourceCountCheck(body int
 	response := models.HardwareResourceCheckResponse{}
 	err = json.Unmarshal(respBody, &response)
 	if err != nil {
-		ss.log.Error("Error while reading unmarshalling response of Hardware resource count check from batch Check API : ", response.Error.Message)
+		ss.log.Error("Error while reading unmarshalled response of Hardware resource count check from batch Check API : ", err)
 		return nil, err
 	}
 	

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger_test.go
@@ -264,11 +264,10 @@ func TestHardwareResourceCountCheck_Run(t *testing.T) {
 			}
 		}
 	})
-
 	t.Run("Returns error", func(t *testing.T) {
 		mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`invalid JSON`))
+			w.Write([]byte(`{"status":"failure", "result":[], "error":{"code":500, "message":"Invalid JSON"}}`))
 		}))
 		err := startMockServerOnCustomPort(mockServer, "1134")
 		assert.NoError(t, err)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/hardwareresourcechecktrigger/hardwareresourcecountchecktrigger_test.go
@@ -267,7 +267,7 @@ func TestHardwareResourceCountCheck_Run(t *testing.T) {
 	t.Run("Returns error", func(t *testing.T) {
 		mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"status":"failure", "result":[], "error":{"code":500, "message":"Invalid JSON"}}`))
+			w.Write([]byte(`{"status":"failure", "result":[], "error":{"code":400, "message":"Invalid JSON"}}`))
 		}))
 		err := startMockServerOnCustomPort(mockServer, "1134")
 		assert.NoError(t, err)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
@@ -2,6 +2,8 @@ package nfsmountbackupchecktrigger
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -50,8 +52,10 @@ func (nbc *NfsBackupConfigCheck) Run(config *models.Config) []models.CheckTrigge
 	//Triggers only one API call for nfs mount API
 	nfsMountAPIResponse, err := nbc.triggerCheckForMountService(nfsMountReq)
 	if err != nil {
-		response := constructErrorResult(config, err)
-		return response
+		if nfsMountAPIResponse!= nil {
+			return constructErrorResult(config, nfsMountAPIResponse.Error.Message, nfsMountAPIResponse.Error.Code)
+		}
+		return constructErrorResult(config, err.Error(), 503)
 
 	}
 	result := constructSuccessResult(*nfsMountAPIResponse)
@@ -76,20 +80,23 @@ func (ss *NfsBackupConfigCheck) triggerCheckForMountService(body models.NFSMount
 	apiResp := &models.NFSMountCheckResponse{}
 	err = json.Unmarshal(respBody, apiResp)
 	if err != nil {
-		ss.log.Error("Error while reading unmarshalling response of NFS Mount respons from batch Check API : ", err)
-		return apiResp, err
+		ss.log.Error("Error while reading unmarshalling response of NFS Mount response from batch Check API : ", err)
+		return nil, err
+	}
+	if apiResp.Error.Message != "" {
+		return apiResp, errors.New(apiResp.Error.Message)
 	}
 	return apiResp, nil
 }
 
 // constructErrorResult constructs the error response when recived from the API
-func constructErrorResult(config *models.Config, err error) []models.CheckTriggerResponse {
+func constructErrorResult(config *models.Config, errMessage string, statusCode int) []models.CheckTriggerResponse {
 	var result []models.CheckTriggerResponse
-
+	fmt.Errorf("Inside the custruct error=%v", errMessage)
 	hostMap := configutils.GetNodeTypeMap(config.Hardware)
 	for ip, types := range hostMap {
 		for i := 0; i < len(types); i++ {
-			result = append(result, checkutils.PrepareTriggerResponse(nil, ip, types[i], err.Error(), "", "", true))
+			result = append(result, checkutils.PrepareTriggerResponse(nil, ip, types[i], errMessage, "", "", true, statusCode))
 		}
 	}
 

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
@@ -54,7 +54,7 @@ func (nbc *NfsBackupConfigCheck) Run(config *models.Config) []models.CheckTrigge
 		if nfsMountAPIResponse!= nil {
 			return constructErrorResult(config, nfsMountAPIResponse.Error.Message, nfsMountAPIResponse.Error.Code)
 		}
-		return constructErrorResult(config, err.Error(), 503)
+		return constructErrorResult(config, err.Error(), 500)
 
 	}
 	result := constructSuccessResult(*nfsMountAPIResponse)
@@ -79,7 +79,7 @@ func (ss *NfsBackupConfigCheck) triggerCheckForMountService(body models.NFSMount
 	apiResp := &models.NFSMountCheckResponse{}
 	err = json.Unmarshal(respBody, apiResp)
 	if err != nil {
-		ss.log.Error("Error while reading unmarshalling response of NFS Mount response from batch Check API : ", err)
+		ss.log.Error("Error while reading unmarshalled response of NFS Mount response from batch Check API : ", err)
 		return nil, err
 	}
 	if apiResp.Error.Message != "" {

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
@@ -3,7 +3,6 @@ package nfsmountbackupchecktrigger
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -92,7 +91,7 @@ func (ss *NfsBackupConfigCheck) triggerCheckForMountService(body models.NFSMount
 // constructErrorResult constructs the error response when recived from the API
 func constructErrorResult(config *models.Config, errMessage string, statusCode int) []models.CheckTriggerResponse {
 	var result []models.CheckTriggerResponse
-	fmt.Errorf("Inside the custruct error=%v", errMessage)
+
 	hostMap := configutils.GetNodeTypeMap(config.Hardware)
 	for ip, types := range hostMap {
 		for i := 0; i < len(types); i++ {

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck_test.go
@@ -682,7 +682,7 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 					},
 				},
 			},
-			response:       "Error while triggering NFS Mount API from Batch Check API: 500 Internal Server Error",
+			response:       "unexpected end of JSON input",
 			isPassed:       false,
 			httpStatusCode: http.StatusInternalServerError,
 			isError:        true,
@@ -759,7 +759,7 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 				assert.Len(t, got, 4)
 				assert.NotNil(t, got[0].Result.Error)
 				assert.NotNil(t, got[0].Host)
-				assert.Contains(t, tt.response, got[0].Result.Error.Error())
+				assert.Contains(t, tt.response, got[0].Result.Error.Message)
 
 			} else {
 				var want []models.CheckTriggerResponse

--- a/components/automate-cli/pkg/verifyserver/utils/checkutils/checkutil.go
+++ b/components/automate-cli/pkg/verifyserver/utils/checkutils/checkutil.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func PrepareTriggerResponse(resp *models.CheckTriggerResponse, host, nodeType, errorString, check, msg string, isError bool) models.CheckTriggerResponse {
+func PrepareTriggerResponse(resp *models.CheckTriggerResponse, host, nodeType, errorString, check, msg string, isError bool, statusCode int) models.CheckTriggerResponse {
 	if isError {
 		return models.CheckTriggerResponse{
 			Host:     host,
@@ -16,7 +16,7 @@ func PrepareTriggerResponse(resp *models.CheckTriggerResponse, host, nodeType, e
 				Passed:  false,
 				Check:   check,
 				Message: msg,
-				Error:   fiber.NewError(fiber.StatusServiceUnavailable, errorString),
+				Error:   fiber.NewError(statusCode, errorString),
 			},
 		}
 	}

--- a/components/automate-cli/pkg/verifyserver/utils/checkutils/checkutil_test.go
+++ b/components/automate-cli/pkg/verifyserver/utils/checkutils/checkutil_test.go
@@ -44,9 +44,10 @@ func TestPrepareTriggerResponse_WithNoError(t *testing.T) {
 	check := "test check"
 	msg := "test message"
 	isError := false
+	statusCode := 200
 
 	// Act
-	result := PrepareTriggerResponse(resp, host, nodeType, errorString, check, msg, isError)
+	result := PrepareTriggerResponse(resp, host, nodeType, errorString, check, msg, isError, statusCode)
 
 	// Assert
 	assert.Equal(t, resp.Status, result.Status)
@@ -68,9 +69,9 @@ func TestPrepareTriggerResponse_WithError(t *testing.T) {
 	check := "test check"
 	msg := "test message"
 	isError := true
-
+	statusCode := 400
 	// Act
-	result := PrepareTriggerResponse(resp, host, nodeType, errorString, check, msg, isError)
+	result := PrepareTriggerResponse(resp, host, nodeType, errorString, check, msg, isError, statusCode)
 
 	// Assert
 	assert.Equal(t, resp.Status, result.Status)

--- a/components/automate-cli/pkg/verifyserver/utils/httputils/httputil.go
+++ b/components/automate-cli/pkg/verifyserver/utils/httputils/httputil.go
@@ -3,7 +3,6 @@ package httputils
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 
@@ -44,9 +43,6 @@ func MakeRequest(requestMethod string, url string, body interface{}) (*http.Resp
 	resp, err := client.Do(req)
 	if err != nil {
 		return resp, err
-	}
-	if err == nil && resp.StatusCode != 200 {
-		return resp, errors.New(resp.Status)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
- The UI was not giving the resolution message that were thrown from trigger or Handler funtions and there resolution in the how to resolve message
- the Hardware tigger and NFS mount where using same util it was giving the error response as string ( "400: Bad Request ) otherwise it should be the error that is coming from the Handlers , also refactored both the trigger files as well 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
- https://chefio.atlassian.net/browse/CHEF-3796
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

- The response from the trigger is now shown in the How Resolve section 

<img width="1792" alt="Screenshot 2023-06-27 at 7 46 59 PM" src="https://github.com/chef/automate/assets/62262938/abb5f5d5-5ee4-4082-93be-9d888252f39c">


- The Error given from the Handlers are also captured now in the error section

<img width="1792" alt="Screenshot 2023-06-27 at 7 47 38 PM" src="https://github.com/chef/automate/assets/62262938/90f25838-10b8-4ed5-bf3f-e6b54846b936">


<img width="1792" alt="Screenshot 2023-06-27 at 7 47 41 PM" src="https://github.com/chef/automate/assets/62262938/4ce52e8b-c3c7-46d9-8787-d34c7d9c0914">


<img width="1792" alt="Screenshot 2023-06-27 at 7 48 26 PM" src="https://github.com/chef/automate/assets/62262938/636f00a2-69d8-40e9-8104-894492d81fbc">
