### PR TITLE
Adding license audit date as last 30 days

### DIFF
--- a/components/compliance-service/api/stats/server/server.go
+++ b/components/compliance-service/api/stats/server/server.go
@@ -160,7 +160,7 @@ func (srv *Server) ReadFailures(ctx context.Context, in *stats.Query) (*stats.Fa
 	return failures, nil
 }
 
-//UpdateTelemetryReported Updates the last compliance telemetry reported date in postgres after the telemetry data is sent
+// UpdateTelemetryReported Updates the last compliance telemetry reported date in postgres after the telemetry data is sent
 func (srv *Server) UpdateTelemetryReported(ctx context.Context, in *stats.UpdateTelemetryReportedRequest) (*stats.UpdateTelemetryReportedResponse, error) {
 	err := srv.pg.UpdateLastTelemetryReported(ctx, in)
 	if err != nil {
@@ -169,7 +169,7 @@ func (srv *Server) UpdateTelemetryReported(ctx context.Context, in *stats.Update
 	return &stats.UpdateTelemetryReportedResponse{}, nil
 }
 
-//GetNodesUsageCount returns the count of unique nodes with lastRun in a given time.
+// GetNodesUsageCount returns the count of unique nodes with lastRun in a given time.
 func (srv *Server) GetNodesUsageCount(ctx context.Context, in *stats.GetNodesUsageCountRequest) (*stats.GetNodesUsageCountResponse, error) {
 	var count int64
 	// Get last telemetry reported date from postgres
@@ -184,7 +184,9 @@ func (srv *Server) GetNodesUsageCount(ctx context.Context, in *stats.GetNodesUsa
 		daysSinceLastPost = utils.DaysBetween(telemetry.LastTelemetryReportedAt, time.Now())
 	}
 	if daysSinceLastPost > 0 {
-		count, err = srv.es.GetUniqueNodesCount(int64(daysSinceLastPost), telemetry.LastTelemetryReportedAt)
+		//CHEF-11615 Making the duration as 30 days
+		duration := 30
+		count, err = srv.es.GetUniqueNodesCount(int64(duration), telemetry.LastTelemetryReportedAt)
 		if err != nil {
 			return nil, err
 		}

--- a/components/compliance-service/api/stats/server/server.go
+++ b/components/compliance-service/api/stats/server/server.go
@@ -179,7 +179,7 @@ func (srv *Server) GetNodesUsageCount(ctx context.Context, in *stats.GetNodesUsa
 	}
 	var daysSinceLastPost int
 	if telemetry.LastTelemetryReportedAt.IsZero() {
-		daysSinceLastPost = 15
+		daysSinceLastPost = 30
 	} else {
 		daysSinceLastPost = utils.DaysBetween(telemetry.LastTelemetryReportedAt, time.Now())
 	}

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/chef/automate/api/interservice/compliance/ingest/events/inspec"
 	"time"
+
+	"github.com/chef/automate/api/interservice/compliance/ingest/events/inspec"
 
 	elastic "github.com/olivere/elastic/v7"
 	"github.com/pkg/errors"
@@ -400,21 +401,21 @@ func (backend ES2Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelem
 	}
 
 	var rangeQueryThreshold *elastic.RangeQuery
-	t := time.Now().AddDate(0, 0, -1)
-	yesterdayEODTimeStamp := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, t.Nanosecond(), t.Location())
+	t := time.Now()
+	startDayTimeStamp := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, t.Nanosecond(), t.Location())
 	lastTelemetryReportedDate := lastTelemetryReportedAt.Format("2006-01-02")
 
 	// if daysSinceLastPost >= three months then take the unique nodes count from last three months
 	// and if daysSinceLastPost > 15 and < three months then take unique nodes count from lastTelemetryReportedDate to yesterday EOD
 	// else take the unique nodes count from last 15 days
 	if daysSinceLastPost >= 90 {
-		startTimeStamp := yesterdayEODTimeStamp.AddDate(0, 0, -91)
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(yesterdayEODTimeStamp)
-	} else if daysSinceLastPost > 15 {
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(lastTelemetryReportedDate).To(yesterdayEODTimeStamp)
+		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -91)
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(time.Now())
+	} else if daysSinceLastPost > 30 {
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(lastTelemetryReportedDate).To(time.Now())
 	} else {
-		startTimeStamp := yesterdayEODTimeStamp.AddDate(0, 0, -16)
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(yesterdayEODTimeStamp)
+		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -31)
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(time.Now())
 	}
 	boolQuery := elastic.NewBoolQuery().
 		Must(rangeQueryThreshold)

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -17,7 +17,7 @@ import (
 	"github.com/chef/automate/components/compliance-service/ingest/ingestic/mappings"
 )
 
