### PR TITLE
Updating config-gen prompt for providing public subnet

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -709,7 +709,7 @@ func (c *certRotateFlow) copyAndExecuteConcurrentlyToFrontEndNodes(ips []string,
 	isError := false
 	for _, result := range copyResults {
 		if result.Error != nil {
-			c.writer.Errorf("Remote copying automate-verify CLI failed on node : %s with error: %v\n", result.HostIP, result.Error)
+			c.writer.Errorf("Remote copying file failed on node : %s with error: %v\n", result.HostIP, result.Error)
 			isError = true
 		}
 	}

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -709,7 +709,7 @@ func (c *certRotateFlow) copyAndExecuteConcurrentlyToFrontEndNodes(ips []string,
 	isError := false
 	for _, result := range copyResults {
 		if result.Error != nil {
-			c.writer.Errorf("Remote copying file failed on node : %s with error: %v\n", result.HostIP, result.Error)
+			c.writer.Errorf("Copying to remote failed on node : %s with error: %v\n", result.HostIP, result.Error)
 			isError = true
 		}
 	}

--- a/lib/config/genconfig/awshaprovisionconfig.go
+++ b/lib/config/genconfig/awshaprovisionconfig.go
@@ -314,7 +314,7 @@ func (c *AwsHaProvisionConfig) PromptPrivateSubnet() (err error) {
 }
 
 func (c *AwsHaProvisionConfig) PromptPublicSubnet() (err error) {
-	hasPublicSubnets, err := c.Prompt.Confirm("Create Public Subnets", "yes", "no")
+	hasPublicSubnets, err := c.Prompt.Confirm("Provide Public Subnets", "yes", "no")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When the config-gen is executing for AWS infra flow, it should ask the user to provide the public subnet 

### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/CHEF-6155

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Updated prompt message:
<img width="942" alt="image" src="https://github.com/chef/automate/assets/54614142/087702ac-7f77-4783-b1a4-8667677dae04">

