### PR TITLE
Showing error message if 7799 port is not opened on remote nodes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -208,7 +208,7 @@ func TestRunVerifyCmd(t *testing.T) {
 			wantErr:    nil,
 		},
 		{
-			description: "bastion without automate-verify - success",
+			description: "bastion without automate-verify",
 			mockHttputils: &httputils.MockHTTPClient{
 				MakeRequestFunc: func(requestMethod, url string, body interface{}) (*http.Response, []byte, error) {
 					if strings.Contains(url, "batch-check") {
@@ -259,7 +259,7 @@ func TestRunVerifyCmd(t *testing.T) {
 				},
 			},
 			configFile: CONFIG_TOML_PATH + CONFIG_FILE,
-			wantErr:    nil,
+			wantErr:    errors.New("This might be due to not enabling the 7799 port"),
 		},
 		{
 			description: "Failed to get automate HA infra details",
@@ -379,6 +379,8 @@ func TestRunVerifyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
+			oldBuildTimeVal := version.BuildTime
+			version.BuildTime = "20230622174934"
 			ConvTfvarToJsonFunc = tt.ConvTfvarToJsonFunc
 			cw := majorupgrade_utils.NewCustomWriter()
 
@@ -402,6 +404,7 @@ func TestRunVerifyCmd(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			version.BuildTime = oldBuildTimeVal
 		})
 	}
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Enchance the error message to say check 7799 port on all the remote machines

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-5795

### :+1: Definition of Done
Now it will show all the nodes where port 7799 is not opened

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Video Link:
Onprem with Chef Managed (Pre Deployment): https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/EaPcntY1hL9IopmnD3-t-VQBwsQYq3lTm_LipuI5vJ5OZA?e=i6iWDm

Onprem with Chef Managed (Post Deployment): https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/ETTg9DkbGjVNuWUyDykvMCcBasTkhH7YWyAdEQ9WPuXkEA?e=XTMGTJ

<img width="1557" alt="Screenshot 2023-08-22 at 7 07 57 PM" src="https://github.com/chef/automate/assets/101255220/cd828f5e-0faa-4962-84b5-95c20e7e5a49">
