### PR TITLE
Removed the hardcoded aws port from the external opensearch check

### DIFF
--- a/components/automate-cli/pkg/verifyserver/constants/externalopensearch.go
+++ b/components/automate-cli/pkg/verifyserver/constants/externalopensearch.go
@@ -8,5 +8,4 @@ const (
 	EXTERNAL_OPENSEARCH_RESOLUTION_MSG = "Ensure that the OpenSearch configuration provided is correct. Review security group or firewall settings as well on the infrastructure"
 	STATUS_PASS                        = "PASS"
 	STATUS_FAIL                        = "FAIL"
-	HTTPS_PORT                         = 443
 )

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/externalopensearch.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/externalopensearch.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/constants"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 	"github.com/chef/automate/components/automate-cli/pkg/verifyserver/response"
 	"github.com/gofiber/fiber/v2"
@@ -26,6 +25,6 @@ func (h *Handler) ExternalOpensearch(c *fiber.Ctx) error {
 		return fiber.NewError(http.StatusBadRequest, "opensearch_domain_name, opensearch_domain_url, opensearch_username, opensearch_user_password or opensearch_root_cert cannot be empty")
 	}
 
-	externalOpensearchResult := h.ExternalOpensearchService.GetExternalOpensearchDetails(reqBody, constants.HTTPS_PORT)
+	externalOpensearchResult := h.ExternalOpensearchService.GetExternalOpensearchDetails(reqBody)
 	return c.JSON(response.BuildSuccessResponse(externalOpensearchResult))
 }

