### PR TITLE
re-naming chef-automate binary to chef-automate in etc verify

### DIFF
--- a/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc.go
+++ b/components/automate-cli/pkg/verifysystemdcreate/systemdcreatesvc.go
@@ -32,13 +32,14 @@ Environment="HOME={{.HomeEnv}}"
 [Install]
 WantedBy=multi-user.target
 `
+	BINARY_FILE_NAME = "chef-automate"
 )
 
 type systemdInput struct {
 	ServiceName        string
 	ServiceDescription string
 	ServiceCommand     string
-	HomeEnv            string  
+	HomeEnv            string
 }
 
 type CreateSystemdServiceImpl struct {
@@ -204,7 +205,7 @@ func (css *CreateSystemdServiceImpl) Create() error {
 	}
 	css.Logger.Debugf("Service %s is not running on this system", SERVICE_NAME)
 
-	fullBinaryDestination := filepath.Join(css.BinaryDestinationFolder, filepath.Base(currentBinaryPath))
+	fullBinaryDestination := filepath.Join(css.BinaryDestinationFolder, BINARY_FILE_NAME)
 	css.Logger.Debugf("Full binary destination path %s", fullBinaryDestination)
 	err = css.SystemdCreateUtils.CreateDestinationAndCopy(currentBinaryPath, fullBinaryDestination)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Jay Sharma <jsharma@progress.com>

### :nut_and_bolt: Description: What code changed, and why?

As an Automate HA user when I have base binary with different name like `my-automate-build` or `chef-autoamte-linux` etc, then verify server was not able to start because to start server it was looking for file as `chef-automate` but copied file in /etc/automate-verify/ was different, with this fix command will copy binary with name of `chef-automate` only for any base binary name given

### :chains: Related Resources

### :+1: Definition of Done

Dev tested

### :athletic_shoe: How to Build and Test the Change

`cd component/automate-cli`
`make linux` or `make darwin`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


<img width="690" alt="Screenshot 2023-07-17 at 6 03 47 PM" src="https://github.com/chef/automate/assets/36661596/b3d3adc5-d5aa-4daa-9ca4-889c6ae144a6">
<img width="1792" alt="Screenshot 2023-07-17 at 6 03 28 PM" src="https://github.com/chef/automate/assets/36661596/1f0ece44-4089-4e82-bd2f-bac8d3322b22">
