### PR TITLE
Reload the HAProxy and PG leader check configuration post deployment for the backend nodes

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -5,4 +5,4 @@ This provides the `automate-backend-deployment` package.
 
 This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
-This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package.
+This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package

--- a/terraform/a2ha-terraform/modules/postgresqlconfigsync/inputs.tf
+++ b/terraform/a2ha-terraform/modules/postgresqlconfigsync/inputs.tf
@@ -7,9 +7,38 @@ variable "postgresql_instance_count" {
   default = 3
 }
 
+variable "postgresql_listen_port" {
+  default = 5432
+}
 
+variable "pgleaderchk_listen_port" {
+  default = 6432
+}
+
+variable "pgleaderchk_pkg_ident" {
+}
+
+variable "pgleaderchk_svc_load_args" {
+}
+
+variable "postgresql_pkg_ident" {
+}
+
+
+variable "postgresql_svc_load_args" {
+}
 variable "private_ips" {
   default = []
+}
+
+variable "proxy_listen_port" {
+  default = 7432
+}
+
+variable "proxy_pkg_ident" {
+}
+
+variable "proxy_svc_load_args" {
 }
 
 variable "public_ips" {

--- a/terraform/a2ha-terraform/modules/postgresqlconfigsync/main.tf
+++ b/terraform/a2ha-terraform/modules/postgresqlconfigsync/main.tf
@@ -1,6 +1,12 @@
 locals {
   configsync = templatefile("${path.module}/templates/postgres_configsync.sh.tpl", {
-    tmp_path                    = var.tmp_path
+    postgresql_pkg_ident      = var.postgresql_pkg_ident,
+    postgresql_svc_load_args  = var.postgresql_svc_load_args,
+    pgleaderchk_pkg_ident     = var.pgleaderchk_pkg_ident,
+    pgleaderchk_svc_load_args = var.pgleaderchk_svc_load_args,
+    proxy_pkg_ident           = var.proxy_pkg_ident,
+    proxy_svc_load_args       = var.proxy_svc_load_args,
+    tmp_path                  = var.tmp_path
   })
 }
 

--- a/terraform/a2ha-terraform/modules/postgresqlconfigsync/main.tf
+++ b/terraform/a2ha-terraform/modules/postgresqlconfigsync/main.tf
@@ -1,7 +1,6 @@
 locals {
   configsync = templatefile("${path.module}/templates/postgres_configsync.sh.tpl", {
     postgresql_pkg_ident      = var.postgresql_pkg_ident,
-    postgresql_svc_load_args  = var.postgresql_svc_load_args,
     pgleaderchk_pkg_ident     = var.pgleaderchk_pkg_ident,
     pgleaderchk_svc_load_args = var.pgleaderchk_svc_load_args,
     proxy_pkg_ident           = var.proxy_pkg_ident,

--- a/terraform/a2ha-terraform/modules/postgresqlconfigsync/templates/postgres_configsync.sh.tpl
+++ b/terraform/a2ha-terraform/modules/postgresqlconfigsync/templates/postgres_configsync.sh.tpl
@@ -6,10 +6,34 @@ export HAB_NONINTERACTIVE=true
 export HAB_NOCOLORING=true
 export HAB_LICENSE=accept-no-persist
 LOCKFILE=".postgres.deployment.done"
+
+PG_ORIGIN_NAME=$(echo "${postgresql_pkg_ident}" | awk -F/ '{print $1}')
+export PG_ORIGIN_NAME
+PG_PKG_NAME=$(echo "${postgresql_pkg_ident}" | awk -F/ '{print $2}')
+export PG_PKG_NAME
+
+PGLEADERCHK_ORIGIN_NAME=$(echo "${pgleaderchk_pkg_ident}" | awk -F/ '{print $1}')
+export PGLEADERCHK_ORIGIN_NAME
+PGLEADERCHK_PKG_NAME=$(echo "${pgleaderchk_pkg_ident}" | awk -F/ '{print $2}')
+export PGLEADERCHK_PKG_NAME
+
+PROXY_ORIGIN_NAME=$(echo "${proxy_pkg_ident}" | awk -F/ '{print $1}')
+export PROXY_ORIGIN_NAME
+PROXY_PKG_NAME=$(echo "${proxy_pkg_ident}" | awk -F/ '{print $2}')
+export PROXY_PKG_NAME
+export LOGCMD='>>${tmp_path}/svc-load.log 2>&1'
+
 if [ ! -f ${tmp_path}/$LOCKFILE ] ; then
     echo "Restarting the Postgres cluster to make the config sync for HA proxy" 
-    sudo systemctl stop hab-sup
-    sudo systemctl start hab-sup
+    # stop and unload the old pkg_ident and then load in the new
+    hab svc unload "$PGLEADERCHK_ORIGIN_NAME/$PGLEADERCHK_PKG_NAME"
+    hab svc unload "$PROXY_ORIGIN_NAME/$PROXY_PKG_NAME"
+
+    # stop and unload the old pkg_ident and then load in the new
+    sleep 5
+    bash -c 'eval hab svc load ${proxy_pkg_ident} ${proxy_svc_load_args} --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
+    bash -c 'eval hab svc load ${pgleaderchk_pkg_ident} ${pgleaderchk_svc_load_args} --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
+
     sudo touch ${tmp_path}/$LOCKFILE
 else
     echo "Postgres cluster restart not required"  

--- a/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/deployment/main.tf
@@ -342,6 +342,13 @@ module "postgresql_config_sync" {
   source                          = "./modules/postgresqlconfigsync"
   postgresql_instance_count       = var.postgresql_instance_count
   private_ips                     = var.existing_postgresql_private_ips
+  postgresql_pkg_ident            = var.postgresql_pkg_ident
+  pgleaderchk_listen_port         = var.pgleaderchk_listen_port
+  pgleaderchk_pkg_ident           = var.pgleaderchk_pkg_ident
+  pgleaderchk_svc_load_args       = var.pgleaderchk_svc_load_args
+  proxy_listen_port               = var.proxy_listen_port
+  proxy_pkg_ident                 = var.proxy_pkg_ident
+  proxy_svc_load_args             = var.proxy_svc_load_args
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
   ssh_port                        = var.ssh_port

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -220,6 +220,7 @@ module "postgresql_config_sync" {
   postgresql_instance_count       = var.postgresql_instance_count
   private_ips                     = var.existing_postgresql_private_ips
   postgresql_pkg_ident            = var.postgresql_pkg_ident
+  postgresql_svc_load_args        = var.postgresql_svc_load_args
   pgleaderchk_listen_port         = var.pgleaderchk_listen_port
   pgleaderchk_pkg_ident           = var.pgleaderchk_pkg_ident
   pgleaderchk_svc_load_args       = var.pgleaderchk_svc_load_args

--- a/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
+++ b/terraform/a2ha-terraform/reference_architectures/existing_nodes/main.tf
@@ -219,6 +219,13 @@ module "postgresql_config_sync" {
   source                          = "./modules/postgresqlconfigsync"
   postgresql_instance_count       = var.postgresql_instance_count
   private_ips                     = var.existing_postgresql_private_ips
+  postgresql_pkg_ident            = var.postgresql_pkg_ident
+  pgleaderchk_listen_port         = var.pgleaderchk_listen_port
+  pgleaderchk_pkg_ident           = var.pgleaderchk_pkg_ident
+  pgleaderchk_svc_load_args       = var.pgleaderchk_svc_load_args
+  proxy_listen_port               = var.proxy_listen_port
+  proxy_pkg_ident                 = var.proxy_pkg_ident
+  proxy_svc_load_args             = var.proxy_svc_load_args
   ssh_key_file                    = var.ssh_key_file
   ssh_user                        = var.ssh_user
   ssh_port                        = var.ssh_port


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Deployment will required the reload the config for haproxy and pg leader check. 
During deployment if all the node for the pg cluster won't we in sycn, then the haproxy config will not be in the sync. 
To make it sync we are using the stop start `hab-sup`, but that also doesn't guarantee that it will be execute in synchronous. i.e. the reason we are unload and load the service to reload the config into the memory 
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
