### PR TITLE
bug fixed restart script ha

### DIFF
--- a/components/automate-cli/cmd/chef-automate/ha_cert_show_test.go
+++ b/components/automate-cli/cmd/chef-automate/ha_cert_show_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/logger"
 	"github.com/chef/automate/lib/majorupgrade_utils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +173,9 @@ func getMockNodeUtilsImpl() *MockNodeUtilsImpl {
 				return nil, nil, errors.New("Failed to convert config to AwsConfigToml")
 			}
 			return awsConfig, nil, nil
+		},
+		postPGCertRotateFunc: func(pgIps []string, sshconfig SSHConfig, fileUtils fileutils.FileUtils, log logger.Logger) error {
+			return nil
 		},
 	}
 }

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -124,7 +124,7 @@ func runStartCommandHA(infra *AutomateHAInfraDetails, args []string, isManagedSe
 		startCommandImplHA(args, *sshConfig, backendIps, POSTGRES_SERVICE, writer, errorList)
 		err := nodeUtils.postPGCertRotate(backendIps, *sshConfig, fileUtils, log)
 		if err != nil {
-			return err
+			errorList.PushBack(err.Error())
 		}
 	}
 	if errorList.Len() > 0 {

--- a/components/automate-cli/cmd/chef-automate/start_linx.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx.go
@@ -11,6 +11,9 @@ import (
 	"github.com/chef/automate/components/automate-cli/pkg/docs"
 	"github.com/chef/automate/components/automate-cli/pkg/status"
 	"github.com/chef/automate/components/automate-deployment/pkg/cli"
+	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/logger"
+	"github.com/chef/automate/lib/platform/command"
 )
 
 const (
@@ -65,7 +68,17 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if err = runStartCommandHA(infra, args, isManagedServicesOn()); err != nil {
+
+		nodeutils := NewNodeUtils(NewRemoteCmdExecutorWithoutNodeMap(NewSSHUtil(&SSHConfig{}), writer), command.NewExecExecutor(), writer)
+		level := "info"
+		if globalOpts.debug {
+			level = "debug"
+		}
+		log, err := logger.NewLogger("text", level)
+		if err != nil {
+			return err
+		}
+		if err = runStartCommandHA(infra, args, isManagedServicesOn(), nodeutils, &fileutils.FileSystemUtils{}, log); err != nil {
 			return err
 		}
 	} else if isDevMode() {
@@ -81,7 +94,7 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runStartCommandHA(infra *AutomateHAInfraDetails, args []string, isManagedServices bool) error {
+func runStartCommandHA(infra *AutomateHAInfraDetails, args []string, isManagedServices bool, nodeUtils NodeOpUtils, fileUtils fileutils.FileUtils, log logger.Logger) error {
 	sshConfig := &SSHConfig{
 		sshUser:    infra.Outputs.SSHUser.Value,
 		sshKeyFile: infra.Outputs.SSHKeyFile.Value,
@@ -109,6 +122,10 @@ func runStartCommandHA(infra *AutomateHAInfraDetails, args []string, isManagedSe
 		}
 		backendIps := infra.Outputs.PostgresqlPrivateIps.Value
 		startCommandImplHA(args, *sshConfig, backendIps, POSTGRES_SERVICE, writer, errorList)
+		err := nodeUtils.postPGCertRotate(backendIps, *sshConfig, fileUtils, log)
+		if err != nil {
+			return err
+		}
 	}
 	if errorList.Len() > 0 {
 		return status.New(status.ServiceStartError, getSingleErrorFromList(errorList).Error())

--- a/components/automate-cli/cmd/chef-automate/start_linx_test.go
+++ b/components/automate-cli/cmd/chef-automate/start_linx_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/chef/automate/components/automate-cli/pkg/status"
+	"github.com/chef/automate/lib/io/fileutils"
+	"github.com/chef/automate/lib/logger"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -280,7 +282,8 @@ func TestStartCommandHA(t *testing.T) {
 			startCmdFlags.opensearch = tc.isForOS
 			startCmdFlags.postgresql = tc.isForPG
 			infra := getMockInfra()
-			err := runStartCommandHA(infra, tc.arguments, tc.isManaged)
+			log, _ := logger.NewLogger("text", "debug")
+			err := runStartCommandHA(infra, tc.arguments, tc.isManaged, getMockNodeUtilsImpl(), &fileutils.FileSystemUtils{}, log)
 			if tc.isErrorExpected {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tc.errorMessage)

--- a/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
+++ b/components/automate-cli/pkg/remotescripts/pgPostCertRotate.go
@@ -4,7 +4,7 @@ const POST_CERT_ROTATE_PG = `#!/bin/bash
 set -Eeuo pipefail
 HAB_NONINTERACTIVE=true
 HAB_NOCOLORING=true
-HAB_LICENSE=accept-no-persist
+export HAB_LICENSE=accept-no-persist
 PG_PKG_NAME=$(echo "%[1]s" | awk -F/ '{print $2}')
 PGLEADERCHK_PKG_NAME=$(echo "%[2]s" | awk -F/ '{print $2}')
 

--- a/lib/io/fileutils/fileutils.go
+++ b/lib/io/fileutils/fileutils.go
@@ -202,7 +202,7 @@ func CreateTempFile(content string, filename string, dir string) (string, error)
 	if err != nil {
 		return "", errors.Wrap(err, "file creation failed ")
 	}
-	_, err = tempFile.WriteString((content))
+	_, err = tempFile.WriteString(content)
 	if err != nil {
 		return "", errors.Wrap(err, "writing to a file failed ")
 	}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
Start command restarts pg and reloads haproxy 
<img width="1312" alt="Screenshot 2024-07-27 at 9 50 04 PM" src="https://github.com/user-attachments/assets/30e36344-9d48-4580-a3bd-fc75081cc25c">


### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
