### PR TITLE
Removed unnecessary flags from oc-id-show-app for automate HA

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -127,18 +127,6 @@ func init() {
 	setConfigCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
 
 	//config oc-id-show-app flags
-	ocIdShowAppCmd.PersistentFlags().BoolVarP(&configCmdFlags.frontend, "frontend", "f", false, "Shows registered OCID app details from all frontend nodes")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("frontend", docs.Compatibility, []string{docs.CompatiblewithHA})
-	ocIdShowAppCmd.PersistentFlags().BoolVar(&configCmdFlags.frontend, "fe", false, "Shows registered OCID app details from all frontend nodes[DUPLICATE]")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("fe", docs.Compatibility, []string{docs.CompatiblewithHA})
-	ocIdShowAppCmd.PersistentFlags().BoolVarP(&configCmdFlags.automate, "automate", "a", false, "Shows registered OCID app details from Automate node(HA)")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
-	ocIdShowAppCmd.PersistentFlags().BoolVarP(&configCmdFlags.chef_server, "chef_server", "c", false, "Shows registered OCID app details from Chef-server node(HA)")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("chef_server", docs.Compatibility, []string{docs.CompatiblewithHA})
-	ocIdShowAppCmd.PersistentFlags().BoolVar(&configCmdFlags.automate, "a2", false, "Shows registered OCID app details from Automate node(HA)[DUPLICATE]")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("a2", docs.Compatibility, []string{docs.CompatiblewithHA})
-	ocIdShowAppCmd.PersistentFlags().BoolVar(&configCmdFlags.chef_server, "cs", false, "Shows registered OCID app details from Chef-server node(HA)[DUPLICATE]")
-	ocIdShowAppCmd.PersistentFlags().SetAnnotation("cs", docs.Compatibility, []string{docs.CompatiblewithHA})
 	ocIdShowAppCmd.PersistentFlags().IntVar(&configCmdFlags.waitTimeout, waitTimeout, DEFAULT_TIMEOUT, "This flag sets the operation timeout duration (in seconds) for each individual node during the config oc-id-show-app process")
 	ocIdShowAppCmd.PersistentFlags().SetAnnotation(waitTimeout, docs.Compatibility, []string{docs.CompatiblewithHA})
 
@@ -677,55 +665,32 @@ func runOcIdShowAppCommand(cmd *cobra.Command, args []string) error {
 		  return errors.Errorf("The operation timeout duration for each individual node during the config oc-id-show-app process should be set to a value greater than %v seconds.", DEFAULT_TIMEOUT)
 		}
 
+		configCmdFlags.frontend = true
+
 		frontendCmd := fmt.Sprintf(CONF_PREFIX_FOR_SHOW_APPS_CMD, OCID_SHOW_APP)
 		frontend := &Cmd{
 		  CmdInputs: &CmdInputs{
 		    Cmd:                      frontendCmd,
 		    WaitTimeout:              configCmdFlags.waitTimeout,
-		    Single:                   false,
+		    Single:                   true,
 		    Args:                     args,
 		    ErrorCheckEnableInOutput: true,
 		    NodeType:                 configCmdFlags.frontend,
 		  },
 		}
-		automateCmd := fmt.Sprintf(CONF_PREFIX_FOR_SHOW_APPS_CMD, OCID_SHOW_APP)
-		automate := &Cmd{
-		  CmdInputs: &CmdInputs{
-		    Cmd:                      automateCmd,
-		    WaitTimeout:              configCmdFlags.waitTimeout,
-		    Single:                   false,
-		    Args:                     args,
-		    ErrorCheckEnableInOutput: true,
-		    NodeType:                 configCmdFlags.automate,
-		  },
-		}
-
-		chefServerCmd := fmt.Sprintf(CONF_PREFIX_FOR_SHOW_APPS_CMD, OCID_SHOW_APP)
-		chefServer := &Cmd{
-		  CmdInputs: &CmdInputs{
-		    Cmd:                      chefServerCmd,
-		    WaitTimeout:              configCmdFlags.waitTimeout,
-		    Single:                   false,
-		    Args:                     args,
-		    ErrorCheckEnableInOutput: true,
-		    NodeType:                 configCmdFlags.chef_server,
-		  },
-		}
-
+		
 		nodeMap := &NodeTypeAndCmd{
 		  Frontend:   frontend,
-		  Automate:   automate,
-		  ChefServer: chefServer,
 		  Infra:      infra,
 		}
 		sshUtil := NewSSHUtil(&SSHConfig{})
 		cmdUtil := NewRemoteCmdExecutor(nodeMap, sshUtil, writer)
 
-		if configCmdFlags.frontend || configCmdFlags.automate || configCmdFlags.chef_server {
-		  _, err := cmdUtil.Execute()
+		if configCmdFlags.frontend {
+		  _, cmdExecErr := cmdUtil.Execute()
 
-		  if err != nil {
-		    return err
+		  if cmdExecErr != nil {
+		    return cmdExecErr
 		  }
 		} else {
 		  writer.Println(cmd.UsageString())


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
