### PR TITLE
UI changes for the apply license and welcome modal popup

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
@@ -50,8 +50,15 @@
           <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="10" autofocus></textarea>
           <chef-error *ngIf="applyForm.get('licenseKey').hasError('required') && applyForm.get('licenseKey').dirty">License key required</chef-error>
         </chef-form-field>
+        <br>
+        <chef-checkbox (change)="updateMLSA($event.detail)" [checked]="mlsaAgree">
+          * I agree to the
+          <a href="https://www.chef.io/terms-of-service" target="_blank">Terms of Service</a>
+          and the
+          <a href="https://www.chef.io/online-master-agreement" target="_blank">Master License and Services Agreement</a>
+        </chef-checkbox>
         <div class="button">
-          <chef-button type="submit" primary [disabled]="!applyForm.valid || applyingLicense">Apply License</chef-button>
+          <chef-button type="submit" primary [disabled]="!(applyForm.valid && mlsaAgree) || applyingLicense">Apply License</chef-button>
           <chef-button tertiary (click)="logout()">Sign Out</chef-button>
         </div>
       </form>

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.scss
@@ -62,7 +62,7 @@
 
 
   .footer {
-    margin-top: 80px;
+    margin-top: 0px;
   }
 
   label {
@@ -79,6 +79,10 @@
     min-height: 175px;
   }
 
