### PR TITLE
Provision AWS LB should have an option to choose the Private subnet

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,4 +5,4 @@ This provides the `automate-backend-deployment` package.
 
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
-This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package
+This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package.

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -1,12 +1,11 @@
-
 /////////////////////////
 // Automate Load Balancing
 resource "aws_alb" "automate_lb" {
   name               = "${var.tag_name}-${random_id.random.hex}-automate-lb"
-  internal           = false
+  internal           = length(var.public_custom_subnets) > 0 ? false : true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.load_balancer.id]
-  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : aws_subnet.public.*.id
+  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : data.aws_subnet.default.*.id
   tags               = var.tags
 }
 
@@ -58,10 +57,10 @@ resource "aws_alb_listener" "automate_lb_listener_80" {
 // Chef Server
 resource "aws_alb" "chef_server_lb" {
   name               = "${var.tag_name}-${random_id.random.hex}-chef-server-lb"
-  internal           = false
+  internal           = length(var.public_custom_subnets) > 0 ? false : true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.load_balancer.id]
-  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : aws_subnet.public.*.id
+  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : data.aws_subnet.default.*.id
   tags               = var.tags
 }
 

--- a/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
+++ b/terraform/a2ha-terraform/modules/aws/loadbalancing.tf
@@ -2,10 +2,10 @@
 // Automate Load Balancing
 resource "aws_alb" "automate_lb" {
   name               = "${var.tag_name}-${random_id.random.hex}-automate-lb"
-  internal           = length(var.public_custom_subnets) > 0 ? false : true
+  internal           = (length(var.public_custom_subnets) > 0 || var.aws_cidr_block_addr != "") ? false : true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.load_balancer.id]
-  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : data.aws_subnet.default.*.id
+  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : (var.aws_cidr_block_addr != "" ? aws_subnet.public.*.id : data.aws_subnet.default.*.id)
   tags               = var.tags
 }
 
