### PR TITLE
Fixed UI Issue in Compliance/Reports tab, unable to scroll

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -617,7 +617,6 @@ dl.waiver-details {
 
 .wrapper {
   height: 100vh;
-  // overflow-y: scroll;
   width: 100%;
 }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.scss
@@ -617,7 +617,7 @@ dl.waiver-details {
 
 .wrapper {
   height: 100vh;
-  overflow-y: scroll;
+  // overflow-y: scroll;
   width: 100%;
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
 Compliance ce/Reports tab, not able to scroll if the user wants to check the scan results
 
### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-2659
### :+1: Definition of Done
I have added CSS changes to fix this issue.

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://github.com/chef/automate/assets/12297653/9d49d12a-3f01-475f-932f-e065969c073b


