### PR TITLE
port 5432 in Port usage definitions

### DIFF
--- a/components/automate-deployment/habitat/plan.sh
+++ b/components/automate-deployment/habitat/plan.sh
@@ -54,4 +54,3 @@ do_strip() {
    return 0
 }
 
-

--- a/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
@@ -145,6 +145,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                      |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader             |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down   |
+| TCP      | 5432        | Allows PostgreSQL node to connect to nodes in its cluster.|
 
 ## Certificates
 

--- a/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
@@ -145,7 +145,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                      |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader             |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down   |
-| TCP      | 5432        | Allows PostgreSQL node to connect to nodes in its cluster.|
+| TCP      | 5432        | Allows PostgreSQL nodes talk to each other in the cluster |
 
 ## Certificates
 

--- a/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_aws_deployment_prerequisites.md
@@ -145,7 +145,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                      |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader             |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down   |
-| TCP      | 5432        | Allows PostgreSQL nodes talk to each other in the cluster |
+| TCP      | 5432        | Allows PostgreSQL nodes to connect with each other        |
 
 ## Certificates
 

--- a/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
@@ -136,6 +136,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                     |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader            |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down  |
+| TCP      | 5432        | Allows PostgreSQL node to connect to nodes in its cluster|
 
 ## Certificates
 

--- a/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
@@ -136,7 +136,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                     |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader            |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down  |
-| TCP      | 5432        | Allows PostgreSQL nodes talk to each other in the cluster|
+| TCP      | 5432        | Allows PostgreSQL nodes to connect with each other       |
 
 ## Certificates
 

--- a/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
+++ b/components/docs-chef-io/content/automate/ha_on_premises_deployment_prerequisites.md
@@ -136,7 +136,7 @@ The first column in the table below represents the source of the connection. The
 | TCP/UDP  | 9638        | Habitat gossip (UDP)                                     |
 | TCP      | 7432        | HAProxy, which redirects to PostgreSQL Leader            |
 | TCP      | 6432        | Re-elect PostgreSQL Leader if PostgreSQL leader is down  |
-| TCP      | 5432        | Allows PostgreSQL node to connect to nodes in its cluster|
+| TCP      | 5432        | Allows PostgreSQL nodes talk to each other in the cluster|
 
 ## Certificates
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
5432 port was missing in Port usage definitions section

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
