### PR TITLE
fixed for - Can't Easily Filter By Nodes When Doing a Wildcard Search in Automate

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -62,6 +62,7 @@ export class ReportingSearchbarComponent implements OnInit {
   highlightedIndex = -1;
   inputText = '';
   delayForNoSuggestions = false;
+  suggestionValueClicked: boolean = false;
 
   constructor(
     public reportQuery: ReportQueryService,
@@ -171,6 +172,7 @@ export class ReportingSearchbarComponent implements OnInit {
         this.suggestionsVisible = true;
         break;
       case 'enter':
+        this.suggestionValueClicked = true;
         this.pressEnter(currentText);
         break;
       case 'backspace':
@@ -224,7 +226,7 @@ export class ReportingSearchbarComponent implements OnInit {
       }
     }
   }
-
+  
   pressEnterCategorySelected(currentText: string): void {
     if (this.highlightedIndex >= 0) {
       const search = this.filterValues[this.highlightedIndex];
@@ -268,7 +270,7 @@ export class ReportingSearchbarComponent implements OnInit {
     }
     this.showKeyInput();
     setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus(); }, 10);
-  }
+  } 
 
   pressDefaultText(currentText: string): void {
     if (this.selectedType) {
@@ -346,6 +348,7 @@ export class ReportingSearchbarComponent implements OnInit {
   }
 
   valueClick(value: any, event: Event) {
+    this.suggestionValueClicked = true;
     const type = this.selectedType;
     event.stopPropagation();
     this.suggestionsVisible = false;
@@ -400,21 +403,24 @@ export class ReportingSearchbarComponent implements OnInit {
     this.clearSuggestions();
     this.requestForSuggestions({
       text: text,
-      type: type,
+      type: type, 
       type_key: this.sugg.selectedControlTagKey
     });
     this.suggestionsVisibleStream.next(true);
+    this.suggestionValueClicked = false;
   }
 
   onValChange(e) {
-    const type = this.selectedType;
-    const text: string = e.target.value;
-    const suggestionValue = this.filterValues.filter(v => v.title === text)[0];
-    if (this.containsWildcardChar(text)) {
-      const wildcardValue = { text, title: text };
-      this.addNewFilter(type, wildcardValue);
-    } else if (suggestionValue && suggestionValue === undefined) {
-      this.addNewFilter(type, suggestionValue);
+    if (this.suggestionValueClicked) {
+      const type = this.selectedType;
+      const text: string = e.target.value;
+      const suggestionValue = this.filterValues.filter(v => v.title === text)[0];
+      if (this.containsWildcardChar(text)) {
+        const wildcardValue = { text, title: text };
+        this.addNewFilter(type, wildcardValue);
+      } else if (suggestionValue && suggestionValue === undefined) {
+        this.addNewFilter(type, suggestionValue);
+      }
     }
   }
 

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting-searchbar/reporting-searchbar.component.ts
@@ -226,7 +226,7 @@ export class ReportingSearchbarComponent implements OnInit {
       }
     }
   }
-  
+
   pressEnterCategorySelected(currentText: string): void {
     if (this.highlightedIndex >= 0) {
       const search = this.filterValues[this.highlightedIndex];
@@ -270,7 +270,7 @@ export class ReportingSearchbarComponent implements OnInit {
     }
     this.showKeyInput();
     setTimeout(() => { this.renderer.selectRootElement('#keyInput').focus(); }, 10);
-  } 
+  }
 
   pressDefaultText(currentText: string): void {
     if (this.selectedType) {

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -377,6 +377,10 @@ export class ReportingComponent implements OnInit, OnDestroy {
     let filterValue = value.text;
     let typeName = type.name;
 
+    if (value.text === undefined) {
+      filterValue = value;
+    }
+
     if (type.name === 'profile_with_version') {
       if ( value.id ) {
         typeName = 'profile_id';


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
As an Automate user, If your mouse is in the wrong position on the screen when you are trying to filter by nodes. You will always get the selected node from the list instead of your wildcard search.
### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-6423
### :+1: Definition of Done
I have added changes to prevent the mouse is clicking outside the suggestion list and the user can easily search the wildcard suggestion after typing in input.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://github.com/chef/automate/assets/12297653/db2466ba-66b5-4e2f-a4bf-22a97afc7802

