### PR TITLE
Fix for efs and Certbyip on aws type setup

### DIFF
--- a/components/automate-cli/cmd/chef-automate/deployedConfig.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig.go
@@ -225,6 +225,7 @@ func CopyAws(awsConfig *AwsConfigToml) *config.HaDeployConfig {
 				PublicKey:         awsConfigAutomateSettings.PublicKey,
 				FqdnRootCA:        awsConfigAutomateSettings.RootCA,
 				TeamsPort:         awsConfigAutomateSettings.TeamsPort,
+				CertsByIP:         &[]config.CertByIP{},
 			},
 		},
 		ChefServer: &config.ChefServerSettings{
@@ -235,6 +236,7 @@ func CopyAws(awsConfig *AwsConfigToml) *config.HaDeployConfig {
 				InstanceCount:     awsConfigChefServerSettings.InstanceCount,
 				PrivateKey:        awsConfigChefServerSettings.PrivateKey,
 				PublicKey:         awsConfigChefServerSettings.PublicKey,
+				CertsByIP:         &[]config.CertByIP{},
 			},
 		},
 		Postgresql: &config.PostgresqlSettings{
@@ -244,6 +246,7 @@ func CopyAws(awsConfig *AwsConfigToml) *config.HaDeployConfig {
 				PrivateKey:        awsConfigPostgresqlSettings.PrivateKey,
 				PublicKey:         awsConfigPostgresqlSettings.PublicKey,
 				RootCA:            awsConfigPostgresqlSettings.RootCA,
+				CertsByIP:         &[]config.CertByIP{},
 			},
 		},
 		Opensearch: &config.OpensearchSettings{
@@ -257,6 +260,7 @@ func CopyAws(awsConfig *AwsConfigToml) *config.HaDeployConfig {
 				PrivateKey:        awsConfigOpensearchSettings.PrivateKey,
 				PublicKey:         awsConfigOpensearchSettings.PublicKey,
 				RootCA:            awsConfigOpensearchSettings.RootCA,
+				CertsByIP:         &[]config.CertByIP{},
 			},
 		},
 		Aws: &config.AwsSettings{
@@ -306,6 +310,22 @@ func CopyAws(awsConfig *AwsConfigToml) *config.HaDeployConfig {
 				LbAccessLogs:                  awsConfigSetting.LBAccessLogs,
 			},
 		},
+	}
+
+	if awsConfigAutomateSettings.CertsByIP != nil {
+		CopyCertsByIP(haDeployConfig.Automate.Config.CertsByIP, awsConfigAutomateSettings.CertsByIP)
+	}
+
+	if awsConfigChefServerSettings.CertsByIP != nil {
+		CopyCertsByIP(haDeployConfig.ChefServer.Config.CertsByIP, awsConfigChefServerSettings.CertsByIP)
+	}
+
+	if awsConfigPostgresqlSettings.CertsByIP != nil {
+		CopyCertsByIP(haDeployConfig.Postgresql.Config.CertsByIP, awsConfigPostgresqlSettings.CertsByIP)
+	}
+
+	if awsConfigOpensearchSettings.CertsByIP != nil {
+		CopyCertsByIP(haDeployConfig.Opensearch.Config.CertsByIP, awsConfigOpensearchSettings.CertsByIP)
 	}
 
 	return haDeployConfig

