### PR TITLE
Adding es-gateway url

### DIFF
--- a/components/automate-cli/pkg/reportgenerator/usagegenerator.go
+++ b/components/automate-cli/pkg/reportgenerator/usagegenerator.go
@@ -78,6 +78,10 @@ func getElasticSearchURL(esHostName string, esPort string, url string) (string, 
 	if externalOsEnabled {
 		return fmt.Sprintf("http://localhost:%d", osGatewayPort), nil
 	}
+
+	if esPort == strconv.Itoa(osGatewayPort) {
+		url = "http://%s:%s"
+	}
 	return fmt.Sprintf(url, esHostName, esPort), nil
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

When es-gateway port is passed, the url should consider http protocol rather than https.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

https://chefio.atlassian.net/browse/CHEF-4290

### :+1: Definition of Done

Now license usage will work as expected

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/automate-cli/
chef-automate license complianceResourceRunCount -p 10144 -s 2023-07-31 -e 2023-07-31
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EUezEJW_HrZDh1lXWYSgtzABozkQM6_OGv0X2mtqQCG8RQ?e=7AmrHQ
