### PR TITLE
config patch command fix

### DIFF
--- a/components/automate-cli/cmd/chef-automate/config.go
+++ b/components/automate-cli/cmd/chef-automate/config.go
@@ -559,7 +559,7 @@ func runPatchCommand(cmd *cobra.Command, args []string) error {
 		}
 
 		// keep chefserver fqdn same as automate fqdn in case of standalone automate
-		if !checkIfFileExist(automateHaPath) && cfg.Global.V1.ChefServer != nil && cfg.Global.V1.ChefServer.Fqdn != nil {
+		if !checkIfFileExist(automateHaPath) && cfg.GetGlobal().GetV1().GetChefServer() != nil && cfg.GetGlobal().GetV1().GetChefServer().GetFqdn() != nil {
 			res, err := client.GetAutomateConfig(configCmdFlags.timeout)
 			if err != nil {
 				return err


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In dev branch, config patch command was giving nil pointer exception. This got fixed now.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-5716
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Install this cli: hab pkg install sahiba3108/automate-cli/0.1.0/20230818064639 -bf

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="711" alt="Screenshot 2023-08-18 at 12 34 35 PM" src="https://github.com/chef/automate/assets/108404805/71e88292-8287-4d03-9600-8ce306f93c84">
<img width="688" alt="Screenshot 2023-08-18 at 12 35 32 PM" src="https://github.com/chef/automate/assets/108404805/9355a609-b9ff-4246-a806-5869abb883c5">
