### PR TITLE
[config-gen-managed-db-default]: Set enable custom cert false for aws managed 

### DIFF
--- a/lib/config/genconfig/awshaprovisionconfig.go
+++ b/lib/config/genconfig/awshaprovisionconfig.go
@@ -211,19 +211,19 @@ func (c *AwsHaProvisionConfig) PromptCidrBlockAddr() (err error) {
 }
 
 func (c *AwsHaProvisionConfig) PromptPrivateSubnet() (err error) {
-	privateSubnet1, err := c.Prompt.InputStringRequired("AWS Private Subnet 1:")
+	privateSubnet1, err := c.Prompt.InputStringRequired("AWS Private Subnet 1")
 	if err != nil {
 		return
 	}
 	c.Config.InitAws().InitConfigAwsSettings().PrivateCustomSubnets = []string{privateSubnet1}
 
-	privateSubnet2, err := c.Prompt.InputStringRequired("AWS Private Subnet 2:")
+	privateSubnet2, err := c.Prompt.InputStringRequired("AWS Private Subnet 2")
 	if err != nil {
 		return
 	}
 	c.Config.InitAws().InitConfigAwsSettings().PrivateCustomSubnets = append(c.Config.InitAws().InitConfigAwsSettings().PrivateCustomSubnets, privateSubnet2)
 
-	privateSubnet3, err := c.Prompt.InputStringRequired("AWS Private Subnet 3:")
+	privateSubnet3, err := c.Prompt.InputStringRequired("AWS Private Subnet 3")
 	if err != nil {
 		return
 	}
@@ -828,7 +828,7 @@ func (c *AwsHaProvisionConfig) PromptAutomateAdminPassword() (err error) {
 }
 
 func (c *AwsHaProvisionConfig) PromptAutomateInstanceType() (err error) {
-	instanceType, err := c.Prompt.InputStringRegexDefault("AWS Instance type for Automate", AWS_MACHINE_TYPE_REGEX, "t3.medium")
+	instanceType, err := c.Prompt.InputStringRegexDefault("AWS Instance type for Automate", AWS_MACHINE_TYPE_REGEX, "m5.large")
 	if err != nil {
 		return
 	}
@@ -899,7 +899,7 @@ func (c *AwsHaProvisionConfig) PromptChefInfraServerNodes() (err error) {
 }
 
 func (c *AwsHaProvisionConfig) PromptChefInfraServerInstanceType() (err error) {
-	instanceType, err := c.Prompt.InputStringRegexDefault("AWS Instance type for Chef Infra Server", AWS_MACHINE_TYPE_REGEX, "t3.medium")
+	instanceType, err := c.Prompt.InputStringRegexDefault("AWS Instance type for Chef Infra Server", AWS_MACHINE_TYPE_REGEX, "m5.large")
 	if err != nil {
 		return
 	}

--- a/lib/config/genconfig/awshaprovisionconfig.go
+++ b/lib/config/genconfig/awshaprovisionconfig.go
@@ -297,7 +297,7 @@ func (c *AwsHaProvisionConfig) PromptDatabases() (err error) {
 		if err != nil {
 			return err
 		}
-		c.SetZeroDBNodes()
+		c.SetDefaultValuesForDBNodes()
 	} else {
 		err := c.PromptChefManaged()
 		if err != nil {
@@ -1278,10 +1278,12 @@ func (c *AwsHaProvisionConfig) PromptBackup() (err error) {
 	return
 }
 
-func (c *AwsHaProvisionConfig) SetZeroDBNodes() {
+func (c *AwsHaProvisionConfig) SetDefaultValuesForDBNodes() {
 	c.Config.InitOpenSearch().InitConfig()
 	c.Config.Opensearch.Config.InstanceCount = "0"
+	c.Config.Opensearch.Config.EnableCustomCerts = false
 
 	c.Config.InitPostgresql().InitConfig()
 	c.Config.Postgresql.Config.InstanceCount = "0"
+	c.Config.Postgresql.Config.EnableCustomCerts = false
 }

--- a/lib/config/genconfig/awshaprovisionconfig_test.go
+++ b/lib/config/genconfig/awshaprovisionconfig_test.go
@@ -90,7 +90,7 @@ func TestPromptsCidrAWSManaged(t *testing.T) {
 	automateNodeCount := 1
 	input(b, fmt.Sprint(automateNodeCount)+"\r")
 
-	automateInstanceType := "t3.medium"
+	automateInstanceType := "m5.large"
 	input(b, "\r")
 
 	automateVolSize := 200
@@ -115,7 +115,7 @@ func TestPromptsCidrAWSManaged(t *testing.T) {
 	chefInfraServerNodeCount := 1
 	input(b, fmt.Sprint(chefInfraServerNodeCount)+"\r")
 
-	chefInfraServerInstanceType := "t3.medium"
+	chefInfraServerInstanceType := "m5.large"
 	input(b, "\r")
 
 	chefInfraServerVolSize := 200
@@ -1552,4 +1552,17 @@ func TestAwsHaProvisionConfigFactory(t *testing.T) {
 	c := AwsHaProvisionConfigFactory(p)
 
 	assert.NotNil(t, c)
+}
+
+func TestSetDefaultValuesForDBNodes(t *testing.T) {
+	defaultInstanceCount := "0"
+	c := AwsHaProvisionConfig{
+		Config: &config.HaDeployConfig{},
+	}
+	c.SetDefaultValuesForDBNodes()
+
+	assert.Equal(t, defaultInstanceCount, c.Config.Postgresql.Config.InstanceCount)
+	assert.Equal(t, defaultInstanceCount, c.Config.Opensearch.Config.InstanceCount)
+	assert.Equal(t, false, c.Config.Postgresql.Config.EnableCustomCerts)
+	assert.Equal(t, false, c.Config.Opensearch.Config.EnableCustomCerts)
 }

--- a/lib/config/genconfig/hadeployconfig.go
+++ b/lib/config/genconfig/hadeployconfig.go
@@ -67,7 +67,7 @@ func (c *HaDeployConfigGen) Prompts() (err error) {
 		return
 	}
 	if isExternalDb {
-		c.SetZeroDBNodes()
+		c.SetDefaultValuesForDBNodes()
 	} else {
 		err = c.PromptOpenSearch()
 		if err != nil {
@@ -106,12 +106,14 @@ func (c *HaDeployConfigGen) PromptCustomCerts() (err error) {
 	return
 }
 
-func (c *HaDeployConfigGen) SetZeroDBNodes() {
+func (c *HaDeployConfigGen) SetDefaultValuesForDBNodes() {
 	c.Config.InitOpenSearch().InitConfig()
 	c.Config.Opensearch.Config.InstanceCount = "0"
+	c.Config.Opensearch.Config.EnableCustomCerts = false
 
 	c.Config.InitPostgresql().InitConfig()
 	c.Config.Postgresql.Config.InstanceCount = "0"
+	c.Config.Postgresql.Config.EnableCustomCerts = false
 }
 
 func (c *HaDeployConfigGen) PromptExternalDb() (hasExternalDb bool, err error) {

--- a/lib/config/genconfig/hadeployconfig_test.go
+++ b/lib/config/genconfig/hadeployconfig_test.go
@@ -1423,3 +1423,16 @@ func TestPromptExternalOpenSearchRootCert(t *testing.T) {
 
 	assert.Equal(t, certFileContent, c.Config.External.Database.OpenSearch.OpensearchRootCert)
 }
+
+func TestSetDefaultValuesForDBNodesOnPrem(t *testing.T) {
+	defaultInstanceCount := "0"
+	c := HaDeployConfigGen{
+		Config: &config.HaDeployConfig{},
+	}
+	c.SetDefaultValuesForDBNodes()
+
+	assert.Equal(t, defaultInstanceCount, c.Config.Postgresql.Config.InstanceCount)
+	assert.Equal(t, defaultInstanceCount, c.Config.Opensearch.Config.InstanceCount)
+	assert.Equal(t, false, c.Config.Postgresql.Config.EnableCustomCerts)
+	assert.Equal(t, false, c.Config.Opensearch.Config.EnableCustomCerts)
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

1. When we select the top most prompt for enable custom cert as true then in case of aws managed it sets enabled_custom_cert as true which fails the provision. 
2. It makes the default value of instance type for all FE nodes to be m5.large
3. General UI fix 

### :chains: Related Resources

### :+1: Definition of Done
This should help generate correct config in case of aws managed when enable custom cert is set true on top
### :athletic_shoe: How to Build and Test the Change

1. cd automate/components/automate-cli
2. make darwin or make linux
3. sudo ./bin/darwin/chef-automate config gen config.toml or sudo ./bin/linux/chef-automate config gen config.toml

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