-//GetStatsSummary - Report #16
+// GetStatsSummary - Report #16
 func (backend ES2Backend) GetStatsSummary(filters map[string][]string) (*stats.ReportSummary, error) {
 	myName := "GetStatsSummary"
 	// Only end_time matters for this call
@@ -68,7 +68,7 @@ func (backend ES2Backend) GetStatsSummary(filters map[string][]string) (*stats.R
 	return depth.getStatsSummaryResult(searchResult), nil
 }
 
-//GetStatsSummaryNodes - Gets summary stats, node centric, aggregate data for the given set of filters
+// GetStatsSummaryNodes - Gets summary stats, node centric, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsSummaryNodes(filters map[string][]string) (*stats.NodeSummary, error) {
 	myName := "GetStatsSummaryNodes"
 	latestOnly := FetchLatestDataOrNot(filters)
@@ -120,7 +120,7 @@ func (backend ES2Backend) GetStatsSummaryNodes(filters map[string][]string) (*st
 	return depth.getStatsSummaryNodesResult(searchResult), nil
 }
 
-//GetStatsSummaryControlsRange - Gets summary stats, control centric, aggregate data for the given set of filters with date range
+// GetStatsSummaryControlsRange - Gets summary stats, control centric, aggregate data for the given set of filters with date range
 func (backend ES2Backend) GetStatsSummaryControlsRange(filters map[string][]string) (*stats.ControlsSummary, error) {
 	myName := "GetStatsSummaryControlsRange"
 
@@ -169,7 +169,7 @@ func (backend ES2Backend) GetStatsSummaryControlsRange(filters map[string][]stri
 	return backend.getStatsSummaryControlsResult(searchResult), nil
 }
 
-//GetStatsSummaryControls - Gets summary stats, control centric, aggregate data for the given set of filters
+// GetStatsSummaryControls - Gets summary stats, control centric, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (*stats.ControlsSummary, error) {
 	myName := "GetStatsSummaryControls"
 
@@ -232,7 +232,7 @@ func (backend ES2Backend) GetStatsSummaryControls(filters map[string][]string) (
 	return depth.getStatsSummaryControlsResult(searchResult), nil
 }
 
-//GetStatsFailures - Gets top failures, aggregate data for the given set of filters
+// GetStatsFailures - Gets top failures, aggregate data for the given set of filters
 func (backend ES2Backend) GetStatsFailures(reportTypes []string, size int, filters map[string][]string) (*stats.Failures, error) {
 	myName := "GetStatsFailures"
 	var failures *stats.Failures
@@ -295,8 +295,8 @@ func (backend ES2Backend) GetStatsFailures(reportTypes []string, size int, filte
 	return depth.getStatsTopFailuresResult(searchResult, reportTypes)
 }
 
-//GetProfileListWithAggregatedComplianceSummaries - Report #6
-//todo - Where in A2 UI is this being called? It now works with deep filtering but not sure if we need it.
+// GetProfileListWithAggregatedComplianceSummaries - Report #6
+// todo - Where in A2 UI is this being called? It now works with deep filtering but not sure if we need it.
 func (backend ES2Backend) GetProfileListWithAggregatedComplianceSummaries(
 	filters map[string][]string, size int32) ([]*stats.ProfileList, error) {
 	myName := "GetProfileListWithAggregatedComplianceSummaries"
@@ -339,7 +339,7 @@ func (backend ES2Backend) GetProfileListWithAggregatedComplianceSummaries(
 	return depth.getProfileListWithAggregatedComplianceSummariesResults(searchResult, filters), nil
 }
 
-//GetControlListStatsByProfileID returns the control list for a given profile or profile and a child control
+// GetControlListStatsByProfileID returns the control list for a given profile or profile and a child control
 // the data retrieved from this appears at the bottom of the a2 page when you select a profile from list
 func (backend ES2Backend) GetControlListStatsByProfileID(profileID string, from int, size int,
 	filters map[string][]string, sortField string, sortAsc bool) ([]*stats.ControlStats, error) {
@@ -392,7 +392,7 @@ func (backend ES2Backend) GetControlListStatsByProfileID(profileID string, from 
 	return depth.getControlListStatsByProfileIdResults(&backend, searchResult, profileID)
 }
 
-//GetUniqueNodesCount: Get the unique nodes count based on the lastTelemetryReportedAt
+// GetUniqueNodesCount: Get the unique nodes count based on the lastTelemetryReportedAt
 func (backend ES2Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelemetryReportedAt time.Time) (int64, error) {
 	client, err := backend.ES2Client()
 	if err != nil {
@@ -406,8 +406,8 @@ func (backend ES2Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelem
 	lastTelemetryReportedDate := lastTelemetryReportedAt.Format("2006-01-02")
 
 	// if daysSinceLastPost >= three months then take the unique nodes count from last three months
-	// and if daysSinceLastPost > 15 and < three months then take unique nodes count from lastTelemetryReportedDate to yesterday EOD
-	// else take the unique nodes count from last 15 days
+	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to today EOD
+	// else take the unique nodes count from last 30 days
 	if daysSinceLastPost >= 90 {
 		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -91)
 		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(time.Now())
@@ -448,7 +448,7 @@ func (backend ES2Backend) getStatsSummaryControlsAggs() map[string]elastic.Aggre
 	return aggs
 }
 
-//getStatsSummaryControlsResult get the aggregations result for the control summary query
+// getStatsSummaryControlsResult get the aggregations result for the control summary query
 func (backend ES2Backend) getStatsSummaryControlsResult(aggRoot *elastic.SearchResult) *stats.ControlsSummary {
 	summary := &stats.ControlsSummary{}
 

--- a/components/compliance-service/reporting/relaxting/stats.go
+++ b/components/compliance-service/reporting/relaxting/stats.go
@@ -406,7 +406,7 @@ func (backend ES2Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelem
 	lastTelemetryReportedDate := lastTelemetryReportedAt.Format("2006-01-02")
 
 	// if daysSinceLastPost >= three months then take the unique nodes count from last three months
-	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to today EOD
+	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to current time
 	// else take the unique nodes count from last 30 days
 	if daysSinceLastPost >= 90 {
 		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -91)

--- a/components/config-mgmt-service/backend/elastic/telemetry.go
+++ b/components/config-mgmt-service/backend/elastic/telemetry.go
@@ -11,21 +11,21 @@ import (
 func (es Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelemetryReportedAt time.Time) (int64, error) {
 
 	var rangeQueryThreshold *elastic.RangeQuery
-	t := time.Now().AddDate(0, 0, -1)
-	yesterdayEODTimeStamp := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, t.Nanosecond(), t.Location())
+	t := time.Now()
+	startDayTimeStamp := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, t.Nanosecond(), t.Location())
 	lastTelemetryReportedDate := lastTelemetryReportedAt.Format("2006-01-02")
 
 	// if daysSinceLastPost >= three months then take the unique nodes count from last three months
-	// and if daysSinceLastPost > 15 and < three months then take unique nodes count from lastTelemetryReportedDate to yesterday EOD
-	// else take the unique nodes count from last 15 days
+	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to yesterday EOD
+	// else take the unique nodes count from last 30 days
 	if daysSinceLastPost >= 90 {
-		startTimeStamp := yesterdayEODTimeStamp.AddDate(0, 0, -91)
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(yesterdayEODTimeStamp)
-	} else if daysSinceLastPost > 15 {
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(lastTelemetryReportedDate).To(yesterdayEODTimeStamp)
+		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -91)
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(time.Now())
+	} else if daysSinceLastPost > 30 {
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(lastTelemetryReportedDate).To(time.Now())
 	} else {
-		startTimeStamp := yesterdayEODTimeStamp.AddDate(0, 0, -16)
-		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(yesterdayEODTimeStamp)
+		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -31)
+		rangeQueryThreshold = elastic.NewRangeQuery("last_run").From(startTimeStamp).To(time.Now())
 	}
 	boolQuery := elastic.NewBoolQuery().
 		Must(rangeQueryThreshold)

--- a/components/config-mgmt-service/backend/elastic/telemetry.go
+++ b/components/config-mgmt-service/backend/elastic/telemetry.go
@@ -7,7 +7,7 @@ import (
 	elastic "github.com/olivere/elastic/v7"
 )
 
-//GetUniqueNodesCount: Get the unique nodes count based on the lastTelemetryReportedAt
+// GetUniqueNodesCount: Get the unique nodes count based on the lastTelemetryReportedAt
 func (es Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelemetryReportedAt time.Time) (int64, error) {
 
 	var rangeQueryThreshold *elastic.RangeQuery
@@ -16,7 +16,7 @@ func (es Backend) GetUniqueNodesCount(daysSinceLastPost int64, lastTelemetryRepo
 	lastTelemetryReportedDate := lastTelemetryReportedAt.Format("2006-01-02")
 
 	// if daysSinceLastPost >= three months then take the unique nodes count from last three months
-	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to yesterday EOD
+	// and if daysSinceLastPost > 30 and < three months then take unique nodes count from lastTelemetryReportedDate to current time
 	// else take the unique nodes count from last 30 days
 	if daysSinceLastPost >= 90 {
 		startTimeStamp := startDayTimeStamp.AddDate(0, 0, -91)

--- a/components/config-mgmt-service/grpcserver/telemetry.go
+++ b/components/config-mgmt-service/grpcserver/telemetry.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-//UpdateTelemetryReported Update the last client run telemetry reported date in postgres
+// UpdateTelemetryReported Update the last client run telemetry reported date in postgres
 func (s *CfgMgmtServer) UpdateTelemetryReported(ctx context.Context, req *request.UpdateTelemetryReportedRequest) (*response.UpdateTelemetryReportedResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
@@ -24,7 +24,7 @@ func (s *CfgMgmtServer) UpdateTelemetryReported(ctx context.Context, req *reques
 	return &response.UpdateTelemetryReportedResponse{}, nil
 }
 
-//GetNodesUsageCount returns the count of unique nodes with lastRun in a given time.
+// GetNodesUsageCount returns the count of unique nodes with lastRun in a given time.
 func (s *CfgMgmtServer) GetNodesUsageCount(ctx context.Context, req *request.GetNodesUsageCountRequest) (*response.GetNodesUsageCountResponse, error) {
 	var count int64
 	// Get last telemetry reported date from postgres
@@ -39,7 +39,8 @@ func (s *CfgMgmtServer) GetNodesUsageCount(ctx context.Context, req *request.Get
 		daysSinceLastPost = DaysBetween(telemetry.LastTelemetryReportedAt, time.Now())
 	}
 	if daysSinceLastPost > 0 {
-		count, err = s.client.GetUniqueNodesCount(int64(daysSinceLastPost), telemetry.LastTelemetryReportedAt)
+		duration := 30
+		count, err = s.client.GetUniqueNodesCount(int64(duration), telemetry.LastTelemetryReportedAt)
 		if err != nil {
 			return nil, err
 		}

--- a/components/config-mgmt-service/grpcserver/telemetry.go
+++ b/components/config-mgmt-service/grpcserver/telemetry.go
@@ -34,7 +34,7 @@ func (s *CfgMgmtServer) GetNodesUsageCount(ctx context.Context, req *request.Get
 	}
 	var daysSinceLastPost int
 	if telemetry.LastTelemetryReportedAt.IsZero() {
-		daysSinceLastPost = 15
+		daysSinceLastPost = 30
 	} else {
 		daysSinceLastPost = DaysBetween(telemetry.LastTelemetryReportedAt, time.Now())
 	}
@@ -46,7 +46,7 @@ func (s *CfgMgmtServer) GetNodesUsageCount(ctx context.Context, req *request.Get
 		}
 	}
 	return &response.GetNodesUsageCountResponse{
-		DaysSinceLastPost: int64(daysSinceLastPost),
+		DaysSinceLastPost: int64(30),
 		NodeCnt:           count,
 	}, nil
 }

--- a/components/config-mgmt-service/grpcserver/telemetry.go
+++ b/components/config-mgmt-service/grpcserver/telemetry.go
@@ -46,7 +46,7 @@ func (s *CfgMgmtServer) GetNodesUsageCount(ctx context.Context, req *request.Get
 		}
 	}
 	return &response.GetNodesUsageCountResponse{
-		DaysSinceLastPost: int64(30),
+		DaysSinceLastPost: int64(daysSinceLastPost),
 		NodeCnt:           count,
 	}, nil
 }

--- a/components/license-control-service/licenseaudit/licenseauditworkflow.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow.go
@@ -32,6 +32,7 @@ func InitCerealManager(ctx context.Context, cerealManager *cereal.Manager, worke
 	}
 
 	log.Info("Successfully registered migration-workflow")
+	log.Info("GOt the url as --------------", endpointurl)
 	err = cerealManager.RegisterTaskExecutor(LicenseAuditTaskName, &LicenseAuditTask{ExecuteCommand: NewExecute(logger.NewLogrusStandardLogger()), Command: Command, EndPointURl: endpointurl}, cereal.TaskExecutorOpts{Workers: workerCount})
 	if err != nil {
 		log.Errorf("Found error in RegisterTaskExecutor for license-audit %v", err)
@@ -219,15 +220,17 @@ func executeCommandforAudit(executeCommand ExecuteCommand, command string) (stri
 // getAppendedCommand gets the appended command with date
 func getAppendedCommand(commandToExecute string, url string) string {
 	//Taking the date time as last 30 days
-	startDate := time.Now().AddDate(0, 0, -30)
+	startDate := time.Now().AddDate(0, 0, -31)
 	//StartDateTime start of the day timestamp as 00:00:00
 	startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 
 	endDate := time.Now().UTC().Format(time.RFC3339)
 	if url == "" {
+		fmt.Println("-----test " + fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName))
 		return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName)
 	}
 	commandToExecute = commandToExecute + " -u %s"
+	fmt.Println("-----test with url---" + fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName))
 	return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName, url)
 }
 

--- a/components/license-control-service/licenseaudit/licenseauditworkflow.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow.go
@@ -218,13 +218,17 @@ func executeCommandforAudit(executeCommand ExecuteCommand, command string) (stri
 
 // getAppendedCommand gets the appended command with date
 func getAppendedCommand(commandToExecute string, url string) string {
-	startDate := time.Now().AddDate(0, 0, -30).UTC().Format("2006-01-02")
-	endDate := time.Now().Format("2006-01-02")
+	//Taking the date time as last 30 days
+	startDate := time.Now().AddDate(0, 0, -30)
+	//StartDateTime start of the day timestamp as 00:00:00
+	startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	endDate := time.Now().UTC().Format(time.RFC3339)
 	if url == "" {
-		return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName)
+		return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName)
 	}
 	commandToExecute = commandToExecute + " -u %s"
-	return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName, url)
+	return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName, url)
 }
 
 func getWorkflowParametersAndEnqueTask(w cereal.WorkflowInstance) (AuditWorkflowParameters, error) {

--- a/components/license-control-service/licenseaudit/licenseauditworkflow.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow.go
@@ -218,12 +218,13 @@ func executeCommandforAudit(executeCommand ExecuteCommand, command string) (stri
 
 // getAppendedCommand gets the appended command with date
 func getAppendedCommand(commandToExecute string, url string) string {
-	yesterdayDate := time.Now().AddDate(0, 0, -1).UTC().Format("2006-01-02")
+	startDate := time.Now().AddDate(0, 0, -30).UTC().Format("2006-01-02")
+	endDate := time.Now().Format("2006-01-02")
 	if url == "" {
-		return fmt.Sprintf(commandToExecute, yesterdayDate, yesterdayDate, OutputFileName)
+		return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName)
 	}
 	commandToExecute = commandToExecute + " -u %s"
-	return fmt.Sprintf(commandToExecute, yesterdayDate, yesterdayDate, OutputFileName, url)
+	return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName, url)
 }
 
 func getWorkflowParametersAndEnqueTask(w cereal.WorkflowInstance) (AuditWorkflowParameters, error) {

--- a/components/license-control-service/licenseaudit/licenseauditworkflow.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow.go
@@ -219,16 +219,15 @@ func executeCommandforAudit(executeCommand ExecuteCommand, command string) (stri
 // getAppendedCommand gets the appended command with date
 func getAppendedCommand(commandToExecute string, url string) string {
 	//Taking the date time as last 30 days
-	startDate := time.Now().AddDate(0, 0, -31)
+	startDate := time.Now().AddDate(0, 0, -31).Format("2006-01-02")
 	//StartDateTime start of the day timestamp as 00:00:00
-	startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 
-	endDate := time.Now().UTC().Format(time.RFC3339)
+	endDate := time.Now().UTC().Format("2006-01-02")
 	if url == "" {
-		return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName)
+		return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName)
 	}
 	commandToExecute = commandToExecute + " -u %s"
-	return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName, url)
+	return fmt.Sprintf(commandToExecute, startDate, endDate, OutputFileName, url)
 }
 
 func getWorkflowParametersAndEnqueTask(w cereal.WorkflowInstance) (AuditWorkflowParameters, error) {

--- a/components/license-control-service/licenseaudit/licenseauditworkflow.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow.go
@@ -32,7 +32,6 @@ func InitCerealManager(ctx context.Context, cerealManager *cereal.Manager, worke
 	}
 
 	log.Info("Successfully registered migration-workflow")
-	log.Info("GOt the url as --------------", endpointurl)
 	err = cerealManager.RegisterTaskExecutor(LicenseAuditTaskName, &LicenseAuditTask{ExecuteCommand: NewExecute(logger.NewLogrusStandardLogger()), Command: Command, EndPointURl: endpointurl}, cereal.TaskExecutorOpts{Workers: workerCount})
 	if err != nil {
 		log.Errorf("Found error in RegisterTaskExecutor for license-audit %v", err)
@@ -226,11 +225,9 @@ func getAppendedCommand(commandToExecute string, url string) string {
 
 	endDate := time.Now().UTC().Format(time.RFC3339)
 	if url == "" {
-		fmt.Println("-----test " + fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName))
 		return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName)
 	}
 	commandToExecute = commandToExecute + " -u %s"
-	fmt.Println("-----test with url---" + fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName))
 	return fmt.Sprintf(commandToExecute, startDateTime, endDate, OutputFileName, url)
 }
 

--- a/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
@@ -345,18 +345,18 @@ func Test_getAppendedCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			startDate := time.Now().AddDate(0, 0, -31)
-			startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
-			endDate := time.Now().UTC().Format(time.RFC3339)
+			startDate := time.Now().AddDate(0, 0, -31).Format("2006-01-02")
+			endDate := time.Now().UTC().Format("2006-01-02")
 
 			got := getAppendedCommand(tt.command, tt.url)
 
 			if tt.url == "" {
-				tt.want = fmt.Sprintf(tt.command, startDateTime, endDate, OutputFileName)
+				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName)
 			} else {
 				tt.command = tt.command + " -u %s"
-				tt.want = fmt.Sprintf(tt.command, startDateTime, endDate, OutputFileName, tt.url)
+				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName, tt.url)
 			}
