### PR TITLE
Chef 3834 - External OS/PG should be skipped when not valid

### DIFF
--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -311,9 +311,13 @@ func (v *verifyCmdFlow) RunVerify(config string) error {
 		v.postgresqlIPs = configDetails.PostgresqlIps
 		v.opensearchIPs = configDetails.OpensearchIps
 
-		batchCheckConfig.ExternalOS.OSRoleArn = configDetails.OsSnapshotRoleArn
-		batchCheckConfig.ExternalOS.OsSnapshotUserAccessKeyId = configDetails.OsSnapshotUserID
-		batchCheckConfig.ExternalOS.OsSnapshotUserAccessKeySecret = configDetails.OsSnapshotUserSecret
+		if v.Config.Aws.Config.SetupManagedServices {
+			batchCheckConfig.ExternalOS = &models.ExternalOS{
+				OSRoleArn:                     configDetails.OsSnapshotRoleArn,
+				OsSnapshotUserAccessKeyId:     configDetails.OsSnapshotUserID,
+				OsSnapshotUserAccessKeySecret: configDetails.OsSnapshotUserSecret,
+			}
+		}
 		// assign ip's to models.Hardware
 		batchCheckHardware := batchCheckConfig.Hardware
 		batchCheckHardware.AutomateNodeIps = configDetails.AutomateIps

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -100,8 +100,6 @@ func NewConfig() *Config {
 		Hardware:    &Hardware{},
 		Certificate: []*Certificate{},
 		SSHUser:     &SSHUser{},
-		ExternalOS:  &ExternalOS{},
-		ExternalPG:  &ExternalPG{},
 	}
 }
 
