### PR TITLE
In verify check changed chmod permissions to allow 600

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger.go
@@ -84,8 +84,8 @@ func (ss *SshUserAccessCheck) getSShUserAPIRequest(ip string, sshUser *models.SS
 	if err != nil {
 		return models.SShUserRequest{}, err
 	}
-	if permisssion > 400 {
-		return models.SShUserRequest{}, errors.New("Provide permission on the SSH key file as 400 (Read Only by Owner).")
+	if permisssion > 600 {
+		return models.SShUserRequest{}, errors.New("Provide permission on the SSH key file as 400 (Read Only by Owner) or 600 (Read and Write by Owner).")
 	}
 	ct, err := ss.fileUtils.ReadFile(sshUser.PrivateKey)
 	if err != nil {

--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/sshuseraccesschecktrigger/sshuseraccesschecktrigger_test.go
@@ -439,7 +439,7 @@ func TestGetSShUserAPIRquest(t *testing.T) {
 		assert.Equal(t, err.Error(), actualerr.Error())
 	})
 
-	t.Run("Permission is greater the 400", func(t *testing.T) {
+	t.Run("Permission is greater than 600", func(t *testing.T) {
 		fwc := NewSshUserAccessCheck(logger.NewLogrusStandardLogger(), &fileutils.MockFileSystemUtils{
 			ReadFileFunc: func(filepath string) ([]byte, error) {
 				return []byte("test_key"), nil
@@ -449,7 +449,7 @@ func TestGetSShUserAPIRquest(t *testing.T) {
 			},
 		}, "1234")
 		ip := "1.2.3.4"
-		expected, err := models.SShUserRequest{}, errors.New("Provide permission on the SSH key file as 400 (Read Only by Owner).")
+		expected, err := models.SShUserRequest{}, errors.New("Provide permission on the SSH key file as 400 (Read Only by Owner) or 600 (Read and Write by Owner).")
 		actual, actualerr := fwc.getSShUserAPIRequest(ip, GetRequestJson().SSHUser)
 		assert.Equal(t, expected, actual)
 		assert.Equal(t, err.Error(), actualerr.Error())
@@ -461,6 +461,21 @@ func TestGetSShUserAPIRquest(t *testing.T) {
 			},
 			GetFilePermissionFunc: func(filePath string) (int64, error) {
 				return 400, nil
+			},
+		}, "1234")
+		ip := "1.2.3.4"
+		expected := GetSshRequest()
+		actual, _ := fwc.getSShUserAPIRequest(ip, GetRequestJson().SSHUser)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Reading was successfull with 600 permissions", func(t *testing.T) {
+		fwc := NewSshUserAccessCheck(logger.NewLogrusStandardLogger(), &fileutils.MockFileSystemUtils{
+			ReadFileFunc: func(filepath string) ([]byte, error) {
+				return []byte("test_key"), nil
+			},
+			GetFilePermissionFunc: func(filePath string) (int64, error) {
+				return 600, nil
 			},
 		}, "1234")
 		ip := "1.2.3.4"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In verify check changed chmod permissions to allow 600 as earlier it only allowed till 400 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-5660

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Build automate-cli
bvtejaswi/automate-cli/0.1.0/20230821095409

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
