### PR TITLE
fetching the snapshot role-arn only if backup config is provided

### DIFF
--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -444,7 +444,14 @@ func (p *PullConfigsImpl) fetchInfraConfig() (*ExistingInfraConfigToml, error) {
 }
 
 func getExternalOpensearchDetails(a2ConfigMap map[string]*dc.AutomateConfig) *ExternalOpensearchToml {
+	var roleArn string
 	for _, ele := range a2ConfigMap {
+		if ele.Global.V1.External.Opensearch.Backup != nil &&
+			ele.Global.V1.External.Opensearch.Backup.S3 != nil &&
+			ele.Global.V1.External.Opensearch.Backup.S3.Settings != nil &&
+			ele.Global.V1.External.Opensearch.Backup.S3.Settings.RoleArn != nil {
+			roleArn = ele.Global.V1.External.Opensearch.Backup.S3.Settings.RoleArn.Value
+		}
 		if ele.Global.V1.External.Opensearch != nil &&
 			ele.Global.V1.External.Opensearch.Auth != nil &&
 			ele.Global.V1.External.Opensearch.Auth.AwsOs != nil {
@@ -455,7 +462,7 @@ func getExternalOpensearchDetails(a2ConfigMap map[string]*dc.AutomateConfig) *Ex
 				ele.Global.V1.External.Opensearch.Ssl.ServerName.Value,
 				ele.Global.V1.External.Opensearch.Auth.AwsOs.AccessKey.Value,
 				ele.Global.V1.External.Opensearch.Auth.AwsOs.SecretKey.Value,
-				ele.Global.V1.External.Opensearch.Backup.S3.Settings.RoleArn.Value,
+				roleArn,
 			)
 		}
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
If the deployment is done without any backup configuration then its trying to fetch snapshot role arn which is not required,Now it will only fetch the role-arn if the backup configuration is provided.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3735

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1031" alt="Screenshot 2023-07-06 at 3 44 40 PM" src="https://github.com/chef/automate/assets/100406225/dd811c72-e6af-4972-b009-38f2ca746c09">

<img width="1792" alt="Screenshot 2023-07-06 at 3 44 57 PM" src="https://github.com/chef/automate/assets/100406225/0c71fac8-7e71-411a-939d-acbaa998a867">