@@ -324,23 +322,20 @@ func (c *Config) populateAwsCerts(haConfig *config.HaDeployConfig) {
 
 func (c *Config) populateAwsManagedServicesConfig(haConfig *config.HaDeployConfig) {
 	awsManagedServicesConfig := haConfig.Aws.Config
-	c.ExternalPG.PGDbUserName = awsManagedServicesConfig.ManagedRdsDbuserUsername
-	c.ExternalPG.PGDbUserPassword = awsManagedServicesConfig.ManagedRdsDbuserPassword
-	c.ExternalPG.PGInstanceURL = awsManagedServicesConfig.ManagedRdsInstanceURL
-
-	// pg root-ca might be nil in pre deploy state
-	c.ExternalPG.PGRootCert = awsManagedServicesConfig.ManagedRdsCertificate
-	c.ExternalPG.PGSuperuserName = awsManagedServicesConfig.ManagedRdsSuperuserUsername
-	c.ExternalPG.PGSuperuserPassword = awsManagedServicesConfig.ManagedRdsSuperuserPassword
+	c.ExternalPG = &ExternalPG{
+		PGDbUserName:        awsManagedServicesConfig.ManagedRdsDbuserUsername,
+		PGDbUserPassword:    awsManagedServicesConfig.ManagedRdsDbuserPassword,
+		PGInstanceURL:       awsManagedServicesConfig.ManagedRdsInstanceURL,
+		PGRootCert:          awsManagedServicesConfig.ManagedRdsCertificate,
+		PGSuperuserName:     awsManagedServicesConfig.ManagedRdsSuperuserUsername,
+		PGSuperuserPassword: awsManagedServicesConfig.ManagedRdsSuperuserPassword,
+	}
 
 	c.ExternalOS.OSDomainName = awsManagedServicesConfig.ManagedOpensearchDomainName
 	c.ExternalOS.OSDomainURL = awsManagedServicesConfig.ManagedOpensearchDomainURL
-
-	// os root-ca might be nil in pre deploy state
 	c.ExternalOS.OSCert = awsManagedServicesConfig.ManagedOpensearchCertificate
 	c.ExternalOS.OSUserPassword = awsManagedServicesConfig.ManagedOpensearchUserPassword
 	c.ExternalOS.OSUsername = awsManagedServicesConfig.ManagedOpensearchUsername
-	c.ExternalOS.OSRoleArn = awsManagedServicesConfig.AwsOsSnapshotRoleArn
 }
 
 func (c *Config) populateExistingInfraCommonConfig(haConfig *config.HaDeployConfig) {
@@ -378,23 +373,24 @@ func addCertificatesInConfig(fqdn, rootCA, nodeType string) *Certificate {
 
 func (c *Config) populateExternalDbConfig(haConfig *config.HaDeployConfig) {
 	externalPgConfig := haConfig.External.Database.PostgreSQL
-	c.ExternalPG.PGDbUserName = externalPgConfig.DbuserUsername
-	c.ExternalPG.PGDbUserPassword = externalPgConfig.DbuserPassword
-	c.ExternalPG.PGInstanceURL = externalPgConfig.InstanceURL
-
-	// pg root-ca might be nil in pre deploy state
-	c.ExternalPG.PGRootCert = externalPgConfig.PostgresqlRootCert
-	c.ExternalPG.PGSuperuserName = externalPgConfig.SuperuserUsername
-	c.ExternalPG.PGSuperuserPassword = externalPgConfig.SuperuserPassword
+	c.ExternalPG = &ExternalPG{
+		PGDbUserName:        externalPgConfig.DbuserUsername,
+		PGDbUserPassword:    externalPgConfig.DbuserPassword,
+		PGInstanceURL:       externalPgConfig.InstanceURL,
+		PGRootCert:          externalPgConfig.PostgresqlRootCert,
+		PGSuperuserName:     externalPgConfig.SuperuserUsername,
+		PGSuperuserPassword: externalPgConfig.SuperuserPassword,
+	}
 
 	externalOsConfig := haConfig.External.Database.OpenSearch
-	c.ExternalOS.OSDomainName = externalOsConfig.OpensearchDomainName
-	c.ExternalOS.OSDomainURL = externalOsConfig.OpensearchDomainURL
 
-	// os root-ca might be nil in pre deploy state
-	c.ExternalOS.OSCert = externalOsConfig.OpensearchRootCert
-	c.ExternalOS.OSUserPassword = externalOsConfig.OpensearchUserPassword
-	c.ExternalOS.OSUsername = externalOsConfig.OpensearchUsername
+	c.ExternalOS = &ExternalOS{
+		OSDomainName:   externalOsConfig.OpensearchDomainName,
+		OSDomainURL:    externalOsConfig.OpensearchDomainURL,
+		OSCert:         externalOsConfig.OpensearchRootCert,
+		OSUserPassword: externalOsConfig.OpensearchUserPassword,
+		OSUsername:     externalOsConfig.OpensearchUsername,
+	}
 
 	if haConfig.IsAwsExternalOsConfigured() {
 		c.ExternalOS.OSRoleArn = externalOsConfig.Aws.AwsOsSnapshotRoleArn

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -322,13 +322,19 @@ func (c *Config) populateAwsCerts(haConfig *config.HaDeployConfig) {
 
 func (c *Config) populateAwsManagedServicesConfig(haConfig *config.HaDeployConfig) {
 	awsManagedServicesConfig := haConfig.Aws.Config
-	c.ExternalPG = &ExternalPG{
-		PGDbUserName:        awsManagedServicesConfig.ManagedRdsDbuserUsername,
-		PGDbUserPassword:    awsManagedServicesConfig.ManagedRdsDbuserPassword,
-		PGInstanceURL:       awsManagedServicesConfig.ManagedRdsInstanceURL,
-		PGRootCert:          awsManagedServicesConfig.ManagedRdsCertificate,
-		PGSuperuserName:     awsManagedServicesConfig.ManagedRdsSuperuserUsername,
-		PGSuperuserPassword: awsManagedServicesConfig.ManagedRdsSuperuserPassword,
+	if c.ExternalPG == nil {
+		c.ExternalPG = &ExternalPG{}
+	}
+
+	c.ExternalPG.PGDbUserName = awsManagedServicesConfig.ManagedRdsDbuserUsername
+	c.ExternalPG.PGDbUserPassword = awsManagedServicesConfig.ManagedRdsDbuserPassword
+	c.ExternalPG.PGInstanceURL = awsManagedServicesConfig.ManagedRdsInstanceURL
+	c.ExternalPG.PGRootCert = awsManagedServicesConfig.ManagedRdsCertificate
+	c.ExternalPG.PGSuperuserName = awsManagedServicesConfig.ManagedRdsSuperuserUsername
+	c.ExternalPG.PGSuperuserPassword = awsManagedServicesConfig.ManagedRdsSuperuserPassword
+
+	if c.ExternalOS == nil {
+		c.ExternalOS = &ExternalOS{}
 	}
 
 	c.ExternalOS.OSDomainName = awsManagedServicesConfig.ManagedOpensearchDomainName
@@ -373,24 +379,27 @@ func addCertificatesInConfig(fqdn, rootCA, nodeType string) *Certificate {
 
 func (c *Config) populateExternalDbConfig(haConfig *config.HaDeployConfig) {
 	externalPgConfig := haConfig.External.Database.PostgreSQL
-	c.ExternalPG = &ExternalPG{
-		PGDbUserName:        externalPgConfig.DbuserUsername,
-		PGDbUserPassword:    externalPgConfig.DbuserPassword,
-		PGInstanceURL:       externalPgConfig.InstanceURL,
-		PGRootCert:          externalPgConfig.PostgresqlRootCert,
-		PGSuperuserName:     externalPgConfig.SuperuserUsername,
-		PGSuperuserPassword: externalPgConfig.SuperuserPassword,
+	if c.ExternalPG == nil {
+		c.ExternalPG = &ExternalPG{}
 	}
+	c.ExternalPG.PGDbUserName = externalPgConfig.DbuserUsername
+	c.ExternalPG.PGDbUserPassword = externalPgConfig.DbuserPassword
+	c.ExternalPG.PGInstanceURL = externalPgConfig.InstanceURL
+	c.ExternalPG.PGRootCert = externalPgConfig.PostgresqlRootCert
+	c.ExternalPG.PGSuperuserName = externalPgConfig.SuperuserUsername
+	c.ExternalPG.PGSuperuserPassword = externalPgConfig.SuperuserPassword
 
 	externalOsConfig := haConfig.External.Database.OpenSearch
 
-	c.ExternalOS = &ExternalOS{
-		OSDomainName:   externalOsConfig.OpensearchDomainName,
-		OSDomainURL:    externalOsConfig.OpensearchDomainURL,
-		OSCert:         externalOsConfig.OpensearchRootCert,
-		OSUserPassword: externalOsConfig.OpensearchUserPassword,
-		OSUsername:     externalOsConfig.OpensearchUsername,
+	if c.ExternalOS == nil {
+		c.ExternalOS = &ExternalOS{}
 	}
+
+	c.ExternalOS.OSDomainName = externalOsConfig.OpensearchDomainName
+	c.ExternalOS.OSDomainURL = externalOsConfig.OpensearchDomainURL
+	c.ExternalOS.OSCert = externalOsConfig.OpensearchRootCert
+	c.ExternalOS.OSUserPassword = externalOsConfig.OpensearchUserPassword
+	c.ExternalOS.OSUsername = externalOsConfig.OpensearchUsername
 
 	if haConfig.IsAwsExternalOsConfigured() {
 		c.ExternalOS.OSRoleArn = externalOsConfig.Aws.AwsOsSnapshotRoleArn

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
@@ -27,7 +27,7 @@ func NewOpensearchS3BucketAccessCheck(log logger.Logger, port string) *Opensearc
 func (osb *OpensearchS3BucketAccessCheck) Run(config *models.Config) []models.CheckTriggerResponse {
 	if config.ExternalOS == nil || config.Backup.ObjectStorage == nil {
 		return []models.CheckTriggerResponse{
-			trigger.SkippedTriggerCheckResp(constants.UNKNOWN_HOST, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH),
+			trigger.SkippedTriggerCheckResp("-", constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH),
 		}
 	}
 

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
@@ -226,7 +226,7 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 			} else {
 				if tt.name == "Nil OS and Object storage" {
 					assert.Len(t, got, 1)
-					assert.Equal(t, constants.UNKNOWN_HOST, got[0].Host)
+					assert.Equal(t, "-", got[0].Host)
 					assert.Equal(t, constants.OPENSEARCH, got[0].NodeType)
 					assert.Equal(t, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, got[0].CheckType)
 					assert.True(t, got[0].Result.Skipped)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/s3backupchecktrigger/s3backupconfigchecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/s3backupchecktrigger/s3backupconfigchecktrigger_test.go
@@ -339,7 +339,7 @@ func TestRunS3BackupCheck(t *testing.T) {
 		got := svc.Run(config)
 
 		assert.Len(t, got, 1)
-		assert.Equal(t, constants.UNKNOWN_HOST, got[0].Host)
+		assert.Equal(t, "-", got[0].Host)
 		assert.Equal(t, constants.AUTOMATE, got[0].NodeType)
 		assert.Equal(t, constants.S3_BACKUP_CONFIG, got[0].CheckType)
 		assert.True(t, got[0].Result.Skipped)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently External OS/PG check execute in every type of infra. These should be skipped if not for a valid infra type

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3834

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

1. Build automate-cli
2. run chef-automate verify --config config.toml

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1127" alt="MicrosoftTeams-image (9)" src="https://github.com/chef/automate/assets/10796521/9e3abac8-f382-461d-8b26-72053caf0985">
<img width="1127" alt="MicrosoftTeams-image (10)" src="https://github.com/chef/automate/assets/10796521/b1277a7a-b865-4841-98a6-b5e4740040ee">
<img width="1535" alt="MicrosoftTeams-image (11)" src="https://github.com/chef/automate/assets/10796521/63cf51e7-a901-4c0e-b249-fae5ce704742">