+  textarea#licenseKey {
+    width: 100%;
+  }
+
   textarea,
   chef-error {
     display: block;
@@ -88,7 +92,7 @@
     display: flex;
     justify-content: flex-start;
     margin-top: 10px;
-    height: 50px;
+    height: 20px;
   }
 
   ::ng-deep chef-alert {

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.ts
@@ -41,6 +41,8 @@ export class LicenseApplyComponent implements AfterViewInit {
   public modalVisible = false;
   public modalLocked = true;
 
+  public mlsaAgree = false;
+
   ngAfterViewInit(): void {
     // Set locale-aware date/time formats
     // Per https://stackoverflow.com/a/50460605, navigator.language
@@ -148,6 +150,13 @@ export class LicenseApplyComponent implements AfterViewInit {
 
   private setExpirationDate(license: LicenseStatus): void {
     this.expirationDate = parsedExpirationDate(license);
+  }
+
+  // Similarly, we must manually add this to the valid logic
+  // in the submit button since chef-button doesn't play nice
+  // with FormBuilder.
+  public updateMLSA(event): void {
+    this.mlsaAgree = event;
   }
 
   public logout() {

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -4,7 +4,8 @@
     <ng-container *ngIf="!fetchStatusInternalError">
       <ng-container *ngIf="!trialLicenseApplied">
         <h2 id="license-lockout-label" class="title">Welcome to Chef Automate!</h2>
-        <div class="subtitle">Register to get started with a 60-day trial or <a href="https://www.chef.io/contact-us/" target="_blank" rel="noopener">contact Chef</a>.</div>
+        <div class="subtitle">In order to use Chef Automate, you will require a license</div>
+        <div class="subtitle">Please select an option to proceed.</div>
         <div class="error-container">
           <chef-alert type="error" *ngIf="fetchStatusInternalError">
             <span>
@@ -29,50 +30,27 @@
             </span>
           </chef-alert>
         </div>
+        <div class="border-box">
+          <a tertiary (click)="backToLicenseApply(); false">I have a license</a>
+          <p>Enter the License key and proceed.</p>
+          <a tertiary (click)="backToLicenseApply(); false">
+            <chef-icon class="icon-right">chevron_right</chef-icon>
+          </a>
+        </div>
+        <br>
+        <div class="border-box">
+          <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">I don't have a license</a>
+          <p>Generate a license key.</p>
+          <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">
+            <chef-icon class="icon-right">chevron_right</chef-icon>
+          </a>
 
-        <form class="trial" [formGroup]="trialForm" (ngSubmit)="onTrialLicenseFormSubmit()" novalidate>
-          <div class="name-container">
-            <chef-form-field>
-              <label for="firstName">First Name <span aria-hidden="true">*</span></label>
-              <div class="suggester-input-wrapper">
-                <input chefInput name="firstName" id="firstName" formControlName="firstName" type="text" autofocus>
-              </div>
-              <chef-error *ngIf="trialForm.get('firstName').hasError('required') && trialForm.get('firstName').dirty">First name required.</chef-error>
-            </chef-form-field>
-            <chef-form-field>
-              <label for="lastName">Last Name <span aria-hidden="true">*</span></label>
-              <div class="suggester-input-wrapper">
-                <input chefInput name="lastName" id="lastName" formControlName="lastName" type="text">
-              </div>
-                <chef-error *ngIf="trialForm.get('lastName').hasError('required') && trialForm.get('lastName').dirty">Last name required.</chef-error>
-            </chef-form-field>
-          </div>
-          <div class="email-container">
-            <chef-form-field>
-              <label for="email">Email <span aria-hidden="true">*</span></label>
-              <div class="suggester-input-wrapper">
-                <input chefInput name="email" id="email" formControlName="email" type="text">
-              </div>
-              <chef-error *ngIf="trialForm.get('email').hasError('email') && trialForm.get('email').dirty">Valid email required.</chef-error>
-            </chef-form-field>
-          </div>
-          <chef-checkbox (change)="updateGDPR($event.detail)" [checked]="gdprAgree">I would like to receive email communications from Chef</chef-checkbox>
-          <chef-checkbox (change)="updateMLSA($event.detail)" [checked]="mlsaAgree">
-            * I agree to the
-            <a href="https://www.chef.io/terms-of-service" target="_blank">Terms of Service</a>
-            and the
-            <a href="https://www.chef.io/online-master-agreement" target="_blank">Master License and Services Agreement</a>
-          </chef-checkbox>
-          <div class="button">
-            <chef-button primary type="submit" [disabled]="!(trialForm.valid && mlsaAgree) || requestingLicense">Register</chef-button>
-          </div>
-        </form>
+        </div>
         <div class="spinner-container">
           <chef-loading-spinner *ngIf="requestingLicense" size="30"></chef-loading-spinner>
         </div>
         <div class="footer">
-          <chef-button tertiary (click)="backToLicenseApply(); false">Already have a license?</chef-button>
-          <chef-button tertiary (click)="logout()">Sign Out</chef-button>
+          <chef-button tertiary (click)="logout()">Sign out and do it later.</chef-button>
         </div>
       </ng-container>
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -10,6 +10,15 @@
     margin-bottom: 7px;
   }
 
+  chef-icon.icon-right {
+    float: right;
+    margin-top: -36px;
+    margin-right: 13px;
+    font-size: 20px;
+    color: #3864F2;
+    cursor: pointer;
+  }
+
   .suggester-input-wrapper {
     display: flex;
     border-radius: 4px;
@@ -148,7 +157,7 @@
     display: flex;
     justify-content: flex-start;
     margin-top: 10px;
-    height: 60px;
+    height: 20px;
   }
 
   chef-alert {
@@ -171,5 +180,16 @@
     display: flex;
     flex-direction: row;
     margin-top: 2em;
+  }
+
+  .border-box {
+    width: 100%;
+    padding: 8px 0px 8px 16px;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, .25);
+
+    a {
+      text-decoration: none;
+      cursor: pointer;
+    }
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Currently, in the “Welcome to Chef Automate” pop-up, we give users an option to either provide their details and get a new trial license or ask them to enter a license key if they have one.
### :chains: Related Resources
https://chefio.atlassian.net/browse/CHEF-13463
### :+1: Definition of Done
I have added UI changes for the license welcome modal
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://github.com/user-attachments/assets/03fcc10d-72da-4767-8234-45cbe0b0f62d

