### PR TITLE
webhook notification error msg fix

### DIFF
--- a/components/automate-gateway/handler/notifications.go
+++ b/components/automate-gateway/handler/notifications.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -148,7 +149,7 @@ func (s *notificationsServer) ValidateWebhook(ctx context.Context,
 
 	resp, err := s.notificationsClient.ValidateWebhook(ctx, &transformUVR)
 	if err != nil {
-		return nil, err
+		return nil, errors.New("something went wrong")
 	}
 
 	switch resp.GetCode() {

--- a/components/automate-gateway/handler/notifications.go
+++ b/components/automate-gateway/handler/notifications.go
@@ -50,7 +50,7 @@ func (s *notificationsServer) AddRule(ctx context.Context, in *pb.RuleAddRequest
 		notifications.RuleAddResponse_VALIDATION_ERROR:
 		return nil, status.Error(codes.InvalidArgument, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 
@@ -77,7 +77,7 @@ func (s *notificationsServer) UpdateRule(ctx context.Context, in *pb.RuleUpdateR
 	case notifications.RuleUpdateResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 
@@ -94,7 +94,7 @@ func (s *notificationsServer) DeleteRule(ctx context.Context, in *pb.RuleIdentif
 	case notifications.RuleDeleteResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 
@@ -115,7 +115,7 @@ func (s *notificationsServer) GetRule(ctx context.Context, in *pb.RuleIdentifier
 	case notifications.RuleGetResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 
@@ -134,7 +134,7 @@ func (s *notificationsServer) ListRules(ctx context.Context, _ *pb.RuleListReque
 		}
 		return &transformedResp, nil
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 
@@ -157,7 +157,7 @@ func (s *notificationsServer) ValidateWebhook(ctx context.Context,
 	case notifications.URLValidationResponse_ERROR, notifications.URLValidationResponse_INVALID_URL:
 		return nil, status.Error(codes.InvalidArgument, "Could not validate url")
 	default:
-		return nil, status.Error(codes.Internal, "Internal Error")
+		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
 	}
 }
 

--- a/components/automate-gateway/handler/notifications.go
+++ b/components/automate-gateway/handler/notifications.go
@@ -149,7 +149,7 @@ func (s *notificationsServer) ValidateWebhook(ctx context.Context,
 
 	resp, err := s.notificationsClient.ValidateWebhook(ctx, &transformUVR)
 	if err != nil {
-		return nil, errors.New("something went wrong")
+		return nil, errors.New("error validating webhook")
 	}
 
 	switch resp.GetCode() {

--- a/components/automate-gateway/handler/notifications.go
+++ b/components/automate-gateway/handler/notifications.go
@@ -51,7 +51,7 @@ func (s *notificationsServer) AddRule(ctx context.Context, in *pb.RuleAddRequest
 		notifications.RuleAddResponse_VALIDATION_ERROR:
 		return nil, status.Error(codes.InvalidArgument, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 
@@ -78,7 +78,7 @@ func (s *notificationsServer) UpdateRule(ctx context.Context, in *pb.RuleUpdateR
 	case notifications.RuleUpdateResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 
@@ -95,7 +95,7 @@ func (s *notificationsServer) DeleteRule(ctx context.Context, in *pb.RuleIdentif
 	case notifications.RuleDeleteResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 
@@ -116,7 +116,7 @@ func (s *notificationsServer) GetRule(ctx context.Context, in *pb.RuleIdentifier
 	case notifications.RuleGetResponse_NOT_FOUND:
 		return nil, status.Error(codes.NotFound, strings.Join(resp.GetMessages(), "\n"))
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 
@@ -135,7 +135,7 @@ func (s *notificationsServer) ListRules(ctx context.Context, _ *pb.RuleListReque
 		}
 		return &transformedResp, nil
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 
@@ -158,7 +158,7 @@ func (s *notificationsServer) ValidateWebhook(ctx context.Context,
 	case notifications.URLValidationResponse_ERROR, notifications.URLValidationResponse_INVALID_URL:
 		return nil, status.Error(codes.InvalidArgument, "Could not validate url")
 	default:
-		return nil, status.Error(codes.Internal, strings.Join(resp.GetMessages(), "\n"))
+		return nil, status.Error(codes.Internal, "Internal Error")
 	}
 }
 

--- a/components/automate-gateway/handler/notifications.go
+++ b/components/automate-gateway/handler/notifications.go
@@ -149,7 +149,7 @@ func (s *notificationsServer) ValidateWebhook(ctx context.Context,
 
 	resp, err := s.notificationsClient.ValidateWebhook(ctx, &transformUVR)
 	if err != nil {
-		return nil, errors.New("error validating webhook")
+		return nil, errors.New("unable to connect: check URL, username and password.")
 	}
 
 	switch resp.GetCode() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
https://chefio.atlassian.net/browse/CHEF-5489

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

Webhook error msg are customised 

### :athletic_shoe: How to Build and Test the Change

`
rebuild components/automate-deployment
`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

Current response
<img width="1792" alt="Screenshot 2023-08-09 at 8 52 47 PM" src="https://github.com/chef/automate/assets/38317160/7883522d-60b5-4c4a-a7b9-2167af58c916">

Response after code change 
<img width="1792" alt="Screenshot 2023-08-11 at 4 43 44 PM" src="https://github.com/chef/automate/assets/38317160/0d4995aa-64d3-45af-8d3b-3f8ecd01af4e">


