### PR TITLE
Changes for removing firewall check for port 22 from bastion to cluster

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger.go
@@ -67,7 +67,6 @@ func makeRequests(config *models.Config, reqMap map[string][]models.FirewallRequ
 	reqMap[constants.CHEF_INFRA_SERVER] = getRequestsForChefServerAsSource(config)
 	reqMap[constants.POSTGRESQL] = getRequestsForPostgresAsSource(config)
 	reqMap[constants.OPENSEARCH] = getRequestsForOpensearchAsSource(config)
-	reqMap[constants.BASTION] = getRequestAsBastionSource(config)
 }
 
 // getRequestsForAutomateAsSource gives the requests for all the ports and types automate as source
@@ -198,61 +197,6 @@ func getRequestsForOpensearchAsSource(config *models.Config) []models.FirewallRe
 
 			}
 
-		}
-	}
-
-	return reqBodies
-}
-
-func getRequestAsBastionSource(config *models.Config) []models.FirewallRequest {
-	var reqBodies []models.FirewallRequest
-
-	for _, destNodeIP := range config.Hardware.AutomateNodeIps {
-		//Dest Chef Infra server
-		for _, port := range a2CsTCPPorts {
-			reqBody := models.FirewallRequest{
-				SourceNodeIP:               constants.LOCALHOST,
-				DestinationNodeIP:          destNodeIP,
-				DestinationServicePort:     port,
-				DestinationServiceProtocol: "tcp",
-			}
-			reqBodies = append(reqBodies, reqBody)
-		}
-	}
-	// Dest Chef Infra
-	for _, destNodeIP := range config.Hardware.ChefInfraServerNodeIps {
-		for _, port := range a2CsTCPPorts {
-			reqBody := models.FirewallRequest{
-				SourceNodeIP:               constants.LOCALHOST,
-				DestinationNodeIP:          destNodeIP,
-				DestinationServicePort:     port,
-				DestinationServiceProtocol: "tcp",
-			}
-			reqBodies = append(reqBodies, reqBody)
-		}
-	}
-	// Dest Postgres
-	for _, destNodeIP := range config.Hardware.PostgresqlNodeIps {
-		for _, port := range postgresBastionPorts {
-			reqBody := models.FirewallRequest{
-				SourceNodeIP:               constants.LOCALHOST,
-				DestinationNodeIP:          destNodeIP,
-				DestinationServicePort:     port,
-				DestinationServiceProtocol: "tcp",
-			}
-			reqBodies = append(reqBodies, reqBody)
-		}
-	}
-	// Dest Opensearch
-	for _, destNodeIP := range config.Hardware.OpenSearchNodeIps {
-		for _, port := range ossBastionPorts {
-			reqBody := models.FirewallRequest{
-				SourceNodeIP:               constants.LOCALHOST,
-				DestinationNodeIP:          destNodeIP,
-				DestinationServicePort:     port,
-				DestinationServiceProtocol: "tcp",
-			}
-			reqBodies = append(reqBodies, reqBody)
 		}
 	}
 

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/firewallchecktrigger_test.go
@@ -77,42 +77,32 @@ const (
 			"status": "SUCCESS",
 			"host": "10.0.0.1",
 			"node_type": "automate",
+			"check_type": "",
 			"result": {
-				"passed": true,
-				"checks": [
-					{
-						"title": "Check for reachability of service at destination port from the source node",
-						"passed": true,
-						"success_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is reachable fro <source_node_ip>",
-						"error_msg": "",
-						"resolution_msg": ""
-					}
-				]
+			  "passed": true,
+			  "msg": "",
+			  "check": "",
+			  "checks": [
+				{
+					"title": "Check for reachability of service at destination port from the source node",
+					"passed": true,
+					"success_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is reachable fro <source_node_ip>",
+					"error_msg": "",
+					"resolution_msg": "",
+				  	"skipped": false
+				},
+				{
+					"title": "Check for reachability of service at destination port from the source node",
+					"passed": true,
+					"success_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is reachable fro <source_node_ip>",
+					"error_msg": "",
+					"resolution_msg": "",
+				  	"skipped": false
+				}
+			  ],
+			  "skipped": false
 			}
-		},
-		{
-			"status": "SUCCESS",
-			"host": "127.0.0.1",
-			"node_type": "bastion",
-			"result": {
-				"passed": true,
-				"checks": [
-					{
-						"title": "Check for reachability of service at destination port from the source node",
-						"passed": true,
-						"success_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is reachable fro <source_node_ip>",
-						"error_msg": "",
-						"resolution_msg": ""
-					},{
-						"title": "Check for reachability of service at destination port from the source node",
-						"passed": true,
-						"success_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is reachable fro <source_node_ip>",
-						"error_msg": "",
-						"resolution_msg": ""
-					}
-				]
-			}
-		}		
+		  }
 	]
 	 `
 
@@ -121,40 +111,30 @@ const (
 			"status": "SUCCESS",
 			"host": "10.0.0.1",
 			"node_type": "automate",
+			"check_type": "",
 			"result": {
 				"passed": false,
+				"msg": "",
+				"check": "",
 				"checks": [
 					{
 						"title": "Check for reachability of service at destination port",
 						"passed": false,
 						"success_msg": "",
 						"error_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is not reachable from <source_ip>",
-						"resolution_msg": "Check your firewall settings to provide access to <destination_node_port> port at <destination_node_ip> from <source_node_ip>"
-					}
-				]
-			}
-		},
-		{
-			"status": "SUCCESS",
-			"host": "127.0.0.1",
-			"node_type": "bastion",
-			"result": {
-				"passed": false,
-				"checks": [
+						"resolution_msg": "Check your firewall settings to provide access to <destination_node_port> port at <destination_node_ip> from <source_node_ip>",
+						"skipped": false
+					},
 					{
 						"title": "Check for reachability of service at destination port",
 						"passed": false,
 						"success_msg": "",
 						"error_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is not reachable from <source_ip>",
-						"resolution_msg": "Check your firewall settings to provide access to <destination_node_port> port at <destination_node_ip> from <source_node_ip>"
-					},{
-						"title": "Check for reachability of service at destination port",
-						"passed": false,
-						"success_msg": "",
-						"error_msg": "The <protocol> service running at <destination_node_ip>:<destination_node_port> is not reachable from <source_ip>",
-						"resolution_msg": "Check your firewall settings to provide access to <destination_node_port> port at <destination_node_ip> from <source_node_ip>"
+						"resolution_msg": "Check your firewall settings to provide access to <destination_node_port> port at <destination_node_ip> from <source_node_ip>",
+						"skipped": false
 					}
-				]
+				],
+				"skipped": false
 			}
 		}
 	]`
