### PR TITLE
[fix][opensearch] Remove curl duplicated arguments in HC script

### DIFF
--- a/components/automate-opensearch/habitat/config/health_check
+++ b/components/automate-opensearch/habitat/config/health_check
@@ -22,7 +22,7 @@ function health_check() {
   es_host="127.0.0.1"
   {{/if ~}}
 
-  color="$(curl -s -XGET https://$es_host:{{svc.me.cfg.http-port}}/_cat/health?h=st -k -u admin:admin -k -u admin:admin)"
+  color="$(curl -s -XGET https://$es_host:{{svc.me.cfg.http-port}}/_cat/health?h=st -k -u admin:admin)"
   #color="$(curl -s --noproxy "$es_host" "http://$es_host:{{svc.me.cfg.http-port}}/_cat/health?h=st")"
 
   case $color in


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The current health check script for opensearch has duplicated arguments.
The functionality does not change as only the last occurrence of the argument will take precedence for curl.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [x] Tests added/updated? (all new code needs new tests)
- [x] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
