### PR TITLE
increased default timeout for cert rotate

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -104,7 +104,7 @@ const (
 	SKIP_FRONT_END_IPS_MSG_PG         = "The following %s %s will skip during root-ca patching as the following %s have same root-ca as currently provided Postgresql root-ca.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_OS         = "The following %s %s will skip during root-ca and common name patching as the following %s have same root-ca and common name as currently provided OpenSearch root-ca and common name.\n\t %s"
 	SKIP_FRONT_END_IPS_MSG_CN         = "The following %s %s will skip during common name patching as the following %s have same common name as currently provided OpenSearch common name.\n\t %s"
-	DEFAULT_TIMEOUT                   = 180
+	DEFAULT_TIMEOUT                   = 600
 )
 
 type certificates struct {


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
increased default timeout for cert rotate previously it was 180 now updated to 600 as the services are not coming up with in 180

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-6182

### :+1: Definition of Done
Tested rotating backend node without giving --wait-timeout flag

### :athletic_shoe: How to Build and Test the Change
build automate-cli
`bvtejaswi/automate-cli/0.1.0/20230905065139`

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1792" alt="Screenshot 2023-09-05 at 12 33 17 PM" src="https://github.com/chef/automate/assets/100406225/f1f0a15b-c4b3-400c-9726-5bea635ee2bc">
<img width="1792" alt="Screenshot 2023-09-05 at 12 33 06 PM" src="https://github.com/chef/automate/assets/100406225/3f187e0d-ebd7-46a7-a471-d0cdb0de4347">
<img width="1536" alt="Screenshot 2023-09-05 at 12 35 54 PM" src="https://github.com/chef/automate/assets/100406225/9fdc0879-d9f9-4045-bc66-58e30e3f7744">