@@ -232,10 +212,6 @@ func TestMakeRequests(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, len(requestsForOpensearch), 8)
 
-	requestsForBastion, ok := mapRequests[constants.BASTION]
-	assert.True(t, ok)
-	assert.Equal(t, len(requestsForBastion), 7)
-
 	require.Equal(t, expected[0].SourceNodeIP, requestsForautomate[0].SourceNodeIP)
 	require.Equal(t, expected[0].DestinationNodeIP, requestsForautomate[0].DestinationNodeIP)
 }
@@ -312,6 +288,7 @@ func TestFirewallCheck_Run(t *testing.T) {
 					Hardware: &models.Hardware{
 						AutomateNodeIps:   []string{"10.0.0.1"},
 						PostgresqlNodeIps: []string{"10.0.0.3"},
+						OpenSearchNodeIps: []string{"10.0.0.5"},
 					},
 					Certificate: certificatelist,
 				},
@@ -326,6 +303,7 @@ func TestFirewallCheck_Run(t *testing.T) {
 					Hardware: &models.Hardware{
 						AutomateNodeIps:   []string{"10.0.0.1"},
 						PostgresqlNodeIps: []string{"10.0.0.3"},
+						OpenSearchNodeIps: []string{"10.0.0.5"},
 					},
 					Certificate: certificatelist,
 				},
@@ -341,6 +319,7 @@ func TestFirewallCheck_Run(t *testing.T) {
 					Hardware: &models.Hardware{
 						AutomateNodeIps:   []string{"10.0.0.1"},
 						PostgresqlNodeIps: []string{"10.0.0.3"},
+						OpenSearchNodeIps: []string{"10.0.0.5"},
 					},
 					Certificate: certificatelist,
 				},
@@ -357,6 +336,7 @@ func TestFirewallCheck_Run(t *testing.T) {
 					Hardware: &models.Hardware{
 						AutomateNodeIps:   []string{"10.0.0.1"},
 						PostgresqlNodeIps: []string{"10.0.0.3"},
+						OpenSearchNodeIps: []string{"10.0.0.5"},
 					},
 					Certificate: certificatelist,
 				},
@@ -372,6 +352,7 @@ func TestFirewallCheck_Run(t *testing.T) {
 					Hardware: &models.Hardware{
 						AutomateNodeIps:   []string{"10.0.0.1"},
 						PostgresqlNodeIps: []string{"10.0.0.3"},
+						OpenSearchNodeIps: []string{"10.0.0.5"},
 					},
 					Certificate: certificatelist,
 				},
@@ -427,9 +408,6 @@ func TestFirewallCheck_Run(t *testing.T) {
 				} else if tt.name == "Hardware Nil" {
 					assert.Len(t, got, 5)
 					for _, v := range got {
-						if v.CheckType == constants.BASTION {
-							assert.Equal(t, constants.LOCALHOST, v.Host)
-						}
 						assert.Equal(t, constants.FIREWALL, v.CheckType)
 						assert.Equal(t, constants.FIREWALL, v.Result.Check)
 						assert.True(t, v.Result.Skipped)

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/vars.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/firewallchecktrigger/vars.go
@@ -1,9 +1,6 @@
 package firewallchecktrigger
 
 var (
-	postgresqlTCPPorts   = [4]string{"9631", "7432", "5432", "6432"}
-	opensearchTCPPorts   = [3]string{"9631", "9200", "9300"}
-	a2CsTCPPorts         = [1]string{"22"}
-	postgresBastionPorts = [1]string{"22"}
-	ossBastionPorts      = [1]string{"22"}
+	postgresqlTCPPorts = [4]string{"9631", "7432", "5432", "6432"}
+	opensearchTCPPorts = [3]string{"9631", "9200", "9300"}
 )


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
this was a duplicate check as ssh-user check was doing the same

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3873

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1023" alt="Screenshot 2023-07-03 at 6 50 30 PM" src="https://github.com/chef/automate/assets/97166721/9dc8edcc-9784-45ca-855a-bee214f10a83">

