### PR TITLE
reload ha proxy restart postgres

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -19,6 +19,11 @@ const AUTOMATE_HA_FILE_PERMISSION_0755 = 0755
 const AUTOMATE_HA_FILE_PERMISSION_0644 = 0644
 const DATE_FORMAT = "%Y%m%d%H%M%S"
 
+const PG_IDENT = "postgresql_pkg_ident"
+const PG_LEADER_IDENT = "pgleaderchk_pkg_ident"
+const HA_PROXY_IDENT = "proxy_pkg_ident"
+const MANIFEST_AUTO_TFVARS = "/hab/a2_deploy_workspace/terraform/a2ha_manifest.auto.tfvars"
+
 const frontendAutotfvarsTemplate = `
 frontend_aib_dest_file = "/var/tmp/{{ .bundleName }}"
 frontend_aib_local_file = "{{ .bundleName }}"

--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -23,6 +23,8 @@ const PG_IDENT = "postgresql_pkg_ident"
 const PG_LEADER_IDENT = "pgleaderchk_pkg_ident"
 const HA_PROXY_IDENT = "proxy_pkg_ident"
 const MANIFEST_AUTO_TFVARS = "/hab/a2_deploy_workspace/terraform/a2ha_manifest.auto.tfvars"
+const PG_SCRIPT_NAME = "pg-restart-script.sh"
+const PG_SCRIPT_PATH = "/hab/var/automate-ha"
 
 const frontendAutotfvarsTemplate = `
 frontend_aib_dest_file = "/var/tmp/{{ .bundleName }}"

