### PR TITLE
Adding Lag for PG follower node in status summary command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -56,7 +56,7 @@ type BeStatusValue struct {
 	process     string
 	upTime      string
 	role        string
-	Lag         string
+	lag         string
 }
 
 type FeStatus []FeStatusValue

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -198,7 +198,7 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 	}
 	sshUtil := NewSSHUtil(&SSHConfig{})
 	remoteCmdExecutor := NewRemoteCmdExecutorWithoutNodeMap(sshUtil, writer)
-	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags, sshUtil, remoteCmdExecutor)
+	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags, remoteCmdExecutor)
 	err = statusSummary.Prepare()
 	if err != nil {
 		return err

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -197,7 +197,8 @@ func executeStatusSummary(cmd *cobra.Command, args []string, statusSummaryCmdFla
 		return err
 	}
 	sshUtil := NewSSHUtil(&SSHConfig{})
-	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags, sshUtil)
+	remoteCmdExecutor := NewRemoteCmdExecutorWithoutNodeMap(sshUtil, writer)
+	statusSummary := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, statusSummaryCmdFlags, sshUtil, remoteCmdExecutor)
 	err = statusSummary.Prepare()
 	if err != nil {
 		return err

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -56,6 +56,7 @@ type BeStatusValue struct {
 	process     string
 	upTime      string
 	role        string
+	Lag         string
 }
 
 type FeStatus []FeStatusValue

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -352,7 +352,6 @@ func (ss *Summary) prepareBEScript(serviceIps []string, nodeMap *NodeTypeAndCmd,
 	}
 
 	for ip, res := range beOutput {
-		// fmt.Printf("ip: %s :: \nres: %v\n", ip, res)
 		status := ss.getBEStatus(res, ip, authToken, serviceName)
 		ss.beStatus = append(ss.beStatus, status)
 	}
@@ -437,8 +436,6 @@ func (ss *Summary) getBEStatus(outputs []*CmdResult, ip string, authToken, servi
 	}
 
 	for _, output := range outputs {
-		// fmt.Printf("\nCmd Output: %+v\n", *output)
-		fmt.Printf("\nScript Name: %v\n", output.ScriptName)
 		cmdResMap[output.ScriptName] = output
 	}
 
@@ -460,9 +457,6 @@ func (ss *Summary) getBEStatus(outputs []*CmdResult, ip string, authToken, servi
 	if err != nil {
 		lag = "Error"
 	}
-	fmt.Printf("\n Lag output: %v", lag)
-
-	// fmt.Printf("cmd map: %v", cmdResMap)
 
 	return BeStatusValue{
 		serviceName: serviceName,
@@ -537,8 +531,6 @@ func (ss *Summary) getFollowerLag(output string, service string, memberId string
 		return lag, err
 	}
 
-	fmt.Println("Service: ", service, " pg: ", postgresql)
-
 	if service == postgresql {
 		if role == "Follower" {
 			// Define the regular expression pattern to match the desired substring
@@ -551,7 +543,6 @@ func (ss *Summary) getFollowerLag(output string, service string, memberId string
 			lag = regExp.FindString(outputMap["stdout"].(string))
 
 			// Print the matched substring
-			fmt.Printf("\n match: %+v", lag)
 			return lag, nil
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -31,6 +31,7 @@ const (
 	initialHealth               = "ERROR"
 	initialFormattedDuration    = "0d 0h 0m 0s"
 	initialRole                 = "Unknown"
+	initialLag                  = "NA"
 	defaultServiceDetails       = "DefaultServiceDetails"
 	defaultServiceHealthDetails = "DefaultServiceHealthDetails"
 	censusDetails               = "CensusDetails"
@@ -433,6 +434,7 @@ func (ss *Summary) getBEStatus(outputs []*CmdResult, ip string, authToken, servi
 		process:     fmt.Sprintf("%s (pid: %s)", initialServiceState, initialServicePid),
 		upTime:      initialFormattedDuration,
 		role:        initialRole,
+		lag:         initialLag,
 	}
 
 	for _, output := range outputs {
@@ -465,7 +467,7 @@ func (ss *Summary) getBEStatus(outputs []*CmdResult, ip string, authToken, servi
 		process:     fmt.Sprintf("%s (pid: %s)", serviceState, servicePid),
 		upTime:      formattedDuration,
 		role:        role,
-		Lag:         lag,
+		lag:         lag,
 	}
 }
 
@@ -525,7 +527,7 @@ func (ss *Summary) getBECensus(output, service, memeberId string) (string, error
 }
 
 func (ss *Summary) getFollowerLag(output string, service string, memberId string, role string) (string, error) {
-	lag := "NA"
+	lag := initialLag
 	outputMap, err := parseStringInToMapStringInterface(output)
 	if err != nil {
 		return lag, err
@@ -663,7 +665,7 @@ func (ss *Summary) ShowBEStatus() string {
 		tTemp := table.Table{}
 		tTemp.Render()
 		for _, status := range ss.beStatus {
-			t.AppendRow(table.Row{status.serviceName, status.ipAddress, status.health, status.process, status.Lag, status.upTime, status.role})
+			t.AppendRow(table.Row{status.serviceName, status.ipAddress, status.health, status.process, status.lag, status.upTime, status.role})
 		}
 		t.AppendHeader(table.Row{"Name", "IP Address", "Health", "Process", "Lag", "Uptime", "Role"})
 		return t.Render()

--- a/components/automate-cli/cmd/chef-automate/summary.go
+++ b/components/automate-cli/cmd/chef-automate/summary.go
@@ -533,16 +533,15 @@ func (ss *Summary) getFollowerLag(output, service, role string) (string, error) 
 
 	if service == postgresql {
 		if role == "Follower" {
-			// Define the regular expression pattern to match the desired substring
+			// Define the regular expression pattern to match the substring
 			pattern := `(\d+ bytes and \d+ seconds)`
 
 			// Compile the regular expression pattern
 			regExp := regexp.MustCompile(pattern)
 
-			// Find the first lag of the pattern in the input string
+			// Find the first matching substring of the stdout string
 			lag = regExp.FindString(outputMap["stdout"].(string))
 
-			// Print the matched substring
 			return lag, nil
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -27,11 +27,11 @@ Incorrect postgresql IP, 127.0.0 IP address validation failed
 Incorrect postgresql IP, 127.0.1 IP address validation failed
 Incorrect postgresql IP, 127.0.2 IP address validation failed
 Incorrect postgresql IP, 127.0.3 IP address validation failed`
-	displayBE = `+------------+--------------+--------+--------------+-------------+---------+
-| NAME       | IP ADDRESS   | HEALTH | PROCESS      | UPTIME      | ROLE    |
-+------------+--------------+--------+--------------+-------------+---------+
-| postgresql | 198.51.100.7 | ERROR  | down (pid: ) | 0d 0h 0m 0s | Unknown |
-+------------+--------------+--------+--------------+-------------+---------+`
+	displayBE = `+------------+--------------+--------+--------------+-----+-------------+---------+
+| NAME       | IP ADDRESS   | HEALTH | PROCESS      | LAG | UPTIME      | ROLE    |
++------------+--------------+--------+--------------+-----+-------------+---------+
+| postgresql | 198.51.100.7 | ERROR  | down (pid: ) | NA  | 0d 0h 0m 0s | Unknown |
++------------+--------------+--------+--------------+-----+-------------+---------+`
 	displayFEAutomate         = `| automate    | 198.51.100.1 | ERROR  | Unknown    |`
 	displayFECS               = `| chef-server | 198.51.100.2 | ERROR  | Unknown    |`
 	mockA2haHabitatAutoTfvars = "../../pkg/testfiles/a2ha_habitat.auto.tfvars"

--- a/dev/populate_chef_backend_data.sh
+++ b/dev/populate_chef_backend_data.sh
@@ -58,7 +58,7 @@ do
   for file in *; 
   do
     # Extract the contents of the tar file
-    knife upload file -s $SERVER_URL/organizations/"org$i" --config-option cookbook_path=/home/ubuntu/cookbook
+    knife upload $file -s $SERVER_URL/organizations/"org$i" --config-option cookbook_path=/home/ubuntu/cookbook
   done
 done
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

As an Automate HA user, along with the service status, the user should see follower node lag for Postgresql as well in the cluster status.

> Note:
>  For the leader node, "NA" will be shown

> Previously, the cumulative cluster status can be fetched in Bastion by the `chef-automate status` command. Now the same can be done by the `chef-automate status summary` command, whereas the `chef-automate status` will now show the service status(on node level) of each nodes (For reference, PFA in the 'Screenshot' column below)

### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/CHEF-3561

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![image](https://github.com/chef/automate/assets/54614142/7107d537-bdb1-46bf-9026-bf41b75c4235)

Demo Video: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EZQhC6ZwjjpCnn3AvV_IZiUBbLHY18dlnnQCVfaR-mea4A?e=0CVU3i



**The output of the `chef-automate status summary` command:**

![image](https://github.com/chef/automate/assets/54614142/ef55e56d-14e6-4911-a3ab-07dba03987e5)
continued...
![image](https://github.com/chef/automate/assets/54614142/f05cb0f5-8dd4-44c2-b09c-c4686fffe6c5)
