### PR TITLE
Fixing cleanup command to ignore uninstalling hab workspace

### DIFF
--- a/components/automate-cli/cmd/chef-automate/cleanup.go
+++ b/components/automate-cli/cmd/chef-automate/cleanup.go
@@ -12,11 +12,15 @@ var (
 	AWS        string = "aws"
 	DEPLOYMENT string = "deployment"
 
+	TERRAFORM_CMD   = "terraform"
+	AWS_DESTROY_DIR = "/hab/a2_deploy_workspace/terraform/destroy/aws/"
+	TERRAFORM_INIT  = "init"
+
 	AWS_PROVISION = `
 	for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform init;cd $i;done
 	%s
 	for i in 1;do i=$PWD;cd /hab/a2_deploy_workspace/terraform/destroy/aws/;terraform destroy  -state=/hab/a2_deploy_workspace/terraform/destroy/aws/terraform.tfstate -auto-approve;cd $i;done
-`
+	`
 
 	DEPLOYMENT_CLEANUP = `hab pkg uninstall chef/automate-ha-deployment`
 	DESTROY_S3_BUCKET  = `HAB_LICENSE=accept-no-persist hab pkg exec core/aws-cli aws s3 rm s3://%s --recursive; hab pkg exec core/aws-cli aws s3 rb s3://%s`
@@ -160,23 +164,29 @@ func runCleanupCmd(cmd *cobra.Command, args []string) error {
 				}
 				writer.Println("Cleaning up all AWS provisioned resources.")
 
-				// 'cleanupScripts' contains array of scripts
-				// [Script to delete AWS reesources, Script to uninstall deployment workspace]
-				var cleanupScripts = []string{fmt.Sprintf(AWS_PROVISION, appendString)}
-
-				// Iteration 1: Removes AWS resource
-				// Iteration 2: Uninstall automate-ha-deployment
-				for i := 0; i < len(cleanupScripts); i++ {
-					args := []string{
-						"-c",
-						cleanupScripts[i],
-					}
-					err = executeCommand("/bin/sh", args, "")
+				// Init terraform folder
+				err = executeCommand(TERRAFORM_CMD, []string{TERRAFORM_INIT}, AWS_DESTROY_DIR)
+				if err != nil {
+					writer.Error("Terraform init failed")
+					return err
+				}
+				// Modify tf state or remove bucket based in "--force" arg
+				writer.Printf("%v", len(appendString) > 0)
+				if len(appendString) > 0 {
+					err = executeCommand("/bin/sh", []string{"-c", appendString}, "")
 					if err != nil {
+						writer.Errorf(err.Error())
 						return err
 					}
 				}
-				writer.Print("If cleanup completed successfully run the following command to remove/uninstall deployment workspace\n hab pkg uninstall chef/automate-ha-deployment\n")
+
+				// Destroy AWS resources provisioned by terraform
+				err = executeCommand(TERRAFORM_CMD, []string{"destroy", "-auto-approve"}, AWS_DESTROY_DIR)
+				if err != nil {
+					writer.Errorf("error while destroying infra, %v", err)
+					return err
+				}
+				writer.Success("cleanup completed successfully. Run the following command to remove/uninstall deployment workspace\n hab pkg uninstall chef/automate-ha-deployment\n")
 			}
 		}
 	} else {

--- a/components/automate-cli/cmd/chef-automate/cleanup.go
+++ b/components/automate-cli/cmd/chef-automate/cleanup.go
@@ -176,7 +176,7 @@ func runCleanupCmd(cmd *cobra.Command, args []string) error {
 						return err
 					}
 				}
-				writer.Success("If cleanup completed successfully run the following command to remove/uninstall deployment workspace\n hab pkg uninstall chef/automate-ha-deployment\n")
+				writer.Print("If cleanup completed successfully run the following command to remove/uninstall deployment workspace\n hab pkg uninstall chef/automate-ha-deployment\n")
 			}
 		}
 	} else {

--- a/components/automate-cli/cmd/chef-automate/cleanup.go
+++ b/components/automate-cli/cmd/chef-automate/cleanup.go
@@ -162,7 +162,7 @@ func runCleanupCmd(cmd *cobra.Command, args []string) error {
 
 				// 'cleanupScripts' contains array of scripts
 				// [Script to delete AWS reesources, Script to uninstall deployment workspace]
-				var cleanupScripts = []string{fmt.Sprintf(AWS_PROVISION, appendString), DEPLOYMENT_CLEANUP}
+				var cleanupScripts = []string{fmt.Sprintf(AWS_PROVISION, appendString)}
 
 				// Iteration 1: Removes AWS resource
 				// Iteration 2: Uninstall automate-ha-deployment
@@ -176,7 +176,7 @@ func runCleanupCmd(cmd *cobra.Command, args []string) error {
 						return err
 					}
 				}
-				writer.Success("Cleaning up completed.")
+				writer.Success("If cleanup completed successfully run the following command to remove/uninstall deployment workspace\n hab pkg uninstall chef/automate-ha-deployment\n")
 			}
 		}
 	} else {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When the cleanup command is triggered, it should not delete the hab deployment workspace

### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/CHEF-2769

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1023" alt="Screenshot 2023-08-28 at 11 47 06 PM" src="https://github.com/chef/automate/assets/54614142/43406ca9-1c9d-4167-bd91-7de25a9459b2">

In case of error, command message won't be shown
<img width="1274" alt="image" src="https://github.com/chef/automate/assets/54614142/04fbdf7c-e571-4ebf-afb3-42824e3ef632">
