### PR TITLE
removed extra details from resp

### DIFF
--- a/components/automate-gateway/gateway/middleware/authz/authz.go
+++ b/components/automate-gateway/gateway/middleware/authz/authz.go
@@ -33,14 +33,14 @@ func (c *client) Handle(ctx context.Context, subjects []string, projectsToFilter
 
 	polInfo := policy.InfoForMethod(method, req)
 	if polInfo == nil {
-		log.Warnf("no policy annotation for method %s", method)
+		log.Errorf("no policy annotation for method %s", method)
 		return nil, status.Errorf(codes.Internal,
 			"missing policy info for method %q", method)
 	}
 
 	action, resource := polInfo.Action, polInfo.Resource
 	if action == "" || resource == "" {
-		log.Warnf("no policy annotation for method %s", method)
+		log.Errorf("no policy annotation for method %s", method)
 		return nil, status.Errorf(codes.Internal,
 			"missing policy info for method %q", method)
 	}
@@ -67,13 +67,13 @@ func (c *client) Handle(ctx context.Context, subjects []string, projectsToFilter
 		}
 		log.WithError(err).Error("error authorizing request")
 		return nil, status.Errorf(codes.PermissionDenied,
-			"error authorizing request")
+			"Permission Denied")
 	}
 	if len(filteredResp.Projects) == 0 {
-		log.Warnf("unauthorized: members %q cannot perform action %q on resource %q filtered by projects %q",
+		log.Errorf("unauthorized: members %q cannot perform action %q on resource %q filtered by projects %q",
 			subjects, action, resource, projectsToFilter)
 		return nil, status.Errorf(codes.PermissionDenied,
-			"unauthorized members")
+			"Permission Denied")
 	}
 	projects := filteredResp.Projects
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
https://chefio.atlassian.net/browse/CHEF-5493

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

`
rebuild components/automate-gateway
`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

Current response
<img width="1792" alt="Screenshot 2023-08-09 at 10 07 12 PM" src="https://github.com/chef/automate/assets/38317160/486b8cbd-cc4a-4cd8-9b2b-ddc7d439e60e">

Response after code change
<img width="1792" alt="Screenshot 2023-08-09 at 10 04 44 PM" src="https://github.com/chef/automate/assets/38317160/ab30ea30-59de-45ff-95c6-76d3d718ad9e">


