### PR TITLE
removing hardcoded commands in deployment output

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
+++ b/components/automate-cli/cmd/chef-automate/automateClusterCtlUtil.go
@@ -109,15 +109,6 @@ func executeAutomateClusterCtlCommandAsync(command string, args []string, helpDo
 	}
 	time.Sleep(5 * time.Second)
 	close(executed)
-	if command == "deploy" && isSuccess {
-		writer.Println("\n")
-		writer.Println("===================================================================================================")
-		writer.Println("\n")
-		writer.Println("Once the deployment is successful, you can run following commands to verify the deployment")
-		writer.Println("To check the consolidated node health: chef-automate status summary ")
-		writer.Println("To check the service health on each node: chef-automate status ")
-		writer.Println("To verify configurations of the deployment: chef-automate verify ")
-	}
 	return err
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
removing duplicated hard-coded commands in deployment output

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
