### PR TITLE
Removed config sync logic for OS

### DIFF
--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -750,21 +750,13 @@ func getNodeObjectsToFetchConfigFromAllNodeTypes() []*NodeObject {
 func getNodeObjectsToPatchWorkspaceConfigToAllNodes() []*NodeObject {
 	timestamp := time.Now().Format("20060102150405")
 	fmt.Println("====================================================================")
-	fmt.Println("sync Config to all nodes")
+	fmt.Println("sync Config to frontend nodes")
 	frontendPrefix := "frontend" + "_" + timestamp + "_"
 	frontend := fmt.Sprintf(FRONTEND_COMMAND, PATCH, frontendPrefix+AUTOMATE_TOML, DATE_FORMAT)
 	chefserver := fmt.Sprintf(FRONTEND_COMMAND, PATCH, frontendPrefix+CHEF_SERVER_TOML, DATE_FORMAT)
-	backendPrefix := "opensearch" + "_" + timestamp + "_"
-	os := fmt.Sprintf(BACKEND_COMMAND, DATE_FORMAT, OPENSEARCH, "%s", backendPrefix+OPENSEARCH_TOML)
 	nodeObjects := []*NodeObject{
 		NewNodeObjectWithOutputFile(frontend, nil, []string{AUTOMATE_HA_AUTOMATE_NODE_CONFIG_DIR + AUTOMATE_TOML}, frontendPrefix, AUTOMATE),
 		NewNodeObjectWithOutputFile(chefserver, nil, []string{AUTOMATE_HA_AUTOMATE_NODE_CONFIG_DIR + CHEF_SERVER_TOML}, frontendPrefix, CHEF_SERVER),
-	}
-	if !isManagedServicesOn() {
-		backendNodeObjects := []*NodeObject{
-			NewNodeObjectWithOutputFile(os, nil, []string{AUTOMATE_HA_AUTOMATE_NODE_CONFIG_DIR + OPENSEARCH_TOML}, backendPrefix, OPENSEARCH),
-		}
-		nodeObjects = append(nodeObjects, backendNodeObjects...)
 	}
 	return nodeObjects
 }
@@ -777,11 +769,6 @@ func createNodeMap(outputFiles []string, inputFiles []string, inputFilesPrefix s
 		cmd.CmdInputs.Args = inputFiles
 	} else if service == OPENSEARCH {
 		cmd.CmdInputs.Args = inputFiles
-		if len(inputFiles) > 0 {
-			cmd.PreExec = prePatchForOsNodes
-			cmd.CmdInputs.InputFilesPrefix = inputFilesPrefix
-			cmd.CmdInputs.WaitTimeout = 300
-		}
 	} else {
 		cmd.CmdInputs.Args = inputFiles
 		// Patch only incase of frontends node
@@ -833,6 +820,7 @@ func prePatchForFrontendNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *Automat
 	return nil
 }
 
+// prePatchForOsNodes is not being in used currently as it was meant for os-config sync
 func prePatchForOsNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInfraDetails, remoteService string, writer *cli.Writer) error {
 	srcPath, err := removeRestrictedKeysFromSrcFileOs(inputs.Args[0])
 	if err != nil {
@@ -844,6 +832,7 @@ func prePatchForOsNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInf
 	return nil
 }
 
+// removeRestrictedKeysFromSrcFileOs is not being in used currently as it was meant for os-config sync
 func removeRestrictedKeysFromSrcFileOs(srcString string) (string, error) {
 	tomlbyt, _ := fileutils.ReadFile(srcString) // nosemgrep
 	destString := string(tomlbyt)

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -808,7 +808,7 @@ func newNodeTypeCmd(nodeMap *NodeTypeAndCmd, cmdString string, outputFiles []str
 	}
 }
 
-// prePatchForFrontendNodes parse frontend config before patch and remove cert related keys-values
+// prePatchForFrontendNodes parse frontend config before patch and remove cert related keys-values.
 func prePatchForFrontendNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInfraDetails, remoteService string, writer *cli.Writer) error {
 	srcPath, err := removeRestrictedKeysFromSrcFile(inputs.Args[0])
 	if err != nil {

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -750,7 +750,7 @@ func getNodeObjectsToFetchConfigFromAllNodeTypes() []*NodeObject {
 func getNodeObjectsToPatchWorkspaceConfigToAllNodes() []*NodeObject {
 	timestamp := time.Now().Format("20060102150405")
 	fmt.Println("====================================================================")
-	fmt.Println("sync Config to frontend nodes")
+	fmt.Println("Syncing configs to frontend nodes")
 	frontendPrefix := "frontend" + "_" + timestamp + "_"
 	frontend := fmt.Sprintf(FRONTEND_COMMAND, PATCH, frontendPrefix+AUTOMATE_TOML, DATE_FORMAT)
 	chefserver := fmt.Sprintf(FRONTEND_COMMAND, PATCH, frontendPrefix+CHEF_SERVER_TOML, DATE_FORMAT)
@@ -808,7 +808,7 @@ func newNodeTypeCmd(nodeMap *NodeTypeAndCmd, cmdString string, outputFiles []str
 	}
 }
 
-// prePatchForFrontendNodes parse frontend config before patch and remove cert related keys-values.
+// prePatchForFrontendNodes parse frontend config before patch and remove cert related keys-values
 func prePatchForFrontendNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInfraDetails, remoteService string, writer *cli.Writer) error {
 	srcPath, err := removeRestrictedKeysFromSrcFile(inputs.Args[0])
 	if err != nil {
@@ -820,7 +820,8 @@ func prePatchForFrontendNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *Automat
 	return nil
 }
 
-// prePatchForOsNodes is not being in used currently as it was meant for os-config sync
+// prePatchForOsNodes 
+// Note: this func is not being in used currently as it was meant for os-config sync
 func prePatchForOsNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInfraDetails, remoteService string, writer *cli.Writer) error {
 	srcPath, err := removeRestrictedKeysFromSrcFileOs(inputs.Args[0])
 	if err != nil {
@@ -832,7 +833,6 @@ func prePatchForOsNodes(inputs *CmdInputs, sshUtil SSHUtil, infra *AutomateHAInf
 	return nil
 }
 
-// removeRestrictedKeysFromSrcFileOs is not being in used currently as it was meant for os-config sync
 func removeRestrictedKeysFromSrcFileOs(srcString string) (string, error) {
 	tomlbyt, _ := fileutils.ReadFile(srcString) // nosemgrep
 	destString := string(tomlbyt)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Removed config sync logic for OS which is not needed

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-5662

### :+1: Definition of Done
After AWS Deployment did the following things:
-  Changed the max-shard-per-node value and patched to OS node
- Added new OS node
- New OS node has updated config
- upgarded with cli
- After upgradation it still has updated config

### :athletic_shoe: How to Build and Test the Change
build components/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[Demo-video](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/ERz0gqXPFxBFtwD2wulL2HAB8cu49VaD1Z9_IqX-3M6QqA?e=hp89Uz)