### PR TITLE
SELinux should be permissive or disabled during deployment 

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -7,4 +7,3 @@ This package will build a package using terraform/a2ha-terraform, inspecs, test,
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package.
 
-

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -148,7 +148,7 @@ func executeConfigVerifyAndPromptConfirmationOnError(configFile string) error {
 	if err != nil {
 		fsu := fileutils.NewFileSystemUtils()
 		p := pmt.PromptFactory(os.Stdin, os.Stdout, fsu)
-		ok, err := p.Confirm("Config verification failed. Do you still wan to continue?", "yes", "no")
+		ok, err := p.Confirm("Config verification failed. Do you still want to continue?", "yes", "no")
 		if err != nil {
 			return status.Wrap(err, status.PromptFailed, err.Error())
 		}

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -32,8 +32,8 @@ check_selinux() {
 
             # Change GRUB to Permissive
             sed -i 's/selinux=1/selinux=0/' /etc/default/grub
-            update-grub
-            echo "GRUB configuration updated to Permissive."
+            # update-grub
+            # echo "GRUB configuration updated to Permissive."
         # fi
 
         # SELinux not found in grub (Disabled or Permissive)

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -2,6 +2,54 @@
 
 set -euo pipefail
 
+# Function to check SELinux status and mode
+check_selinux() {
+    # Check if /etc/selinux exists (common to RHEL, CentOS, Fedora)
+    if [ -e /etc/selinux/config ]; then
+        echo "SELinux configuration file found."
+
+        # Check for SELinux status and mode
+        selinux_status=$(getenforce)
+        selinux_mode=$(awk -F= '/^SELINUX=/ {print $2}' /etc/selinux/config)
+
+        echo "SELinux Status: $selinux_status"
+        echo "SELinux Mode: $selinux_mode"
+
+        # If SELinux is enabled (Enforcing), set it to Permissive
+        if [ "$selinux_status" == "Enforcing" ]; then
+            echo "SELinux is currently in Enforcing mode. Changing to Permissive..."
+            setenforce Permissive
+            echo "SELinux mode set to Permissive."
+        fi
+
+    # Check if /etc/selinux does not exist (common to Debian, Ubuntu)
+    elif [ -e /etc/default/grub ]; then
+        echo "SELinux configuration file not found."
+
+        # Check if "selinux=1" is present in grub (Enforcing)
+        if grep -q "selinux=1" /etc/default/grub; then
+            echo "SELinux is enabled (Enforcing) in GRUB."
+
+            # Change GRUB to Permissive
+            sed -i 's/selinux=1/selinux=0/' /etc/default/grub
+            update-grub
+            echo "GRUB configuration updated to Permissive."
+        # fi
+
+        # SELinux not found in grub (Disabled or Permissive)
+        else
+            echo "SELinux is not found or is already disabled in GRUB."
+        fi
+
+    # SELinux configuration file not found (SUSE, Amazon Linux, etc.)
+    else
+        echo "SELinux configuration file not found."
+    fi
+}
+
+# Check SELinux
+check_selinux
+
 umask 0022
 
 export HAB_NONINTERACTIVE=true


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate HA user, when I use RHEL, the SELinux should set to permissive while deployment.

- Deploy will handle setting SELinux config to permissive during deployment for RHEL 8
- Same for Add node flow


### :chains: Related Resources
Jira: https://chefio.atlassian.net/browse/CHEF-6159

### :+1: Definition of Done
- [x] Deploy with RHEL 8
- [x] Added new node in RHEL 8
- [x] Deploy with Ubuntu 20.04

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="832" alt="image" src="https://github.com/chef/automate/assets/54614142/9c83429f-b3ff-463d-b780-73c6fabfc3d1">