+
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
@@ -345,7 +345,7 @@ func Test_getAppendedCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			startDate := time.Now().AddDate(0, 0, -30)
+			startDate := time.Now().AddDate(0, 0, -31)
 			startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
 			endDate := time.Now().UTC().Format(time.RFC3339)
 

--- a/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
@@ -355,7 +355,7 @@ func Test_getAppendedCommand(t *testing.T) {
 				tt.want = fmt.Sprintf(tt.command, startDateTime, endDate, OutputFileName)
 			} else {
 				tt.command = tt.command + " -u %s"
-				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName, tt.url)
+				tt.want = fmt.Sprintf(tt.command, startDateTime, endDate, OutputFileName, tt.url)
 			}
 			assert.Equal(t, tt.want, got)
 		})

--- a/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
@@ -345,15 +345,16 @@ func Test_getAppendedCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dateToBeAppended := time.Now().AddDate(0, 0, -1).UTC().Format("2006-01-02")
+			startDate := time.Now().AddDate(0, 0, -30).UTC().Format("2006-01-02")
+			endDate := time.Now().Format("2006-01-02")
 
 			got := getAppendedCommand(tt.command, tt.url)
 
 			if tt.url == "" {
-				tt.want = fmt.Sprintf(tt.command, dateToBeAppended, dateToBeAppended, OutputFileName)
+				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName)
 			} else {
 				tt.command = tt.command + " -u %s"
-				tt.want = fmt.Sprintf(tt.command, dateToBeAppended, dateToBeAppended, OutputFileName, tt.url)
+				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName, tt.url)
 			}
 			assert.Equal(t, tt.want, got)
 		})

