### PR TITLE
Stop Automate-installed Chef Server Frontends for restore

### DIFF
--- a/components/docs-chef-io/content/automate/ha_backup_restore.md
+++ b/components/docs-chef-io/content/automate/ha_backup_restore.md
@@ -32,6 +32,12 @@ In information technology, a data backup is a copy of computer data taken and st
 
 Data restore is the process of copying backup data from secondary storage and restoring it to its original location or a new location. A restoring process is carried out to return lost, stolen, or damaged data to its original condition or move it to a new location.
 
+{{< note >}}
+
+When restoring an Automate HA system, you will need to stop the Automate-installed Chef frontends so that they are not contacting the database during the restore.
+
+{{< /note >}}
+
 ## Chef Automate High Availability (HA) Backups
 
 You can manually back up the OpenSearch, Postgres, and Chef Automate Server data and configurations. The built-in Chef Automate CLI has no automated backup procedure that periodically backups the data.


### PR DESCRIPTION
We want to stop Automate-installed Chef Server Frontends before an attempt to restore.

If we don't, the Chef Server frontends will still have connection to the database, preventing the operations needed for a successful restore.

### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
