### PR TITLE
Block auto-indexing of static assets more narrowly

### DIFF
--- a/components/automate-load-balancer/habitat/config/nginx.conf
+++ b/components/automate-load-balancer/habitat/config/nginx.conf
@@ -211,28 +211,6 @@ http {
       return 200;
     }
 
-    location ~ .(assets/?)$ {
-      return 404;
-    }
-    location ~ .(assets/img/?)$ {
-      return 404;
-    }
-    location ~ .(assets/fonts/?)$ {
-      return 404;
-    }
-    location ~ .(assets/chef-ui-library/?)$ {
-      return 404;
-    }
-
-    location ~ .(dex/?)$ {
-      return 404;
-    }
-    location ~ .(dex/static/?)$ {
-      return 404;
-    }
-    location ~ .(dex/static/img/?)$ {
-      return 404;
-    }
     #######################################################################
     # Automate Gateway
     #######################################################################
@@ -292,6 +270,12 @@ http {
     #######################################################################
     # Auth System
     #######################################################################
+    # Block auto-indexing of dex static assets
+    # (Ideally dex would do this itself)
+    location ~ ^/(dex|dex/static|dex/static/img|dex/static/fonts|dex/static/font-awesome-[^/]+)/?$ {
+      return 404;
+    }
+
     location /dex/ {
       proxy_pass https://automate-dex;
       proxy_set_header Connection ""; # Required to make persistent connections happen
@@ -336,6 +320,12 @@ http {
       add_header x-xss-protection "1; mode=block" always;
       add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
       add_header X-Content-Type-Options "nosniff" always;
+    }
+
+    # Serve 404 instead of 403 for automate-ui assets
+    # See https://github.com/chef/automate/issues/4855
+    location ~ ^/(assets|assets/img|assets/fonts|assets/chef-ui-library)/?$ {
+      return 404;
     }
 
     location /nginx_status {


### PR DESCRIPTION
In c870cc3, we added rules to 404 instead of serving a 403 or auto-indexing on static asset directories in automate-ui and dex respectively. The regexes used are overly broad in that they cause any URIs ending in "dex" or "assets" to 404[^1] including unrelated API endpoints. For example, this is blocking us from publishing policyfiles named "index".

I'm not so familiar with these internals, but I believe it's sufficient to use regexes `^/dex/` and `^/assets/` etc instead of `.dex` and `.assets` etc. I also blocked auto-indexing of two other static asset directories under dex (`fonts` and `font-awesome-*`). I made a note that ideally dex itself should be handling this.

I'll note that the 404s served at the loadbalancer look different than the 404s of underlying servers, so an attacker can still know they "hit" something. For example:

```
$ curl -k -v -H 'Host: chef-automate' 'https://127.0.0.1/dex/foo/bar'
...
< HTTP/2 404
< date: Wed, 28 Aug 2024 17:35:03 GMT
< content-type: text/plain; charset=utf-8
< content-length: 19
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
<
404 page not found
$ curl -k -v -H 'Host: chef-automate' 'https://127.0.0.1/dex/static'
< HTTP/2 404
< date: Wed, 28 Aug 2024 17:35:55 GMT
< content-type: text/html
< content-length: 146
< x-xss-protection: 1; mode=block
< strict-transport-security: max-age=63072000; includeSubDomains
< x-content-type-options: nosniff
<
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

At least it doesn't auto-index, but I do question the integrity of this approach. As I stated above it should be handled by dex itself. I suspect there's a way to handle the automate-ui assets more elegantly as well.

[^1]: https://community.progress.com/s/article/Paths-or-URIs-ending-with-dex-or-assets-Lead-to-a-404-in-Chef-Automate

---

### :nut_and_bolt: Description: What code changed, and why?

Fix nginx 404 rules

### :chains: Related Resources

* https://github.com/chef/automate/issues/4855
* https://github.com/chef/automate/pull/5872
* https://github.com/chef/automate/commit/c870cc374fd371efe7aaaeed4d2a02c1affc98d5
* https://community.progress.com/s/article/Paths-or-URIs-ending-with-dex-or-assets-Lead-to-a-404-in-Chef-Automate

### :+1: Definition of Done

For us, the ability to publish policyfiles named "index"

### :athletic_shoe: How to Build and Test the Change

curl assets and dex endpoints

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

n/a