### PR TITLE
CHEF-14374 Updated license input pop-up per UX mockup

### DIFF
--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
@@ -1,4 +1,4 @@
-<chef-modal label="license-lockout-label" [locked]="modalLocked" [visible]="modalVisible" (closeModal)="closeModal()">
+<chef-modal label="license-apply-label" [locked]="modalLocked" [visible]="modalVisible" (closeModal)="closeModal()">
   <div class="license-wrapper">
     <ng-container *ngIf="!licenseApplied">
 
@@ -8,8 +8,21 @@
         LICENSE_ABOUT_TO_EXPIRE = 3
       -->
       <ng-container *ngIf="licenseApplyReason === 1">
-        <div class="title">Welcome to Chef Automate!</div>
-        <div class="subtitle">Enter your license key.</div>
+        <div class="full-width">
+          <div class="left-fixed">
+            <h2 class="title">
+              <a left tertiary (click)="backToLicenseLockout(); false">
+                <chef-icon class="icon-left">chevron_left</chef-icon>
+              </a>
+            </h2>
+          </div>
+          <div class="right-flexible">
+            <h2 id="license-apply-label" class="title">
+              Welcome to Chef Automate!</h2>
+          </div>
+          <div class="right-fixed">
+          </div>
+        </div>
       </ng-container>
 
       <ng-container *ngIf="licenseApplyReason === 2">
@@ -49,11 +62,10 @@
         </chef-alert>
       </div>
 
-      <div class="note">Required fields are marked with an asterisk (*).</div>
       <form class="apply" [formGroup]="applyForm" (ngSubmit)="onApplyLicenseFormSubmit()" novalidate>
         <chef-form-field>
-          <label for="licenseKey">License Key <span aria-hidden="true">*</span></label>
-          <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="10" autofocus></textarea>
+          <label for="licenseKey"><h3 class="subtitle">Enter License Key<span aria-hidden="true">*</span></h3></label>
+          <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="7" placeholder="Enter here" autofocus></textarea>
           <chef-error *ngIf="applyForm.get('licenseKey')?.hasError('required') && applyForm.get('licenseKey')?.dirty">License key required</chef-error>
         </chef-form-field>
         <br>
@@ -63,23 +75,16 @@
           and the
           <a href="https://www.chef.io/online-master-agreement" target="_blank">Master License and Services Agreement</a>
         </chef-checkbox>
-        <div class="button">
-          <chef-button type="submit" primary [disabled]="!(applyForm.valid && mlsaAgree) || applyingLicense">Apply License</chef-button>
-          <chef-button tertiary (click)="logout()">Sign Out</chef-button>
+        <div class="footer">
+          <chef-button type="submit" class="button" primary [disabled]="!(applyForm.valid && mlsaAgree) || applyingLicense">Apply License</chef-button>
+          <br>
+          <chef-button tertiary class="button" (click)="logout()">Sign out and do it later.</chef-button>
         </div>
       </form>
       <div *ngIf="applyingLicense" class="spinner-container">
         <chef-loading-spinner size="30"></chef-loading-spinner>
       </div>
 
-      <!-- Only show footer to get trial if this is the initial apply -->
-      <ng-container *ngIf="licenseApplyReason === 1 && !licenseExpired">
-        <div class="footer">
-          <a href="" (click)="backToLicenseLockout(); false" class="active bright-link">Sign up for the trial</a>.
-          Or
-          <a href="https://www.chef.io/contact-us/" target="_blank">contact us</a> to get a license.
-        </div>
-      </ng-container>
     </ng-container>
 
     <!-- display confirmation once license applied -->

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.html
@@ -65,7 +65,7 @@
       <form class="apply" [formGroup]="applyForm" (ngSubmit)="onApplyLicenseFormSubmit()" novalidate>
         <chef-form-field>
           <label for="licenseKey"><h3 class="subtitle">Enter License Key<span aria-hidden="true">*</span></h3></label>
-          <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="7" placeholder="Enter here" autofocus></textarea>
+          <textarea name="licenseKey" id="licenseKey" formControlName="licenseKey" cols="65" rows="7" placeholder="Enter key here" autofocus></textarea>
           <chef-error *ngIf="applyForm.get('licenseKey')?.hasError('required') && applyForm.get('licenseKey')?.dirty">License key required</chef-error>
         </chef-form-field>
         <br>

--- a/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-apply/license-apply.component.scss
@@ -31,8 +31,9 @@
   }
 
   .button {
-    margin-top: 1em;
+    margin-top: 0.5em;
     text-align: center;
+    width: 500px;
   }
 
   ul {
@@ -62,7 +63,14 @@
 
 
   .footer {
-    margin-top: 0px;
+    margin-top: 10px;
+    font-size: 14px;
+    text-align: center;
+    width: 100%;
+
+    button:first-of-type {
+      margin-right: 60px;
+    }
   }
 
   label {
@@ -73,10 +81,14 @@
   }
 
   textarea {
-    font-size: 12px;
-    min-width: 636px;
+    font-size: 14px;
+    min-width: 600px;
     max-width: 600px;
-    min-height: 175px;
+    min-height: 100px;
+    padding: 8px;
+    border-radius: 4px;
+    border-color: #7D868C47;
+    resize: none;
   }
 
   textarea#licenseKey {
@@ -85,6 +97,7 @@
 
   textarea,
   chef-error {
+    font-size: 14px;
     display: block;
   }
 
@@ -92,7 +105,6 @@
     display: flex;
     justify-content: flex-start;
     margin-top: 10px;
-    height: 20px;
   }
 
   ::ng-deep chef-alert {
@@ -111,6 +123,35 @@
     width: 210px;
   }
 