--- a/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
@@ -170,6 +170,14 @@ var awsConfig = &AwsConfigToml{
 			PublicKey:         "/aws/public/key",
 			RootCA:            "/aws/root/ca",
 			TeamsPort:         "9090",
+			CertsByIP: []CertByIP{
+				{
+					IP:         "10.0.0.1",
+					PrivateKey: "/aws/cert1/private/key",
+					PublicKey:  "/aws/cert1/public/key",
+					NodesDn:    "/aws/cert1/nodes/dn",
+				},
+			},
 		},
 	},
 	ChefServer: ChefServerToml{
@@ -178,6 +186,14 @@ var awsConfig = &AwsConfigToml{
 			InstanceCount:     "3",
 			PrivateKey:        "/existing/private/key",
 			PublicKey:         "/existing/public/key",
+			CertsByIP: []CertByIP{
+				{
+					IP:         "10.0.0.1",
+					PrivateKey: "/aws/cert1/private/key",
+					PublicKey:  "/aws/cert1/public/key",
+					NodesDn:    "/aws/cert1/nodes/dn",
+				},
+			},
 		},
 	},
 	Postgresql: PostgresqlToml{
@@ -187,6 +203,14 @@ var awsConfig = &AwsConfigToml{
 			PrivateKey:        "/existing/private/key",
 			PublicKey:         "/existing/public/key",
 			RootCA:            "/existing/root/ca",
+			CertsByIP: []CertByIP{
+				{
+					IP:         "10.0.0.1",
+					PrivateKey: "/aws/cert1/private/key",
+					PublicKey:  "/aws/cert1/public/key",
+					NodesDn:    "/aws/cert1/nodes/dn",
+				},
+			},
 		},
 	},
 	Opensearch: OpensearchToml{
@@ -200,6 +224,14 @@ var awsConfig = &AwsConfigToml{
 			PrivateKey:        "/existing/private/key",
 			PublicKey:         "/existing/public/key",
 			RootCA:            "/existing/root/ca",
+			CertsByIP: []CertByIP{
+				{
+					IP:         "10.0.0.1",
+					PrivateKey: "/aws/cert1/private/key",
+					PublicKey:  "/aws/cert1/public/key",
+					NodesDn:    "/aws/cert1/nodes/dn",
+				},
+			},
 		},
 	},
 	Aws: AwsToml{
@@ -573,12 +605,20 @@ func TestCopyAws(t *testing.T) {
 	assert.Equal(t, "/aws/public/key", automate.PublicKey)
 	assert.Equal(t, "/aws/root/ca", automate.FqdnRootCA)
 	assert.Equal(t, "9090", automate.TeamsPort)
+	assert.Equal(t, "10.0.0.1", (*automate.CertsByIP)[0].IP)
+	assert.Equal(t, "/aws/cert1/private/key", (*automate.CertsByIP)[0].PrivateKey)
+	assert.Equal(t, "/aws/cert1/public/key", (*automate.CertsByIP)[0].PublicKey)
+	assert.Equal(t, "/aws/cert1/nodes/dn", (*automate.CertsByIP)[0].NodesDn)
 
 	chefServer := haDeployConfig.ChefServer.Config
 	assert.Equal(t, true, chefServer.EnableCustomCerts)
 	assert.Equal(t, "3", chefServer.InstanceCount)
 	assert.Equal(t, "/existing/private/key", chefServer.PrivateKey)
 	assert.Equal(t, "/existing/public/key", chefServer.PublicKey)
+	assert.Equal(t, "10.0.0.1", (*chefServer.CertsByIP)[0].IP)
+	assert.Equal(t, "/aws/cert1/private/key", (*chefServer.CertsByIP)[0].PrivateKey)
+	assert.Equal(t, "/aws/cert1/public/key", (*chefServer.CertsByIP)[0].PublicKey)
+	assert.Equal(t, "/aws/cert1/nodes/dn", (*chefServer.CertsByIP)[0].NodesDn)
 
 	postgresql := haDeployConfig.Postgresql.Config
 	assert.Equal(t, true, postgresql.EnableCustomCerts)
@@ -586,6 +626,10 @@ func TestCopyAws(t *testing.T) {
 	assert.Equal(t, "/existing/private/key", postgresql.PrivateKey)
 	assert.Equal(t, "/existing/public/key", postgresql.PublicKey)
 	assert.Equal(t, "/existing/root/ca", postgresql.RootCA)
+	assert.Equal(t, "10.0.0.1", (*postgresql.CertsByIP)[0].IP)
+	assert.Equal(t, "/aws/cert1/private/key", (*postgresql.CertsByIP)[0].PrivateKey)
+	assert.Equal(t, "/aws/cert1/public/key", (*postgresql.CertsByIP)[0].PublicKey)
+	assert.Equal(t, "/aws/cert1/nodes/dn", (*postgresql.CertsByIP)[0].NodesDn)
 
 	opensearch := haDeployConfig.Opensearch.Config
 	assert.Equal(t, "/existing/admin/cert", opensearch.AdminCert)
@@ -597,6 +641,10 @@ func TestCopyAws(t *testing.T) {
 	assert.Equal(t, "/existing/private/key", opensearch.PrivateKey)
 	assert.Equal(t, "/existing/public/key", opensearch.PublicKey)
 	assert.Equal(t, "/existing/root/ca", opensearch.RootCA)
+	assert.Equal(t, "10.0.0.1", (*opensearch.CertsByIP)[0].IP)
+	assert.Equal(t, "/aws/cert1/private/key", (*opensearch.CertsByIP)[0].PrivateKey)
+	assert.Equal(t, "/aws/cert1/public/key", (*opensearch.CertsByIP)[0].PublicKey)
+	assert.Equal(t, "/aws/cert1/nodes/dn", (*opensearch.CertsByIP)[0].NodesDn)
 
 	aws := haDeployConfig.Aws.Config
 	assert.Equal(t, "my-profile", aws.Profile)

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -167,7 +167,7 @@ func (c *Config) PopulateWith(haConfig *config.HaDeployConfig) error {
 		c.populateConfigInitials(haConfig)
 	}
 
-	if haConfig.GetConfigInitials().BackupConfig == "file_system" && c.Backup == nil {
+	if (haConfig.GetConfigInitials().BackupConfig == "file_system" && c.Backup == nil) || (haConfig.GetConfigInitials().BackupConfig == "efs" && c.Backup == nil) {
 		c.Backup = &Backup{
 			FileSystem: &FileSystem{
 				MountLocation: haConfig.GetConfigInitials().BackupMount,

--- a/components/automate-cli/pkg/verifyserver/models/batchcheck.go
+++ b/components/automate-cli/pkg/verifyserver/models/batchcheck.go
@@ -295,14 +295,14 @@ func (c *Config) populateAwsCerts(haConfig *config.HaDeployConfig) {
 	automateConfig := haConfig.Automate.Config
 	cert := addCertificatesInConfig(automateConfig.Fqdn, automateConfig.FqdnRootCA, config.AUTOMATE)
 	if automateConfig.EnableCustomCerts {
-		cert.Nodes = appendCertsByIpToNodeCerts(nil, c.Hardware.AutomateNodeIps, automateConfig.PrivateKey, automateConfig.PublicKey, "", "", "")
+		cert.Nodes = appendCertsByIpToNodeCerts(automateConfig.CertsByIP, c.Hardware.AutomateNodeIps, automateConfig.PrivateKey, automateConfig.PublicKey, "", "", "")
 	}
 	c.Certificate = append(c.Certificate, cert)
 	chefserverConfig := haConfig.ChefServer.Config
 	//We can populate this later as well in config
 	cert = addCertificatesInConfig(chefserverConfig.ChefServerFqdn, chefserverConfig.FqdnRootCA, config.CHEFSERVER)
 	if chefserverConfig.EnableCustomCerts {
-		cert.Nodes = appendCertsByIpToNodeCerts(nil, c.Hardware.ChefInfraServerNodeIps, chefserverConfig.PrivateKey, chefserverConfig.PublicKey, "", "", "")
+		cert.Nodes = appendCertsByIpToNodeCerts(chefserverConfig.CertsByIP, c.Hardware.ChefInfraServerNodeIps, chefserverConfig.PrivateKey, chefserverConfig.PublicKey, "", "", "")
 	}
 
 	c.Certificate = append(c.Certificate, cert)
@@ -310,14 +310,14 @@ func (c *Config) populateAwsCerts(haConfig *config.HaDeployConfig) {
 	postgresqlConfig := haConfig.Postgresql.Config
 	if postgresqlConfig.EnableCustomCerts {
 		cert = addCertificatesInConfig("", "", config.POSTGRESQL)
-		cert.Nodes = appendCertsByIpToNodeCerts(nil, c.Hardware.PostgresqlNodeIps, postgresqlConfig.PrivateKey, postgresqlConfig.PublicKey, "", "", postgresqlConfig.RootCA)
+		cert.Nodes = appendCertsByIpToNodeCerts(postgresqlConfig.CertsByIP, c.Hardware.PostgresqlNodeIps, postgresqlConfig.PrivateKey, postgresqlConfig.PublicKey, "", "", postgresqlConfig.RootCA)
 		c.Certificate = append(c.Certificate, cert)
 	}
 
 	openSearchConfig := haConfig.Opensearch.Config
 	if openSearchConfig.EnableCustomCerts {
 		cert = addCertificatesInConfig("", "", config.OPENSEARCH)
-		cert.Nodes = appendCertsByIpToNodeCerts(nil, c.Hardware.OpenSearchNodeIps, openSearchConfig.PrivateKey, openSearchConfig.PublicKey, openSearchConfig.AdminKey, openSearchConfig.AdminCert, openSearchConfig.RootCA)
+		cert.Nodes = appendCertsByIpToNodeCerts(openSearchConfig.CertsByIP, c.Hardware.OpenSearchNodeIps, openSearchConfig.PrivateKey, openSearchConfig.PublicKey, openSearchConfig.AdminKey, openSearchConfig.AdminCert, openSearchConfig.RootCA)
 		c.Certificate = append(c.Certificate, cert)
 	}
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

- Efs was skipping in case of aws type setup
- Certbyip support for both pre-deployment and post-deployment 


<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/CHEF-3737

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
When backup_config="" :-
<img width="965" alt="Screenshot 2023-07-05 at 7 52 35 PM" src="https://github.com/chef/automate/assets/97166721/e30232bf-9cdc-47e5-9780-427c8d35961f">
When backup_config="efs"(pre-deployment) :-
<img width="837" alt="Screenshot 2023-07-05 at 7 55 15 PM" src="https://github.com/chef/automate/assets/97166721/95800193-21ea-42b3-b3a9-10a91cf94357">
When backup_config="efs"(post-deployment) :-
<img width="819" alt="Screenshot 2023-07-05 at 7 57 36 PM" src="https://github.com/chef/automate/assets/97166721/6a3340ab-54bd-4292-8be1-4befe2a3ba37">

CertbyIp Pre-deployment:-
<img width="884" alt="Screenshot 2023-07-05 at 11 00 23 PM" src="https://github.com/chef/automate/assets/97166721/62ec905a-70be-48f5-81f4-4f032a3399b0">
CertbyIp  Post-deployment:-
<img width="861" alt="Screenshot 2023-07-05 at 9 38 21 PM" src="https://github.com/chef/automate/assets/97166721/ee88052f-bdbd-43aa-861f-3049a92f657b">
