### PR TITLE
chef-1636_gather_logs

### DIFF
--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -34,6 +34,7 @@ var testExpectedEnv = []string{
 	"PGUSER=test-user",
 	"PGHOST=test-db.example.com",
 	"PGPORT=5432",
+	"PGPASSWORD=test",
 	"PGSSLMODE=verify-ca",
 	"PGSSLKEY=/hab/svc/automate-postgresql/config/server.key",
 	"PGSSLCERT=/hab/svc/automate-postgresql/config/server.crt",
@@ -43,13 +44,14 @@ var testExpectedEnv = []string{
 }
 
 var connInfo = &pg.A2ConnInfo{
-	Host:  "test-db.example.com",
-	User:  "test-user",
-	Port:  5432,
-	Certs: pg.A2SuperuserCerts,
+	Host:     "test-db.example.com",
+	User:     "test-user",
+	Password: "test",
+	Port:     5432,
+	Certs:    pg.A2SuperuserCerts,
 }
 
-var connURITemplate = "postgresql://test-user@test-db.example.com:5432/%s?sslmode=verify-ca&sslcert=/hab/svc/automate-postgresql/config/server.crt&sslkey=/hab/svc/automate-postgresql/config/server.key&sslrootcert=/hab/svc/automate-postgresql/config/root.crt"
+var connURITemplate = "postgresql://test-user:test@test-db.example.com:5432/%s?sslmode=verify-ca&sslcert=/hab/svc/automate-postgresql/config/server.crt&sslkey=/hab/svc/automate-postgresql/config/server.key&sslrootcert=/hab/svc/automate-postgresql/config/root.crt"
 
 func connURI(dbName string) string {
 	return fmt.Sprintf(connURITemplate, dbName)

--- a/lib/platform/pg/exporter_test.go
+++ b/lib/platform/pg/exporter_test.go
@@ -27,7 +27,6 @@ func NewDBMock() (pg.DBProvider, *pg.MockDB) {
 	return mockDBProvider{
 		mockDB: &db,
 	}, &db
-
 }
 
 var testExpectedEnv = []string{


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In Standalone Automate when we trigger the chef-automate gathers-logs command it collect the logs. 
In case of Automate is using external database then it is not able to pull the basic details because it is using localhost instead of it have to user the external postgres url.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-1636
### :+1: Definition of Done
Now, chef-automate gathers-logs command collect the logs in case if we are using external postgresql.
### :athletic_shoe: How to Build and Test the Change
Use the below pkg:

- sahiba3108/deployment-service/0.1.0/20230720103238

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Video Link: https://progresssoftware-my.sharepoint.com/:v:/g/personal/sgoyal_progress_com/EeoYSvsuOAJBtDyXAkdwpuABCEFiEo7row7TbcSRoathJQ?e=ao0E1U