@@ -57,10 +57,10 @@ resource "aws_alb_listener" "automate_lb_listener_80" {
 // Chef Server
 resource "aws_alb" "chef_server_lb" {
   name               = "${var.tag_name}-${random_id.random.hex}-chef-server-lb"
-  internal           = length(var.public_custom_subnets) > 0 ? false : true
+  internal           = (length(var.public_custom_subnets) > 0 || var.aws_cidr_block_addr != "") ? false : true
   load_balancer_type = "application"
   security_groups    = [aws_security_group.load_balancer.id]
-  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : data.aws_subnet.default.*.id
+  subnets            = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public.*.id : (var.aws_cidr_block_addr != "" ? aws_subnet.public.*.id : data.aws_subnet.default.*.id)
   tags               = var.tags
 }
 

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -1,9 +1,5 @@
-
 resource "random_id" "random" {
   byte_length = 4
-}
-
-data "aws_availability_zones" "available" {
 }
 
 data "aws_vpc" "default" {
@@ -26,143 +22,8 @@ locals {
 }
 
 data "aws_subnet" "public" {                                  
-  count = length(var.private_custom_subnets) > 0 ? 3 : 0            
+  count = length(var.public_custom_subnets) > 0 ? 3 : 0            
   id    = local.public_subnet_ids_list[count.index]
-}
-
-data "aws_internet_gateway" "default" {
-  filter {
-    name   = "attachment.vpc-id"
-    values = [data.aws_vpc.default.id]
-  }
-}
-
-resource "aws_subnet" "default" {
-  count             = length(var.private_custom_subnets) > 0 ? 0 : 3
-  vpc_id            = data.aws_vpc.default.id
-  cidr_block        = cidrsubnet("${var.aws_cidr_block_addr}/18", 8, count.index + 1)
-  availability_zone = data.aws_availability_zones.available.names[count.index]
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_${data.aws_availability_zones.available.names[count.index]}_private"))
-}
-
-resource "aws_subnet" "public" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 3
-  vpc_id                  = data.aws_vpc.default.id
-  cidr_block              = cidrsubnet("${var.aws_cidr_block_addr}/18", 8, count.index + 4)
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_${data.aws_availability_zones.available.names[count.index]}_public"))
-}
-
-resource "aws_eip" "eip1" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc              = true
-  public_ipv4_pool = "amazon"
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_eip"))
-}
-
-resource "aws_eip" "eip2" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc              = true
-  public_ipv4_pool = "amazon"
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_eip"))
-}
-
-resource "aws_eip" "eip3" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc              = true
-  public_ipv4_pool = "amazon"
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_eip"))
-}
-
-resource "aws_nat_gateway" "nat1" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  allocation_id = aws_eip.eip1[0].id
-  subnet_id     = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public[0].id : aws_subnet.public[0].id
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_nat_gw"))
-
-  depends_on = [data.aws_internet_gateway.default]
-}
-
-resource "aws_nat_gateway" "nat2" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  allocation_id = aws_eip.eip2[0].id
-  subnet_id     = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public[1].id : aws_subnet.public[1].id
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_nat_gw"))
-
-  depends_on = [data.aws_internet_gateway.default]
-}
-
-resource "aws_nat_gateway" "nat3" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  allocation_id = aws_eip.eip3[0].id
-  subnet_id     = length(var.public_custom_subnets) > 0 ? data.aws_subnet.public[2].id : aws_subnet.public[2].id
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_nat_gw"))
-
-  depends_on = [data.aws_internet_gateway.default]
-}
-
-resource "aws_route_table" "route1" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc_id = data.aws_vpc.default.id
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat1[0].id
-  }
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_route_table"))
-
-}
-
-resource "aws_route_table" "route2" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc_id = data.aws_vpc.default.id
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat2[0].id
-  }
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_route_table"))
-
-}
-
-resource "aws_route_table" "route3" {
-  count                   = length(var.public_custom_subnets) > 0 ? 0 : 1
-  vpc_id = data.aws_vpc.default.id
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat3[0].id
-  }
-
-  tags = merge(var.tags, map("Name", "${var.tag_name}_${random_id.random.hex}_route_table"))
-
-}
-
-
-resource "aws_route_table_association" "nat1" {
-  count          = length(var.public_custom_subnets) > 0 ? 0 : 1
-  subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[0].id : aws_subnet.default[0].id
-  route_table_id = aws_route_table.route1[0].id
-}
-
-resource "aws_route_table_association" "nat2" {
-  count          = length(var.public_custom_subnets) > 0 ? 0 : 1
-  subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[1].id : aws_subnet.default[1].id
-  route_table_id = aws_route_table.route2[0].id
-}
-
-resource "aws_route_table_association" "nat3" {
-  count          = length(var.public_custom_subnets) > 0 ? 0 : 1
-  subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[2].id : aws_subnet.default[2].id
-  route_table_id = aws_route_table.route3[0].id
 }
 
 locals {
@@ -170,12 +31,12 @@ locals {
 }
 
 resource "aws_instance" "chef_automate_postgresql" {
-  count = var.setup_managed_services ? 0 : var.postgresql_instance_count
+  count = (length(var.private_custom_subnets) == 0 || var.setup_managed_services) ? 0 : var.postgresql_instance_count
 
   ami                         = local.ami
   instance_type               = var.postgresql_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
-  subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
+  subnet_id                   = element(data.aws_subnet.default.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false
   ebs_optimized               = true
@@ -217,16 +78,15 @@ resource "aws_instance" "chef_automate_postgresql" {
     http_tokens            = "required"
     instance_metadata_tags = "enabled"
   }
-  depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
 
 }
 resource "aws_instance" "chef_automate_opensearch" {
-  count = var.setup_managed_services ? 0 : var.opensearch_instance_count
+  count = (length(var.private_custom_subnets) == 0 || var.setup_managed_services) ? 0 : var.opensearch_instance_count
 
   ami                         = local.ami
   instance_type               = var.opensearch_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
-  subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
+  subnet_id                   = element(data.aws_subnet.default.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id]
   associate_public_ip_address = false //Changes to false as Dashboards are no longer enabled
   ebs_optimized               = true
@@ -257,17 +117,16 @@ resource "aws_instance" "chef_automate_opensearch" {
     http_tokens            = "required"
     instance_metadata_tags = "enabled"
   }
-  depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
 
 }
 
 resource "aws_instance" "chef_automate" {
-  count = var.automate_instance_count
+  count = length(var.private_custom_subnets) > 0 ? var.automate_instance_count : 0
 
   ami                         = local.ami
   instance_type               = var.automate_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
-  subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
+  subnet_id                   = element(data.aws_subnet.default.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id, aws_security_group.chef_automate_ui.id]
   associate_public_ip_address = false
   ebs_optimized               = true
@@ -300,18 +159,17 @@ resource "aws_instance" "chef_automate" {
     http_tokens            = "required"
     instance_metadata_tags = "enabled"
   }
-  depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
   
 }
 
 resource "aws_instance" "chef_server" {
-  count = var.chef_server_instance_count
+  count = length(var.private_custom_subnets) > 0 ? var.chef_server_instance_count : 0
 
 
   ami                         = local.ami
   instance_type               = var.chef_server_instance_type
   key_name                    = var.aws_ssh_key_pair_name
-  subnet_id                   = length(var.private_custom_subnets) > 0 ? element(data.aws_subnet.default.*.id, count.index) : element(aws_subnet.default.*.id, count.index)
+  subnet_id                   = element(data.aws_subnet.default.*.id, count.index)
   vpc_security_group_ids      = [aws_security_group.base_linux.id, aws_security_group.habitat_supervisor.id, aws_security_group.chef_automate.id, aws_security_group.chef_automate_ui.id]
   associate_public_ip_address = false
   ebs_optimized               = true
@@ -344,6 +202,5 @@ resource "aws_instance" "chef_server" {
     http_tokens            = "required"
     instance_metadata_tags = "enabled"
   }
-  depends_on = [aws_route_table.route1,aws_route_table.route2,aws_route_table.route3]
 
 }

--- a/terraform/a2ha-terraform/modules/aws/main.tf
+++ b/terraform/a2ha-terraform/modules/aws/main.tf
@@ -147,19 +147,19 @@ resource "aws_route_table" "route3" {
 
 
 resource "aws_route_table_association" "nat1" {
-  count          = (length(var.public_custom_subnets) == 0 && (var.aws_cidr_block_addr != "" || length(var.private_custom_subnets) > 0)) ? 1 : 0
+  count          = (length(var.public_custom_subnets) == 0 && var.aws_cidr_block_addr != "") ? 1 : 0
   subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[0].id : aws_subnet.default[0].id
   route_table_id = aws_route_table.route1[0].id
 }
 
 resource "aws_route_table_association" "nat2" {
-  count          = (length(var.public_custom_subnets) == 0 && (var.aws_cidr_block_addr != "" || length(var.private_custom_subnets) > 0)) ? 1 : 0
+  count          = (length(var.public_custom_subnets) == 0 && var.aws_cidr_block_addr != "") ? 1 : 0
   subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[1].id : aws_subnet.default[1].id
   route_table_id = aws_route_table.route2[0].id
 }
 
 resource "aws_route_table_association" "nat3" {
-  count          = (length(var.public_custom_subnets) == 0 && (var.aws_cidr_block_addr != "" || length(var.private_custom_subnets) > 0)) ? 1 : 0
+  count          = (length(var.public_custom_subnets) == 0 && var.aws_cidr_block_addr != "") ? 1 : 0
   subnet_id      = length(var.private_custom_subnets) > 0 ? data.aws_subnet.default[2].id : aws_subnet.default[2].id
   route_table_id = aws_route_table.route3[0].id
 }

--- a/terraform/a2ha-terraform/modules/aws/outputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/outputs.tf
@@ -66,9 +66,7 @@ output "random_id" {
 }
 
 output "subnet_id" {
-
-  value = length(var.private_custom_subnets) > 0 ? var.private_custom_subnets : aws_subnet.default.*.id
-
+  value = var.private_custom_subnets
 }
 
 output "mount_id" {
@@ -85,7 +83,7 @@ output "tags" {
 
 
 output "private_subnets" {
-  value = length(var.private_custom_subnets) > 0 ? var.private_custom_subnets : aws_subnet.default.*.id
+  value = var.private_custom_subnets
 }
 
 output "base_linux_aws_security_group_id" {

--- a/terraform/a2ha-terraform/modules/aws/outputs.tf
+++ b/terraform/a2ha-terraform/modules/aws/outputs.tf
@@ -66,7 +66,7 @@ output "random_id" {
 }
 
 output "subnet_id" {
-  value = var.private_custom_subnets
+  value = length(var.private_custom_subnets) > 0 ? var.private_custom_subnets : aws_subnet.default.*.id
 }
 
 output "mount_id" {
@@ -83,7 +83,7 @@ output "tags" {
 
 
 output "private_subnets" {
-  value = var.private_custom_subnets
+  value = length(var.private_custom_subnets) > 0 ? var.private_custom_subnets : aws_subnet.default.*.id
 }
 
 output "base_linux_aws_security_group_id" {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Made public subnet optional in config.toml

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-3646
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Use Package: `akrishna/automate-ha-deployment/0.1.0/20230718130731`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![Screenshot 2023-07-21 at 7 32 48 PM](https://github.com/chef/automate/assets/11033984/d7f83fb8-b120-4cdf-8589-9fae91b2fd11)

Demo: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EdNK_u6VKlJHo23cpq6GKwIBgbqSUH5M7v8bzYIpsw1tVg?e=cFbIec