### PR TITLE
service_versions command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/service_versions.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED = "Showing the service-versions for externally configured %s is not supported."
-	BACKEND_SERVICE_VERSIONS_CMD           = `sudo HAB_LICENSE=accept-no-persist hab svc status | hab pkg exec core/gawk gawk 'NR>1 {split($1,a,"/"); printf "%s/%s %s %s\n", a[1], a[2], a[3], a[4]}'`
+	BACKEND_SERVICE_VERSIONS_CMD           = `sudo HAB_LICENSE=accept-no-persist hab svc status | awk 'NR>1 {split($1,a,"/"); printf "%s/%s %s %s\n", a[1], a[2], a[3], a[4]}'`
 	FRONTEND_SERVICE_VERSIONS_CMD          = "sudo chef-automate service-versions"
 )
 

--- a/components/automate-cli/cmd/chef-automate/service_versions.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions.go
@@ -75,7 +75,7 @@ func runServiceVersionsCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
 		nodeOpUtils := &NodeUtilsImpl{}
 		remoteExecutor := NewRemoteCmdExecutorWithoutNodeMap(&SSHUtilImpl{}, cli.NewWriter(os.Stdout, os.Stderr, os.Stdin))
-		if err := isFlagSet(cmd); err != nil {
+		if err := isFlagSet(cmd, &serviceVersionsCmdFlag); err != nil {
 			return err
 		}
 		return runServiceVersionsFromBastion(&serviceVersionsCmdFlag, nodeOpUtils, remoteExecutor, printServiceVersionsOutput)
@@ -273,9 +273,9 @@ func printServiceVersionsErrorOutput(cmdResult *CmdResult, remoteService string,
 	}
 }
 
