### PR TITLE
Fixed event feed fails to show data after filtering, event feed date.

### DIFF
--- a/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
+++ b/components/automate-ui/src/app/page-components/event-feed-guitar-strings/event-feed-guitar-strings.component.html
@@ -94,7 +94,6 @@
           <span class="guitar-tooltip-text">
             <span class="guitar-tooltip-date">
               {{ item.start | datetime: DateTime.CHEF_DATE_TIME }}
-              {{ item.start | datetime: DateTime.CHEF_HOURS_MINS }} - {{ item.end | datetime: DateTime.CHEF_HOURS_MINS }} UTC
             </span>
             <span [innerHTML]="getTooltipText(item, item.isMultiple(), guitarString)"></span>
           </span>

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { EventFeedComponent } from './event-feed.component';
+import { Store } from '@ngrx/store';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LayoutFacadeService, Sidebar } from 'app/entities/layout/layout.facade';
+import { of } from 'rxjs';
+import * as eventFeedActions from '../../services/event-feed/event-feed.actions';
+
+describe('EventFeedComponent', () => {
+  let component: EventFeedComponent;
+  let fixture: ComponentFixture<EventFeedComponent>;
+  let mockStore: any;
+  let mockActivatedRoute: any;
+  let mockRouter: any;
+  let mockLayoutFacadeService: any;
+  let router: Router;
+
+  beforeEach(async () => {
+    mockStore = {
+      select: jasmine.createSpy('select').and.returnValue(of([])),
+      dispatch: jasmine.createSpy('dispatch')
+    };
+
+    mockActivatedRoute = {
+        snapshot: {
+          queryParamMap: of({}), // Mocking queryParamMap to return an observable with an empty object
+        },
+        // Provide a mock for the pipe method of queryParamMap
+        queryParamMap: {
+          pipe: () => of({}) // Mocking the pipe method to return an observable with an empty object
+        }
+      };
+    
+
+    mockRouter = {
+      navigate: jasmine.createSpy('navigate')
+    };
+
+    mockLayoutFacadeService = {
+      showSidebar: jasmine.createSpy('showSidebar')
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [EventFeedComponent],
+      providers: [
+        { provide: Store, useValue: mockStore },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: LayoutFacadeService, useValue: mockLayoutFacadeService },
+        { provide: Router, useValue: mockRouter }, 
+      ]
+    }).compileComponents();
+    router = TestBed.inject(Router);
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EventFeedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize component properly', () => {
+    expect(mockLayoutFacadeService.showSidebar).toHaveBeenCalledWith(Sidebar.Dashboards);
+  });
+
+  it('should toggle filters visibility', () => {
+    const initialVisibility = component.filtersVisible;
+    component.toggleFilters();
+    expect(component.filtersVisible).toEqual(!initialVisibility);
+  });
+
+  it('should dispatch suggestion action on suggest values', () => {
+    const type = 'test';
+    const text = 'test';
+    component.onSuggestValues({ detail: { type, text } });
+    expect(mockStore.dispatch).toHaveBeenCalledWith(eventFeedActions.getSuggestions(type, text));
+  });
+
+  it('should update router on filter added', () => {
+    const event = { detail: { type: 'test', text: 'test' } };
+    const navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+    component.onFilterAdded(event);
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      queryParams: { test: ['test'] }
+    }); 
+  });
+  
+
+  it('should update router on filters clear', () => {
+    const event = {};
+    component.onFiltersClear(event);
+    expect(mockRouter.navigate).toHaveBeenCalled();
+  });
+
+  it('should update router on filter removed', () => {
+    const event = { detail: { type: 'test', text: 'test' } };
+    component.onFilterRemoved(event);
+    expect(mockRouter.navigate).toHaveBeenCalled();
+  });
+
+  it('should dispatch load more action on load more', () => {
+    component.loadMore();
+    expect(mockStore.dispatch).toHaveBeenCalledWith(eventFeedActions.loadMoreFeed());
+  });
+
+  it('should dispatch date range filter action on select date range', fakeAsync(() => {
+    const dateRange = { start: new Date(), end: new Date() };
+    component.selectDateRange(dateRange);
+    tick();
+    expect(mockStore.dispatch).toHaveBeenCalled();
+  }));
+});

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.spec.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.spec.ts
@@ -15,6 +15,7 @@ import { of } from "rxjs";
 import * as eventFeedActions from "../../services/event-feed/event-feed.actions";
 import * as eventFeedSelectors from "../../services/event-feed/event-feed.selectors";
 import { EventTaskCount } from "../../types/types";
