### PR TITLE
[WIP Testing] adding check for /tmp file permission in verify per-deployment

### DIFF
--- a/components/automate-cli/pkg/verifyserver/constants/systemresourcesfordepconstants.go
+++ b/components/automate-cli/pkg/verifyserver/constants/systemresourcesfordepconstants.go
@@ -30,6 +30,8 @@ const (
 	ROOT_FREE_DISK_IN_PER = 0.20
 
 	GB_TO_BYTES = 1024 * 1024 * 1024
+
+	TMP_DIR_REQUIRED_PERMISSION = "rwxrwxrwt"
 )
 
 const (
@@ -43,4 +45,8 @@ const (
 	SUCCESS_MSG_IN_PER = " or %v%% of total size of /hab"
 
 	RESOLUTION_MSG = "Please run system on supported platform"
+
+	PERMISSION_CHECK       = "%s permission check"
+	PERMISSION_SUCCESS_MSG = "%s should have %s permission"
+	PERMISSION_ERROR_MSG   = "%s permission is %s"
 )


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

As an Automate HA user when I do Deployment I may missed the required directory permission for /tmp which is 1777 or "rwxrwxrwt" we need to have a check in verify.

### :chains: Related Resources

### :+1: Definition of Done


Testing in progress

### :athletic_shoe: How to Build and Test the Change


build automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