--- a/components/automate-cli/cmd/chef-automate/certRotate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate.go
@@ -149,6 +149,7 @@ type certRotateFlow struct {
 	writer      *cli.Writer
 	pullConfigs PullConfigs
 	log         logger.Logger
+	nodeUtils   *NodeUtilsImpl
 }
 
 type NodeIpHealth struct {
@@ -156,13 +157,14 @@ type NodeIpHealth struct {
 	Health string
 }
 
-func NewCertRotateFlow(fileUtils fileutils.FileUtils, sshUtil sshutils.SSHUtil, writer *cli.Writer, pullConfigs PullConfigs, log logger.Logger) *certRotateFlow {
+func NewCertRotateFlow(fileUtils fileutils.FileUtils, sshUtil sshutils.SSHUtil, writer *cli.Writer, pullConfigs PullConfigs, log logger.Logger, nodeUtils *NodeUtilsImpl) *certRotateFlow {
 	return &certRotateFlow{
 		fileUtils:   fileUtils,
 		sshUtil:     sshUtil,
 		writer:      writer,
 		pullConfigs: pullConfigs,
 		log:         log,
+		nodeUtils:   nodeUtils,
 	}
 }
 
@@ -232,7 +234,7 @@ func certRotateCmdFunc(flagsObj *certRotateFlags) func(cmd *cobra.Command, args 
 		if err != nil {
 			return err
 		}
-		c := NewCertRotateFlow(&fileutils.FileSystemUtils{}, sshutils.NewSSHUtilWithCommandExecutor(sshutils.NewSshClient(), log, command.NewExecExecutor()), writer, NewPullConfigs(&AutomateHAInfraDetails{}, &SSHUtilImpl{}), log)
+		c := NewCertRotateFlow(&fileutils.FileSystemUtils{}, sshutils.NewSSHUtilWithCommandExecutor(sshutils.NewSshClient(), log, command.NewExecExecutor()), writer, NewPullConfigs(&AutomateHAInfraDetails{}, &SSHUtilImpl{}), log, &NodeUtilsImpl{})
 		return c.certRotate(cmd, args, flagsObj)
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/certRotateFromTemplate.go
+++ b/components/automate-cli/cmd/chef-automate/certRotateFromTemplate.go
@@ -162,7 +162,7 @@ func (c *certRotateFlow) rotatePGCertAndRestartPGNode(pgIps []IP, statusSummary 
 }
 
 func (c *certRotateFlow) rotatePGLeaderNodeCert(pgIps []IP, pgLeaderIpAndHealth *NodeIpHealth, infra *AutomateHAInfraDetails, sshUtil SSHUtil, currentCertsInfo *certShowCertificates, pgRootCA string, concurrent bool) error {
-	if pgLeaderIpAndHealth.Health == "ok" {
+	if pgLeaderIpAndHealth.Health == "OK" {
 		for _, pgIp := range pgIps {
 			if strings.EqualFold(pgIp.IP, pgLeaderIpAndHealth.IP) {
 				err := c.rotatePGNodeCerts(infra, sshUtil, currentCertsInfo, pgRootCA, &pgIp, concurrent)

--- a/components/automate-cli/cmd/chef-automate/certRotateHelper.go
+++ b/components/automate-cli/cmd/chef-automate/certRotateHelper.go
@@ -111,10 +111,10 @@ func getMaxPGLag(log logger.Logger, statusSummary StatusSummary) (int64, error) 
 func frontendMaintainenceModeOnOFF(infra *AutomateHAInfraDetails, sshConfig sshutils.SSHConfig, sshUtil sshutils.SSHUtil, onOFFSwitch string, hostIps []string, log logger.Logger, writer *cli.Writer, totalWaitTimeOut time.Duration) {
 	sshConfig.Timeout = int(totalWaitTimeOut.Seconds())
 	if onOFFSwitch == ON {
-		writer.Println("turning ON maintenace mode")
+		writer.Println("turning ON maintenance mode")
 	}
 	if onOFFSwitch == OFF {
-		writer.Println("turning OFF maintenace mode")
+		writer.Println("turning OFF maintenance mode")
 	}
 	command := fmt.Sprintf(MAINTENANCE_ON_OFF, onOFFSwitch)
 	log.Debug("========================== MAINTENANCE_ON_OFF ========================")

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -2493,7 +2493,7 @@ func NewMockInfra() *AutomateHAInfraDetails {
 
 func NewCertRotate() *certRotateFlow {
 	log, _ := logger.NewLogger("text", "debug")
-	c := NewCertRotateFlow(mockFS(), &sshutils.MockSSHUtilsImpl{}, writer, &MockPullConfigs{}, log)
+	c := NewCertRotateFlow(mockFS(), &sshutils.MockSSHUtilsImpl{}, writer, &MockPullConfigs{}, log, &NodeUtilsImpl{})
 	return c
 }
 

--- a/components/automate-cli/cmd/chef-automate/cliUtils.go
+++ b/components/automate-cli/cmd/chef-automate/cliUtils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
@@ -168,4 +169,14 @@ func markGlobalFlagsHiddenExcept(command *cobra.Command, unhidden ...string) {
 			f.Hidden = true
 		}
 	})
+}
+
+func findIdentValue(content, val string) (string, error) {
+	re := regexp.MustCompile(fmt.Sprintf(`%s\s*=\s*"([^"]+)"`, val))
+	matches := re.FindStringSubmatch(content)
+	if len(matches) > 1 {
+		return matches[1], nil
+	} else {
+		return "", fmt.Errorf("failed to find value")
+	}
 }

--- a/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
+++ b/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
@@ -1,21 +1,19 @@
 package remotescripts
 
-const POST_CERT_ROTATE_PG = `set -Eeuo pipefail
+const POST_CERT_ROTATE_PG = `#!/bin/bash
+set -Eeuo pipefail
 HAB_NONINTERACTIVE=true
 HAB_NOCOLORING=true
 HAB_LICENSE=accept-no-persist
-PG_ORIGIN_NAME=$(echo "%[1]s" | awk -F/ '{print $1}')
 PG_PKG_NAME=$(echo "%[1]s" | awk -F/ '{print $2}')
-PGLEADERCHK_ORIGIN_NAME=$(echo "%[2]s" | awk -F/ '{print $1}')
 PGLEADERCHK_PKG_NAME=$(echo "%[2]s" | awk -F/ '{print $2}')
-PROXY_ORIGIN_NAME=$(echo "%[3]s" | awk -F/ '{print $1}')
-PROXY_PKG_NAME=$(echo "%[3]s" | awk -F/ '{print $2}')
+
 LOGCMD='>>/hab/var/automate-ha/svc-load.log 2>&1'
-hab svc unload "$PG_ORIGIN_NAME/$PG_PKG_NAME"
-hab svc unload "$PGLEADERCHK_ORIGIN_NAME/$PGLEADERCHK_PKG_NAME"
-hab svc unload "$PROXY_ORIGIN_NAME/$PROXY_PKG_NAME"
+hab svc unload %[1]s
+hab svc unload %[2]s
+hab svc unload %[3]s
 sleep 10
-bash -c 'eval hab svc load %[1]s --topology leader --strategy none "$LOGCMD"'
-bash -c 'eval hab svc load %[2]s --topology standalone --strategy none --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
-bash -c 'eval hab svc load %[3]s --topology standalone --strategy none --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
+bash -c 'hab svc load %[1]s --topology leader --strategy none '"$LOGCMD"
+bash -c 'hab svc load %[2]s --topology standalone --strategy none --bind database:'"$PG_PKG_NAME"'.default --binding-mode=relaxed '"$LOGCMD"
+bash -c 'hab svc load %[3]s --topology standalone --strategy none --bind database:'"$PG_PKG_NAME"'.default --bind pgleaderchk:'"$PGLEADERCHK_PKG_NAME"'.default --binding-mode=relaxed '"$LOGCMD"
 `

--- a/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
+++ b/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
@@ -1,0 +1,22 @@
+package remotescripts
+
+const POST_CERT_ROTATE_PG = `#!/bin/bash
+set -Eeuo pipefail
+HAB_NONINTERACTIVE=true
+HAB_NOCOLORING=true
+HAB_LICENSE=accept-no-persist
+PG_ORIGIN_NAME=$(echo "%[1]s" | awk -F/ '{print $1}')
+PG_PKG_NAME=$(echo "%[1]s" | awk -F/ '{print $2}')
+PGLEADERCHK_ORIGIN_NAME=$(echo "%[2]s" | awk -F/ '{print $1}')
+PGLEADERCHK_PKG_NAME=$(echo "%[2]s" | awk -F/ '{print $2}')
+PROXY_ORIGIN_NAME=$(echo "%[3]s" | awk -F/ '{print $1}')
+PROXY_PKG_NAME=$(echo "%[3]s" | awk -F/ '{print $2}')
+LOGCMD='>>/hab/var/automate-ha/svc-load.log 2>&1'
+hab svc unload "$PG_ORIGIN_NAME/$PG_PKG_NAME"
+hab svc unload "$PGLEADERCHK_ORIGIN_NAME/$PGLEADERCHK_PKG_NAME"
+hab svc unload "$PROXY_ORIGIN_NAME/$PROXY_PKG_NAME"
+sleep 10
+bash -c 'eval hab svc load %[1]s --topology leader --strategy none "$LOGCMD"'
+bash -c 'eval hab svc load %[2]s --topology standalone --strategy none --bind database:"$PG_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
+bash -c 'eval hab svc load %[3]s --topology standalone --strategy none --bind database:"$PG_PKG_NAME".default --bind pgleaderchk:"$PGLEADERCHK_PKG_NAME".default --binding-mode=relaxed "$LOGCMD"'
+`

--- a/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
+++ b/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
@@ -1,7 +1,6 @@
 package remotescripts
 
-const POST_CERT_ROTATE_PG = `#!/bin/bash
-set -Eeuo pipefail
+const POST_CERT_ROTATE_PG = `set -Eeuo pipefail
 HAB_NONINTERACTIVE=true
 HAB_NOCOLORING=true
 HAB_LICENSE=accept-no-persist


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

in cert rotate command earlier postgres was getting in an error state because ha proxy was not loading the updated configuration. To resolve this we are reloading ha proxy / pgleadercheck and reloading postgres also since we need to update certs in postgres

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
