### PR TITLE
In pullAndGenerate fetching private and public keys from the same ip

### DIFF
--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -873,9 +873,6 @@ func (p *PullConfigsImpl) fetchAwsConfig() (*AwsConfigToml, error) {
 		sharedConfigToml.Automate.Config.PrivateKey = a2PrivKey
 		sharedConfigToml.Automate.Config.PublicKey = a2PubKey
 	}
-	// if a2PubKey := getPublicKeyFromFE(a2ConfigMap); len(a2PubKey) > 0 {
-	// 	sharedConfigToml.Automate.Config.PublicKey = a2PubKey
-	// }
 	sharedConfigToml.Automate.Config.EnableCustomCerts = true
 
 	// Build CertsByIP for ChefServer
@@ -899,9 +896,6 @@ func (p *PullConfigsImpl) fetchAwsConfig() (*AwsConfigToml, error) {
 		sharedConfigToml.ChefServer.Config.PrivateKey = csPrivKey
 		sharedConfigToml.ChefServer.Config.PublicKey = csPubKey
 	}
-	// if csPubKey := getPublicKeyFromFE(csConfigMap); len(csPubKey) > 0 {
-	// 	sharedConfigToml.ChefServer.Config.PublicKey = csPubKey
-	// }
 	sharedConfigToml.ChefServer.Config.EnableCustomCerts = true
 
 	objStorageConfig := getOpenSearchObjectStorageConfig(a2ConfigMap)
