### PR TITLE
pull and generate gcs config

### DIFF
--- a/components/automate-cli/cmd/chef-automate/deployedConfig.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig.go
@@ -76,11 +76,13 @@ func CopyExistingInfra(existingInfraConfig *ExistingInfraConfigToml) *config.HaD
 		},
 		ObjectStorage: &config.ObjectStorage{
 			Config: &config.ConfigObjectStorage{
-				AccessKey:  existingInfraConfigObjectStorageConfig.AccessKey,
-				BucketName: existingInfraConfigObjectStorageConfig.BucketName,
-				Endpoint:   existingInfraConfigObjectStorageConfig.Endpoint,
-				Region:     existingInfraConfigObjectStorageConfig.Region,
-				SecretKey:  existingInfraConfigObjectStorageConfig.SecretKey,
+				AccessKey:                existingInfraConfigObjectStorageConfig.AccessKey,
+				BucketName:               existingInfraConfigObjectStorageConfig.BucketName,
+				Endpoint:                 existingInfraConfigObjectStorageConfig.Endpoint,
+				Region:                   existingInfraConfigObjectStorageConfig.Region,
+				SecretKey:                existingInfraConfigObjectStorageConfig.SecretKey,
+				Location:                 existingInfraConfigObjectStorageConfig.Location,
+				GoogleServiceAccountFile: existingInfraConfigObjectStorageConfig.GoogleServiceAccountFile,
 			},
 		},
 		Automate: &config.AutomateSettings{

--- a/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
@@ -132,11 +132,13 @@ var existingInfraConfig = &ExistingInfraConfigToml{
 	},
 	ObjectStorage: ObjectStorageToml{
 		Config: ObjectStorageConfigToml{
-			AccessKey:  "existing-access-key",
-			BucketName: "existing-bucket",
-			Endpoint:   "existing-endpoint",
-			Region:     "existing-region",
-			SecretKey:  "existing-secret-key",
+			AccessKey:                "existing-access-key",
+			BucketName:               "existing-bucket",
+			Endpoint:                 "existing-endpoint",
+			Region:                   "existing-region",
+			SecretKey:                "existing-secret-key",
+			Location:                 "gcs",
+			GoogleServiceAccountFile: "googleServiceAccount.json",
 		},
 	},
 }

--- a/components/automate-cli/cmd/chef-automate/initConfigHa.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHa.go
@@ -294,11 +294,13 @@ type ObjectStorageToml struct {
 }
 
 type ObjectStorageConfigToml struct {
-	BucketName string `toml:"bucket_name"`
-	AccessKey  string `toml:"access_key"`
-	SecretKey  string `toml:"secret_key"`
-	Endpoint   string `toml:"endpoint"`
-	Region     string `toml:"region"`
+	BucketName               string `toml:"bucket_name"`
+	AccessKey                string `toml:"access_key"`
+	SecretKey                string `toml:"secret_key"`
+	Endpoint                 string `toml:"endpoint"`
+	Region                   string `toml:"region"`
+	Location                 string `toml:"location"`
+	GoogleServiceAccountFile string `json:"google_service_account_file"`
 }
 
 func init() {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Now able to pull the latest GCS config in pull and generate.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-5620
https://chefio.atlassian.net/browse/CHEF-5625

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
Build the cli or use this cli: `ssanju/automate-cli/0.1.0/20230828052937`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Video Link: https://progresssoftware-my.sharepoint.com/:v:/g/personal/ssanju_progress_com/ETQ2B_TFat1Eh9R0ci3I3ZgBMGTmjIbk2Xs6fZXtUZgGmg?e=znhU8k 