### PR TITLE
Added new flag for status and service-versions command to accept hab license

### DIFF
--- a/components/automate-cli/cmd/chef-automate/restart.go
+++ b/components/automate-cli/cmd/chef-automate/restart.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	RESTART_FRONTEND_COMMAND    = `sudo chef-automate restart-services`
-	RESTART_BACKEND_COMMAND     = `sudo HAB_LICENSE=accept-no-persist systemctl restart hab-sup`
+	RESTART_BACKEND_COMMAND     = `sudo systemctl restart hab-sup`
 	DEFAULT_TIMEOUT_FOR_RESTART = 1200
 	ERROR_ON_MANAGED_SERVICES   = "Restart for externally configured %s is not supported."
 	CMD_FAILED_MSG              = "Command failed on %s node : %s with error:\n %s\n"

--- a/components/automate-cli/cmd/chef-automate/service_versions_test.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions_test.go
@@ -59,10 +59,11 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 		{
 			description: "Want service_versions of backend services",
 			flags: &ServiceVersionsCmdFlags{
-				automate:   false,
-				chefServer: false,
-				opensearch: true,
-				postgresql: true,
+				automate:         false,
+				chefServer:       false,
+				opensearch:       true,
+				postgresql:       true,
+				acceptHabLicense: true,
 			},
 			mockNodeOpUtils: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -179,6 +180,30 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 			},
 			errorWant: errors.New("Some error occured while remote execution"),
 		},
