### PR TITLE
skipping aws-opensearch-s3-bucket-access check for Onprem customer-managed

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/utils/checkutils"
 	"github.com/chef/automate/lib/logger"
+	cfg "github.com/chef/automate/lib/config"
 )
 
 type OpensearchS3BucketAccessCheck struct {
@@ -31,7 +32,11 @@ func (osb *OpensearchS3BucketAccessCheck) Run(config *models.Config) []models.Ch
 			trigger.SkippedTriggerCheckResp("-", constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH),
 		}
 	}
-
+	if config.ExternalDbType == cfg.SELF_MANAGED {
+		return []models.CheckTriggerResponse{
+			trigger.SkippedTriggerCheckResp(config.ExternalOS.OSDomainURL, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH),
+		}
+	}
 	if isEmptyExternalOS(config.ExternalOS) || isObjectStorage(config.Backup) {
 		return []models.CheckTriggerResponse{
 			trigger.ErrTriggerCheckResp(config.ExternalOS.OSDomainURL, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH, constants.OBJECT_STORAGE_MISSING),


### PR DESCRIPTION

### :nut_and_bolt: Description: What code changed, and why?
1. `aws-opensearch-s3-bucket-access` check should be skipped for Onprem customer managed setup

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3876

### :+1: Definition of Done
`aws-opensearch-s3-bucket-access` check  is now skipped for Onprem customer managed setup

### :athletic_shoe: How to Build and Test the Change
1. git checkout this branch
2. rebuild components/automate-cli
3. install automate-cli on bastion
4. Run `chef-automate verify`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Skipping `aws-opensearch-s3-bucket-access` check:

![image](https://github.com/chef/automate/assets/101619541/6313fcfe-89b2-49cc-afd5-eb406d8e4dba)

![image](https://github.com/chef/automate/assets/101619541/f0a2fc15-f8d4-4ed7-b3ff-49efa33e5271)


Before this change: Failed `aws-opensearch-s3-bucket-access`

![image](https://github.com/chef/automate/assets/101619541/f7b1953b-bd92-4d1e-8739-bfa35931b772)

![image](https://github.com/chef/automate/assets/101619541/43d4810f-5001-447f-a77a-41fa25af9a5d)
