### PR TITLE
Upgrading to ocid 15.8.0 in Automate

### DIFF
--- a/components/automate-cs-ocid/habitat/config/tasks/oauth_application.rake
+++ b/components/automate-cs-ocid/habitat/config/tasks/oauth_application.rake
@@ -30,7 +30,7 @@ namespace :oauth_application do
 
   desc "Task to generate a file with the details of all the registered oauth application under OC-ID"
   task :save_registered_app_details_to_file => :environment do
-    registered_apps = Doorkeeper::Application.select(:name, :redirect_uri, :uid, :secret).group_by(&:name).as_json
+    registered_apps = Doorkeeper::Application.select(:name, :redirect_uri, :uid, :secret).map(&:attributes).group_by{|app| app["name"]}
     yaml_file_content = registered_apps.to_yaml
     file_path = ENV['REGISTERED_OAUTH_APPS_FILE_PATH']
     begin

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -7,7 +7,7 @@ pkg_name="automate-cs-ocid"
 pkg_description="Wrapper package for chef/ocid"
 pkg_origin="chef"
 # WARNING: Version managed by .expeditor/update_chef_server.sh
-pkg_version="15.4.0"
+pkg_version="15.8.0"
 vendor_origin="chef"
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
@@ -21,7 +21,7 @@ pkg_deps=(
   chef/mlsa
   "${local_platform_tools_origin:-chef}/automate-platform-tools"
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
-  "${vendor_origin}/oc_id/15.4.0/20230105061030"
+  "${vendor_origin}/oc_id/15.8.0/20230929110850"
 )
 
 pkg_binds=(
@@ -38,27 +38,27 @@ pkg_exposes=(http-port)
 pkg_scaffolding="${local_scaffolding_origin:-chef}/automate-scaffolding"
 automate_scaffolding_include_templates=(sqerl.config)
 
-do_prepare() {
-  GO_LDFLAGS="-X main.RubyPath=$(hab pkg path 'core/ruby27')"
-  export GO_LDFLAGS
+# do_prepare() {
+#   GO_LDFLAGS="-X main.RubyPath=$(hab pkg path 'core/ruby30')"
+#   export GO_LDFLAGS
 
-  build_line "Setting link for /usr/bin/env to 'coreutils'"
-  [[ ! -f /usr/bin/env ]] && ln -s "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
-  return 0
-}
+#   build_line "Setting link for /usr/bin/env to 'coreutils'"
+#   [[ ! -f /usr/bin/env ]] && ln -s "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+#   return 0
+# }
 
 do_download() {
   return 0
 }
 
 do_build() {
-  # TODO :: Remove following section once new ocid hab package is used which includes gem: "tzinfo-data"
-  cd $(pkg_path_for "chef/oc_id")/oc_id
-  bundle config path "vendor/bundle"
-  if ! grep -q "gem 'tzinfo-data'" Gemfile; then
-    echo "gem 'tzinfo-data'" >> Gemfile
-    bundle install
-  fi
+   # TODO :: Remove following section once new ocid hab package is used which includes gem: "tzinfo-data"
+  # cd $(pkg_path_for "chef/oc_id")/oc_id
+  # bundle config path "vendor/bundle"
+  # if ! grep -q "gem 'tzinfo-data'" Gemfile; then
+  #   echo "gem 'tzinfo-data'" >> Gemfile
+  #   bundle install
+  # fi
 
   return 0
 }

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -38,28 +38,11 @@ pkg_exposes=(http-port)
 pkg_scaffolding="${local_scaffolding_origin:-chef}/automate-scaffolding"
 automate_scaffolding_include_templates=(sqerl.config)
 
-# do_prepare() {
-#   GO_LDFLAGS="-X main.RubyPath=$(hab pkg path 'core/ruby30')"
-#   export GO_LDFLAGS
-
-#   build_line "Setting link for /usr/bin/env to 'coreutils'"
-#   [[ ! -f /usr/bin/env ]] && ln -s "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
-#   return 0
-# }
-
 do_download() {
   return 0
 }
 
 do_build() {
-   # TODO :: Remove following section once new ocid hab package is used which includes gem: "tzinfo-data"
-  # cd $(pkg_path_for "chef/oc_id")/oc_id
-  # bundle config path "vendor/bundle"
-  # if ! grep -q "gem 'tzinfo-data'" Gemfile; then
-  #   echo "gem 'tzinfo-data'" >> Gemfile
-  #   bundle install
-  # fi
-
   return 0
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The oc-id component of the infra server has been upgraded to use ruby 3+ and rails 7+ in version `15.8.0`. This PR aims to upgrade the bundled ocid to use `15.8.0` from `15.4.0` in the `automate-cs-ocid` component of chef-automate.

1. The `do_build` block in ocid's `plan.sh` has been removed as part of this PR as intended since the tzinfo-data  gem has been packaged with the new ocid bundle 15.8.0 and is not required in this block anymore.
2. The changes in the [oauth_application.rake](https://github.com/chef/automate/pull/8248/files#diff-921e5bd864e753670926ffc22d3add4674f9aad090969c922fc365cd54198d04) is part of a security fix for [CVE-2020-10187](https://nvd.nist.gov/vuln/detail/CVE-2020-10187) 



<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change
All the following topologies of automate and automate HA and have verified with the new ocid package and they are working as expected:

1. Standalone installation of airgapped automate integration with supermarket.
2. Standalone installation of non- airgapped automate integration with supermarket
3. HA installation of airgapped automate integration with supermarket.
4. HA installation of non-airgapped automate integration with supermarket.


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
 Below are the demo recordings in different topologies:

1. non-airgapped: [ocid-15.8.0-with automate-standalone-non-airgapped.mp4](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EexuE8tr9URLjqpVq5SPuH8Bs6mgBtK6UEtjQ0w1ncV0dg?e=R3Di0Z)
2. airgapped: [ocid-15.8.0-with-automate-standalone-airgapped.mp4](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EQZD3E135UtPocDBV6MSxZcB6C8yQMU8p-Zv7gf8mZ356A?e=b2TEMf)
3.  airgapped automate HA with ocid 15.8.0: [ocid-15.8.0-with-automate-HA-airgapped.mp4](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EV57Frdh3tlAu0CZyWrBMbABQwHWr0W3T2IxsCABl4viTw?e=x4HBVW)
4. non-airgapped automate HA with ocid 15.8.0: [ocid-15.8.0-with-automate-HA-non-airgapped.mp4](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EYYJ8TfMr_5PvevhG56Ny0AB2beYLnxYQGdSrdz0DB6Ekg?e=32Gc2G&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZyIsInJlZmVycmFsQXBwUGxhdGZvcm0iOiJXZWIiLCJyZWZlcnJhbE1vZGUiOiJ2aWV3In19)