@@ -1212,23 +1206,11 @@ func getPrivateAndPublicKeyFromFE(config map[string]*dc.AutomateConfig) (string,
 		return "", ""
 	}
 	for _, ele := range config {
-		if ele.Global.V1.FrontendTls[0] != nil && ele.Global.V1.FrontendTls[0].Key != "" {
+		if ele.Global.V1.FrontendTls[0] != nil && ele.Global.V1.FrontendTls[0].Key != "" && ele.Global.V1.FrontendTls[0].Cert != "" {
 			return ele.GetGlobal().V1.FrontendTls[0].Key, ele.GetGlobal().V1.FrontendTls[0].Cert
 		}
 	}
 	return "", ""
-}
-
-func getPublicKeyFromFE(config map[string]*dc.AutomateConfig) string {
-	if config == nil {
-		return ""
-	}
-	for _, ele := range config {
-		if ele.Global.V1.FrontendTls[0] != nil && ele.Global.V1.FrontendTls[0].Cert != "" {
-			return ele.GetGlobal().V1.FrontendTls[0].Cert
-		}
-	}
-	return ""
 }
 
 func getOSAdminCertAndAdminKey(config map[string]*ConfigKeys) (string, string) {

--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig.go
@@ -869,12 +869,13 @@ func (p *PullConfigsImpl) fetchAwsConfig() (*AwsConfigToml, error) {
 	if len(a2Fqdn) > 0 {
 		sharedConfigToml.Automate.Config.Fqdn = a2Fqdn
 	}
-	if a2PrivKey := getPrivateKeyFromFE(a2ConfigMap); len(a2PrivKey) > 0 {
+	if a2PrivKey, a2PubKey := getPrivateAndPublicKeyFromFE(a2ConfigMap); len(a2PrivKey) > 0 && len(a2PubKey) > 0 {
 		sharedConfigToml.Automate.Config.PrivateKey = a2PrivKey
-	}
-	if a2PubKey := getPublicKeyFromFE(a2ConfigMap); len(a2PubKey) > 0 {
 		sharedConfigToml.Automate.Config.PublicKey = a2PubKey
 	}
+	// if a2PubKey := getPublicKeyFromFE(a2ConfigMap); len(a2PubKey) > 0 {
+	// 	sharedConfigToml.Automate.Config.PublicKey = a2PubKey
+	// }
 	sharedConfigToml.Automate.Config.EnableCustomCerts = true
 
 	// Build CertsByIP for ChefServer
@@ -894,12 +895,13 @@ func (p *PullConfigsImpl) fetchAwsConfig() (*AwsConfigToml, error) {
 	if csRootCA := getRootCAFromCS(csConfigMap); len(csRootCA) > 0 {
 		sharedConfigToml.Automate.Config.RootCA = csRootCA
 	}
-	if csPrivKey := getPrivateKeyFromFE(csConfigMap); len(csPrivKey) > 0 {
+	if csPrivKey, csPubKey := getPrivateAndPublicKeyFromFE(csConfigMap); len(csPrivKey) > 0 && len(csPubKey) > 0 {
 		sharedConfigToml.ChefServer.Config.PrivateKey = csPrivKey
-	}
-	if csPubKey := getPublicKeyFromFE(csConfigMap); len(csPubKey) > 0 {
 		sharedConfigToml.ChefServer.Config.PublicKey = csPubKey
 	}
+	// if csPubKey := getPublicKeyFromFE(csConfigMap); len(csPubKey) > 0 {
+	// 	sharedConfigToml.ChefServer.Config.PublicKey = csPubKey
+	// }
 	sharedConfigToml.ChefServer.Config.EnableCustomCerts = true
 
 	objStorageConfig := getOpenSearchObjectStorageConfig(a2ConfigMap)
@@ -1205,16 +1207,16 @@ func getRootCAFromCS(config map[string]*dc.AutomateConfig) string {
 	return ""
 }
 
-func getPrivateKeyFromFE(config map[string]*dc.AutomateConfig) string {
+func getPrivateAndPublicKeyFromFE(config map[string]*dc.AutomateConfig) (string, string) {
 	if config == nil {
-		return ""
+		return "", ""
 	}
 	for _, ele := range config {
 		if ele.Global.V1.FrontendTls[0] != nil && ele.Global.V1.FrontendTls[0].Key != "" {
-			return ele.GetGlobal().V1.FrontendTls[0].Key
+			return ele.GetGlobal().V1.FrontendTls[0].Key, ele.GetGlobal().V1.FrontendTls[0].Cert
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func getPublicKeyFromFE(config map[string]*dc.AutomateConfig) string {

--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig_test.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig_test.go
@@ -251,54 +251,34 @@ func TestGetOSORPGRootCAEmpty(t *testing.T) {
 	assert.Equal(t, "", out)
 }
 
-func Test_getPrivateKeyFromFE(t *testing.T) {
+func Test_getPrivateAndPublicKeyFromFE(t *testing.T) {
 	automateConfigKeys.Global.V1.FrontendTls = []*shared.FrontendTLSCredential{
 		{
-			Key: PrivateKeyContents,
-		},
-	}
-	output := getPrivateKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
-	assert.Equal(t, PrivateKeyContents, output)
-}
-
-func Test_getPrivateKeyFromFEEmpty(t *testing.T) {
-	automateConfigKeys.Global.V1.FrontendTls = []*shared.FrontendTLSCredential{
-		{
-			Key: "",
-		},
-	}
-	output := getPrivateKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
-	assert.Equal(t, "", output)
-}
-
-func Test_getPrivateKeyFromFEEmptyMap(t *testing.T) {
-	output := getPrivateKeyFromFE(map[string]*dc.AutomateConfig{})
-	assert.Equal(t, "", output)
-}
-
-func Test_getPublicKeyFromFE(t *testing.T) {
-	automateConfigKeys.Global.V1.FrontendTls = []*shared.FrontendTLSCredential{
-		{
+			Key:  PrivateKeyContents,
 			Cert: PublicKeyContents,
 		},
 	}
-	output := getPublicKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
-	assert.Equal(t, PublicKeyContents, output)
+	privateKey, publicKey := getPrivateAndPublicKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
+	assert.Equal(t, PrivateKeyContents, privateKey)
+	assert.Equal(t, PublicKeyContents, publicKey)
 }
 
-func Test_getPublicKeyFromFEEmpty(t *testing.T) {
+func Test_getPrivateAndPublicKeyFromFEEmpty(t *testing.T) {
 	automateConfigKeys.Global.V1.FrontendTls = []*shared.FrontendTLSCredential{
 		{
+			Key:  "",
 			Cert: "",
 		},
 	}
-	output := getPublicKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
-	assert.Equal(t, "", output)
+	privateKey, publicKey := getPrivateAndPublicKeyFromFE(map[string]*dc.AutomateConfig{ip1: automateConfigKeys})
+	assert.Equal(t, "", privateKey)
+	assert.Equal(t, "", publicKey)
 }
 
-func Test_getPublicKeyKeyFromFEEmptyMap(t *testing.T) {
-	output := getPrivateKeyFromFE(map[string]*dc.AutomateConfig{})
-	assert.Equal(t, "", output)
+func Test_getPrivateAndPublicKeyFromFEEmptyMap(t *testing.T) {
+	privateKey, publicKey := getPrivateAndPublicKeyFromFE(map[string]*dc.AutomateConfig{})
+	assert.Equal(t, "", privateKey)
+	assert.Equal(t, "", publicKey)
 }
 
 func Test_getPrivateKeyAndPublicKeyFromBE(t *testing.T) {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In case of add node the common certs is fetching the private key from one ip and public key from the other ip so its causing error while adding a node with this change it will fetch both the keys from single ip

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
