### PR TITLE
Unique ips while rotating the certs

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -703,6 +703,7 @@ func (c *certRotateFlow) copyAndExecute(ips []string, sshUtil SSHUtil, timestamp
 
 // copyAndExecuteConcurrently will copy the toml file to each required nodes concurrently and then execute the set of commands.
 func (c *certRotateFlow) copyAndExecuteConcurrentlyToFrontEndNodes(ips []string, sshConfig sshutils.SSHConfig, timestamp string, remoteService string, fileName string, scriptCommands string, flagsObj *certRotateFlags) error {
+	ips = uniqueIps(ips)
 	sshConfig.Timeout = flagsObj.timeout
 	copyResults := c.sshUtil.CopyFileToRemoteConcurrently(sshConfig, fileName, remoteService+timestamp, TMP_DIR, false, ips)
 	isError := false
@@ -1137,4 +1138,16 @@ func (c *certRotateFlow) getMerger(fileName string, timestamp string, remoteType
 	}
 
 	return tomlFile, nil
+}
+
+func uniqueIps(ips []string) []string {
+	var uniqueIps []string
+	mp := make(map[string]bool)
+	for _, ip := range ips {
+		mp[ip] = true
+	}
+	for ip := range mp {
+		uniqueIps = append(uniqueIps, ip)
+	}
+	return uniqueIps
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Earlier this error is coming in 5 nodes cluster deployment.
<img width="1728" alt="Screenshot 2023-09-05 at 3 45 35 PM" src="https://github.com/chef/automate/assets/101255220/50f9e7cb-8a7c-4601-a61b-3df4a2925e6f">

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
rebuild the cli or use this cli `ssanju/automate-cli/0.1.0/20230905100216`
### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1728" alt="Screenshot 2023-09-05 at 3 40 39 PM" src="https://github.com/chef/automate/assets/101255220/9264b237-f801-453f-be3d-6e926ac01d07">
