### PR TITLE
Changes to show error if incorrect config provided for patch

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -991,6 +991,7 @@ func getExistingAndRequestedConfigForPostgres(args []string, infra *AutomateHAIn
 	//Getting Existing config from server
 	var existingConfig PostgresqlConfig
 	var reqConfig PostgresqlConfig
+	var dummyConfig PostgresqlConfig
 	srcInputString, err := getConfigFromRemoteServer(infra, postgresql, config, sshUtil)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
@@ -1007,6 +1008,9 @@ func getExistingAndRequestedConfigForPostgres(args []string, infra *AutomateHAIn
 		return existingConfig, reqConfig, err
 	}
 	reqConfig = reqConfigInterface.(PostgresqlConfig)
+	if !isConfigChanged(dummyConfig, reqConfig) {
+		return existingConfig, reqConfig, status.Annotate(errors.New("Incorrect Config"), status.ConfigError)
+	}
 	mergo.Merge(&reqConfig, existingConfig)
 	return existingConfig, reqConfig, nil
 }
@@ -1016,6 +1020,7 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomateHA
 	//Getting Existing config from server
 	var existingConfig OpensearchConfig
 	var reqConfig OpensearchConfig
+	var dummyConfig OpensearchConfig
 	srcInputString, err := getConfigFromRemoteServer(infra, opensearch_const, config, sshUtil)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
@@ -1032,7 +1037,9 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomateHA
 		return existingConfig, reqConfig, err
 	}
 	reqConfig = reqConfigInterface.(OpensearchConfig)
-
+	if !isConfigChanged(dummyConfig, reqConfig) {
+		return existingConfig, reqConfig, status.Annotate(errors.New("Incorrect Config"), status.ConfigError)
+	}
 	mergo.Merge(&reqConfig, existingConfig)
 	return existingConfig, reqConfig, nil
 }

--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -991,7 +991,7 @@ func getExistingAndRequestedConfigForPostgres(args []string, infra *AutomateHAIn
 	//Getting Existing config from server
 	var existingConfig PostgresqlConfig
 	var reqConfig PostgresqlConfig
-	var dummyConfig PostgresqlConfig
+	var emptyConfig PostgresqlConfig
 	srcInputString, err := getConfigFromRemoteServer(infra, postgresql, config, sshUtil)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
@@ -1008,7 +1008,7 @@ func getExistingAndRequestedConfigForPostgres(args []string, infra *AutomateHAIn
 		return existingConfig, reqConfig, err
 	}
 	reqConfig = reqConfigInterface.(PostgresqlConfig)
-	if !isConfigChanged(dummyConfig, reqConfig) {
+	if !isConfigChanged(emptyConfig, reqConfig) {
 		return existingConfig, reqConfig, status.Annotate(errors.New("Incorrect Config"), status.ConfigError)
 	}
 	mergo.Merge(&reqConfig, existingConfig)
@@ -1020,7 +1020,7 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomateHA
 	//Getting Existing config from server
 	var existingConfig OpensearchConfig
 	var reqConfig OpensearchConfig
-	var dummyConfig OpensearchConfig
+	var emptyConfig OpensearchConfig
 	srcInputString, err := getConfigFromRemoteServer(infra, opensearch_const, config, sshUtil)
 	if err != nil {
 		return existingConfig, reqConfig, errors.Wrapf(err, "Unable to get config from the server with error")
@@ -1037,7 +1037,7 @@ func getExistingAndRequestedConfigForOpenSearch(args []string, infra *AutomateHA
 		return existingConfig, reqConfig, err
 	}
 	reqConfig = reqConfigInterface.(OpensearchConfig)
-	if !isConfigChanged(dummyConfig, reqConfig) {
+	if !isConfigChanged(emptyConfig, reqConfig) {
 		return existingConfig, reqConfig, status.Annotate(errors.New("Incorrect Config"), status.ConfigError)
 	}
 	mergo.Merge(&reqConfig, existingConfig)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Config patch command was not throwing error is incorrect provided for patch for pg and os
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-1464

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

- checkout this branch `CHEF-1464` and rebuild cli
- now use this cli on any HA setup where os and pg nodes are available 
- trying patch incorrect config on pg or os nodes

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="598" alt="Screenshot 2023-07-10 at 8 52 45 PM" src="https://github.com/chef/automate/assets/97166721/eb6895c8-a81c-4b3f-85f7-676658f8ec6d">

[Demo video](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EZqbhhQknM9Ih6Vsf_Atf1gB1K15SRpyltXYKCJIPfxwcA?e=os3KWl)
