### PR TITLE
Remvoing config patch for old configs in upgrade and add/remove node

### DIFF
--- a/components/automate-backend-deployment/habitat/plan.sh
+++ b/components/automate-backend-deployment/habitat/plan.sh
@@ -26,7 +26,6 @@ pkg_deps=(
   chef/automate-ha-cluster-ctl
 )
 
-
 pkg_build_deps=(
   core/gcc
 )

--- a/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
+++ b/components/automate-cli/cmd/chef-automate/initConfigHaTmpl.go
@@ -64,6 +64,8 @@ instance_count = ""
 # automate_setup_type = "automate"
 
 # teams_port = ""
+
+# config_file will be deprecated
 config_file = "configs/automate.toml"
 
 # Set enable_custom_certs = true to provide custom certificates during deployment
@@ -396,6 +398,7 @@ instance_count = ""
 ## === ===
 
 # teams_port = ""
+# config_file will be deprecated
 config_file = "configs/automate.toml"
 
 # Set enable_custom_certs = true to provide custom certificates during deployment

--- a/components/automate-cli/cmd/chef-automate/upgrade.go
+++ b/components/automate-cli/cmd/chef-automate/upgrade.go
@@ -29,7 +29,6 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/toml"
 	"github.com/chef/automate/lib/io/fileutils"
 	"github.com/chef/automate/lib/majorupgrade_utils"
-	"github.com/chef/automate/lib/platform/command"
 	"github.com/fatih/color"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -39,18 +38,6 @@ import (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade COMMAND",
 	Short: "upgrade automate to the latest version",
-}
-
-type UpgradeClusterImpl struct {
-	nodeOptUtil NodeOpUtils
-}
-
-// Change constructor function name to NewUpgradeClusterImpl
-// if Implementer is modified
-func NewNodeUtilForUpgradeClusterImpl(nodeUtils NodeOpUtils) *UpgradeClusterImpl {
-	return &UpgradeClusterImpl{
-		nodeOptUtil: nodeUtils,
-	}
 }
 
 var upgradeRunCmdFlags = struct {
@@ -488,15 +475,6 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 	}
 
 	if offlineMode {
-
-		// Save node config to workspace
-		fmt.Println("saving config")
-		upgradeClusterImpl := NewNodeUtilForUpgradeClusterImpl(NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor(), writer))
-		err := upgradeClusterImpl.nodeOptUtil.saveConfigToBastion()
-		if err != nil {
-			return err
-		}
-
 		// Always upgrade the workspace
 		upgradeRunCmdFlags.upgradeHAWorkspace = "yes"
 		uperr, upgraded := upgradeWorspace(upgradeRunCmdFlags.airgap, upgradeRunCmdFlags.saas, upgradeRunCmdFlags.upgradefrontends, upgradeRunCmdFlags.upgradebackends)
@@ -550,25 +528,7 @@ func runAutomateHAFlow(args []string, offlineMode bool) error {
 			args = append(args, "--skip-deploy")
 		} */
 	}
-
-	// Save node config to workspace
-	fmt.Println("saving config")
-	upgradeClusterImpl := NewNodeUtilForUpgradeClusterImpl(NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor(), writer))
-	err := upgradeClusterImpl.nodeOptUtil.saveConfigToBastion()
-	if err != nil {
-		return err
-	}
-
-	err = executeAutomateClusterCtlCommandAsync("deploy", args, upgradeHaHelpDoc, true)
-	fmt.Println("syncying config")
-	syncErr := upgradeClusterImpl.nodeOptUtil.syncConfigToAllNodes()
-	if syncErr != nil {
-		if err != nil {
-			return errors.Wrap(err, syncErr.Error())
-		}
-		return syncErr
-	}
-	return err
+	return executeAutomateClusterCtlCommandAsync("deploy", args, upgradeHaHelpDoc, true)
 }
 
 func removeCommonContentFromAwsAutoTfvar(filePath string) error {

--- a/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
+++ b/terraform/a2ha-terraform/modules/automate/templates/provision.sh.tpl
@@ -294,8 +294,10 @@ if [ -e "/hab/user/deployment-service/config/user.toml" ]; then
 
    wait_for_upgrade
 
-  echo "Applying /etc/chef-automate/config.toml"
-  chef-automate config patch /etc/chef-automate/config.toml
+  # Below command is commented as patch is not required during upgrade and add/remove node
+  # Also when it is being applied, it was reverting patched configs (automate) to the older ones
+  # echo "Applying /etc/chef-automate/config.toml"
+  # chef-automate config patch /etc/chef-automate/config.toml
 
   echo "MAINTENANCE MODE OFF"
   chef-automate maintenance off


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
When user upgrade the bundle to latest, some configuration belongs to Automate config which are updated are reverting back to initial values. In this PR, that is addressed

### :chains: Related Resources
Jira ticket: https://chefio.atlassian.net/browse/CHEF-8418

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

In the below screenshot, when the deployment done, the original base path highlighted would be "elasticsearch", which lated updated to "opensearch".

After upgrade, the same value is intact
[Screenshot](https://progresssoftware.sharepoint.com/:i:/s/ChefCoreC/EZU33NVRF-dIvZs1doQ7iTEBEhfp5MceF8gRsqkXme_Ddw?e=ONBWpn)
