### PR TITLE
opensearch-s3-access-check failing

### DIFF
--- a/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
+++ b/components/automate-cli/pkg/verifyserver/services/batchcheckservice/trigger/opensearchs3bucketaccesschecktrigger/opensearchs3bucketaccesscheck.go
@@ -37,7 +37,7 @@ func (osb *OpensearchS3BucketAccessCheck) Run(config *models.Config) []models.Ch
 			trigger.SkippedTriggerCheckResp(config.ExternalOS.OSDomainURL, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH, constants.SKIP_OS_BUCKET_TEST_SELF_MANAGED_MESSAGE),
 		}
 	}
-	if isEmptyExternalOS(config.ExternalOS) || isObjectStorage(config.Backup) {
+	if isEmptyExternalOS(config.ExternalOS) && isObjectStorage(config.Backup) {
 		return []models.CheckTriggerResponse{
 			trigger.ErrTriggerCheckResp(config.ExternalOS.OSDomainURL, constants.AWS_OPENSEARCH_S3_BUCKET_ACCESS, constants.OPENSEARCH, constants.OBJECT_STORAGE_MISSING),
 		}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
aws-opensearch-s3-bucket-access check is failing for AWS with AWS Managed Services, modified the trigger check.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

- Modified the trigger check to pass the aws-opensearch-s3-bucket-access

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
Before the check is failing with the following error
<img width="942" alt="Screenshot 2023-09-05 at 6 53 09 PM" src="https://github.com/chef/automate/assets/98326242/a632e67e-235a-47a3-8f14-94bd13e38c0f">
After
<img width="974" alt="Screenshot 2023-09-05 at 6 53 53 PM" src="https://github.com/chef/automate/assets/98326242/42e245c4-10c2-450a-b3ff-cc081a8dbb2c">