### PR TITLE
Restart all the PostgreSQL nodes after Add/Remove command

### DIFF
--- a/components/automate-backend-haproxy/habitat/config/haproxy.conf
+++ b/components/automate-backend-haproxy/habitat/config/haproxy.conf
@@ -20,10 +20,10 @@ listen postgresql
     default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {{~#if bind.database}}
   {{~#eachAlive bind.database.members as |dbmember|}}
-    server {{dbmember.sys.ip}} {{dbmember.sys.ip}}:{{dbmember.cfg.port}} maxconn {{cfg.server.maxconn}} check port "${PGLEADERCHK_PORT}"
+    server {{dbmember.sys.ip}} {{dbmember.sys.ip}}:{{dbmember.cfg.port}} maxconn {{cfg.server.maxconn}} check port 6432
   {{~/eachAlive}}
 {{~else}}
-    server {{sys.ip}} {{sys.ip}}:{{cfg.pg.port}} maxconn {{cfg.server.maxconn}} check port "${PGLEADERCHK_PORT}"
+    server {{sys.ip}} {{sys.ip}}:{{cfg.pg.port}} maxconn {{cfg.server.maxconn}} check port 6432
 {{~/if}}
 
 {{#if cfg.status.enabled}}

--- a/components/automate-backend-haproxy/habitat/config/haproxy.conf
+++ b/components/automate-backend-haproxy/habitat/config/haproxy.conf
@@ -20,10 +20,10 @@ listen postgresql
     default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
 {{~#if bind.database}}
   {{~#eachAlive bind.database.members as |dbmember|}}
-    server {{dbmember.sys.ip}} {{dbmember.sys.ip}}:{{dbmember.cfg.port}} maxconn {{cfg.server.maxconn}} check port 6432
+    server {{dbmember.sys.ip}} {{dbmember.sys.ip}}:{{dbmember.cfg.port}} maxconn {{cfg.server.maxconn}} check port {{cfg.pgleaderchk.port}}
   {{~/eachAlive}}
 {{~else}}
-    server {{sys.ip}} {{sys.ip}}:{{cfg.pg.port}} maxconn {{cfg.server.maxconn}} check port 6432
+    server {{sys.ip}} {{sys.ip}}:{{cfg.pg.port}} maxconn {{cfg.server.maxconn}} check port {{cfg.pgleaderchk.port}}
 {{~/if}}
 
 {{#if cfg.status.enabled}}

--- a/components/automate-backend-haproxy/habitat/hooks/reconfigure
+++ b/components/automate-backend-haproxy/habitat/hooks/reconfigure
@@ -1,0 +1,3 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+echo "HAProxy reconfigure hook running..."

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_aws_test.go
@@ -30,7 +30,7 @@ func TestAddnodeAWSValidateError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Either one of automate-count or chef-server-count or opensearch-count or postgresql-count must be more than 0.")
@@ -54,7 +54,7 @@ func TestAddnodeAWSValidate(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	assert.Equal(t, "6", nodeAdd.(*AddNodeAWSImpl).config.Opensearch.Config.InstanceCount)
@@ -78,7 +78,7 @@ func TestAddnodeAWSValidateErrorIsManagedServicesOn(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf(TYPE_ERROR, "add"))
@@ -104,7 +104,7 @@ func TestAddnodeModifyAws(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -124,12 +124,15 @@ func TestAddAwsnodePrompt(t *testing.T) {
 		isManagedServicesOnFunc: func() bool {
 			return false
 		},
+		restartPgNodesFunc: func(leaderNode NodeIpHealth, pgIps []string, infra *AutomateHAInfraDetails, statusSummary StatusSummary) error {
+			return nil
+		},
 		pullAndUpdateConfigAwsFunc: PullAwsConfFunc,
 	}, CONFIG_TOML_PATH_AWS, &fileutils.MockFileSystemUtils{}, &MockSSHUtilsImpl{
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -209,7 +212,7 @@ func TestAddnodeDeployWithNewOSNodeInAws(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -251,7 +254,7 @@ func TestAddnodeWithExecuteA2haRbNotExist(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `Invalid bastion, to run this command use automate bastion`)
@@ -309,7 +312,7 @@ func TestAddnodeWithExecuteFuncGenConfigErr(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.Contains(t, w.Output(), `Existing node count:
 ================================================
@@ -385,7 +388,7 @@ func TestAddnodeWithSaveConfigToBasionErr(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "error removing header")
@@ -456,7 +459,7 @@ func TestAddnodeWithSyncConfigToAllNodesErr(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 
 	err := nodeAdd.Execute(nil, nil)
 	assert.Error(t, err)
@@ -532,7 +535,7 @@ func TestAddnodeWithSyncConfigToAllNodesErrAndDeployError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 
 	err := nodeAdd.Execute(nil, nil)
 	assert.Error(t, err)
@@ -612,7 +615,7 @@ func TestAddnodeWithExecuteFunc(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing node count:

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_onprem_test.go
@@ -71,7 +71,7 @@ func TestAddnodeValidateError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "IP address validation failed: \nIncorrect Automate IP address format for ip ewewedw")
@@ -100,7 +100,7 @@ func TestAddnodeValidateErrorMultiple(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `IP address validation failed: 
@@ -134,7 +134,7 @@ func TestAddnodeReadfileError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "random")
@@ -166,7 +166,7 @@ func TestAddnodeValidateTypeAwsOrSelfManaged(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf(TYPE_ERROR, "add"))
@@ -199,7 +199,7 @@ func TestAddnodeValidateTypeAwsOrSelfManaged2(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf(TYPE_ERROR, "add"))
@@ -225,7 +225,7 @@ func TestAddnodeModifyAutomate(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -256,7 +256,7 @@ func TestAddnodeModifyInfra(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -287,7 +287,7 @@ func TestAddnodeModifyPostgresql(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -318,7 +318,7 @@ func TestAddnodeModifyOpensearch(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -349,7 +349,7 @@ func TestAddnodePrompt(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -409,7 +409,7 @@ func TestAddnodeDeployWithNewOSNode(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -467,7 +467,7 @@ func TestAddnodeDeployWithNewOSNodeGenconfigError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.NoError(t, err)
 	err = nodeAdd.modifyConfig()
@@ -552,7 +552,7 @@ func TestAddnodeExecuteWithNewOSNodeNoCertByIP(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing nodes:
@@ -620,7 +620,7 @@ func TestAddnodeExecuteWithNewOSNode(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing nodes:
@@ -772,5 +772,5 @@ func createNewAddNodeOnprem(mockNodeUtilsImpl *MockNodeUtilsImpl, mockSSHUtilsIm
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_add_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_add_test.go
@@ -11,7 +11,7 @@ func TestHaNodeAddFactoryIfDeployerTypeMatchesFlagAWS(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := AWS_MODE
-	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := addNode.(*AddNodeAWSImpl)
 	assert.True(t, ok)
@@ -22,7 +22,7 @@ func TestHaNodeAddFactoryIfDeployerTypeMatchesFlagOnPrem(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := addNode.(*AddNodeOnPremImpl)
 	assert.True(t, ok)
@@ -31,7 +31,7 @@ func TestHaNodeAddFactoryIfDeployerTypeMatchesFlagOnPrem(t *testing.T) {
 func TestHaNodeAddFactoryIfNoFlagGivenTypeOnprem(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := EXISTING_INFRA_MODE
-	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := addNode.(*AddNodeOnPremImpl)
 	assert.True(t, ok)
@@ -40,7 +40,7 @@ func TestHaNodeAddFactoryIfNoFlagGivenTypeOnprem(t *testing.T) {
 func TestHaNodeAddFactoryIfNoFlagGivenTypeAWS(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := AWS_MODE
-	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	addNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := addNode.(*AddNodeAWSImpl)
 	assert.True(t, ok)
@@ -51,7 +51,7 @@ func TestHaNodeAddFactoryIfDeployerTypeDoesNotMatchFlagAWS(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := AWS_MODE
-	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Flag given does not match with the current deployment type AWS_MODE. Try with --aws-mode flag")
 }
@@ -61,7 +61,7 @@ func TestHaNodeAddFactoryIfDeployerTypeDoesNotMatchFlagOnPrem(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Flag given does not match with the current deployment type EXISTING_INFRA_MODE. Try with --onprem-mode flag")
 }
@@ -72,7 +72,7 @@ func TestHaNodeAddFactoryIfBothflagGiven(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Cannot use both --onprem-mode and --aws-mode together. Provide only one at a time")
 }
@@ -82,7 +82,7 @@ func TestHaNodeAddFactoryWithFlagOrDeployerModeNotMatch(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := "SOMETHING_ELSE"
-	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unsupported deployment type. Current deployment type is SOMETHING_ELSE")
 }
@@ -90,7 +90,7 @@ func TestHaNodeAddFactoryWithFlagOrDeployerModeNotMatch(t *testing.T) {
 func TestHaNodeAddFactoryNoFlagOrDeployerModeNotMatch(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := "SOMETHING_ELSE"
-	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unsupported deployment type. Current deployment type is SOMETHING_ELSE")
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -271,7 +271,7 @@ func (dna *DeleteNodeAWSImpl) runDeploy() error {
 	// Restart all PostgreSQL nodes in order to apply the new configuration
 	if dna.nodeType == POSTGRESQL {
 		leader := getPGLeader(dna.statusSummary)
-		infra, err := getAutomateHAInfraDetails()
+		infra, err := getAutomateHAInfraDetailsFunc()
 		if err != nil {
 			return err
 		}

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws.go
@@ -29,6 +29,7 @@ type DeleteNodeAWSImpl struct {
 	sshUtil       SSHUtil
 	AWSConfigIp
 	unreachableIpMap map[string][]string
+	statusSummary    StatusSummary
 }
 
 type AWSConfigIp struct {
@@ -53,7 +54,7 @@ var (
 	moveStateCommand = `terraform state mv "module.aws.aws_instance.%[1]s[%[2]d]" "module.aws.aws_instance.%[1]s[%[3]d]"`
 )
 
-func NewDeleteNodeAWS(writer *cli.Writer, flags AddDeleteNodeHACmdFlags, nodeUtils NodeOpUtils, haDirPath string, fileutils fileutils.FileUtils, sshUtil SSHUtil) HAModifyAndDeploy {
+func NewDeleteNodeAWS(writer *cli.Writer, flags AddDeleteNodeHACmdFlags, nodeUtils NodeOpUtils, haDirPath string, fileutils fileutils.FileUtils, sshUtil SSHUtil, statusSummary StatusSummary) HAModifyAndDeploy {
 	return &DeleteNodeAWSImpl{
 		config:        AwsConfigToml{},
 		nodeUtils:     nodeUtils,
@@ -63,6 +64,7 @@ func NewDeleteNodeAWS(writer *cli.Writer, flags AddDeleteNodeHACmdFlags, nodeUti
 		writer:        writer,
 		fileUtils:     fileutils,
 		sshUtil:       sshUtil,
+		statusSummary: statusSummary,
 	}
 }
 
@@ -265,6 +267,20 @@ func (dna *DeleteNodeAWSImpl) runDeploy() error {
 		}
 		return syncErr
 	}
+
+	// Restart all PostgreSQL nodes in order to apply the new configuration
+	if dna.nodeType == POSTGRESQL {
+		leader := getPGLeader(dna.statusSummary)
+		infra, err := getAutomateHAInfraDetails()
+		if err != nil {
+			return err
+		}
+		err = dna.nodeUtils.restartPgNodes(*leader, infra.Outputs.PostgresqlPrivateIps.Value, infra, dna.statusSummary)
+		if err != nil {
+			return err
+		}
+	}
+
 	return err
 }
 

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -68,7 +68,7 @@ func TestDeletenodeAWSValidateIsManagedServicesOnError(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -119,7 +119,7 @@ func TestDeletenodeAWSValidateErrorIpAddressNotMatched(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -172,7 +172,7 @@ func TestDeletenodeAWSValidateErrorMoreThenOneIpAddress(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -222,7 +222,7 @@ func TestDeletenodeAWSModifyA2(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -275,7 +275,7 @@ func TestDeletenodeAWSModifyCS(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 
@@ -329,7 +329,7 @@ func TestDeletenodeAWSModifyPG(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -382,7 +382,7 @@ func TestDeletenodeAWSModifyOS(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.(*DeleteNodeAWSImpl).getAwsHAIp()
 	assert.NoError(t, err)
 	err = nodeDelete.validate()
@@ -435,7 +435,7 @@ func TestDeleteAwsnodePrompt(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.validate()
 	assert.NoError(t, err)
 	err = nodeDelete.modifyConfig()
@@ -528,7 +528,7 @@ func TestDeletenodeDeployWithNewOSNodeInAws(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.validate()
 	assert.NoError(t, err)
 	err = nodeDelete.modifyConfig()
@@ -571,7 +571,7 @@ func TestDeletenodeWithExecuteA2haRbNotExist(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeDelete.Execute(nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `Invalid bastion, to run this command use automate bastion`)
@@ -657,7 +657,7 @@ func TestDeletenodeAWSExecuteWithError(t *testing.T) {
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 	err := nodeDelete.Execute(nil, nil)
 	assert.True(t, tfArchModified)
 	assert.True(t, ipAddres)
@@ -763,7 +763,7 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 				connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 					return "", nil
 				},
-			})
+			}, getMockStatusSummary())
 		err := nodeDelete.Execute(nil, nil)
 		assert.NoError(t, err)
 		assert.True(t, tfArchModified)
@@ -958,5 +958,5 @@ func createNewDeleteNodeAWS(mockNodeUtilsImpl *MockNodeUtilsImpl, mockSSHUtilsIm
 			connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 				return "", nil
 			},
-		})
+		}, getMockStatusSummary())
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_aws_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/chef/automate/lib/io/fileutils"
@@ -735,6 +736,9 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 		syncConfigToAllNodesFunc: func(unreachableNodes map[string][]string) error {
 			return nil
 		},
+		restartPgNodesFunc: func(leaderNode NodeIpHealth, pgIps []string, infra *AutomateHAInfraDetails, statusSummary StatusSummary) error {
+			return nil
+		},
 	}
 	flagsArr := []AddDeleteNodeHACmdFlags{
 		{
@@ -752,7 +756,13 @@ func TestDeletenodeAWSExecuteNoError(t *testing.T) {
 	}
 
 	for _, flags := range flagsArr {
+		fmt.Println(flags)
 		w := majorupgrade_utils.NewCustomWriterWithInputs("y")
+		getAutomateHAInfraDetailsFunc = func() (*AutomateHAInfraDetails, error) {
+			infra := &AutomateHAInfraDetails{}
+			infra.Outputs.PostgresqlPrivateIps.Value = []string{ValidIP7, ValidIP8, ValidIP9}
+			return infra, nil
+		}
 		nodeDelete := NewDeleteNodeAWS(
 			w.CliWriter,
 			flags,

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_onprem_test.go
@@ -50,7 +50,7 @@ func TestDeleteNodeValidateError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `
@@ -77,7 +77,7 @@ func TestDeleteNodeValidateErrorMultiple(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(),
@@ -104,7 +104,7 @@ func TestDeleteNodeModifyAutomate(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -141,7 +141,7 @@ func TestRemovenodeValidateTypeAwsOrSelfManaged(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf(TYPE_ERROR, "remove"))
@@ -174,7 +174,7 @@ func TestRemovenodeValidateTypeAwsOrSelfManaged2(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), multipleNodeError)
@@ -200,7 +200,7 @@ func TestDeleteNodeModifyInfra(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unable to remove node. Chef-Server instance count cannot be less than 1. Final count 0 not allowed.")
@@ -233,7 +233,7 @@ func TestDeletenodeModifyOpensearch(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -264,7 +264,7 @@ func TestDeletenodeModifyPostgresql(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Unable to remove node. Postgresql instance count cannot be less than 3. Final count 2 not allowed.")
@@ -297,7 +297,7 @@ func TestDeleteNodePrompt(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -362,7 +362,7 @@ func TestDeleteNodeDeployWithNewOSNode(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -428,7 +428,7 @@ func TestDeleteNodeDeployWithSaveConfigToBastionError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.Execute(nil, nil)
 	assert.Error(t, err, "error on removing output header in fetched config")
 }
@@ -474,7 +474,7 @@ func TestDeleteNodeDeployWithError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -539,8 +539,7 @@ func TestDeleteNodeDeployWithErrorSync(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	},
-	)
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -605,8 +604,7 @@ func TestDeleteNodeDeployWithErrorSyncAndDeployError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	},
-	)
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -666,7 +664,7 @@ func TestDeleteNodeDeployWithNewOSMinCountError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(),
@@ -706,7 +704,7 @@ func TestDeleteNodeDeployWithNewOSNodeError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodedelete.validate()
 	assert.NoError(t, err)
 	err = nodedelete.modifyConfig()
@@ -801,7 +799,7 @@ func TestRemovenodeExecuteWithNewOSNodeNoCertsByIP(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing nodes:
@@ -879,7 +877,7 @@ func TestRemovenodeExecuteWithNewOSNode(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing nodes:
@@ -957,7 +955,7 @@ func TestRemovenodeExecuteWithProvisionError(t *testing.T) {
 		connectAndExecuteCommandOnRemoteFunc: func(remoteCommands string, spinner bool) (string, error) {
 			return "", nil
 		},
-	})
+	}, getMockStatusSummary())
 	err := nodeAdd.Execute(nil, nil)
 	assert.NoError(t, err)
 	assert.Contains(t, w.Output(), `Existing nodes:

--- a/components/automate-cli/cmd/chef-automate/ha_node_delete_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_delete_test.go
@@ -11,7 +11,7 @@ func TestHaNodeDeleteFactoryIfDeployerTypeMatchesFlagAWS(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := AWS_MODE
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 
 }
@@ -21,7 +21,7 @@ func TestHaNodeDeleteFactoryIfDeployerTypeMatchesFlagOnPrem(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	deleteNode, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	deleteNode, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := deleteNode.(*DeleteNodeOnPremImpl)
 	assert.True(t, ok)
@@ -30,7 +30,7 @@ func TestHaNodeDeleteFactoryIfDeployerTypeMatchesFlagOnPrem(t *testing.T) {
 func TestHaNodeDeleteFactoryIfNoFlagGivenTypeOnprem(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := EXISTING_INFRA_MODE
-	deleteNode, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	deleteNode, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := deleteNode.(*DeleteNodeOnPremImpl)
 	assert.True(t, ok)
@@ -39,7 +39,7 @@ func TestHaNodeDeleteFactoryIfNoFlagGivenTypeOnprem(t *testing.T) {
 func TestHaNodeDeleteFactoryIfNoFlagGivenTypeAWS(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := AWS_MODE
-	deleteNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	deleteNode, err := haAddNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.NoError(t, err)
 	_, ok := deleteNode.(*AddNodeAWSImpl)
 	assert.True(t, ok)
@@ -50,7 +50,7 @@ func TestHaNodeDeleteFactoryIfDeployerTypeDoesNotMatchFlagAWS(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := AWS_MODE
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "flag given does not match with the current deployment type AWS_MODE. Try with --aws-mode flag")
 }
@@ -60,7 +60,7 @@ func TestHaNodeDeleteFactoryIfDeployerTypeDoesNotMatchFlagOnPrem(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "flag given does not match with the current deployment type EXISTING_INFRA_MODE. Try with --onprem-mode flag")
 }
@@ -71,7 +71,7 @@ func TestHaNodeDeleteFactoryIfBothflagGiven(t *testing.T) {
 		onPremMode: true,
 	}
 	deployerType := EXISTING_INFRA_MODE
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Cannot use both --onprem-mode and --aws-mode together. Provide only one at a time")
 }
@@ -81,7 +81,7 @@ func TestHaNodeDeleteFactoryWithFlagOrDeployerModeNotMatch(t *testing.T) {
 		awsMode: true,
 	}
 	deployerType := "SOMETHING_ELSE"
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported deployment type. Current deployment type is SOMETHING_ELSE")
 }
@@ -89,7 +89,7 @@ func TestHaNodeDeleteFactoryWithFlagOrDeployerModeNotMatch(t *testing.T) {
 func TestHaNodeDeleteFactoryNoFlagOrDeployerModeNotMatch(t *testing.T) {
 	addDeleteNodeHACmdFlags := &AddDeleteNodeHACmdFlags{}
 	deployerType := "SOMETHING_ELSE"
-	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType)
+	_, err := haDeleteNodeFactory(addDeleteNodeHACmdFlags, deployerType, getMockStatusSummary())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported deployment type. Current deployment type is SOMETHING_ELSE")
 }

--- a/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
+++ b/components/automate-cli/cmd/chef-automate/ha_node_operations_utils.go
@@ -1010,3 +1010,27 @@ func removeRestrictedKeysFromSrcFile(srcString string) (string, error) {
 		return srcString, nil
 	}
 }
+
+func (nu *NodeUtilsImpl) restartHabSupOnBackend(service string) error {
+	remoteExcecutor := NewRemoteCmdExecutorWithoutNodeMap(&SSHUtilImpl{}, cli.NewWriter(os.Stdout, os.Stderr, os.Stdin))
+	infra, _, err := nu.getHaInfraDetails()
+	if err != nil {
+		return err
+	}
+	flags := &RestartCmdFlags{
+		postgresql: true,
+	}
+	restartCmdResults := make(chan restartCmdResult, 4)
+	runRestartCmdForBackend(infra, flags, remoteExcecutor, restartCmdResults)
+
+	return getChannelValue(restartCmdResults, printRestartOutput)
+}
+
+func getPGLeader(statusSummary StatusSummary) *NodeIpHealth {
+	ip, health := statusSummary.GetPGLeaderNode()
+	nodeIpHealth := NodeIpHealth{
+		IP:     ip,
+		Health: health,
+	}
+	return &nodeIpHealth
+}

--- a/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
+++ b/components/automate-cli/cmd/chef-automate/sshAutomateHA.go
@@ -238,6 +238,8 @@ func runSshCommand(_ *cobra.Command, _ []string) error {
 	return executeShellCommand(sshTokens[0], sshTokens[1:], "")
 }
 
+var getAutomateHAInfraDetailsFunc func() (*AutomateHAInfraDetails, error) = getAutomateHAInfraDetails
+
 func getAutomateHAInfraDetails() (*AutomateHAInfraDetails, error) {
 
 	infraConfigFile, err := FileContainingAutomateHAInfraDetails()

--- a/components/automate-cli/cmd/chef-automate/summary_test.go
+++ b/components/automate-cli/cmd/chef-automate/summary_test.go
@@ -457,3 +457,17 @@ func TestGetFollowerLag(t *testing.T) {
 		}
 	}
 }
+
+func getMockStatusSummary() StatusSummary {
+	infra := &AutomateHAInfraDetails{}
+	infra.Outputs.PostgresqlPrivateIps.Value = []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
+	beOutput := make(map[string][]*CmdResult)
+	ss := NewStatusSummary(infra, FeStatus{}, BeStatus{}, 10, time.Second, &StatusSummaryCmdFlags{
+		isPostgresql: true,
+	}, &MockRemoteCmdExecutor{
+		ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
+			return beOutput, nil
+		},
+	})
+	return ss
+}

--- a/components/automate-ha-pgleaderchk/habitat/hooks/reconfigure
+++ b/components/automate-ha-pgleaderchk/habitat/hooks/reconfigure
@@ -1,0 +1,3 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+echo "PGLeaderChk reconfigure hook running..."


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Added PostgreSQL nodes restart logic in the Add/Remove flow, in order to apply the newest HAProxy configuration. Currently the configuration is being updated, but due to the `reconfigure` hook we introduced for HAProxy, the service isn't getting restarted and is not using the latest configuration (thus routing traffic to outdated nodes). That's why we want to restart the habitat supervisor of all the PostgreSQL nodes, if a PostgreSQL node/s is added/removed.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
