### PR TITLE
fix for fetch config for aws

### DIFF
--- a/components/automate-cli/cmd/chef-automate/deployedConfig.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig.go
@@ -6,22 +6,27 @@ import (
 	"github.com/chef/automate/lib/config"
 )
 
+var GetModeOfDeployment func() string = getModeOfDeployment
+
 func PopulateHaCommonConfig(configPuller PullConfigs) (haDeployConfig *config.HaDeployConfig, err error) {
-	existingInfraConfig, err := configPuller.fetchInfraConfig()
-	if err != nil {
-		return nil, err
-	}
-	if existingInfraConfig != nil {
-		return CopyExistingInfra(existingInfraConfig), nil
-	}
+	modeOfDeployment := GetModeOfDeployment()
+	if modeOfDeployment == EXISTING_INFRA_MODE {
+		existingInfraConfig, err := configPuller.fetchInfraConfig()
+		if err != nil {
+			return nil, err
+		}
+		if existingInfraConfig != nil {
+			return CopyExistingInfra(existingInfraConfig), nil
+		}
+	} else if modeOfDeployment == AWS_MODE {
+		awsConfig, err := configPuller.fetchAwsConfig()
+		if err != nil {
+			return nil, err
+		}
 
-	awsConfig, err := configPuller.fetchAwsConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	if awsConfig != nil {
-		return CopyAws(awsConfig), nil
+		if awsConfig != nil {
+			return CopyAws(awsConfig), nil
+		}
 	}
 
 	return nil, errors.New("deployed config was not found")


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
PopulateHaCommonConfig function was fetching config for existing infra in both case for on-prem and aws as the check was if existing infra config is nil or not. Now first deployment type is checked then config is fetched.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3737

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Before:-
<img width="444" alt="Screenshot 2023-06-28 at 2 48 41 PM" src="https://github.com/chef/automate/assets/97166721/66a5d9cc-c334-47a2-9373-e478535abdfa">

After:-
<img width="619" alt="Screenshot 2023-06-28 at 2 57 00 PM" src="https://github.com/chef/automate/assets/97166721/a3cf9461-15c9-45a5-adc7-f7de5f7c91e9">
