### PR TITLE
CHEF-6969 Added minio into the backup gateway 

### DIFF
--- a/components/backup-gateway/habitat/plan.sh
+++ b/components/backup-gateway/habitat/plan.sh
@@ -5,6 +5,7 @@ pkg_version="0.1.0"
 pkg_origin=chef
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Apache-2.0')
+pkg_build_deps=(core/go19 core/git core/gcc)
 pkg_deps=(
   core/minio
   core/cacerts
@@ -16,16 +17,27 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
-do_unpack() {
-    return 0
+do_before() {
+ GOPATH=$HAB_CACHE_SRC_PATH/$pkg_dirname
+ export GOPATH
 }
 
+do_unpack() {
+ git clone "https://github.com/chef/minio" "$GOPATH/src/github.com/chef/minio"
+ ( cd "$GOPATH/src/github.com/chef/minio" || exit
+   git checkout -b add_invalid_attempts
+ )
+}
+
+
 do_build(){
-    return 0
+  build_line "build minio"
+  cd "$GOPATH/src/github.com/chef/minio"
+  go build --ldflags "${GO_LDFLAGS}" -o "$pkg_prefix/bin/"
 }
 
 do_install() {
-    return 0
+  return 0
 }
 
 do_strip() {

--- a/components/backup-gateway/habitat/plan.sh
+++ b/components/backup-gateway/habitat/plan.sh
@@ -6,8 +6,9 @@ pkg_origin=chef
 pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=('Apache-2.0')
 pkg_build_deps=(core/go19 core/git core/gcc)
+pkg_bin_dirs=(bin)
+
 pkg_deps=(
-  core/minio
   core/cacerts
   chef/automate-platform-tools
 )
@@ -25,7 +26,7 @@ do_before() {
 do_unpack() {
  git clone "https://github.com/chef/minio" "$GOPATH/src/github.com/chef/minio"
  ( cd "$GOPATH/src/github.com/chef/minio" || exit
-   git checkout -b add_invalid_attempts
+   git checkout automate_minio
  )
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Build the minio binary in backup-gateway 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1784" alt="MicrosoftTeams-image (23)" src="https://github.com/chef/automate/assets/108404805/6f7870f9-050a-4e6a-9e14-7c789e3db70c">
<img width="1784" alt="MicrosoftTeams-image (24)" src="https://github.com/chef/automate/assets/108404805/1baf558b-6fdd-4f7f-90d6-b23c99848b4d">

