### PR TITLE
CHEF-2498 Fix for viewing control details in reports older than past 24 hours

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -205,16 +205,16 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     this.openControls[key] = toggled;
 
     // to fetch the past control details we need to pass the start and end time
-    var start_time = this.activeReport.end_time;
-    var end_time = moment(start_time).endOf('day').toISOString();
+    const start_time = this.activeReport.end_time;
+    const end_time = moment(start_time).endOf('day').toISOString();
     if (toggled.open === true) {
       if (!this.reportIdArray.includes(key)) {
         this.reportIdArray.push(key);
         const payload = {
           report_id : this.activeReport.id,
           filters : [
-            {"type": "start_time", "values": [start_time]},
-            {"type": "end_time", "values": [end_time]},
+            {'type': 'start_time', 'values': [start_time]},
+            {'type': 'end_time', 'values': [end_time]},
             {'type': 'profile_id', 'values': [`${control.profile_id}`]},
             {'type': 'control', 'values': [`${control.id}`]}]
         };

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -203,12 +203,18 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     const state = this.openControls[key];
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
     this.openControls[key] = toggled;
+
+    // to fetch the passed control details
+    var start_time = this.activeReport.end_time
+    var end_time = moment(start_time).endOf('day').toISOString()
     if (toggled.open === true) {
       if (!this.reportIdArray.includes(key)) {
         this.reportIdArray.push(key);
         const payload = {
           report_id : this.activeReport.id,
           filters : [
+            {"type": "start_time", "values": [start_time]},
+            {"type": "end_time", "values": [end_time]},
             {'type': 'profile_id', 'values': [`${control.profile_id}`]},
             {'type': 'control', 'values': [`${control.id}`]}]
         };

--- a/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/+reporting-node/reporting-node.component.ts
@@ -204,9 +204,9 @@ export class ReportingNodeComponent implements OnInit, OnDestroy {
     const toggled = state ? ({...state, open: !state.open}) : ({open: true, pane: 'results'});
     this.openControls[key] = toggled;
 
-    // to fetch the passed control details
-    var start_time = this.activeReport.end_time
-    var end_time = moment(start_time).endOf('day').toISOString()
+    // to fetch the past control details we need to pass the start and end time
+    var start_time = this.activeReport.end_time;
+    var end_time = moment(start_time).endOf('day').toISOString();
     if (toggled.open === true) {
       if (!this.reportIdArray.includes(key)) {
         this.reportIdArray.push(key);


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Expected: I should be able to click on each control of a node report to see the results.
Actual: I can only do this for the reports which are within the 24hrs time. For any report that is past 24hrs, I am getting the below error when I click on the + sign beside each control, it gives me the error below:
e.g. Could not get control details: Not found for id: de71b89f-5314-4460-a217-0b321f07b85c

### :chains: Related Resources
@vinay033's PR https://github.com/chef/automate/pull/7946 rebased with latest changes in `main` branch. 
### :+1: Definition of Done

Added changes to fetch the past control details.

### :athletic_shoe: How to Build and Test the Change

```
STEP 1
inside the hab studio

# build components/automate-ui-devproxy/
# start_automate_ui_background
# start_all_services
```

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="1581" alt="Screenshot 2024-08-02 at 1 25 28 PM" src="https://github.com/user-attachments/assets/c3603df1-6d8d-4b14-ba33-d1163a48c52f">
