### PR TITLE
Fixed Automate url when we filter with node name in compliance report page

### DIFF
--- a/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
+++ b/components/automate-ui/src/app/pages/+compliance/+reporting/reporting.component.ts
@@ -391,8 +391,8 @@ export class ReportingComponent implements OnInit, OnDestroy {
       }
     } else if (type.name === 'node') {
       if ( value.id ) {
-        typeName = 'node_id';
-        filterValue = value.id;
+        typeName = 'node_name';
+        filterValue = value.title;
         this.reportQuery.setFilterTitle(typeName, value.id, value.title);
       } else {
         typeName = 'node_name';


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Automate compliance URL node name vs node_id | node name not reflecting in Automate url when we filter with node name in compliance report page
### :chains: Related Resources
https://progresssoftware.atlassian.net/browse/CHEF-10397
### :+1: Definition of Done
I have added changes to fix the URL and filter on compliance report page.
### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

https://github.com/user-attachments/assets/ea57c1d4-d8e7-46e8-8680-159dd0c03131