+import * as moment from 'moment';
 
 describe("EventFeedComponent", () => {
   let component: EventFeedComponent;
@@ -32,10 +33,10 @@ describe("EventFeedComponent", () => {
     };
 
     mockActivatedRoute = {
-        snapshot: {
-          queryParamMap: { get: () => {} }, // Simulate snapshot queryParamMap
-        },
-        queryParamMap: of({ get: () => {} }), // Simulate observable queryParamMap
+      snapshot: {
+        queryParamMap: { getAll: () => [] },
+      },
+      queryParamMap: of({ getAll: () => [] }),
     };
       
     mockRouter = {
@@ -123,6 +124,7 @@ describe("EventFeedComponent", () => {
     expect(mockStore.dispatch).toHaveBeenCalled();
   }));
 
+  // addFeedDateRangeFilter
   it("should disable resetTimescale and clear filterTimeScaleDates when date range is within 6 days", () => {
     const dateRange = { start: new Date(), end: new Date() };
     component.selectDateRange(dateRange);
@@ -134,6 +136,7 @@ describe("EventFeedComponent", () => {
     );
   });
   
+  // addFeedDateRangeFilter
   it("should enable resetTimescale and set filterTimeScaleDates when date range exceeds 6 days", () => {
     const startDate = new Date("2024-05-01");
     const endDate = new Date("2024-05-08");
@@ -150,6 +153,7 @@ describe("EventFeedComponent", () => {
     );
   });
   
+  // setHeadersCountOnFilterTimeScale
   it("should update header counts after a delay", fakeAsync(() => {
     const initialCounts: EventTaskCount = {
       total: 10,
@@ -168,4 +172,37 @@ describe("EventFeedComponent", () => {
     expect(component.createCounts).toEqual(initialCounts.create);
     expect(component.deleteCounts).toEqual(initialCounts.delete);
   }));
+
+  // getAllDatesInRange
+  it('should generate correct array of dates between start and end date', () => {
+    const startDate = new Date('2024-05-01');
+    const endDate = new Date('2024-05-05');
+    const expectedDates = ['2024-05-01', '2024-05-02', '2024-05-03', '2024-05-04', '2024-05-05'];
+    const generatedDates = component.getAllDatesInRange(startDate, endDate);
+    expect(generatedDates).toEqual(expectedDates);
+  });
+
+  it('should handle the case when start and end dates are the same', () => {
+    const startDate = new Date('2024-05-01');
+    const endDate = new Date('2024-05-01');
+    const expectedDates = ['2024-05-01'];
+    const generatedDates = component.getAllDatesInRange(startDate, endDate);
+    expect(generatedDates).toEqual(expectedDates);
+  });
+
+  it('should handle the case when end date is before the start date', () => {
+    const startDate = new Date('2024-05-05');
+    const endDate = new Date('2024-05-01');
+    const generatedDates = component.getAllDatesInRange(startDate, endDate);
+    expect(generatedDates.length).toBe(0);
+  });
+
+  it('should handle edge cases for large date ranges', () => {
+    const startDate = new Date('2024-05-01');
+    const endDate = new Date('2024-05-10');
+    const generatedDates = component.getAllDatesInRange(startDate, endDate);
+    const expectedLength = moment(endDate).diff(startDate, 'days') + 1;
+    expect(generatedDates.length).toBe(expectedLength);
+  });
+  
 });

--- a/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
+++ b/components/automate-ui/src/app/pages/event-feed/event-feed.component.ts
@@ -244,9 +244,9 @@ export class EventFeedComponent implements OnInit, OnDestroy {
 
     if (start.add(6, 'days').format('l') !== end.format('l')) {
       this.resetTimescaleDisabled = false;
-      const isStartDate = moment(dateRange.start).toDate();
-      const isEndDate = moment(dateRange.end).toDate();
-      const dateInRange = this.getAllDatesInRange(isStartDate, isEndDate)
+      const startDateFrom = moment(dateRange.start).toDate();
+      const endDateTo = moment(dateRange.end).toDate();
+      const dateInRange = this.getAllDatesInRange(startDateFrom, endDateTo)
       this.filterTimeScaleDates = [...dateInRange];
     } else {
       this.resetTimescaleDisabled = true;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Event Feed fails to show data after filtering, event feed date and timescale in Automate UI, show the difference of N-1 days.
### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-10006
### :+1: Definition of Done
I have added changes to fix the event feed data to show properly after filter apply.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
![event2](https://github.com/chef/automate/assets/12297653/6872245b-ac2e-41d5-81b8-09d825481321)
![eventfeed1](https://github.com/chef/automate/assets/12297653/b1e89e53-3f63-4871-bc63-6359ae58e34e)


