### PR TITLE
Gather logs should capture logs from different locations (PG)

### DIFF
--- a/components/automate-cli/cmd/chef-automate/gather-logs.go
+++ b/components/automate-cli/cmd/chef-automate/gather-logs.go
@@ -446,6 +446,8 @@ func runGatherLogsLocalCmd(outfileOverride string, logLines uint64) error {
 	g.AddCopiesFromPath("config", "/hab/svc")
 	g.AddCopiesFromPath("logs", "/hab/svc")
 
+	g.AddCopiesFromPath("pg_log", "/hab/svc")
+
 	// local status
 	g.AddCommand("df_h", "df", "-h")
 	g.AddCommand("df_i", "df", "-i")


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Modified the gather logs to capture logs from below location in chef managed postgres cluster
`/hab/svc/automate-ha-postgresql/var/pg_log`
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3363
### :+1: Definition of Done
Added  `/hab/svc/automate-ha-postgresql/var/pg_log`  to Postgresql cluster in gather-logs
### :athletic_shoe: How to Build and Test the Change
`rebuild components/automate-cli/`
`chef-automate gather-logs`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EaVpTKYMTVNAsYIdQ4ESRgEB761RZB0LpQGJdAi8qtWB8A?e=Z7d7vZ

