### PR TITLE
Added the correct response type in NFS Mount Service Response

### DIFF
--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -87,6 +87,7 @@ type Config struct {
 	SSHUser         *SSHUser       `json:"ssh_user"`
 	Arch            string         `json:"arch"`
 	Backup          *Backup        `json:"backup"`
+	ExternalDbType  string         `json:"external_db_type"`
 	Hardware        *Hardware      `json:"hardware"`
 	Certificate     []*Certificate `json:"certificate"`
 	ExternalOS      *ExternalOS    `json:"external_opensearch"`
@@ -377,6 +378,7 @@ func addCertificatesInConfig(fqdn, rootCA, nodeType string) *Certificate {
 }
 
 func (c *Config) populateExternalDbConfig(haConfig *config.HaDeployConfig) {
+	c.ExternalDbType = haConfig.External.Database.Type
 	externalPgConfig := haConfig.External.Database.PostgreSQL
 	c.ExternalPG.PGDbUserName = externalPgConfig.DbuserUsername
 	c.ExternalPG.PGDbUserPassword = externalPgConfig.DbuserPassword

--- a/components/automate-cli/pkg/verifyserver/models/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/models/nfsmount.go
@@ -1,6 +1,7 @@
 package models
 
 type NFSMountRequest struct {
+	ExternalDbType         string   `json:"external_db_type"`
 	AutomateNodeIPs        []string `json:"automate_node_ips"`
 	ChefInfraServerNodeIPs []string `json:"chef_infra_server_node_ips"`
 	PostgresqlNodeIPs      []string `json:"postgresql_node_ips"`

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount.go
@@ -14,10 +14,16 @@ func (h *Handler) NFSMount(c *fiber.Ctx) error {
 		h.Logger.Error(err.Error())
 		return fiber.NewError(http.StatusBadRequest, "Invalid Body Request")
 	}
-	if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 || len(reqBody.PostgresqlNodeIPs) == 0 || len(reqBody.OpensearchNodeIPs) == 0 {
-		return fiber.NewError(http.StatusBadRequest, "AutomateNodeIPs, ChefInfraServerNodeIPs, PostgresqlNodeIPs or OpensearchNodeIPs cannot be empty")
-	}
 
+	if reqBody.ExternalDbType == "self-managed" {
+		if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 {
+			return fiber.NewError(http.StatusBadRequest, "AutomateNodeIPs or ChefInfraServerNodeIPs cannot be empty")
+		}
+	} else {
+		if len(reqBody.AutomateNodeIPs) == 0 || len(reqBody.ChefInfraServerNodeIPs) == 0 || len(reqBody.PostgresqlNodeIPs) == 0 || len(reqBody.OpensearchNodeIPs) == 0 {
+			return fiber.NewError(http.StatusBadRequest, "AutomateNodeIPs, ChefInfraServerNodeIPs, PostgresqlNodeIPs or OpensearchNodeIPs cannot be empty")
+		}
+	}
 	if reqBody.MountLocation == "" {
 		return fiber.NewError(http.StatusBadRequest, "Mount Location cannot be empty")
 	}

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/nfsmount_test.go
@@ -519,6 +519,7 @@ func TestNFSMount(t *testing.T) {
 				]
 			}`,
 			RequestBody: `{
+				"external_db_type":"",
 				"automate_node_ips": [
 					"localhost",
 					"localhost"
@@ -554,7 +555,7 @@ func TestNFSMount(t *testing.T) {
 			RequestBody: "Invalid Body",
 		},
 		{
-			TestName:     "Not Given all the required IPs",
+			TestName:     "Not Given all the required IPs in On-Prem chef managed",
 			ExpectedCode: 400,
 			ExpectedBody: `{
 				"status": "FAILED",
@@ -565,6 +566,23 @@ func TestNFSMount(t *testing.T) {
 				}
 			}`,
 			RequestBody: `{
+				"external_db_type":"",
+				"automate_node_ips": []
+			}`,
+		},
+		{
+			TestName:     "Not Given all the required IPs in On-Prem self managed",
+			ExpectedCode: 400,
+			ExpectedBody: `{
+				"status": "FAILED",
+				"result": null,
+				"error": {
+					"code": 400,
+					"message": "AutomateNodeIPs or ChefInfraServerNodeIPs cannot be empty"
+				}
+			}`,
+			RequestBody: `{
+				"external_db_type":"self-managed",
 				"automate_node_ips": []
 			}`,
 		},

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck.go
@@ -40,6 +40,7 @@ func (nbc *NfsBackupConfigCheck) Run(config *models.Config) []models.CheckTrigge
 	}
 
 	nfsMountReq := models.NFSMountRequest{
+		ExternalDbType:         config.ExternalDbType,
 		AutomateNodeIPs:        config.Hardware.AutomateNodeIps,
 		ChefInfraServerNodeIPs: config.Hardware.ChefInfraServerNodeIps,
 		PostgresqlNodeIPs:      config.Hardware.PostgresqlNodeIps,

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/nfsmountbackupchecktrigger/nfsmountbackupcheck_test.go
@@ -29,6 +29,7 @@ var (
 
 const (
 	mountLocation = "test-mount"
+	TYPE          = "self-managed"
 
 	nfsMountResponse = `{
 		"status": "SUCCESS",
@@ -635,7 +636,8 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			name: "Passed Response for chef-server,automate,opensearch and postgresql",
 			args: args{
 				config: &models.Config{
-					Hardware: hardware,
+					ExternalDbType: TYPE,
+					Hardware:       hardware,
 					Backup: &models.Backup{
 						FileSystem: &models.FileSystem{
 							MountLocation: mountLocation,
@@ -654,7 +656,8 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			name: "Failure Mount Response for chef-server,automate,opensearch and postgresql",
 			args: args{
 				config: &models.Config{
-					Hardware: hardware,
+					ExternalDbType: TYPE,
+					Hardware:       hardware,
 					Backup: &models.Backup{
 						FileSystem: &models.FileSystem{
 							MountLocation: mountLocation,
@@ -674,7 +677,8 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			name: "Recived Internal Server Error From the API",
 			args: args{
 				config: &models.Config{
-					Hardware: hardware,
+					ExternalDbType: TYPE,
+					Hardware:       hardware,
 					Backup: &models.Backup{
 						FileSystem: &models.FileSystem{
 							MountLocation: mountLocation,
@@ -693,7 +697,8 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			name: "Invalid Response from service",
 			args: args{
 				config: &models.Config{
-					Hardware: hardware,
+					ExternalDbType: TYPE,
+					Hardware:       hardware,
 					Backup: &models.Backup{
 						FileSystem: &models.FileSystem{
 							MountLocation: mountLocation,
@@ -713,6 +718,7 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			name: "Checking for Same Front end Nodes",
 			args: args{
 				config: &models.Config{
+					ExternalDbType: TYPE,
 					Hardware: &models.Hardware{
 						AutomateNodeIps:        hardware.AutomateNodeIps,
 						ChefInfraServerNodeIps: hardware.AutomateNodeIps,
@@ -732,6 +738,7 @@ func TestNfsBackupConfigCheck_Run(t *testing.T) {
 			httpStatusCode:        http.StatusOK,
 			isError:               false,
 			wantRequest: models.NFSMountRequest{
+				ExternalDbType:         TYPE,
 				AutomateNodeIPs:        hardware.AutomateNodeIps,
 				ChefInfraServerNodeIPs: hardware.AutomateNodeIps,
 				PostgresqlNodeIPs:      hardware.PostgresqlNodeIps,
@@ -820,6 +827,7 @@ func createDummyServer(t *testing.T, requiredStatusCode int, isPassed bool, pars
 
 func getRequest() models.NFSMountRequest {
 	return models.NFSMountRequest{
+		ExternalDbType:         TYPE,
 		AutomateNodeIPs:        hardware.AutomateNodeIps,
 		ChefInfraServerNodeIPs: hardware.ChefInfraServerNodeIps,
 		PostgresqlNodeIPs:      hardware.PostgresqlNodeIps,

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gofiber/fiber/v2"
-
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
@@ -188,7 +186,8 @@ func prepareMountResp(ip, nodeType, mountLocation string, mountLocResp *models.N
 	node.NodeType = nodeType
 
 	if err != nil {
-		node.Error = fiber.NewError(http.StatusBadRequest, err.Error())
+		checkList := createCheck("NFS mount", false, "", "NFS mount location not found", "NFS volume should be mounted on "+mountLocation)
+		node.CheckList = append(node.CheckList, checkList)
 		return node
 	}
 	checkMount(mountLocation, &node, mountLocResp)

--- a/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/nfsmountservice/nfsmountservice_test.go
@@ -348,21 +348,27 @@ func TestGetNFSMountDetails(t *testing.T) {
 			Response: []models.NFSMountResponse{
 				{IP: "localhost", NodeType: "automate", CheckList: []models.Checks{
 					{Passed: true},
-					{Passed: true},
+					{Passed: false},
 				}, Error: nil},
-				{IP: "192.168.54.34", NodeType: "automate", CheckList: nil, Error: errors.New("")},
+				{IP: "192.168.54.34", NodeType: "automate", CheckList: []models.Checks{
+					{Passed: false},
+					{Passed: false},
+				}, Error: nil},
 				{IP: "localhost", NodeType: "chef-infra-server", CheckList: []models.Checks{
 					{Passed: true},
-					{Passed: true},
+					{Passed: false},
 				}, Error: nil},
-				{IP: "anything.com", NodeType: "postgresql", CheckList: nil, Error: errors.New("")},
+				{IP: "anything.com", NodeType: "postgresql", CheckList: []models.Checks{
+					{Passed: false},
+					{Passed: false},
+				}, Error: nil},
 				{IP: "localhost", NodeType: "postgresql", CheckList: []models.Checks{
 					{Passed: true},
-					{Passed: true},
+					{Passed: false},
 				}, Error: nil},
 				{IP: "localhost", NodeType: "opensearch", CheckList: []models.Checks{
 					{Passed: true},
-					{Passed: true},
+					{Passed: false},
 				}, Error: nil},
 			},
 		},


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
- The NFS Service was not giving the ideal response when one of instance was unmounted it was giving the error into a different variable whereas it should have given the error message into a checks response of the api 
- As we support the NFS backup in Onprem customer managed as well so added the condition around it as well 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
- https://chefio.atlassian.net/browse/CHEF-3819
### :+1: Definition of Done
- The Response should come in the checks rather than giving the different response
### :athletic_shoe: How to Build and Test the Change
- Checkout this Branch
- rebuild components/automate-cli
- create the Hab package and install it on your bastion 
- Run the cmd `chef-automate verify --config config.toml`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
- The Success Response from the Service 

<img width="1792" alt="NFS Mount Success Response" src="https://github.com/chef/automate/assets/62262938/5c2cbf29-486f-4da6-9e91-2def60e8d1ad">



- The Error response when one is unmounted as if one is unmounted then other should show error in the shared location 


<img width="1236" alt="Screenshot 2023-06-28 at 5 25 38 PM" src="https://github.com/chef/automate/assets/62262938/1a491732-91c1-4a41-802d-833455fd2d1f">



- The Error from the node where it was unmounted 

<img width="1230" alt="Screenshot 2023-06-28 at 5 32 02 PM" src="https://github.com/chef/automate/assets/62262938/788852d1-5c04-4e3d-a0bd-31b8761d08e3">


- Success for ExternalDB type as self-managed ( customer -managed )

<img width="1792" alt="Screenshot 2023-06-28 at 8 48 58 PM" src="https://github.com/chef/automate/assets/62262938/0d7ca918-98e2-463d-9309-d6328d3341c8">

- Failure if one node is down for the Self-managed case ( customer-managed) 

<img width="1238" alt="Screenshot 2023-06-28 at 8 49 40 PM" src="https://github.com/chef/automate/assets/62262938/89bcb898-dd03-4552-9365-2219059c66eb">