--- a/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
+++ b/components/license-control-service/licenseaudit/licenseauditworkflow_test.go
@@ -345,13 +345,14 @@ func Test_getAppendedCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			startDate := time.Now().AddDate(0, 0, -30).UTC().Format("2006-01-02")
-			endDate := time.Now().Format("2006-01-02")
+			startDate := time.Now().AddDate(0, 0, -30)
+			startDateTime := time.Date(startDate.Year(), startDate.Month(), startDate.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+			endDate := time.Now().UTC().Format(time.RFC3339)
 
 			got := getAppendedCommand(tt.command, tt.url)
 
 			if tt.url == "" {
-				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName)
+				tt.want = fmt.Sprintf(tt.command, startDateTime, endDate, OutputFileName)
 			} else {
 				tt.command = tt.command + " -u %s"
 				tt.want = fmt.Sprintf(tt.command, startDate, endDate, OutputFileName, tt.url)


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Changing the days of license audit data to be 30 days. Now it will send all the unique nodes for last 30 days.
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-11615

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

```
rebuild components/compliance-service/
rebuild components/config-mgmt-service/
rebuild components/license-control-service
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
[CHEF-11615.mov](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EcTZJYOcNi5Eqqnvm0_m-u0B7_y9CI9_-Qt6UZ5vqNAdwQ?e=5czWkM&isSPOFile=1)