### PR TITLE
docs: resizing huge images in Automate invalid login attempts doc

### DIFF
--- a/components/docs-chef-io/content/automate/invalid_login_attempts.md
+++ b/components/docs-chef-io/content/automate/invalid_login_attempts.md
@@ -16,11 +16,11 @@ Invalid Login Attempts is available only in case of local or LDAP users.
 
 Chef Automate shows error message for invalid login attempts for local or LDAP user as shown below.
 
-![Chef Automate Invalid Login Attempts](/images/automate/invalid_login_attempts_error_msg.png)
+{{< figure src="/images/automate/invalid_login_attempts_error_msg.png" width="500" alt="Chef Automate Invalid Login Attempts">}}
 
 Chef Automate shows error message for blocked local or LDAP user as shown below.
 
-![Chef Automate Blocked User](/images/automate/blockd_user_login_error_msg.png)
+{{< figure src="/images/automate/blockd_user_login_error_msg.png" width="500" alt="Chef Automate Blocked User">}}
 
 Chef Automate lets you configure **Invalid Login Attempts**, which is enabled (by default) to avoid multiple failed login attempts in a shorter time. Chef Automate also blocks the user for a specified duration (in minutes) once the maximum allowed number of invalid login attempts reached
 


### PR DESCRIPTION
Obvious fix. Document change.

### :nut_and_bolt: Description: What code changed, and why?

The current images in the following doc page  are huge and would help to reduce them in size.
* https://docs.chef.io/automate/invalid_login_attempts

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)* 
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests) - N/A
- [x] Docs added/updated? (all customer-facing changes)



