### PR TITLE
CHEF-5310: Added case insensitive match for search

### DIFF
--- a/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
+++ b/components/automate-ui/src/app/page-components/search-bar/search-bar.component.ts
@@ -180,7 +180,7 @@ export class SearchBarComponent implements OnChanges {
             type: type}});
         } else if (!this.suggestions.isEmpty()) {
           const foundSuggestion = this.suggestions.find((suggestion: SuggestionItem,
-            _key: number, _iter: any) => suggestion.title === currentText);
+            _key: number, _iter: any) => (suggestion.title || "").toLowerCase() === (currentText || "").toLowerCase());
 
           if (foundSuggestion) {
             const type = this.selectedCategoryType.type;
@@ -218,7 +218,7 @@ export class SearchBarComponent implements OnChanges {
         if (!this.hasStaticSuggestions()) {
           const type = this.selectedCategoryType.type;
           this.clearSuggestions();
-          this.requestForSuggestions({ text: currentText,
+          this.requestForSuggestions({ text: (currentText || "").toLowerCase(),
             type: type });
         } else {
           this.updateVisibleProvidedSuggestions(currentText);
@@ -240,7 +240,7 @@ export class SearchBarComponent implements OnChanges {
       if (!this.hasStaticSuggestions()) {
         const type = this.selectedCategoryType.type;
         this.clearSuggestions();
-        this.requestForSuggestions({ text: currentText,
+        this.requestForSuggestions({ text: (currentText || "").toLowerCase(),
           type: type });
       } else {
         this.updateVisibleProvidedSuggestions(currentText);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
The search is not sensitive to the case, the fix can be seen in the recording below.



https://github.com/chef/automate/assets/141399313/1b2b86a7-042f-42d9-8d89-eeb189cd39b8



<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
