### PR TITLE
Fixing AWS OpenSearch S3 Bucket access check errors

### DIFF
--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -405,6 +405,8 @@ func (c *Config) populateExternalDbConfig(haConfig *config.HaDeployConfig) {
 
 	if haConfig.IsAwsExternalOsConfigured() {
 		c.ExternalOS.OSRoleArn = externalOsConfig.Aws.AwsOsSnapshotRoleArn
+		c.ExternalOS.OsSnapshotUserAccessKeyId = externalOsConfig.Aws.OsSnapshotUserAccessKeyID
+		c.ExternalOS.OsSnapshotUserAccessKeySecret= externalOsConfig.Aws.OsSnapshotUserAccessKeySecret
 	}
 }
 

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
@@ -2,6 +2,7 @@ package opensearchs3bucketaccesschecktrigger
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
@@ -20,7 +21,7 @@ func NewOpensearchS3BucketAccessCheck(log logger.Logger, port string) *Opensearc
 	return &OpensearchS3BucketAccessCheck{
 		log:  log,
 		port: port,
-		host: constants.LOCAL_HOST_URL,
+		host: constants.LOCALHOST,
 	}
 }
 
@@ -48,10 +49,14 @@ func (osb *OpensearchS3BucketAccessCheck) Run(config *models.Config) []models.Ch
 		Password:   config.ExternalOS.OSUserPassword,
 		S3Bucket:   config.Backup.ObjectStorage.BucketName,
 		S3BasePath: config.Backup.ObjectStorage.BasePath,
-		AccessKey:  config.Backup.ObjectStorage.AccessKey,
-		SecretKey:  config.Backup.ObjectStorage.SecretKey,
+		AccessKey:  config.ExternalOS.OsSnapshotUserAccessKeyId,
+		SecretKey:  config.ExternalOS.OsSnapshotUserAccessKeySecret,
 		AWSRegion:  config.Backup.ObjectStorage.AWSRegion,
 		AWSRoleArn: config.ExternalOS.OSRoleArn,
+	}
+
+	if !strings.Contains(s3OpensearchBackupRequest.Endpoint, "https://") {
+		s3OpensearchBackupRequest.Endpoint = "https://" + s3OpensearchBackupRequest.Endpoint
 	}
 
 	endPoint := checkutils.PrepareEndPoint(osb.host, osb.port, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS_API_PATH)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
@@ -1,7 +1,6 @@
 package opensearchs3bucketaccesschecktrigger
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -55,18 +54,14 @@ func (osb *OpensearchS3BucketAccessCheck) Run(config *models.Config) []models.Ch
 		AWSRegion:  config.Backup.ObjectStorage.AWSRegion,
 		AWSRoleArn: config.ExternalOS.OSRoleArn,
 	}
-	fmt.Printf("s3OpensearchBackupRequest.Endpoint 1: %v\n", s3OpensearchBackupRequest.Endpoint)
 
 	if !strings.Contains(s3OpensearchBackupRequest.Endpoint, "https://") {
 		s3OpensearchBackupRequest.Endpoint = "https://" + s3OpensearchBackupRequest.Endpoint
 	}
 
-	fmt.Printf("s3OpensearchBackupRequest.Endpoint 2: %v\n", s3OpensearchBackupRequest.Endpoint)
-
 	endPoint := checkutils.PrepareEndPoint(osb.host, osb.port, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS_API_PATH)
 
 	response := triggerCheckForOpensearchS3Backup(endPoint, osb.log, http.MethodPost, s3OpensearchBackupRequest)
-	fmt.Printf("response: %v\n", response)
 	return setHostAsOpensearchInResponse(response, config.ExternalOS.OSDomainURL)
 
 }
@@ -78,7 +73,6 @@ func (ss *OpensearchS3BucketAccessCheck) GetPortsForMockServer() map[string]map[
 
 // setHostAsOpensearchInResponse sets the Host as external OS endpoint as this will help us in mapping the result correctly
 func setHostAsOpensearchInResponse(response []models.CheckTriggerResponse, osExternalUrl string) []models.CheckTriggerResponse {
-	fmt.Printf("osExternalUrl: %v\n", osExternalUrl)
 	for i := range response {
 		response[i].Host = osExternalUrl
 
@@ -93,15 +87,12 @@ func triggerCheckForOpensearchS3Backup(endPoint string, log logger.Logger, metho
 	log.Debugf("Triggering the api call for Opensearch for S3 backup")
 	outputCh := make(chan models.CheckTriggerResponse)
 
-	fmt.Printf("reqBody: %v\n", reqBody)
 	//There will be only one request which will check the connection
 	go trigger.TriggerCheckAPI(endPoint, reqBody.Endpoint, constants.OPENSEARCH, method, outputCh, reqBody)
 
 	//As we are triggering only one request for checking the connection for opensearch and s3 bucket
 	res := <-outputCh
-	fmt.Printf("res.Host: %v\n", res.Host)
 	result = append(result, res)
-	fmt.Printf("result: %+v\n", result)
 	return result
 
 }

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
@@ -2,7 +2,6 @@ package opensearchs3bucketaccesschecktrigger
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,6 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 	"github.com/chef/automate/lib/logger"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -246,38 +244,12 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 				} else {
 					assert.Equal(t, want, got)
 					assert.NotNil(t, got)
-					assert.NotNil(t, got[0].Result.Error)
 					assert.Equal(t, "https://open-search-url", got[0].Host)
 				}
 			}
 
 		})
 	}
