### PR TITLE
log level fix for automate-cds

### DIFF
--- a/components/automate-cds/habitat/default.toml
+++ b/components/automate-cds/habitat/default.toml
@@ -6,7 +6,7 @@ key_contents =""
 cert_contents = ""
 root_cert_contents = ""
 
-[logger]
+[log]
 format = "text"
 level = "info"
 

--- a/components/automate-cds/server/root.go
+++ b/components/automate-cds/server/root.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/chef/automate/api/external/cds/request"
 	"github.com/chef/automate/api/external/cds/response"
@@ -17,7 +17,6 @@ import (
 	"github.com/chef/automate/components/automate-cds/service"
 	"github.com/chef/automate/lib/io/chunks"
 	"github.com/chef/automate/lib/version"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -223,10 +222,9 @@ func (s *Server) DownloadContentItem(request *request.DownloadContentItem,
 	}
 
 	if !found {
-		return fmt.Errorf("Content item not found with ID %q", request.Id)
+		return fmt.Errorf("content item not found with ID %q", request.Id)
 	}
-
-	log.Infof("DownloadContentItem: Downloading content item with ID %s ...", request.Id)
+	s.service.Logger.Infof("DownloadContentItem: Downloading content item with ID %s ...", request.Id)
 
 	// Get the data
 	resp, err := http.Get(contentItem.DownloadURL)
@@ -243,7 +241,7 @@ func (s *Server) DownloadContentItem(request *request.DownloadContentItem,
 
 	_, err = reader.WriteTo(writer)
 	if err != nil {
-		return fmt.Errorf("Failed to stream: %+v", err)
+		return fmt.Errorf("failed to stream: %+v", err)
 	}
 
 	return nil
@@ -251,7 +249,7 @@ func (s *Server) DownloadContentItem(request *request.DownloadContentItem,
 
 func (s *Server) installProfile(ctx context.Context,
 	contentItem cloud.ContentItem, owner string, credentials creds.Credentials) error {
-	log.Infof("Installing profile content item with ID %s ...", contentItem.ID)
+	s.service.Logger.Infof("Installing profile content item with ID %s ...", contentItem.ID)
 
 	// Get the data
 	resp, err := http.Get(contentItem.DownloadURL)
@@ -265,7 +263,7 @@ func (s *Server) installProfile(ctx context.Context,
 		return status.Errorf(codes.Internal, "Failed connecting to the compliance-service")
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return status.Errorf(codes.Internal, "Failed streaming from SaaS")
 	}

--- a/components/automate-cds/server/server.go
+++ b/components/automate-cds/server/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/chef/automate/components/automate-cds/service"
 	"github.com/chef/automate/lib/grpc/health"
 	"github.com/chef/automate/lib/tracing"
-	log "github.com/sirupsen/logrus"
 )
 
 // NewGRPCServer creates a grpc server that serves all Teams GRPC APIs
@@ -38,7 +37,7 @@ func GRPC(config config.AutomateCdsConfig, s *service.Service) error {
 	complianceConn, err := s.ConnFactory.Dial("compliance-service", config.ComplianceService.Address)
 	if err != nil {
 		// This should never happen
-		log.WithError(err).Error("Failed to create compliance-service connection")
+		s.Logger.WithError(err).Error("Failed to create compliance-service connection")
 		return err
 	}
 	defer complianceConn.Close() // nolint: errcheck


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When we were patching any log level, it was not considering that level and showing all logs. So fixed this issue
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-7332
### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1288" alt="Screenshot 2023-10-18 at 6 55 20 PM" src="https://github.com/chef/automate/assets/108404805/5c6f3066-b4c4-4d85-9cef-337ebb36c2e7">
<img width="1293" alt="Screenshot 2023-10-18 at 7 00 24 PM" src="https://github.com/chef/automate/assets/108404805/b8a2f8fb-01a7-4350-b2ca-1c876c90fb0f">
<img width="1293" alt="Screenshot 2023-10-18 at 7 06 55 PM" src="https://github.com/chef/automate/assets/108404805/b7f7a32a-ed8b-4351-9f28-b3e8a66d667b">
