### PR TITLE
Infrastructure node cli license changes

### DIFF
--- a/components/automate-cli/cmd/chef-automate/infrastructure.go
+++ b/components/automate-cli/cmd/chef-automate/infrastructure.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
+	"time"
 
 	api "github.com/chef/automate/api/interservice/deployment"
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
@@ -10,6 +13,7 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
@@ -31,11 +35,12 @@ var infrastructureCmd = &cobra.Command{
 }
 
 var nodeDeleteCmd = &cobra.Command{
-	Use:   "node-delete [uuid]",
-	Short: "Delete node by node uuid",
-	Long:  "",
-	RunE:  runDeleteNodeCmd,
-	Args:  cobra.ExactArgs(1),
+	Use:               "node-delete [uuid]",
+	Short:             "Delete node by node uuid",
+	Long:              "",
+	PersistentPreRunE: checkLicenseStatusForExpiry,
+	RunE:              runDeleteNodeCmd,
+	Args:              cobra.ExactArgs(1),
 	Annotations: map[string]string{
 		docs.Tag: docs.BastionHost,
 	},
@@ -49,6 +54,23 @@ type DSClient interface {
 type InfraFlow struct {
 	DsClient DSClient
 	Writer   *cli.Writer
+}
+
+type LicenseResult struct {
+	Result           LicenseStatus `json:"result"`
+	ErrorType        string        `json:"error_type"`
+	ErrorDescription string        `json:"error_description"`
+}
+
+type LicenseStatus struct {
+	CustomerName   string         `json:"customer_name"`
+	LicenseType    string         `json:"license_type"`
+	LicenseId      string         `json:"license_id"`
+	ExpirationDate ExpirationDate `json:"expiration_date"`
+}
+
+type ExpirationDate struct {
+	Seconds int64 `json:"seconds"`
 }
 
 func runDeleteNodeCmd(cmd *cobra.Command, args []string) error {
@@ -73,6 +95,75 @@ func preInfrastructureCmd(cmd *cobra.Command, args []string) error {
 		os.Exit(0)
 	}
 	return nil
+}
+
+func checkLicenseStatusForExpiry(cmd *cobra.Command, args []string) error {
+	fileName := "/tmp/license"
+	err := commandPrePersistent(cmd)
+	if err != nil {
+		return status.Wrap(err, status.CommandExecutionError, "unable to set command parent settings")
+	}
+
+	cmd1 := exec.Command("chef-automate", "license", "status", "--result-json", fileName)
+	//Not checking for error, as if the license is expired it will still return error and for commercial license a grace period is required
+	cmd1.Output()
+
+	licenseResult, err := readFileAndMarshal(fileName)
+	if err != nil {
+		return err
+	}
+
+	err = checkLicenseExpiry(licenseResult)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readFileAndMarshal(fileName string) (*LicenseResult, error) {
+	var result LicenseResult
+
+	byteValue, err := os.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	defer os.Remove(fileName)
+	json.Unmarshal([]byte(byteValue), &result)
+
+	return &result, nil
+
+}
+
+func checkLicenseExpiry(licenseResult *LicenseResult) error {
+	commercial := "commercial"
+	if licenseResult.Result.LicenseId == "" {
+		if licenseResult.ErrorType != "" {
+			return status.New(
+				status.DeploymentServiceCallError,
+				licenseResult.ErrorDescription,
+			)
+		}
+		return errors.New("Please apply a license")
+	}
+	licenseValidDate := time.Unix(licenseResult.Result.ExpirationDate.Seconds, 0) //gives unix time stamp in utc
+
+	//If the license type is commercial, adding grace period of 1 week
+	if licenseResult.Result.LicenseType == commercial {
+		//Adding grace period for 7 days i.e. one week
+		licenseValidDate = licenseValidDate.AddDate(0, 0, 7)
+	}
+
+	if licenseValidDate.Before(time.Now()) {
+		return status.New(
+			status.LicenseError,
+			"This license has expired. Please contact sales@chef.io to renew your Chef Automate license.",
+		)
+	}
+
+	return nil
+
 }
 
 func NewDeleteNode(writer *cli.Writer) (*InfraFlow, error) {

--- a/components/automate-cli/cmd/chef-automate/infrastructure.go
+++ b/components/automate-cli/cmd/chef-automate/infrastructure.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
 	"github.com/chef/automate/components/automate-deployment/pkg/client"
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
@@ -145,7 +144,10 @@ func checkLicenseExpiry(licenseResult *LicenseResult) error {
 				licenseResult.ErrorDescription,
 			)
 		}
-		return errors.New("Please apply a license")
+		return status.New(
+			status.LicenseError,
+			"Please apply a license.Please contact sales@chef.io to have your Chef Automate license.",
+		)
 	}
 	licenseValidDate := time.Unix(licenseResult.Result.ExpirationDate.Seconds, 0) //gives unix time stamp in utc
 

--- a/components/automate-cli/pkg/status/result.go
+++ b/components/automate-cli/pkg/status/result.go
@@ -63,6 +63,9 @@ func NewCmdResult(err error) *CmdResult {
 	cr.ErrorStackTrace = fmt.Sprintf("Stack trace: %+v", StackTrace(err))
 	cr.ErrorRecovery = Recovery(err)
 	cr.ErrorType = ErrorType(err)
+	if GlobalResult != nil {
+		cr.Result = GlobalResult
+	}
 	return cr
 }
 


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

Now license status will be checked when a user is using infrastructure node-delete command.

### :chains: Related Resources

https://chefio.atlassian.net/browse/CHEF-11900

### :+1: Definition of Done

License failure is responded back in case of no license applied

### :athletic_shoe: How to Build and Test the Change

rebuild components/automate-cli

### :white_check_mark: Checklist

**All PRs** must tick these:

- [X] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [X] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [X] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [X] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [X] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [X] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [X] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [X] Tests added/updated? (all new code needs new tests)
- [X] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EbxR7Zs6lR5HqlitmAZQzocB9fmT_a2id0B9SxCnrnvn9Q?e=MyDcoq