### PR TITLE
Application Command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/applications.go
+++ b/components/automate-cli/cmd/chef-automate/applications.go
@@ -514,7 +514,7 @@ func (s *serviceSet) PrintTSV() error {
 		len(s.statusLabelFor(svc)),
 	)
 
-	fmt.Fprintf(os.Stderr, fmtString, "id", "svc.group", "release", "FQDN", "app:env", "status")
+	fmt.Printf(fmtString, "id", "svc.group", "release", "FQDN", "app:env", "status")
 	for _, svc := range s.services {
 		fmt.Printf("%s\t%s\t%s\t%s\t%s:%s\t%s\n",
 			svc.Id,

--- a/components/automate-cli/cmd/chef-automate/applications.go
+++ b/components/automate-cli/cmd/chef-automate/applications.go
@@ -24,7 +24,7 @@ const (
 
 type IExecutor interface {
 	execCommand(string) (string, error)
-	RunCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error)
+	runCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error)
 }
 
 type Executor struct{}
@@ -89,74 +89,74 @@ func (a applicationsServiceFilters) FilterApplied() bool {
 	return false
 }
 
-var ApplicationsServiceFiltersFlags = applicationsServiceFilters{}
+var applicationsServiceFiltersFlags = applicationsServiceFilters{}
 
 func addFilteringFlagsToCmd(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(
-		&ApplicationsServiceFiltersFlags.disconnected,
+		&applicationsServiceFiltersFlags.disconnected,
 		"disconnected",
 		"D",
 		false,
 		"Select only services that are disconnected",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.origin,
+		&applicationsServiceFiltersFlags.origin,
 		"origin",
 		"o",
 		"",
 		"Select only services where the origin matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.serviceName,
+		&applicationsServiceFiltersFlags.serviceName,
 		"service-name",
 		"n",
 		"",
 		"Select only services where the name matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.version,
+		&applicationsServiceFiltersFlags.version,
 		"version",
 		"v",
 		"",
 		"Select only services where the package version matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.channel,
+		&applicationsServiceFiltersFlags.channel,
 		"channel",
 		"c",
 		"",
 		"Select only services where the subscribed channel matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.application,
+		&applicationsServiceFiltersFlags.application,
 		"application",
 		"a",
 		"",
 		"Select only services where the application name matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.environment,
+		&applicationsServiceFiltersFlags.environment,
 		"environment",
 		"e",
 		"",
 		"Select only services where the application environment matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.site,
+		&applicationsServiceFiltersFlags.site,
 		"site",
 		"s",
 		"",
 		"Select only services where the site matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.buildTimestamp,
+		&applicationsServiceFiltersFlags.buildTimestamp,
 		"buildstamp",
 		"b",
 		"",
 		"Select only services where the buildstamp matches the given pattern",
 	)
 	cmd.PersistentFlags().StringVarP(
-		&ApplicationsServiceFiltersFlags.groupName,
+		&applicationsServiceFiltersFlags.groupName,
 		"group",
 		"g",
 		"",
@@ -186,7 +186,7 @@ type removeSvcsOptions struct {
 	yes bool
 }
 
-var RemoveSvcsFlags = removeSvcsOptions{}
+var removeSvcsFlags = removeSvcsOptions{}
 
 func newApplicationsRemoveSvcsCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -210,14 +210,14 @@ services database.
 	addFilteringFlagsToCmd(c)
 
 	c.PersistentFlags().BoolVar(
-		&RemoveSvcsFlags.all,
+		&removeSvcsFlags.all,
 		"all",
 		false,
 		"Delete all services in the database. This flag must be given if no other filter is given.",
 	)
 
 	c.PersistentFlags().BoolVarP(
-		&RemoveSvcsFlags.yes,
+		&removeSvcsFlags.yes,
 		"yes",
 		"y",
 		false,
@@ -230,7 +230,7 @@ services database.
 func makeServicesReqWithFilters() *applications.ServicesReq {
 	req := &applications.ServicesReq{}
 
-	flags := ApplicationsServiceFiltersFlags
+	flags := applicationsServiceFiltersFlags
 
 	// disconnected   bool
 	if flags.disconnected {
@@ -276,8 +276,8 @@ func makeServicesReqWithFilters() *applications.ServicesReq {
 	return req
 }
 
-func ShowApplicationsHA(cmd *cobra.Command, args []string, e IExecutor) error {
-	output, err := e.RunCommandOnSingleAutomateNode(cmd, args)
+func showApplicationsHA(cmd *cobra.Command, args []string, e IExecutor) error {
+	output, err := e.runCommandOnSingleAutomateNode(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -285,9 +285,9 @@ func ShowApplicationsHA(cmd *cobra.Command, args []string, e IExecutor) error {
 	return nil
 }
 
-func ShowApplicationsStandalone() error {
+func showApplicationsStandalone() error {
 	s := &serviceSet{
-		applicationsServiceFilters: ApplicationsServiceFiltersFlags,
+		applicationsServiceFilters: applicationsServiceFiltersFlags,
 	}
 	err := s.Connect()
 	if err != nil {
@@ -306,11 +306,11 @@ func ShowApplicationsStandalone() error {
 
 func runApplicationsShowSvcsCmd(cmd *cobra.Command, args []string) error {
 	if isA2HARBFileExist() {
-		if err := ShowApplicationsHA(cmd, args, Executor{}); err != nil {
+		if err := showApplicationsHA(cmd, args, Executor{}); err != nil {
 			return err
 		}
 	} else {
-		if err := ShowApplicationsStandalone(); err != nil {
+		if err := showApplicationsStandalone(); err != nil {
 			return err
 		}
 	}
@@ -345,11 +345,11 @@ func showAndPrompt(cmd *cobra.Command, e IExecutor, w *cli.Writer) ([]string, bo
 	return splittedString, true, nil
 }
 
-func RemoveApplicationsHA(cmd *cobra.Command, args []string, e IExecutor, w *cli.Writer) error {
+func removeApplicationsHA(cmd *cobra.Command, args []string, e IExecutor, w *cli.Writer) error {
 	var splittedString []string
 	// If user is not passing -y flag, then first we need to show the list with given conditions and then
 	// give confirmation prompt
-	if !RemoveSvcsFlags.yes {
+	if !removeSvcsFlags.yes {
 		var proceed bool
 		var err error
 		splittedString, proceed, err = showAndPrompt(cmd, e, w)
@@ -361,13 +361,13 @@ func RemoveApplicationsHA(cmd *cobra.Command, args []string, e IExecutor, w *cli
 		}
 	}
 	args = append(args, "-y")
-	output, err := e.RunCommandOnSingleAutomateNode(cmd, args)
+	output, err := e.runCommandOnSingleAutomateNode(cmd, args)
 	if err != nil {
 		return err
 	}
 	// len(splittedString) == 2 means list is empty it's just containing table header and empty line which means we haven't
 	// got any services to remove
-	if RemoveSvcsFlags.yes || len(splittedString) == 2 {
+	if removeSvcsFlags.yes || len(splittedString) == 2 {
 		writer.Println(output)
 	} else {
 		writer.Println(fmt.Sprintf("Removed %d services", len(splittedString)-2))
@@ -376,9 +376,9 @@ func RemoveApplicationsHA(cmd *cobra.Command, args []string, e IExecutor, w *cli
 	return nil
 }
 
-func RemoveApplicationsStandalone() error {
+func removeApplicationsStandalone() error {
 	s := &serviceSet{
-		applicationsServiceFilters: ApplicationsServiceFiltersFlags,
+		applicationsServiceFilters: applicationsServiceFiltersFlags,
 	}
 	err := s.Connect()
 	if err != nil {
@@ -399,7 +399,7 @@ func RemoveApplicationsStandalone() error {
 		return err
 	}
 
-	if !RemoveSvcsFlags.yes {
+	if !removeSvcsFlags.yes {
 		fmt.Println("")
 		prompt := fmt.Sprintf("The above %d services will be deleted. Do you wish to continue?", len(s.services))
 		proceed, err := writer.Confirm(prompt)
@@ -419,15 +419,15 @@ func RemoveApplicationsStandalone() error {
 }
 
 func runApplicationsRemoveSvcsCmd(cmd *cobra.Command, args []string) error {
-	if !ApplicationsServiceFiltersFlags.FilterApplied() && !RemoveSvcsFlags.all {
+	if !applicationsServiceFiltersFlags.FilterApplied() && !removeSvcsFlags.all {
 		return errors.New("You must filter the services to be deleted or pass the --all flag to delete all services")
 	}
 	if isA2HARBFileExist() {
-		if err := RemoveApplicationsHA(cmd, args, Executor{}, writer); err != nil {
+		if err := removeApplicationsHA(cmd, args, Executor{}, writer); err != nil {
 			return err
 		}
 	} else {
-		if err := RemoveApplicationsStandalone(); err != nil {
+		if err := removeApplicationsStandalone(); err != nil {
 			return err
 		}
 	}
@@ -450,7 +450,7 @@ func (e Executor) execCommand(cmd string) (string, error) {
 	return string(output), nil
 }
 
-func (e Executor) RunCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error) {
+func (e Executor) runCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error) {
 	return RunCmdOnSingleAutomateNode(cmd, args)
 }
 

--- a/components/automate-cli/cmd/chef-automate/applications.go
+++ b/components/automate-cli/cmd/chef-automate/applications.go
@@ -43,7 +43,7 @@ func newApplicationsRootSubcmd() *cobra.Command {
 		Use:   "applications COMMAND",
 		Short: "Manage applications observability features",
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 }
@@ -173,7 +173,7 @@ Display a list of the habitat services stored in the applications database.
 `,
 		RunE: runApplicationsShowSvcsCmd,
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 
@@ -203,7 +203,7 @@ services database.
 `,
 		RunE: runApplicationsRemoveSvcsCmd,
 		Annotations: map[string]string{
-			docs.Tag: docs.Automate,
+			docs.Tag: docs.BastionHost,
 		},
 	}
 

--- a/components/automate-cli/cmd/chef-automate/applications_test.go
+++ b/components/automate-cli/cmd/chef-automate/applications_test.go
@@ -2,12 +2,32 @@ package main
 
 import (
 	"errors"
+	"os"
+	"runtime"
 	"testing"
 
+	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/chef/automate/lib/majorupgrade_utils"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
+type MockExecutor struct{}
+
+func (me MockExecutor) execCommand(cmd string) (string, error) {
+	return `id   	svc.group    	release                         	FQDN                                       	app:env            	status
+37035	redis.default	core/redis/4.0.14/20220311173537	ip-172-31-41-174.eu-west-3.compute.internal	DummyApp:acceptance	OK
+37033	nginx.default	core/nginx/1.21.4/20220311143833	ip-172-31-41-174.eu-west-3.compute.internal	DummyApp:acceptance	OK
+37034	postgresql94.default	core/postgresql94/9.4.26/20220311203133	ip-172-31-41-174.eu-west-3.compute.internal	DummyApp:acceptance	OK
+`, nil
+}
+
+func (me MockExecutor) RunCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error) {
+	return "", nil
+}
+
 func TestExecCommand(t *testing.T) {
+	e := Executor{}
 	tests := []struct {
 		TestName       string
 		Input          string
@@ -17,15 +37,245 @@ func TestExecCommand(t *testing.T) {
 		{"Valid Command", "echo Hello", "Hello\n", nil},
 		{"Invalid Command", "ech Hello", "", errors.New("")},
 	}
-	for _, e := range tests {
-		t.Run(e.TestName, func(t *testing.T) {
-			output, err := execCommand(e.Input)
-			if e.ExpectedError != nil {
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			output, err := e.execCommand(tt.Input)
+			if tt.ExpectedError != nil {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, e.ExpectedOutput, output)
+				assert.Equal(t, tt.ExpectedOutput, output)
 			}
 		})
 	}
+}
+
+func TestRemoveApplicationsHA(t *testing.T) {
+	mockExec := MockExecutor{}
+	actualExec := Executor{}
+	cmd := &cobra.Command{}
+	args := []string{}
+	YesMockWriter := majorupgrade_utils.NewCustomWriterWithInputs("y")
+	NoMockWriter := majorupgrade_utils.NewCustomWriterWithInputs("n")
+	tests := []struct {
+		TestName               string
+		Executor               IExecutor
+		CliWriter              *cli.Writer
+		AutoApproveFlagEnabled bool
+		ExpectedError          error
+	}{
+		{
+			TestName:               "used -y flag while running the command and everything works fine",
+			Executor:               mockExec,
+			CliWriter:              YesMockWriter.CliWriter,
+			AutoApproveFlagEnabled: true,
+			ExpectedError:          nil,
+		},
+		{
+			TestName:               "not used -y flag and mocked show command returned list of services and user entered 'y' for confirmation prompt to remove",
+			Executor:               mockExec,
+			CliWriter:              YesMockWriter.CliWriter,
+			AutoApproveFlagEnabled: false,
+			ExpectedError:          nil,
+		},
+		{
+			TestName:               "not used -y flag and but show command failed to run",
+			Executor:               actualExec,
+			CliWriter:              YesMockWriter.CliWriter,
+			AutoApproveFlagEnabled: false,
+			ExpectedError:          errors.New(""),
+		},
+		{
+			TestName:               "not used -y flag, mocked show command returned list of services but user entered 'n' for confirmation prompt to remove",
+			Executor:               mockExec,
+			CliWriter:              NoMockWriter.CliWriter,
+			AutoApproveFlagEnabled: false,
+			ExpectedError:          nil,
+		},
+		{
+			TestName:               "not used -y flag, mocked show command returned list of services but writer gave some error",
+			Executor:               mockExec,
+			CliWriter:              writer,
+			AutoApproveFlagEnabled: false,
+			ExpectedError:          errors.New("failed to read user input in confirmation: EOF"),
+		},
+		{
+			TestName:               "used -y flag while running the command but Command running on automate node not successfully ended",
+			Executor:               actualExec,
+			CliWriter:              YesMockWriter.CliWriter,
+			AutoApproveFlagEnabled: true,
+			ExpectedError:          errors.New("Automate Ha infra confile file not exist"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			RemoveSvcsFlags.yes = tt.AutoApproveFlagEnabled
+			err := RemoveApplicationsHA(cmd, args, tt.Executor, tt.CliWriter)
+			if tt.ExpectedError != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.ExpectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunApplicationsRemoveSvcsCmd(t *testing.T) {
+	cmd := &cobra.Command{}
+	args := []string{}
+
+	tests := []struct {
+		TestName       string
+		FilterApplied  bool
+		AllFlagEnabled bool
+		HA             bool
+		ExpectedError  error
+	}{
+		{
+			TestName:       "HA System && Didn't used all or any filter flag",
+			FilterApplied:  false,
+			AllFlagEnabled: false,
+			HA:             true,
+			ExpectedError:  errors.New("You must filter the services to be deleted or pass the --all flag to delete all services"),
+		},
+		{
+			TestName:       "HA System && used all flag",
+			FilterApplied:  false,
+			AllFlagEnabled: true,
+			HA:             true,
+			ExpectedError:  errors.New(""),
+		},
+		{
+			TestName:       "HA System && used some filter flag",
+			FilterApplied:  true,
+			AllFlagEnabled: false,
+			HA:             true,
+			ExpectedError:  errors.New(""),
+		},
+		{
+			TestName:       "Standalone System",
+			FilterApplied:  false,
+			AllFlagEnabled: true,
+			HA:             false,
+			ExpectedError:  errors.New(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			if tt.HA {
+				// In mac we can't create directory at root level, but for this test we need directory at root level.
+				// So we are omitting the test in case of Mac OS.
+				if runtime.GOOS == "darwin" {
+					return
+				}
+				defer os.Remove(MakeHASystem(t).Name())
+			}
+			RemoveSvcsFlags.all = tt.AllFlagEnabled
+			if tt.FilterApplied {
+				ApplicationsServiceFiltersFlags.serviceName = "anything"
+			} else {
+				ApplicationsServiceFiltersFlags.serviceName = ""
+			}
+			err := runApplicationsRemoveSvcsCmd(cmd, args)
+			if tt.ExpectedError != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.ExpectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestShowApplicationsHA(t *testing.T) {
+	mockExec := MockExecutor{}
+	actualExec := Executor{}
+	cmd := &cobra.Command{}
+	args := []string{}
+
+	tests := []struct {
+		TestName      string
+		Executor      IExecutor
+		ExpectedError error
+	}{
+		{
+			TestName:      "Command Ran Successfully",
+			Executor:      mockExec,
+			ExpectedError: nil,
+		},
+		{
+			TestName:      "Command Gave Error ",
+			Executor:      actualExec,
+			ExpectedError: errors.New(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			err := ShowApplicationsHA(cmd, args, tt.Executor)
+			if tt.ExpectedError != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.ExpectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunApplicationsShowSvcsCmd(t *testing.T) {
+	cmd := &cobra.Command{}
+	args := []string{}
+
+	tests := []struct {
+		TestName      string
+		HA            bool
+		ExpectedError error
+	}{
+		{
+			TestName:      "HA System",
+			HA:            true,
+			ExpectedError: errors.New(""),
+		},
+		{
+			TestName:      "Standalone System",
+			HA:            false,
+			ExpectedError: errors.New(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.TestName, func(t *testing.T) {
+			if tt.HA {
+				// In mac we can't create directory at root level, but for this test we need directory at root level.
+				// So we are omitting the test in case of Mac OS.
+				if runtime.GOOS == "darwin" {
+					return
+				}
+				defer os.Remove(MakeHASystem(t).Name())
+			}
+			err := runApplicationsShowSvcsCmd(cmd, args)
+			if tt.ExpectedError != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.ExpectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func MakeHASystem(t *testing.T) *os.File {
+	dirPath := initConfigHabA2HAPathFlag.a2haDirPath
+	filePath := dirPath + "/a2ha.rb"
+
+	err := os.MkdirAll(dirPath, os.ModePerm)
+	assert.NoError(t, err, "Error creating directories")
+
+	file, err := os.Create(filePath)
+	assert.NoError(t, err, "Error creating file")
+	return file
 }

--- a/components/automate-cli/cmd/chef-automate/applications_test.go
+++ b/components/automate-cli/cmd/chef-automate/applications_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecCommand(t *testing.T) {
+	tests := []struct {
+		TestName       string
+		Input          string
+		ExpectedOutput string
+		ExpectedError  error
+	}{
+		{"Valid Command", "echo Hello", "Hello\n", nil},
+		{"Invalid Command", "ech Hello", "", errors.New("")},
+	}
+	for _, e := range tests {
+		t.Run(e.TestName, func(t *testing.T) {
+			output, err := execCommand(e.Input)
+			if e.ExpectedError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, e.ExpectedOutput, output)
+			}
+		})
+	}
+}

--- a/components/automate-cli/cmd/chef-automate/applications_test.go
+++ b/components/automate-cli/cmd/chef-automate/applications_test.go
@@ -21,7 +21,7 @@ func (me MockExecutor) execCommand(cmd string) (string, error) {
 `, nil
 }
 
-func (me MockExecutor) RunCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error) {
+func (me MockExecutor) runCommandOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, error) {
 	return "", nil
 }
 
@@ -109,8 +109,8 @@ func TestRemoveApplicationsHA(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.TestName, func(t *testing.T) {
-			RemoveSvcsFlags.yes = tt.AutoApproveFlagEnabled
-			err := RemoveApplicationsHA(cmd, args, tt.Executor, tt.CliWriter)
+			removeSvcsFlags.yes = tt.AutoApproveFlagEnabled
+			err := removeApplicationsHA(cmd, args, tt.Executor, tt.CliWriter)
 			if tt.ExpectedError != nil {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tt.ExpectedError.Error())
@@ -120,7 +120,7 @@ func TestRemoveApplicationsHA(t *testing.T) {
 		})
 	}
 	// Resetting the Global variable to its default value
-	RemoveSvcsFlags.yes = false
+	removeSvcsFlags.yes = false
 }
 
 func TestRunApplicationsRemoveSvcsCmd(t *testing.T) {
@@ -155,11 +155,11 @@ func TestRunApplicationsRemoveSvcsCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.TestName, func(t *testing.T) {
-			RemoveSvcsFlags.all = tt.AllFlagEnabled
+			removeSvcsFlags.all = tt.AllFlagEnabled
 			if tt.FilterApplied {
-				ApplicationsServiceFiltersFlags.serviceName = "anything"
+				applicationsServiceFiltersFlags.serviceName = "anything"
 			} else {
-				ApplicationsServiceFiltersFlags.serviceName = ""
+				applicationsServiceFiltersFlags.serviceName = ""
 			}
 			err := runApplicationsRemoveSvcsCmd(cmd, args)
 			if tt.ExpectedError != nil {
@@ -172,8 +172,8 @@ func TestRunApplicationsRemoveSvcsCmd(t *testing.T) {
 	}
 
 	// Resetting the Global variable to its default value
-	RemoveSvcsFlags.all = false
-	ApplicationsServiceFiltersFlags.serviceName = ""
+	removeSvcsFlags.all = false
+	applicationsServiceFiltersFlags.serviceName = ""
 }
 
 func TestShowApplicationsHA(t *testing.T) {
@@ -201,7 +201,7 @@ func TestShowApplicationsHA(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.TestName, func(t *testing.T) {
-			err := ShowApplicationsHA(cmd, args, tt.Executor)
+			err := showApplicationsHA(cmd, args, tt.Executor)
 			if tt.ExpectedError != nil {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tt.ExpectedError.Error())
@@ -240,15 +240,15 @@ func TestRunApplicationsShowSvcsCmd(t *testing.T) {
 }
 
 func TestMakeServicesReqWithFilters(t *testing.T) {
-	ApplicationsServiceFiltersFlags.origin = "origin_value"
-	ApplicationsServiceFiltersFlags.serviceName = "servicename_value"
-	ApplicationsServiceFiltersFlags.version = "version_value"
-	ApplicationsServiceFiltersFlags.channel = "channel_value"
-	ApplicationsServiceFiltersFlags.application = "app_value"
-	ApplicationsServiceFiltersFlags.environment = "environment_value"
-	ApplicationsServiceFiltersFlags.site = "site_value"
-	ApplicationsServiceFiltersFlags.buildTimestamp = "timestamp_value"
-	ApplicationsServiceFiltersFlags.groupName = "group_value"
+	applicationsServiceFiltersFlags.origin = "origin_value"
+	applicationsServiceFiltersFlags.serviceName = "servicename_value"
+	applicationsServiceFiltersFlags.version = "version_value"
+	applicationsServiceFiltersFlags.channel = "channel_value"
+	applicationsServiceFiltersFlags.application = "app_value"
+	applicationsServiceFiltersFlags.environment = "environment_value"
+	applicationsServiceFiltersFlags.site = "site_value"
+	applicationsServiceFiltersFlags.buildTimestamp = "timestamp_value"
+	applicationsServiceFiltersFlags.groupName = "group_value"
 	res := makeServicesReqWithFilters()
 	ExpectedResp := &applications.ServicesReq{
 		Filter: []string{
@@ -266,7 +266,7 @@ func TestMakeServicesReqWithFilters(t *testing.T) {
 	assert.Equal(t, ExpectedResp, res)
 
 	// Setting Disconnected Flag
-	ApplicationsServiceFiltersFlags.disconnected = true
+	applicationsServiceFiltersFlags.disconnected = true
 	res = makeServicesReqWithFilters()
 	ExpectedResp = &applications.ServicesReq{
 		Filter: []string{
@@ -285,7 +285,7 @@ func TestMakeServicesReqWithFilters(t *testing.T) {
 	assert.Equal(t, ExpectedResp, res)
 
 	// Resetting the Global variable to its default value
-	ApplicationsServiceFiltersFlags = applicationsServiceFilters{}
+	applicationsServiceFiltersFlags = applicationsServiceFilters{}
 }
 
 func TestPrintTSV(t *testing.T) {

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -53,7 +53,6 @@ func RunCmdOnSingleAutomateNode(cmd *cobra.Command, args []string) (string, erro
 		}
 		return "", err
 	}
-	// writer.Print(output)
 	return output, nil
 }
 

--- a/components/automate-cli/cmd/chef-automate/iam.go
+++ b/components/automate-cli/cmd/chef-automate/iam.go
@@ -292,12 +292,13 @@ func preIAMCmd(cmd *cobra.Command, args []string) error {
 		return status.Wrap(err, status.CommandExecutionError, "unable to set command parent settings")
 	}
 	if isA2HARBFileExist() {
-		err = RunCmdOnSingleAutomateNode(cmd, args)
+		output, err := RunCmdOnSingleAutomateNode(cmd, args)
 		if err != nil {
 			return err
 		}
+		writer.Print(output)
 		// NOTE: used os.exit as need to stop next lifecycle method to execute
-		os.Exit(1)
+		os.Exit(0)
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/infrastructure.go
+++ b/components/automate-cli/cmd/chef-automate/infrastructure.go
@@ -65,10 +65,12 @@ func preInfrastructureCmd(cmd *cobra.Command, args []string) error {
 		return status.Wrap(err, status.CommandExecutionError, "unable to set command parent settings")
 	}
 	if isA2HARBFileExist() {
-		if err = RunCmdOnSingleAutomateNode(cmd, args); err != nil {
+		output, err := RunCmdOnSingleAutomateNode(cmd, args)
+		if err != nil {
 			return err
 		}
-		os.Exit(1)
+		writer.Print(output)
+		os.Exit(0)
 	}
 	return nil
 }

--- a/components/automate-cli/cmd/chef-automate/license.go
+++ b/components/automate-cli/cmd/chef-automate/license.go
@@ -460,12 +460,13 @@ func preLicenseCmd(cmd *cobra.Command, args []string) error {
 		return status.Wrap(err, status.CommandExecutionError, "unable to set command parent settings")
 	}
 	if isA2HARBFileExist() {
-		err = RunCmdOnSingleAutomateNode(cmd, args)
+		output, err := RunCmdOnSingleAutomateNode(cmd, args)
 		if err != nil {
 			return err
 		}
+		writer.Print(output)
 		// NOTE: used os.exit as need to stop next lifecycle method to execute
-		os.Exit(1)
+		os.Exit(0)
 	}
 	return nil
 }
@@ -495,7 +496,7 @@ func getPreLicenseReportCmd(fileNamePrefix string) func(*cobra.Command, []string
 				return err
 			}
 			// NOTE: used os.exit as need to stop next lifecycle method to execute
-			os.Exit(1)
+			os.Exit(0)
 		}
 		return nil
 	}

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications.yaml
@@ -20,4 +20,4 @@ see_also:
 - chef-automate - Chef Automate CLI
 - remove-svcs - Remove services from the applications database
 - show-svcs - Show services in the applications database
-supported_on: Automate
+supported_on: Bastion

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications_remove-svcs.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications_remove-svcs.yaml
@@ -75,4 +75,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate applications - Manage applications observability features
-supported_on: Automate
+supported_on: Bastion

--- a/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications_show-svcs.yaml
+++ b/components/docs-chef-io/data/automate/cli_chef_automate/commands/chef-automate_applications_show-svcs.yaml
@@ -61,4 +61,4 @@ inherited_options:
   usage: Write command result as JSON to PATH
 see_also:
 - chef-automate applications - Manage applications observability features
-supported_on: Automate
+supported_on: Bastion


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added applications command for HA which can be run from bastion node.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-726

### :+1: Definition of Done
Added applications command for HA which can be run from bastion node. 
applications command has 2 subcommands:

`show-svcs`: Show all the services or you can also use some flags to filter out the data
`remove-svcs`: This will remove the services based on the given flags.

### :athletic_shoe: How to Build and Test the Change
Upload some data to Applications tab. 
Install this cli package: `ssanju/automate-cli/0.1.0/20230810092307`
Then you can run applications command. Some of the examples are:

`chef-automate applications show-svcs` (show all the services)
`chef-automate applications show-svcs --service-name nginx` (show service which is having service name as nginx)
`chef-automate applications remove-svcs --service-name nginx` (show service which is having service name as nginx and wait for your confirmation prompt to remove it)
`chef-automate applications remove-svcs --service-name nginx -y` (show service which is having service name as nginx and delete it directly)
`chef-automate applications remove-svcs --all` (show all the services and wait for your confirmation prompt to remove it)
`chef-automate applications remove-svcs --all -y` (show all the services and delete it directly)


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
OnPrem with Chef Managed: https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/EblRNpXqvxVBru913LcUHwoBsZ33tR_k9D73TeRfuuI58Q?e=NuSYCw

AWS with Chef Managed: https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/EbUzLH-QCS5Fuj_BiG27rpABp1oZ1_FHGc7wUc6GIzPqPw?e=0i947t

AWS with AWS Managed: https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/EY7qQ5zxlZdOmDwsCtKTTI0BfN2AZrgQqGEscCP33V-1HA?e=qDN6BN