-
-	t.Run("Endpoint without https", func(t *testing.T) {
-		config := &models.Config{
-			ExternalOS: &models.ExternalOS{
-				OSDomainName:                  "Name of the domain",
-				OSDomainURL:                   "open-search-url",
-				OSRoleArn:                     "Role-ARN",
-				OSUsername:                    "username",
-				OSUserPassword:                "password",
-				OSCert:                        "___CERT____",
-				OsSnapshotUserAccessKeySecret: "secret-key",
-				OsSnapshotUserAccessKeyId:     "access-kkey",
-			},
-			Backup: &models.Backup{
-				ObjectStorage: s3Properties,
-			},
-		}
-
-		osb := NewOpensearchS3BucketAccessCheck(logger.NewLogrusStandardLogger(), "8080")
-
-		got := osb.Run(config)
-		require.Len(t, got, 2)
-		fmt.Printf("got: %+v\n", got)
-		require.Equal(t, "https://open-search-url", got[0].Host)
-	})
 }
 
 // Helper function to create a dummy server

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
@@ -22,6 +22,8 @@ var (
 		OSUsername:     "username",
 		OSUserPassword: "password",
 		OSCert:         "___CERT____",
+		OsSnapshotUserAccessKeySecret: "secret-key",
+		OsSnapshotUserAccessKeyId: "access-kkey",
 	}
 
 	s3Properties = &models.ObjectStorage{
@@ -221,7 +223,7 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 				assert.NotNil(t, got[0].Result.Error.Error)
 				assert.Equal(t, constants.OPENSEARCH, got[0].NodeType)
 				assert.Equal(t, tt.httpResponseCode, got[0].Result.Error.Code)
-				assert.Equal(t, "open-search-url", got[0].Host)
+				assert.Equal(t, "https://open-search-url", got[0].Host)
 				assert.Equal(t, tt.response, got[0].Result.Error.Error())
 			} else {
 				if tt.name == "Nil OS and Object storage" {
@@ -243,7 +245,7 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 					assert.Equal(t, want, got)
 					assert.NotNil(t, got)
 					assert.Nil(t, got[0].Result.Error)
-					assert.Equal(t, "open-search-url", got[0].Host)
+					assert.Equal(t, "https://open-search-url", got[0].Host)
 				}
 			}
 

--- a/components/automate-cli/pkg/verifyserver/services/opensearchbackupservice/opensearchs3backupmanaged.go
+++ b/components/automate-cli/pkg/verifyserver/services/opensearchbackupservice/opensearchs3backupmanaged.go
@@ -94,7 +94,7 @@ func (ss *OSS3BackupService) OSS3BackupVerify(request models.S3BackupDetails, ct
 		}, err
 	}
 
-	if status, err := ss.OSOperations.GetSnapshotStatus(client, ctx, constant.TEST_REPO_NAME, constant.TEST_SNAPSHOT_NAME); err != nil || status != "SUCCESS" {
+	if status, err := ss.OSOperations.GetSnapshotStatus(client, ctx, constant.TEST_REPO_NAME, constant.TEST_SNAPSHOT_NAME); err != nil || status == "FAILED" {
 		ss.Log.Error("Snapshot Status check failed: ", err)
 		return models.S3BackupManagedResponse{
 			Passed: false,


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As a user when I was doing batch check for aws-opensearch-s3-access its failing with 500 error
The checks are failing because of the following errors:

- The request url have two http protocols.
- os_snapshot_user_access_key_id,`os_snapshot_user_secretkey` values are not mapping in the batch check.
- For this check the Os endpoint url should have ‘https' protocol.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3836

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Before this change
<img width="916" alt="Screenshot 2023-06-30 at 6 04 25 PM" src="https://github.com/chef/automate/assets/100406225/ab08159c-bbf9-44e0-8982-22c5f295dad8">

After this change
<img width="916" alt="Screenshot 2023-06-30 at 6 03 47 PM" src="https://github.com/chef/automate/assets/100406225/15f26d55-3fc5-4dbf-b629-da2fea55a6a7">
