### PR TITLE
Fixing bug -  to take region from input while making AWS connection

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/s3backupchecktrigger/s3backupconfigchecktrigger.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/s3backupchecktrigger/s3backupconfigchecktrigger.go
@@ -33,7 +33,7 @@ func (svc *S3BackupConfigCheck) Run(config *models.Config) []models.CheckTrigger
 		return s3ConfigSkippedResponse(config, constants.S3_BACKUP_CONFIG, constants.SKIP_BACKUP_TEST_MESSAGE_S3)
 	}
 
-	if !isObjectStorage(config ) {
+	if !isObjectStorage(config) {
 		return emptyResp(config, constants.S3_BACKUP_CONFIG)
 	}
 

--- a/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice.go
@@ -37,7 +37,7 @@ func (ss *S3ConfigService) GetS3Connection(req *models.S3ConfigRequest) *models.
 	// https://s3.amazonaws.com by default belongs to us-east-1 region and if the bucket is in someother region, the check will not pass
 	// So manipulating the endpoint URL pattern for S3 (ONLY FOR AWS S3)
 	if strings.Contains(ss.Req.Endpoint, "://s3.amazonaws.com") {
-		ss.Req.Endpoint = strings.Replace(ss.Req.Endpoint, "s3.amazonaws.com", "s3."+ss.Req.Region+".amazonaws.com", 1)
+		ss.Req.Endpoint = strings.Replace(ss.Req.Endpoint, ss.Req.Endpoint, "", 1)
 	}
 	sess, err := ss.AwsConnection(ss.Req.Endpoint, ss.Req.AccessKey, ss.Req.SecretKey, ss.Req.Region)
 	if err != nil {

--- a/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice.go
@@ -30,7 +30,7 @@ func NewS3ConfigService(logger logger.Logger, awsUtils awsutils.AwsUtils) IS3Con
 
 func (ss *S3ConfigService) GetS3Connection(req *models.S3ConfigRequest) *models.Checks {
 	ss.Req = req
-	sess, err := ss.AwsConnection(ss.Req.Endpoint, ss.Req.AccessKey, ss.Req.SecretKey, "")
+	sess, err := ss.AwsConnection(ss.Req.Endpoint, ss.Req.AccessKey, ss.Req.SecretKey, ss.Req.Region)
 	if err != nil {
 		return ss.Response(constants.S3_CONNECTION_TITLE, "", errors.Wrap(err, constants.S3_CONNECTION_ERROR_MSG).Error(), constants.S3_CONNECTION_RESOLUTION_MSG, false)
 	}

--- a/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/s3configservice/s3configservice_test.go
@@ -46,7 +46,7 @@ func TestGetS3Connection(t *testing.T) {
 		},
 	})
 	services := cs.GetS3Connection(&models.S3ConfigRequest{
-		Endpoint:   "s3://example-s3.aws.region.com",
+		Endpoint:   "http://s3.amazonaws.com",
 		BucketName: "backups",
 		BasePath:   "automate",
 		AccessKey:  "VALID-ACCESS-KEY",


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When the user is configuring S3 as a backup in AWS, the verify command fails for S3-backup-check in the pre-deployment flow with the following error in the screenshot.

![Screenshot 2023-08-22 at 7 29 45 PM](https://github.com/chef/automate/assets/54614142/8c4b1577-9444-4fbd-9ee2-b34e8dd9566a)

Reason:
While creating a new session in AWS the region is not taken. So the session created is not proper and unable to connect to the bucket, as it takes us-east-1 as the default region and the user bucket is in the ap-south-1 region.

**Other issue:**
- AWS-SDK expects the endpoint URL to be in the following pattern `https://s3.REGION.amazonaws.com`. For **https://s3.amazonaws.com** , it consider it as the bucket is in us-east-1 (default region)

To fix this, the endpoint URL is programmatically changed to the `https://s3.REGION.amazonaws.com` pattern which is only applicable to the AWS S3 bucket endpoint URL.

### :chains: Related Resources
Jira ticket: https://chefio.atlassian.net/browse/CHEF-5820

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
#### AWS:
![image](https://github.com/chef/automate/assets/54614142/d9a62b69-0255-48f9-b757-aa3b61400b7e)


#### On-Prem:
**AWS s3:**
![Screenshot 2023-08-23 at 8 37 55 PM](https://github.com/chef/automate/assets/54614142/c4ff2ac7-9ff4-48d2-b331-3ecc49617ff6)
![Screenshot 2023-08-23 at 8 37 26 PM](https://github.com/chef/automate/assets/54614142/a00c6179-0b36-497b-8de9-c5e587322959)


**MinIO:**
![Screenshot 2023-08-23 at 8 36 42 PM](https://github.com/chef/automate/assets/54614142/18c2de7d-8b03-4b40-b4d8-5f58b67b2c6c)
![Screenshot 2023-08-23 at 8 36 14 PM](https://github.com/chef/automate/assets/54614142/1b48d6fa-6669-441d-aa42-0523a6fd134f)


