### PR TITLE
[CHEF-11758] Add support for config verification of backup in HA restore command

### DIFF
--- a/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
+++ b/components/automate-cli/cmd/chef-automate/deployedConfig_test.go
@@ -286,18 +286,20 @@ var awsConfig = &AwsConfigToml{
 }
 
 type MockPullConfigs struct {
-	fetchInfraConfigFunc      func(removeUnreachableNodes bool) (*ExistingInfraConfigToml, map[string][]string, error)
-	fetchAwsConfigFunc        func(removeUnreachableNodes bool) (*AwsConfigToml, map[string][]string, error)
-	pullOpensearchConfigsFunc func(removeUnreachableNodes bool) (map[string]*ConfigKeys, []string, error)
-	pullPGConfigsFunc         func(removeUnreachableNodes bool) (map[string]*ConfigKeys, []string, error)
-	pullAutomateConfigsFunc   func(removeUnreachableNodes bool) (map[string]*dc.AutomateConfig, []string, error)
-	pullChefServerConfigsFunc func(removeUnreachableNodes bool) (map[string]*dc.AutomateConfig, []string, error)
-	generateInfraConfigFunc   func(removeUnreachableNodes bool) (*ExistingInfraConfigToml, map[string][]string, error)
-	generateAwsConfigFunc     func(removeUnreachableNodes bool) (*AwsConfigToml, map[string][]string, error)
-	getExceptionIpsFunc       func() []string
-	setExceptionIpsFunc       func(ips []string)
-	getOsCertsByIpFunc        func(map[string]*ConfigKeys) []CertByIP
-	setInfraAndSSHUtilFunc    func(*AutomateHAInfraDetails, SSHUtil)
+	fetchInfraConfigFunc         	      func(removeUnreachableNodes bool) (*ExistingInfraConfigToml, map[string][]string, error)
+	fetchAwsConfigFunc                    func(removeUnreachableNodes bool) (*AwsConfigToml, map[string][]string, error)
+	pullOpensearchConfigsFunc             func(removeUnreachableNodes bool) (map[string]*ConfigKeys, []string, error)
+	pullPGConfigsFunc                     func(removeUnreachableNodes bool) (map[string]*ConfigKeys, []string, error)
+	pullAutomateConfigsFunc               func(removeUnreachableNodes bool) (map[string]*dc.AutomateConfig, []string, error)
+	pullChefServerConfigsFunc             func(removeUnreachableNodes bool) (map[string]*dc.AutomateConfig, []string, error)
+	generateInfraConfigFunc               func(removeUnreachableNodes bool) (*ExistingInfraConfigToml, map[string][]string, error)
+	generateAwsConfigFunc     			  func(removeUnreachableNodes bool) (*AwsConfigToml, map[string][]string, error)
+	getExceptionIpsFunc                   func() []string
+	setExceptionIpsFunc                   func(ips []string)
+	getOsCertsByIpFunc                    func(map[string]*ConfigKeys) []CertByIP
+	setInfraAndSSHUtilFunc                func(*AutomateHAInfraDetails, SSHUtil)
+	getBackupPathFromAutomateConfigFunc   func(map[string]*dc.AutomateConfig, string) (string, error)
+	getBackupPathFromOpensearchConfigFunc func() (string, error)
 }
 
 func (m *MockPullConfigs) setInfraAndSSHUtil(*AutomateHAInfraDetails, SSHUtil) {
@@ -346,6 +348,16 @@ func (m *MockPullConfigs) setExceptionIps(ips []string) {
 func (m *MockPullConfigs) getOsCertsByIp(configKeysMap map[string]*ConfigKeys) []CertByIP {
 	return m.getOsCertsByIpFunc(configKeysMap)
 }
+
+func (m *MockPullConfigs) getBackupPathFromAutomateConfig(a2ConfigMap map[string]*dc.AutomateConfig, backupLocation string) (string, error) {
+	return m.getBackupPathFromAutomateConfigFunc(a2ConfigMap, backupLocation)
+}
+
+func (m *MockPullConfigs) getBackupPathFromOpensearchConfig() (string, error) {
+	return m.getBackupPathFromOpensearchConfigFunc()
+}
+
+
 
 func TestPopulateHaCommonConfig(t *testing.T) {
 	tests := []struct {

--- a/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig_test.go
+++ b/components/automate-cli/cmd/chef-automate/pullAndGenerateConfig_test.go
@@ -1297,3 +1297,138 @@ func TestFindCommonPath(t *testing.T) {
 		assert.Equal(t, test["result"][2], unique2)
 	}
 }
+func TestGetBackupPathFromAutomateConfig(t *testing.T) {
+	tests := []struct {
+		testCaseDescription string
+		a2ConfigMap         map[string]*dc.AutomateConfig
+		backupLocation      string
+		expectedResult      string
+		expectedError       error
+	}{
+		{
+			testCaseDescription: "when backupLocation is fs",
+			backupLocation:      "fs",
+			a2ConfigMap: map[string]*dc.AutomateConfig{
+				"config": {
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Backups: &shared.Backups{
+								Location: &wrapperspb.StringValue{
+									Value: "fs",
+								},
+								Filesystem: &shared.Backups_Filesystem{
+									Path: &wrapperspb.StringValue{
+										Value: "/mnt/automate_backups/opensearch",
+									},
+								},
+							},
+							External: &shared.External{
+								Opensearch: &shared.External_Opensearch{
+									Backup: &shared.External_Opensearch_Backup{
+										Location: &wrapperspb.StringValue{
+											Value: "fs",
+										},
+										Fs: &shared.External_Opensearch_Backup_FsSettings{
+											Path: &wrapperspb.StringValue{
+												Value: "/mnt/automate_backups/opensearch",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: "/mnt/automate_backups/opensearch",
+			expectedError:  nil,
+		},
+		{
+			testCaseDescription: "when backupLocation is s3",
+			backupLocation:      "s3",
+			a2ConfigMap: map[string]*dc.AutomateConfig{
+				"config": {
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Backups: &shared.Backups{
+								Location: &wrapperspb.StringValue{
+									Value: "s3",
+								},
+							},
+							External: &shared.External{
+								Opensearch: &shared.External_Opensearch{
+									Backup: &shared.External_Opensearch_Backup{
+										Location: &wrapperspb.StringValue{
+											Value: "s3",
+										},
+										S3: &shared.External_Opensearch_Backup_S3Settings{
+											Bucket: &wrapperspb.StringValue{
+												Value: "s3-test-bucketname",
+											},
+											BasePath: &wrapperspb.StringValue{
+												Value: "opensearch",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: "opensearch",
+			expectedError:  nil,
+		},
+		{
+			testCaseDescription: "when backupLocation is gcs",
+			backupLocation:      "gcs",
+			a2ConfigMap: map[string]*dc.AutomateConfig{
+				"config": {
+					Global: &shared.GlobalConfig{
+						V1: &shared.V1{
+							Backups: &shared.Backups{
+								Location: &wrapperspb.StringValue{
+									Value: "gcs",
+								},
+							},
+							External: &shared.External{
+								Opensearch: &shared.External_Opensearch{
+									Backup: &shared.External_Opensearch_Backup{
+										Location: &wrapperspb.StringValue{
+											Value: "gcs",
+										},
+										Gcs: &shared.External_Opensearch_Backup_GCSSettings{
+											Bucket: &wrapperspb.StringValue{
+												Value: "gcs-test-bucketname",
+											},
+											BasePath: &wrapperspb.StringValue{
+												Value: "opensearch",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: "opensearch",
+			expectedError:  nil,
+		},
+	}
+	pullconfig := &PullConfigsImpl{
+		infra:        NewMockInfra(),
+		sshUtil:      GetMockSSHUtil(&SSHConfig{}, nil, completedMessage, nil, "", nil),
+		exceptionIps: []string{"198.51.100.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.testCaseDescription, func(t *testing.T) {
+			result, err := pullconfig.getBackupPathFromAutomateConfig(tc.a2ConfigMap, tc.backupLocation)
+			if tc.expectedError != nil {
+				assert.Equal(t, tc.expectedError, err)
+			} else {
+				assert.Equal(t, tc.expectedResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: 
Add support for config verification of backup in HA restore command

Jira ID - https://progresssoftware.atlassian.net/browse/CHEF-11758

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

1. Error message when indices of all the snapshots are not the same when the backup type is object storage
![RestoreFailureScenarioForS3(a)](https://github.com/user-attachments/assets/9478a17c-342d-4458-80b0-4a577eabef2e)
![RestoreFailureScenarioForS3(b)](https://github.com/user-attachments/assets/0613b6c4-b5fe-4712-b78f-32194d383464)

Recording is attached in the ticket https://progresssoftware.atlassian.net/browse/CHEF-11758

Screenshots after incorporating review comments

1. Success message
<img width="869" alt="RestoreSuccessScenario" src="https://github.com/user-attachments/assets/346cef6b-89bd-42ab-aaba-78b4fbf96d81" />



2. Error message when backup path in automate node does not match with the backup path configured in opensearch node
<img width="924" alt="RestoreFailureScenario1" src="https://github.com/user-attachments/assets/c50657cc-ab7c-4d7d-b62c-2fd835e785ec" />



3. Error message when backup path in automate node does not match with the indices of snapshots
<img width="930" alt="RestoreFailureScenario2" src="https://github.com/user-attachments/assets/14775654-1763-45ea-be65-ecc10a70b92b" />



4. Error message when indices of all the snapshots are not the same
<img width="875" alt="RestoreFailureScenario3" src="https://github.com/user-attachments/assets/9511e948-fd5b-4dee-a69c-d7a53928da30" />