--- a/components/automate-cli/pkg/verifyserver/server/api/v1/externalopensearch_test.go
+++ b/components/automate-cli/pkg/verifyserver/server/api/v1/externalopensearch_test.go
@@ -41,7 +41,7 @@ func SetupExternalOpensearchMountHandler(eos externalopensearchservice.IExternal
 
 func SetupMockExternalOpensearchService() externalopensearchservice.IExternalOpensearchService {
 	return &externalopensearchservice.MockExternalOpensearchService{
-		GetExternalOpensearchDetailsFunc: func(reqBody models.ExternalOSRequest, port int) models.ExternalOpensearchResponse {
+		GetExternalOpensearchDetailsFunc: func(reqBody models.ExternalOSRequest) models.ExternalOpensearchResponse {
 			return models.ExternalOpensearchResponse{
 				Passed: true,
 				Checks: []models.ExternalOpensearchCheck{

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck_test.go
@@ -179,7 +179,7 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 			isError: false,
 		},
 		{
-			name: "Internal Server Error",
+			name: "Entered Incorrect Request Body",
 			args: args{
 				config: &models.Config{
 					ExternalOS: externalOs,
@@ -188,9 +188,9 @@ func TestOpensearchS3BucketAccessCheck_Run(t *testing.T) {
 					},
 				},
 			},
-			httpResponseCode: http.StatusInternalServerError,
+			httpResponseCode: http.StatusBadRequest,
 			isPassed:         false,
-			response:         "error while connecting to the endpoint, received invalid status code",
+			response:         "Invalid request body for S3 backup check",
 			isError:          true,
 		},
 		{
@@ -305,6 +305,7 @@ func createDummyServer(t *testing.T, requiredStatusCode int, isPassed bool) (*ht
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(requiredStatusCode)
+		w.Write([]byte(`{"error":{"code":400, "message":"Invalid request body for S3 backup check"}}`))
 	}))
 
 	// Extract IP and port from the server's URL

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/systemuserchecktrigger/systemuserchecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/systemuserchecktrigger/systemuserchecktrigger_test.go
@@ -89,7 +89,7 @@ func TestSystemUserCheck_Run(t *testing.T) {
 		require.Len(t, ctr, 1)
 		require.NotNil(t, ctr[0].Result.Error)
 		require.Equal(t, ctr[0].Result.Error.Code, http.StatusInternalServerError)
-		assert.Equal(t, "error while connecting to the endpoint, received invalid status code", ctr[0].Result.Error.Error())
+		assert.Equal(t, "error while parsing the response data:unexpected end of JSON input", ctr[0].Result.Error.Error())
 	})
 
 	t.Run("Nil Hardware", func(t *testing.T) {

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/triggerapi_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/triggerapi_test.go
@@ -269,10 +269,11 @@ func TestTriggerCheckAPI(t *testing.T) {
 
 		// Wait for the response
 		response := <-output
+
 		// Assert the expected error response
 		require.NotNil(t, response.Result.Error)
-		require.Equal(t, http.StatusNotFound, response.Result.Error.Code)
-		assert.Contains(t, response.Result.Error.Message, "error while connecting to the endpoint")
+		require.Equal(t, http.StatusInternalServerError, response.Result.Error.Code)
+		assert.Contains(t, response.Result.Error.Message, "error while parsing the response data:invalid character '<' looking for beginning of value")
 	})
 	t.Run("Invalid Request Body", func(t *testing.T) {
 		endPoint := "http://example.com/api/v1/checks/software-versions"

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/triggerapi_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/triggerapi_test.go
@@ -212,13 +212,20 @@ func TestTriggerCheckAPI(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Return a non-OK status code
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"code":400, "message":"Request Parameters that is 'ip', 'user_name', 'ssh_port' and 'private_key' cannot be empty"}}`))
 		}))
 		defer server.Close()
-
+		requestBody := models.SshUserChecksRequest{
+			Ip: "1.1.1.1",
+			UserName: "admin",
+			Port: "22",
+			PrivateKey: "",
+			SudoPassword: "",
+		}
 		output := make(chan models.CheckTriggerResponse)
 
 		// Call the function under test
-		go TriggerCheckAPI(server.URL+constants.SOFTWARE_VERSION_CHECK_API_PATH, server.URL, constants.AUTOMATE, http.MethodGet, output, nil)
+		go TriggerCheckAPI(server.URL+constants.SSH_USER_CHECK_API_PATH, server.URL, constants.AUTOMATE, http.MethodPost, output, requestBody)
 
 		// Wait for the response
 		response := <-output
@@ -226,7 +233,7 @@ func TestTriggerCheckAPI(t *testing.T) {
 		// Assert the expected error response
 		require.NotNil(t, response.Result.Error)
 		assert.Equal(t, http.StatusBadRequest, response.Result.Error.Code)
-		assert.Equal(t, "error while connecting to the endpoint, received invalid status code", response.Result.Error.Message)
+		assert.Equal(t, "Request Parameters that is 'ip', 'user_name', 'ssh_port' and 'private_key' cannot be empty", response.Result.Error.Message)
 	})
 
 	t.Run("Error decoding response JSON", func(t *testing.T) {

--- a/components/automate-cli/pkg/verifyserver/services/externalopensearchservice/externalopensearch.go
+++ b/components/automate-cli/pkg/verifyserver/services/externalopensearchservice/externalopensearch.go
@@ -15,7 +15,7 @@ import (
 )
 
 type IExternalOpensearchService interface {
-	GetExternalOpensearchDetails(models.ExternalOSRequest, int) models.ExternalOpensearchResponse
+	GetExternalOpensearchDetails(models.ExternalOSRequest) models.ExternalOpensearchResponse
 }
 
 type ExternalOpensearchService struct {
@@ -30,7 +30,7 @@ func NewExternalOpensearchService(log logger.Logger, timeout time.Duration) IExt
 	}
 }
 
-func (eos *ExternalOpensearchService) checkReachability(reqBody models.ExternalOSRequest, port int) models.ExternalOpensearchCheck {
+func (eos *ExternalOpensearchService) checkReachability(reqBody models.ExternalOSRequest) models.ExternalOpensearchCheck {
 	eos.log.Debug("Checking External Opensearch Reachability")
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM([]byte(reqBody.OSCert))
@@ -45,7 +45,7 @@ func (eos *ExternalOpensearchService) checkReachability(reqBody models.ExternalO
 		},
 	}
 
-	err := eos.triggerRequest(reqBody, port, client)
+	err := eos.triggerRequest(reqBody, client)
 	if err != nil {
 		eos.log.Error(err)
 		return createExternalOpensearchCheck(false, constants.EXTERNAL_OPENSEARCH_FAILED_TITLE, constants.STATUS_FAIL, "", constants.EXTERNAL_OPENSEARCH_ERROR_MSG, constants.EXTERNAL_OPENSEARCH_RESOLUTION_MSG, err.Error())
@@ -55,11 +55,11 @@ func (eos *ExternalOpensearchService) checkReachability(reqBody models.ExternalO
 	return createExternalOpensearchCheck(true, constants.EXTERNAL_OPENSEARCH_SUCCESS_TITLE, constants.STATUS_PASS, constants.EXTERNAL_OPENSEARCH_SUCCESS_MSG, "", "", "")
 }
 
-func (eos *ExternalOpensearchService) triggerRequest(reqBody models.ExternalOSRequest, port int, client *http.Client) error {
+func (eos *ExternalOpensearchService) triggerRequest(reqBody models.ExternalOSRequest, client *http.Client) error {
 	eos.log.Debug("Triggering Request...")
 	// Create a new request with basic authentication
 	// hitting /_cat/indices API of opensearch just to make sure there is OS running or not
-	url := fmt.Sprintf("https://%s:%d/_cat/indices", reqBody.OSDomainURL, port)
+	url := fmt.Sprintf("https://%s/_cat/indices", reqBody.OSDomainURL)
 	eos.log.Debug("URL: ", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -87,10 +87,10 @@ func (eos *ExternalOpensearchService) triggerRequest(reqBody models.ExternalOSRe
 	return nil
 }
 
-func (eos *ExternalOpensearchService) GetExternalOpensearchDetails(reqBody models.ExternalOSRequest, port int) models.ExternalOpensearchResponse {
+func (eos *ExternalOpensearchService) GetExternalOpensearchDetails(reqBody models.ExternalOSRequest) models.ExternalOpensearchResponse {
 	result := models.ExternalOpensearchResponse{}
 
-	reachableCheck := eos.checkReachability(reqBody, port)
+	reachableCheck := eos.checkReachability(reqBody)
 	result.Checks = append(result.Checks, reachableCheck)
 
 	// We are setting initial value as true because if any check got failed then we are directly putting false.

--- a/components/automate-cli/pkg/verifyserver/services/externalopensearchservice/externalopensearchservicemock.go
+++ b/components/automate-cli/pkg/verifyserver/services/externalopensearchservice/externalopensearchservicemock.go
@@ -3,9 +3,9 @@ package externalopensearchservice
 import "github.com/chef/automate/components/automate-cli/pkg/verifyserver/models"
 
 type MockExternalOpensearchService struct {
-	GetExternalOpensearchDetailsFunc func(reqBody models.ExternalOSRequest, port int) models.ExternalOpensearchResponse
+	GetExternalOpensearchDetailsFunc func(reqBody models.ExternalOSRequest) models.ExternalOpensearchResponse
 }
 
-func (meos *MockExternalOpensearchService) GetExternalOpensearchDetails(reqBody models.ExternalOSRequest, port int) models.ExternalOpensearchResponse {
-	return meos.GetExternalOpensearchDetailsFunc(reqBody, port)
+func (meos *MockExternalOpensearchService) GetExternalOpensearchDetails(reqBody models.ExternalOSRequest) models.ExternalOpensearchResponse {
+	return meos.GetExternalOpensearchDetailsFunc(reqBody)
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
- Removed the hardcoded value of port form the external opens each API check
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done
- The domain url present in the request should have the port as the value for connection
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
- External running open search on a instance 

<img width="1792" alt="Screenshot 2023-07-04 at 6 40 53 PM" src="https://github.com/chef/automate/assets/62262938/31297857-e1a0-4f4f-a578-5134ac6de4f2">


- External Postgres running on AWS 

<img width="1792" alt="Screenshot 2023-07-04 at 6 41 55 PM" src="https://github.com/chef/automate/assets/62262938/89d5b59e-670b-4d7c-bf14-29b3689de0e7">