+		{
+			description: "Want service_versions of backend services with --accept-hab-license",
+			flags: &ServiceVersionsCmdFlags{
+				automate:   false,
+				chefServer: false,
+				opensearch: true,
+				postgresql: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -281,7 +306,7 @@ func TestConstructNodeMapForServiceVersions(t *testing.T) {
 				},
 				Postgresql: &Cmd{
 					CmdInputs: &CmdInputs{
-						Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+						Cmd:                      "",
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,
@@ -291,7 +316,7 @@ func TestConstructNodeMapForServiceVersions(t *testing.T) {
 				},
 				Opensearch: &Cmd{
 					CmdInputs: &CmdInputs{
-						Cmd:                      BACKEND_SERVICE_VERSIONS_CMD,
+						Cmd:                      "",
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -28,6 +28,7 @@ type StatusCmdFlags struct {
 	postgresql          bool
 	opensearch          bool
 	node                string
+	acceptHabLicense    bool
 }
 type StatusCmdResult struct {
 	cmdResult map[string][]*CmdResult
@@ -63,10 +64,11 @@ type FeStatus []FeStatusValue
 type BeStatus []BeStatusValue
 
 const (
-	STATUS_ERROR_ON_SELF_MANAGED = "Showing the status for externally configured %s is not supported."
-	CMD_FAIL_MSG                 = "Command failed on %s node : %s with error:\n %s\n"
-	BACKEND_STATUS_CMD           = "sudo HAB_LICENSE=accept-no-persist hab svc status"
-	FRONTEND_STATUS_CMD          = "sudo chef-automate status"
+	STATUS_ERROR_ON_SELF_MANAGED          = "Showing the status for externally configured %s is not supported."
+	CMD_FAIL_MSG                          = "Command failed on %s node : %s with error:\n %s\n"
+	BACKEND_STATUS_CMD                    = "sudo HAB_LICENSE=accept-no-persist hab svc status"
+	ACCEPTED_LICENENSE_BACKEND_STATUS_CMD = "sudo echo yes | hab svc status"
+	FRONTEND_STATUS_CMD                   = "sudo chef-automate status"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -116,6 +118,7 @@ func newStatusCmd() *cobra.Command {
 	statusCmd.Flags().SetAnnotation("os", docs.Compatibility, []string{docs.CompatiblewithHA})
 	statusCmd.Flags().StringVar(&statusCmdFlag.node, "node", "", "Pass this flag to check status of perticular node in the cluster")
 	statusCmd.Flags().SetAnnotation("node", docs.Compatibility, []string{docs.CompatiblewithHA})
+	statusCmd.Flags().StringVar(&statusCmdFlag.node, "--accept-hab-license", "", "Pass this flag to accept hab license for PostgresQL/OpenSearch nodes")
 
 	statusCmd.AddCommand(newStatusSummaryCmd())
 	return statusCmd

--- a/components/automate-cli/cmd/chef-automate/status_test.go
+++ b/components/automate-cli/cmd/chef-automate/status_test.go
@@ -131,7 +131,7 @@ func TestConstructNodeMapForStatus(t *testing.T) {
 				},
 				Postgresql: &Cmd{
 					CmdInputs: &CmdInputs{
-						Cmd:                      BACKEND_STATUS_CMD,
+						Cmd:                      "",
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,
@@ -142,7 +142,7 @@ func TestConstructNodeMapForStatus(t *testing.T) {
 				},
 				Opensearch: &Cmd{
 					CmdInputs: &CmdInputs{
-						Cmd:                      BACKEND_STATUS_CMD,
+						Cmd:                      "",
 						NodeIps:                  []string{""},
 						ErrorCheckEnableInOutput: true,
 						NodeType:                 false,
@@ -273,6 +273,71 @@ func TestRunStatusFromBastion(t *testing.T) {
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
 			errorWant: status.Errorf(status.InvalidCommandArgsError, STATUS_ERROR_ON_SELF_MANAGED, POSTGRESQL),
+		},
+		{
+			description: "Want status pg services when --accept-hab-license provided",
+			flags: &StatusCmdFlags{
+				postgresql:       true,
+				acceptHabLicense: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
+		{
+			description: "Want status os services when --accept-hab-license provided",
+			flags: &StatusCmdFlags{
+				opensearch:       true,
+				acceptHabLicense: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
+		},
+		{
+			description: "Want status all services when --accept-hab-license provided",
+			flags: &StatusCmdFlags{
+				acceptHabLicense: true,
+			},
+			mockNodeOpUtils: &MockNodeUtilsImpl{
+				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
+					return &AutomateHAInfraDetails{}, &SSHConfig{}, nil
+				},
+				isManagedServicesOnFunc: func() bool {
+					return false
+				},
+			},
+			mockRemoteCmdExec: &MockRemoteCmdExecutor{
+				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+					return map[string][]*CmdResult{}, nil
+				},
+				SetWriterFunc: func(cli *cli.Writer) {},
+			},
+			errorWant: nil,
 		},
 	}
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
In some environment they are not allowing to set the env variable.
For `chef-automate status` and `chef-automate service-versions` command internally we are using env variable in a command `sudo HAB_LICENSE=accept-no-persist hab svc status` so to accept hab license we are making use of a new flag which will accept the license
In automate installation setting the HAB_LICENSE is required and it is mandatory, with out setting this env flag we can not install the standalone automate and automate-HA.
By doing this ticket we are just adding the support for the flag --accept-hab-licence for chef-automate status command. 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-6574

### :+1: Definition of Done
Tested with `chef-automate status` and `chef-automate service-versions` backend flags 

### :athletic_shoe: How to Build and Test the Change
build automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[video](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/ER85y99EumJEtq9WudMcBpIBvBiZ7QsCj62pp7G9GSyPkA?e=h96rSp)
[chef-automate status --accept-hab-license](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EQKLBuOy-GxMn1i_mfjPgzkBCILnPrjM-ATgzpiZkVFEZA?e=FOWi85)
[chef-automate service-versions --accept-hab-license](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/ETD9FaZQM31Cm2j_OOWbKwABOg2ElZivRBc559LzWfjnSA?e=sI6v25)
Here's how the output looks if its accepting license via flag `accept-hab-license` same behaviour for both status and service-versions command
[chef-automate status --pg --accept-hab-license](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EbB8_-HcXpxFhEE-DN9Zl3gBEajEuCiPcHQnfp0ceZqcqQ?e=y6bV0B)