+  chef-icon.icon-left {
+    float: left;
+    margin-left: 13px;
+    font-size: 32px;
+    color: #3864F2;
+    cursor: pointer;
+  }
+
+  .full-width {
+    width: 100%;
+    display: flex;
+  }
+
+  .left-fixed {
+    width: 32px;
+    float: left;
+    text-align: left;
+  }
+
+  .right-fixed {
+    width: 32px;
+    float: right;
+  }
+
+  .right-flexible {
+    flex-grow: 1;
+    text-align: center;
+  }
+
   .note {
     font-style: italic;
     font-size: 12px;
@@ -122,4 +163,5 @@
   app-telemetry-checkbox {
     margin: 20px 50px 0;
   }
+
 }

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -4,7 +4,7 @@
     <ng-container *ngIf="!fetchStatusInternalError">
       <ng-container *ngIf="!trialLicenseApplied">
         <h2 id="license-lockout-label" class="title">Welcome to Chef Automate!</h2>
-        <div class="subtitle">In order to use Chef Automate, you will require a license</div>
+        <div class="subtitle">In order to use Chef Automate, you will require a license.</div>
         <div class="subtitle">Please select an option to proceed.</div>
         <div class="error-container">
           <chef-alert type="error" *ngIf="fetchStatusInternalError">
@@ -31,20 +31,36 @@
           </chef-alert>
         </div>
         <div class="border-box">
-          <a tertiary (click)="backToLicenseApply(); false">I have a license</a>
-          <p>Enter the License key and proceed.</p>
-          <a tertiary (click)="backToLicenseApply(); false">
-            <chef-icon class="icon-right">chevron_right</chef-icon>
-          </a>
+          <table class="compact-table">
+            <tr>
+              <td class="compact-cell">
+                <a tertiary (click)="backToLicenseApply(); false">I have a license</a>
+                <br><span class="regular-text">Enter the License key and proceed.</span>
+              </td>
+              <td class="compact-cell">
+                <a tertiary (click)="backToLicenseApply(); false">
+                  <chef-icon class="icon-right">chevron_right</chef-icon>
+                </a>
+              </td>
+            </tr>
+          </table>
         </div>
         <br>
         <div class="border-box">
-          <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">I don't have a license</a>
-          <p>Generate a license key.</p>
-          <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">
-            <chef-icon class="icon-right">chevron_right</chef-icon>
-          </a>
-
+          <table class="compact-table">
+            <tr>
+              <td class="compact-cell">
+                <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">I don't have a
+                  license</a>
+                <br><span class="regular-text">Generate a license key.</span>
+              </td>
+              <td class="compact-cell">
+                <a href="https://www.chef.io/license-generation-free-trial" target="_blank" rel="noopener">
+                  <chef-icon class="icon-right">chevron_right</chef-icon>
+                </a>
+              </td>
+            </tr>
+          </table>
         </div>
         <div class="spinner-container">
           <chef-loading-spinner *ngIf="requestingLicense" size="30"></chef-loading-spinner>

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.html
@@ -50,7 +50,7 @@
           <chef-loading-spinner *ngIf="requestingLicense" size="30"></chef-loading-spinner>
         </div>
         <div class="footer">
-          <chef-button tertiary (click)="logout()">Sign out and do it later.</chef-button>
+          <chef-button class="button" tertiary (click)="logout()">Sign out and do it later.</chef-button>
         </div>
       </ng-container>
 

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -61,8 +61,9 @@
   }
 
   .button {
-    margin-top: 1em;
+    margin-top: 0.5em;
     text-align: center;
+    width: 500px;
   }
 
   .trial {

--- a/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
+++ b/components/automate-ui/src/app/modules/license/license-lockout/license-lockout.component.scss
@@ -12,7 +12,6 @@
 
   chef-icon.icon-right {
     float: right;
-    margin-top: -36px;
     margin-right: 13px;
     font-size: 20px;
     color: #3864F2;
@@ -192,5 +191,21 @@
       text-decoration: none;
       cursor: pointer;
     }
+  }
+
+  .compact-table {
+    border-collapse: collapse;
+    padding: 0;
+    margin: 0;
+  }
+
+  .compact-cell {
+    vertical-align: middle;
+    padding: 0;
+    margin: 0;
+  }
+
+  .regular-text {
+    font-size: .875em;
   }
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

License input screen updated to match UX mockup

### :+1: Definition of Done
Tested on local setup for success and failure scenarios. 

### :athletic_shoe: How to Build and Test the Change
Check the updated screen by running local development environment using habitat.

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable
<img width="703" alt="Screenshot 2024-08-21 at 5 03 36 PM" src="https://github.com/user-attachments/assets/aad702cf-2ec6-4a3b-929e-94ae1b4528cc">
<img width="704" alt="Screenshot 2024-08-21 at 5 03 21 PM" src="https://github.com/user-attachments/assets/1c9691fe-af78-4e36-a55e-5b8192cdf949">