-func isFlagSet(cmd *cobra.Command) error {
-	if !serviceVersionsCmdFlag.automate && !serviceVersionsCmdFlag.chefServer && !serviceVersionsCmdFlag.opensearch && !serviceVersionsCmdFlag.postgresql {
-		if len(serviceVersionsCmdFlag.node) != 0 {
+func isFlagSet(cmd *cobra.Command, flags *ServiceVersionsCmdFlags) error {
+	if !flags.automate && !flags.chefServer && !flags.opensearch && !flags.postgresql {
+		if len(flags.node) != 0 {
 			return status.Errorf(status.InvalidCommandArgsError, "Please provide service flag")
 		}
 		writer.Println(cmd.UsageString())

--- a/components/automate-cli/cmd/chef-automate/service_versions.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions.go
@@ -66,7 +66,7 @@ func init() {
 	serviceVersionsCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
 	serviceVersionsCmd.PersistentFlags().BoolVar(&serviceVersionsCmdFlag.opensearch, "os", false, "Shows service-versions for OpenSearch nodes[DUPLICATE]")
 	serviceVersionsCmd.PersistentFlags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
-	serviceVersionsCmd.PersistentFlags().StringVar(&serviceVersionsCmdFlag.node, "node", "", "Pass this flag to check service-versions of perticular node in the cluster")
+	serviceVersionsCmd.PersistentFlags().StringVar(&serviceVersionsCmdFlag.node, "node", "", "Pass this flag to check service-versions of particular node in the cluster")
 	serviceVersionsCmd.PersistentFlags().SetAnnotation("node", docs.Compatibility, []string{docs.CompatiblewithHA})
 	RootCmd.AddCommand(serviceVersionsCmd)
 }

--- a/components/automate-cli/cmd/chef-automate/service_versions.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED = "Showing the service-versions for externally configured %s is not supported."
-	BACKEND_SERVICE_VERSIONS_CMD           = `sudo HAB_LICENSE=accept-no-persist hab svc status | awk 'NR>1 {split($1,a,"/"); printf "%s/%s %s %s\n", a[1], a[2], a[3], a[4]}'`
+	BACKEND_SERVICE_VERSIONS_CMD           = `sudo HAB_LICENSE=accept-no-persist hab svc status | hab pkg exec core/gawk gawk 'NR>1 {split($1,a,"/"); printf "%s/%s %s %s\n", a[1], a[2], a[3], a[4]}'`
 	FRONTEND_SERVICE_VERSIONS_CMD          = "sudo chef-automate service-versions"
 )
 

--- a/components/automate-cli/cmd/chef-automate/service_versions.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions.go
@@ -4,26 +4,287 @@ package main
 
 import (
 	"context"
+	"os"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 )
 
-var serviceVersionsCmd = &cobra.Command{
-	Use:   "service-versions",
-	Short: "Retrieve the versions of the individual Chef Automate services",
-	Long:  "Retrieve the versions of the individual Chef Automate services",
-	RunE:  runServiceVersionsCmd,
-	Annotations: map[string]string{
-		docs.Tag: docs.FrontEnd,
-	},
+const (
+	SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED = "Showing the service-versions for externally configured %s is not supported."
+	BACKEND_SERVICE_VERSIONS_CMD           = `sudo HAB_LICENSE=accept-no-persist hab svc status | awk 'NR>1 {split($1,a,"/"); printf "%s/%s %s %s\n", a[1], a[2], a[3], a[4]}'`
+	FRONTEND_SERVICE_VERSIONS_CMD          = "sudo chef-automate service-versions"
+)
+
+type ServiceVersionsCmdFlags struct {
+	automate   bool
+	chefServer bool
+	postgresql bool
+	opensearch bool
+	node       string
+}
+
+var serviceVersionsCmdFlag = ServiceVersionsCmdFlags{}
+
+type ServiceVersionsCmdResult struct {
+	cmdResult map[string][]*CmdResult
+	writer    *cli.Writer
+	nodeType  string
+	err       error
+}
+
+func init() {
+	var serviceVersionsCmd = &cobra.Command{
+		Use:   "service-versions",
+		Short: "Retrieve the versions of the individual Chef Automate services",
+		Long:  "Retrieve the versions of the individual Chef Automate services",
+		RunE:  runServiceVersionsCmd,
+		Annotations: map[string]string{
+			docs.Tag: docs.BastionHost,
+		},
+	}
+	serviceVersionsCmd.PersistentFlags().BoolVarP(&serviceVersionsCmdFlag.automate, "automate", "a", false, "Shows service-versions for Automate nodes")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("automate", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVarP(&serviceVersionsCmdFlag.chefServer, "chef_server", "c", false, "Shows service-versions for Chef-server nodes")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("chef_server", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVarP(&serviceVersionsCmdFlag.postgresql, "postgresql", "p", false, "Shows service-versions for PostgresQL nodes")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("postgresql", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVarP(&serviceVersionsCmdFlag.opensearch, "opensearch", "o", false, "Shows service-versions for OpenSearch nodes")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("opensearch", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVar(&serviceVersionsCmdFlag.automate, "a2", false, "Shows service-versions for Automate nodes[DUPLICATE]")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("a2", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVar(&serviceVersionsCmdFlag.chefServer, "cs", false, "Shows service-versions for Chef-server nodes[DUPLICATE]")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("cs", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVar(&serviceVersionsCmdFlag.postgresql, "pg", false, "Shows service-versions for PostgresQL nodes[DUPLICATE]")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("pg", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().BoolVar(&serviceVersionsCmdFlag.opensearch, "os", false, "Shows service-versions for OpenSearch nodes[DUPLICATE]")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
+	serviceVersionsCmd.PersistentFlags().StringVar(&serviceVersionsCmdFlag.node, "node", "", "Pass this flag to check service-versions of perticular node in the cluster")
+	serviceVersionsCmd.PersistentFlags().SetAnnotation("node", docs.Compatibility, []string{docs.CompatiblewithHA})
+	RootCmd.AddCommand(serviceVersionsCmd)
 }
 
 func runServiceVersionsCmd(cmd *cobra.Command, args []string) error {
+	if isA2HARBFileExist() {
+		nodeOpUtils := &NodeUtilsImpl{}
+		remoteExecutor := NewRemoteCmdExecutorWithoutNodeMap(&SSHUtilImpl{}, cli.NewWriter(os.Stdout, os.Stderr, os.Stdin))
+		if err := isFlagSet(cmd); err != nil {
+			return err
+		}
+		return runServiceVersionsFromBastion(&serviceVersionsCmdFlag, nodeOpUtils, remoteExecutor, printServiceVersionsOutput)
+	}
+	if err := runServiceVersionsOnStandalone(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func runServiceVersionsFromBastion(flags *ServiceVersionsCmdFlags, nodeOpUtils NodeOpUtils, remoteExe RemoteCmdExecutor, printServiceVersionsOutput func(map[string][]*CmdResult, string, *cli.Writer)) error {
+
+	infra, _, err := nodeOpUtils.getHaInfraDetails()
+	if err != nil {
+		return err
+	}
+	serviceVersionsCmdResults := make(chan ServiceVersionsCmdResult, 4)
+
+	runServiceVersionsCmdForFrontEnd(flags, infra, serviceVersionsCmdResults, remoteExe)
+
+	if nodeOpUtils.isManagedServicesOn() {
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+		err = getValueFromResultChannel(serviceVersionsCmdResults, printServiceVersionsOutput)
+		if err != nil {
+			return err
+		}
+		return handleManagedServiceErrorForServiceVersionsCmd(flags)
+	}
+
+	runServiceVersionsCmdForBackend(flags, infra, serviceVersionsCmdResults, remoteExe)
+
+	return getValueFromResultChannel(serviceVersionsCmdResults, printServiceVersionsOutput)
+}
+
+func runServiceVersionsCmdForFrontEnd(flags *ServiceVersionsCmdFlags, infra *AutomateHAInfraDetails, serviceVersionsCmdResults chan ServiceVersionsCmdResult, remoteExe RemoteCmdExecutor) {
+
+	if flags.automate {
+		go nodeServiceVersions(*flags, AUTOMATE, infra, serviceVersionsCmdResults, remoteExe)
+	} else {
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+	}
+	if flags.chefServer {
+		flags.automate = false
+		go nodeServiceVersions(*flags, CHEF_SERVER, infra, serviceVersionsCmdResults, remoteExe)
+	} else {
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+	}
+}
+func getValueFromResultChannel(serviceVersionsCmdResults chan ServiceVersionsCmdResult, printServiceVersionsOutput func(map[string][]*CmdResult, string, *cli.Writer)) error {
+	for i := 0; i < 4; i++ {
+		cmdResult := <-serviceVersionsCmdResults
+		if cmdResult.err != nil {
+			return cmdResult.err
+		} else {
+			if cmdResult.writer != nil {
+				printServiceVersionsOutput(cmdResult.cmdResult, cmdResult.nodeType, cmdResult.writer)
+			}
+		}
+	}
+	return nil
+}
+
+func handleManagedServiceErrorForServiceVersionsCmd(flags *ServiceVersionsCmdFlags) error {
+
+	if flags.postgresql && flags.opensearch {
+		return status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL+" and "+OPENSEARCH)
+	}
+
+	if flags.postgresql {
+		return status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL)
+	}
+
+	if flags.opensearch {
+		return status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, OPENSEARCH)
+	}
+
+	return nil
+}
+func runServiceVersionsCmdForBackend(flags *ServiceVersionsCmdFlags, infra *AutomateHAInfraDetails, serviceVersionsCmdResults chan ServiceVersionsCmdResult, remoteExe RemoteCmdExecutor) {
+
+	if flags.postgresql {
+		flags.automate = false
+		flags.chefServer = false
+		go nodeServiceVersions(*flags, POSTGRESQL, infra, serviceVersionsCmdResults, remoteExe)
+	} else {
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+	}
+
+	if flags.opensearch {
+		flags.automate = false
+		flags.chefServer = false
+		flags.postgresql = false
+		go nodeServiceVersions(*flags, OPENSEARCH, infra, serviceVersionsCmdResults, remoteExe)
+	} else {
+		serviceVersionsCmdResults <- ServiceVersionsCmdResult{}
+	}
+
+}
+
+func nodeServiceVersions(flags ServiceVersionsCmdFlags, nodeType string, infra *AutomateHAInfraDetails, serviceVersionsCmdResults chan ServiceVersionsCmdResult, remoteExe RemoteCmdExecutor) {
+	writer := cli.NewWriter(os.Stdout, os.Stderr, os.Stdin)
+	remoteExe.SetWriter(writer)
+	nodeMap := constructNodeMapForServiceVersions(infra, &flags)
+	cmdResult, err := remoteExe.ExecuteWithNodeMap(nodeMap)
+	serviceVersionsCmdResults <- ServiceVersionsCmdResult{
+		cmdResult: cmdResult,
+		writer:    writer,
+		nodeType:  nodeType,
+		err:       err,
+	}
+}
+
+func constructNodeMapForServiceVersions(infra *AutomateHAInfraDetails, flags *ServiceVersionsCmdFlags) *NodeTypeAndCmd {
+	nodeMap := &NodeTypeAndCmd{
+		Frontend: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Automate: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+				ErrorCheckEnableInOutput: true,
+				NodeIps:                  []string{flags.node},
+				NodeType:                 flags.automate,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		ChefServer: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+				ErrorCheckEnableInOutput: true,
+				NodeIps:                  []string{flags.node},
+				NodeType:                 flags.chefServer,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Postgresql: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+				NodeIps:                  []string{flags.node},
+				ErrorCheckEnableInOutput: true,
+				NodeType:                 flags.postgresql,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Opensearch: &Cmd{
+			CmdInputs: &CmdInputs{
+				Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+				NodeIps:                  []string{flags.node},
+				ErrorCheckEnableInOutput: true,
+				NodeType:                 flags.opensearch,
+				SkipPrintOutput:          true,
+				HideSSHConnectionMessage: true,
+			},
+		},
+		Infra: infra,
+	}
+	return nodeMap
+}
+
+func printServiceVersionsOutput(cmdResult map[string][]*CmdResult, remoteService string, writer *cli.Writer) {
+	writer.Printf("\n=====================================================%s =======================================================\n", " Service-Versions on "+remoteService)
+
+	for _, value := range cmdResult {
+		for _, cmdResult := range value {
+			if cmdResult.Error != nil {
+				printServiceVersionsErrorOutput(cmdResult, remoteService, writer)
+			} else {
+				writer.Printf("Output for Host IP %s : \n%s", cmdResult.HostIP, cmdResult.Output+"\n")
+				writer.Success("Command is executed on " + remoteService + " node : " + cmdResult.HostIP + "\n")
+			}
+			writer.BufferWriter().Flush()
+		}
+	}
+}
+
+func printServiceVersionsErrorOutput(cmdResult *CmdResult, remoteService string, writer *cli.Writer) {
+	isOutputError := false
+
+	if strings.Contains(cmdResult.Output, "DeploymentServiceUnreachableError") {
+		isOutputError = true
+		writer.Failf(CMD_FAIL_MSG, remoteService, cmdResult.HostIP, cmdResult.Output)
+	}
+
+	if !isOutputError {
+		writer.Failf(CMD_FAIL_MSG, remoteService, cmdResult.HostIP, cmdResult.Error.Error())
+	}
+}
+
+func isFlagSet(cmd *cobra.Command) error {
+	if !serviceVersionsCmdFlag.automate && !serviceVersionsCmdFlag.chefServer && !serviceVersionsCmdFlag.opensearch && !serviceVersionsCmdFlag.postgresql {
+		if len(serviceVersionsCmdFlag.node) != 0 {
+			return status.Errorf(status.InvalidCommandArgsError, "Please provide service flag")
+		}
+		writer.Println(cmd.UsageString())
+		return errors.New("No flag is enabled. Please provide any flag")
+	}
+	return nil
+}
+
+func runServiceVersionsOnStandalone() error {
 	connection, err := client.Connection(client.DefaultClientTimeout)
 	if err != nil {
 		return err
@@ -40,10 +301,5 @@ func runServiceVersionsCmd(cmd *cobra.Command, args []string) error {
 	for _, s := range response.Services {
 		writer.Printf("%s/%s %s %s\n", s.Origin, s.Name, s.Version, s.Release)
 	}
-
 	return nil
-}
-
-func init() {
-	RootCmd.AddCommand(serviceVersionsCmd)
 }

--- a/components/automate-cli/cmd/chef-automate/service_versions_test.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions_test.go
@@ -346,39 +346,34 @@ func TestRunServiceVersionsCmd(t *testing.T) {
 func TestIsFalgSet(t *testing.T) {
 
 	testCases := []struct {
-		isForAutomate   bool
-		isForChefServer bool
-		isForPG         bool
-		isForOS         bool
-		node            string
-		errorExepected  error
+		flags          *ServiceVersionsCmdFlags
+		errorExepected error
 	}{
 		{
+			flags:          &ServiceVersionsCmdFlags{},
 			errorExepected: errors.New("No flag is enabled. Please provide any flag"),
 		},
 		{
-			node: "12",
-
+			flags: &ServiceVersionsCmdFlags{
+				node: "12",
+			},
 			errorExepected: status.Errorf(status.InvalidCommandArgsError, "Please provide service flag"),
 		},
 		{
 
-			node:           "12",
-			isForAutomate:  true,
+			flags: &ServiceVersionsCmdFlags{
+				node:     "12",
+				automate: true,
+			},
 			errorExepected: nil,
 		},
 	}
 
-	for _, testCase := range testCases {
-		serviceVersionsCmdFlag.automate = testCase.isForAutomate
-		serviceVersionsCmdFlag.chefServer = testCase.isForChefServer
-		serviceVersionsCmdFlag.opensearch = testCase.isForOS
-		serviceVersionsCmdFlag.postgresql = testCase.isForPG
-		serviceVersionsCmdFlag.node = testCase.node
-		err := isFlagSet(&cobra.Command{})
+	for _, testCases := range testCases {
+		err := isFlagSet(&cobra.Command{}, testCases.flags)
 
-		if testCase.errorExepected != nil {
-			assert.EqualError(t, err, testCase.errorExepected.Error())
+		if testCases.errorExepected != nil {
+			assert.EqualError(t, err, testCases.errorExepected.Error())
 		} else {
 			assert.Nil(t, err)
 		}

--- a/components/automate-cli/cmd/chef-automate/service_versions_test.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions_test.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunServiceVersionsFromBastion(t *testing.T) {
+	type testCase struct {
+		description       string
+		flags             *ServiceVersionsCmdFlags
+		mockNodeOpUtils   *MockNodeUtilsImpl
+		mockRemoteCmdExec *MockRemoteCmdExecutor
+		errorWant         error
+	}
+
+	printServiceVersionsOutput := func(m map[string][]*CmdResult, s string, w *cli.Writer) {}
+	testCases := []testCase{
+
+		{
+			description: "Error while reading infra details",
+			flags:       &ServiceVersionsCmdFlags{},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return nil, nil, errors.New("Error occured while reading infra details")
+				},
+			},
+			errorWant: errors.New("Error occured while reading infra details"),
+		},
+		{
+			description: "Want service-versions of all services",
+			flags: &ServiceVersionsCmdFlags{
+				automate:   true,
+				chefServer: true,
+				opensearch: true,
+				postgresql: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
+		{
+			description: "Want service_versions of backend services",
+			flags: &ServiceVersionsCmdFlags{
+				automate:   false,
+				chefServer: false,
+				opensearch: true,
+				postgresql: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
+		{
+			description: "Want service_versions of frontend services",
+			flags: &ServiceVersionsCmdFlags{
+				automate:   true,
+				chefServer: true,
+				opensearch: false,
+				postgresql: false,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
+		{
+			description: "Want service-versions of all services but error occured while remote execution",
+			flags: &ServiceVersionsCmdFlags{
+				automate:   true,
+				chefServer: true,
+				opensearch: true,
+				postgresql: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, errors.New("Some error occured while remote execution")
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: errors.New("Some error occured while remote execution"),
+		},
+		{
+			description: "Managed services and pg flag provided",
+
+			flags: &ServiceVersionsCmdFlags{
+				postgresql: true,
+			},
+
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return true
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL),
+		},
+		{
+			description: "Want service-versions of all services but error occured while remote execution",
+			flags: &ServiceVersionsCmdFlags{
+				automate: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return true
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					cmdResultWithError := &CmdResult{
+						ScriptName: "script_1",
+						HostIP:     "192.168.1.1",
+						Error:      errors.New("Error occurred"),
+					}
+					return map[string][]*CmdResult{
+						"1": {cmdResultWithError},
+					}, errors.New("Some error occured while remote execution")
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: errors.New("Some error occured while remote execution"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			err := runServiceVersionsFromBastion(testCase.flags, testCase.mockNodeOpUtils, testCase.mockRemoteCmdExec, printServiceVersionsOutput)
+			if err != nil {
+				assert.EqualError(t, testCase.errorWant, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestHandleManagedServiceForServiceVersionCmd(t *testing.T) {
+
+	testCases := []struct {
+		flags          *ServiceVersionsCmdFlags
+		errorExepected error
+	}{
+		{
+			flags: &ServiceVersionsCmdFlags{
+
+				postgresql: true,
+			},
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL),
+		},
+		{
+			flags: &ServiceVersionsCmdFlags{
+
+				opensearch: true,
+			},
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, OPENSEARCH),
+		},
+		{
+			flags: &ServiceVersionsCmdFlags{},
+
+			errorExepected: nil,
+		},
+		{
+			flags: &ServiceVersionsCmdFlags{
+				opensearch: true,
+				postgresql: true,
+			},
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL+" and "+OPENSEARCH),
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := handleManagedServiceErrorForServiceVersionsCmd(testCase.flags)
+
+		if testCase.errorExepected != nil {
+			assert.EqualError(t, err, testCase.errorExepected.Error())
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+}
+
+func TestConstructNodeMapForServiceVersions(t *testing.T) {
+	type testCase struct {
+		flags           *ServiceVersionsCmdFlags
+		nodeMapExpected *NodeTypeAndCmd
+	}
+	infra := &AutomateHAInfraDetails{}
+
+	testCases := []testCase{
+		{
+			flags: &ServiceVersionsCmdFlags{
+				automate:   true,
+				chefServer: true,
+			},
+			nodeMapExpected: &NodeTypeAndCmd{
+				Frontend: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Automate: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+						ErrorCheckEnableInOutput: true,
+						NodeIps:                  []string{""},
+						NodeType:                 true,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				ChefServer: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      FRONTEND_SERVICE_VERSIONS_CMD,
+						ErrorCheckEnableInOutput: true,
+						NodeIps:                  []string{""},
+						NodeType:                 true,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Postgresql: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+						NodeIps:                  []string{""},
+						ErrorCheckEnableInOutput: true,
+						NodeType:                 false,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Opensearch: &Cmd{
+					CmdInputs: &CmdInputs{
+						Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+						NodeIps:                  []string{""},
+						ErrorCheckEnableInOutput: true,
+						NodeType:                 false,
+						SkipPrintOutput:          true,
+						HideSSHConnectionMessage: true,
+					},
+				},
+				Infra: infra,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		nodeMapGet := constructNodeMapForServiceVersions(infra, testCase.flags)
+		assert.Equal(t, testCase.nodeMapExpected, nodeMapGet)
+	}
+}
+
+func TestRunServiceVersionsCmd(t *testing.T) {
+	tests := []struct {
+		testName        string
+		isHA            bool
+		isDevMode       bool
+		isStandalone    bool
+		isExpectedError bool
+		errorMessage    string
+		mockNodeOpUtils *MockNodeUtilsImpl
+	}{
+		{
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				isA2HARBFileExistFunc: func() bool {
+					return true
+				},
+			},
+			isExpectedError: true,
+			errorMessage:    "Failed to read deployment-service TLS certificates: Could not read the service cert: open /hab/svc/deployment-service/data/deployment-service.crt: no such file or directory",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			err := runServiceVersionsCmd(&cobra.Command{}, []string{})
+			if tc.isExpectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsFalgSet(t *testing.T) {
+
+	testCases := []struct {
+		isForAutomate   bool
+		isForChefServer bool
+		isForPG         bool
+		isForOS         bool
+		node            string
+		errorExepected  error
+	}{
+		{
+			errorExepected: errors.New("No flag is enabled. Please provide any flag"),
+		},
+		{
+			node: "12",
+
+			errorExepected: status.Errorf(status.InvalidCommandArgsError, "Please provide service flag"),
+		},
+		{
+
+			node:           "12",
+			isForAutomate:  true,
+			errorExepected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		serviceVersionsCmdFlag.automate = testCase.isForAutomate
+		serviceVersionsCmdFlag.chefServer = testCase.isForChefServer
+		serviceVersionsCmdFlag.opensearch = testCase.isForOS
+		serviceVersionsCmdFlag.postgresql = testCase.isForPG
+		serviceVersionsCmdFlag.node = testCase.node
+		err := isFlagSet(&cobra.Command{})
+
+		if testCase.errorExepected != nil {
+			assert.EqualError(t, err, testCase.errorExepected.Error())
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/service_versions_test.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions_test.go
@@ -346,12 +346,21 @@ func TestRunServiceVersionsCmd(t *testing.T) {
 func TestIsFalgSet(t *testing.T) {
 
 	testCases := []struct {
-		flags          *ServiceVersionsCmdFlags
-		errorExepected error
+		flags           *ServiceVersionsCmdFlags
+		mockNodeOpUtils *MockNodeUtilsImpl
+		errorExepected  error
 	}{
 		{
-			flags:          &ServiceVersionsCmdFlags{},
-			errorExepected: errors.New("No flag is enabled. Please provide any flag"),
+			flags: &ServiceVersionsCmdFlags{},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			errorExepected: nil,
 		},
 		{
 			flags: &ServiceVersionsCmdFlags{
@@ -370,7 +379,7 @@ func TestIsFalgSet(t *testing.T) {
 	}
 
 	for _, testCases := range testCases {
-		err := isFlagSet(&cobra.Command{}, testCases.flags)
+		err := isServiceVersionsFlagSet(&cobra.Command{}, testCases.flags, testCases.mockNodeOpUtils)
 
 		if testCases.errorExepected != nil {
 			assert.EqualError(t, err, testCases.errorExepected.Error())

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_service-versions.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_service-versions.yaml
@@ -5,10 +5,50 @@ usage: chef-automate service-versions [flags]
 description: |
   Retrieve the versions of the individual Chef Automate services
 options:
+- name: a2
+  default_value: "false"
+  usage: Shows service-versions for Automate nodes[DUPLICATE]
+  compatible_with_options: AutomateHA
+- name: automate
+  shorthand: a
+  default_value: "false"
+  usage: Shows service-versions for Automate nodes
+  compatible_with_options: AutomateHA
+- name: chef_server
+  shorthand: c
+  default_value: "false"
+  usage: Shows service-versions for Chef-server nodes
+  compatible_with_options: AutomateHA
+- name: cs
+  default_value: "false"
+  usage: Shows service-versions for Chef-server nodes[DUPLICATE]
+  compatible_with_options: AutomateHA
 - name: help
   shorthand: h
   default_value: "false"
   usage: help for service-versions
+- name: node
+  usage: |
+    Pass this flag to check service-versions of particular node in the cluster
+  compatible_with_options: AutomateHA
+- name: opensearch
+  shorthand: o
+  default_value: "false"
+  usage: Shows service-versions for OpenSearch nodes
+  compatible_with_options: AutomateHA
+- name: os
+  default_value: "false"
+  usage: Shows service-versions for OpenSearch nodes[DUPLICATE]
+  compatible_with_options: AutomateHA
+- name: pg
+  default_value: "false"
+  usage: Shows service-versions for PostgresQL nodes[DUPLICATE]
+  compatible_with_options: AutomateHA
+- name: postgresql
+  shorthand: p
+  default_value: "false"
+  usage: Shows service-versions for PostgresQL nodes
+  compatible_with_options: AutomateHA
 inherited_options:
 - name: debug
   shorthand: d
@@ -21,4 +61,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate - Chef Automate CLI
-supported_on: FrontEnd
+supported_on: Bastion

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_service-versions.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_service-versions.yaml
@@ -42,12 +42,12 @@ options:
   compatible_with_options: AutomateHA
 - name: pg
   default_value: "false"
-  usage: Shows service-versions for PostgresQL nodes[DUPLICATE]
+  usage: Shows service-versions for Postgresql nodes[DUPLICATE]
   compatible_with_options: AutomateHA
 - name: postgresql
   shorthand: p
   default_value: "false"
-  usage: Shows service-versions for PostgresQL nodes
+  usage: Shows service-versions for Postgresql nodes
   compatible_with_options: AutomateHA
 inherited_options:
 - name: debug


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added service-versions command for HA which can be run from bastion node to get the service-versions of automate, chef_server, postgresql, opensearch.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-716
### :+1: Definition of Done
- Added service-versions command for particular node
- Added service-versions command for all the services(automate, chef server, Postgresql,opensearch)
- Added service-versions command for either of the nodes.

### :athletic_shoe: How to Build and Test the Change
`build components/automate-cli`
Run command from the Bastion:
`chef-automate service-versions --a2`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

AWS Managed Services
https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/Ee0VB2kj9eROjdvQuN8eKOQBA_Pz-UXBkKxOQ6CAmoNzSQ?e=nUpaMW

AWS Chef Managed
https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EStj8_ZRBblDvwxXaok0VsQB7ZMM2v3Nx8T-VhFeK_JobA?e=Ovcnlf

OnPrem Chef Managed
https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/ETah5Bj1xH9HutY6BWnLFckBOQl2aSiu44lXraciedi9SA?e=nlNPKs