### PR TITLE
Ruby Upgrade to 3.1.0 from 3.0.0

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -86,7 +86,7 @@ steps:
 
   - label: ":ruby: :buildkite: a2-ha-backend/automate-cluster-ctl"
     commands:
-      - gem install bundler:1.16.6
+      - gem install bundler:2.3.27
       - cd components/automate-cluster-ctl/; bundle install --jobs=3 --retry=3
       - bundle exec rspec
     expeditor:

--- a/components/automate-backend-ctl/habitat/bin/knife
+++ b/components/automate-backend-ctl/habitat/bin/knife
@@ -23,7 +23,7 @@ cd "$pkg_prefix"
 
 # These shouldn't be needed as habitat will have these in the path already
 #BUNDLE_BIN_DIR=$(hab pkg path "core/bundler")/bin
-#RUBY_BIN_DIR=$(hab pkg path "core/ruby30")/bin
+#RUBY_BIN_DIR=$(hab pkg path "core/ruby31")/bin
 
 #export PATH=$PATH:$BUNDLE_BIN_DIR:$RUBY_BIN_DIR
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(hab pkg path "core/libffi")/lib

--- a/components/automate-backend-ctl/habitat/plan.sh
+++ b/components/automate-backend-ctl/habitat/plan.sh
@@ -13,7 +13,7 @@ do_before() {
 }
 
 pkg_deps=(
-  core/ruby30
+  core/ruby31
   core/libffi
   chef/mlsa
   core/bash
@@ -96,7 +96,7 @@ if test -n "\$DEBUG"; then set -x; fi
 export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 unset RUBYOPT GEMRC
-exec $(pkg_path_for ruby30)/bin/ruby -I $pkg_prefix/lib ${bin}.real \$@
+exec $(pkg_path_for ruby31)/bin/ruby -I $pkg_prefix/lib ${bin}.real \$@
 EOF
   chmod -v 755 "$bin"
 }

--- a/components/automate-backend-ctl/habitat/plan.sh
+++ b/components/automate-backend-ctl/habitat/plan.sh
@@ -46,7 +46,7 @@ do_prepare() {
   gem update --system --no-document
   gem install bundler -v "$(grep -A 1 "BUNDLED WITH" $PLAN_CONTEXT/Gemfile.lock | tail -n 1)"
 
-  export GEM_HOME="$pkg_prefix/vendor/bundle/ruby/3.0.0"
+  export GEM_HOME="$pkg_prefix/vendor/bundle/ruby/3.1.0"
   build_line "Setting GEM_HOME='$GEM_HOME'"
   export GEM_PATH="$GEM_HOME"
   build_line "Setting GEM_PATH='$GEM_PATH'"

--- a/components/automate-backend-deployment/habitat/plan.sh
+++ b/components/automate-backend-deployment/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_license=("Chef-MLSA")
 
 
 pkg_deps=(
-  core/ruby30
+  core/ruby31
   core/aws-cli
   core/bash
   core/coreutils

--- a/components/automate-backend-opensearch/habitat/config/sidecar
+++ b/components/automate-backend-opensearch/habitat/config/sidecar
@@ -1,4 +1,4 @@
 #!{{pkgPathFor "core/bash"}}/bin/bash
 echo "------------- starting opensearch sidecar -------------------"
-HAB_LICENSE=accept-no-persist GEM_PATH={{pkg.path}}/lib/gems {{pkgPathFor "core/ruby30"}}/bin/ruby {{pkg.path}}/bin/opensearch_sidecar.rb
+HAB_LICENSE=accept-no-persist GEM_PATH={{pkg.path}}/lib/gems {{pkgPathFor "core/ruby31"}}/bin/ruby {{pkg.path}}/bin/opensearch_sidecar.rb
 echo "-------------------------------------------------------------"

--- a/components/automate-backend-opensearch/habitat/plan.sh
+++ b/components/automate-backend-opensearch/habitat/plan.sh
@@ -26,7 +26,7 @@ pkg_deps=(
   core/curl # health_check
   chef/automate-openjdk
   chef/automate-platform-tools
-  core/ruby30
+  core/ruby31
 )
 pkg_interpreters=(bin/ruby)
 pkg_bin_dirs=(os/bin)

--- a/components/automate-cluster-ctl/habitat/plan.sh
+++ b/components/automate-cluster-ctl/habitat/plan.sh
@@ -9,9 +9,9 @@ pkg_maintainer="Chef Software Inc. <support@chef.io>"
 pkg_license=("Chef-MLSA")
 
 pkg_deps=(
-  core/ruby30
+  core/ruby31
   core/aws-cli
-  chef/inspec/4.56.61
+  # chef/inspec/4.56.61
   core/bash
   core/coreutils
   core/cacerts
@@ -100,7 +100,7 @@ do_unpack() {
 }
 
 do_setup_environment() {
-  export GEM_HOME="$pkg_prefix/vendor/bundle/ruby/3.0.0"
+  export GEM_HOME="$pkg_prefix/vendor/bundle/ruby/3.1.0"
   export GEM_PATH="$GEM_HOME"
 
   set_runtime_env GEM_HOME "$GEM_HOME"

--- a/components/automate-cluster-ctl/libexec/automate-cluster-ctl
+++ b/components/automate-cluster-ctl/libexec/automate-cluster-ctl
@@ -43,8 +43,8 @@ export _CLUSTER_CTL_VERSION="${AUTOMATE_CLUSTER_VERSION:-DEV}"
 
 # If not provided to use set it to our vendor/bundle
 if [[ -z "${GEM_PATH}" ]]; then
-  export GEM_PATH="$_CLUSTER_CTL_ROOT/vendor/bundle/ruby/3.0.0"
-  export GEM_HOME="$_CLUSTER_CTL_ROOT/vendor/bundle/ruby/3.0.0"
+  export GEM_PATH="$_CLUSTER_CTL_ROOT/vendor/bundle/ruby/3.1.0"
+  export GEM_HOME="$_CLUSTER_CTL_ROOT/vendor/bundle/ruby/3.1.0"
 fi
 
 export PATH="${libexec_path}:$PATH"

--- a/components/automate-cs-nginx/habitat/plan.sh
+++ b/components/automate-cs-nginx/habitat/plan.sh
@@ -20,7 +20,7 @@ pkg_deps=(
   # chef-server-* packages.
   #
   core/curl
-  core/ruby30
+  core/ruby31
   # WARNING: Version pin managed by .expeditor/update_chef_server.sh
   "${vendor_origin}/chef-server-nginx/15.10.21/20241126094216"
   "${vendor_origin}/chef-server-ctl/15.10.21/20241126093701"
@@ -67,7 +67,7 @@ scaffolding_go_binary_list=(
 chef_automate_hab_binding_mode="relaxed"
 
 do_prepare() {
-  GO_LDFLAGS="-X main.RubyPath=$(pkg_path_for core/ruby30)"
+  GO_LDFLAGS="-X main.RubyPath=$(pkg_path_for core/ruby31)"
   GO_LDFLAGS="$GO_LDFLAGS -X main.ChefServerCtlPath=$(pkg_path_for chef/chef-server-ctl)"
   GO_LDFLAGS="$GO_LDFLAGS -X main.KnifePath=${pkg_prefix}/bin/knife"
   GO_LDFLAGS="$GO_LDFLAGS -X main.Version=${pkg_version}/${pkg_release}"
@@ -83,6 +83,6 @@ do_install() {
   install "$PLAN_CONTEXT/bin/knife" "$wrapper_bin_path/knife"
 
   sed -i "s!__BUILDTIME_HAB_PKG_PATH_CHEF_SERVER_CTL__!$(pkg_path_for chef/chef-server-ctl)!g" "$wrapper_bin_path/knife"
-  sed -i "s!__BUILDTIME_HAB_PKG_PATH_RUBY__!$(pkg_path_for core/ruby30)!g" "$wrapper_bin_path/knife"
+  sed -i "s!__BUILDTIME_HAB_PKG_PATH_RUBY__!$(pkg_path_for core/ruby31)!g" "$wrapper_bin_path/knife"
 }
 

--- a/components/automate-cs-oc-erchef/habitat/hooks/run
+++ b/components/automate-cs-oc-erchef/habitat/hooks/run
@@ -48,7 +48,7 @@ HOME="{{pkg.svc_data_path}}" BUNDLE_GEMFILE="{{pkgPathFor "chef/oc_erchef"}}/Gem
     bundle exec ruby "{{pkg.svc_config_path}}/chef_server_data_bootstrap.rb"
 
 # ruby vars are needed in order to make depselector start up
-export PATH={{pkgPathFor "core/ruby30"}}/bin:${PATH}
+export PATH={{pkgPathFor "core/ruby31"}}/bin:${PATH}
 export LD_LIBRARY_PATH={{pkgPathFor "core/libffi"}}/lib:${LD_LIBRARY_PATH}
 export GEM_HOME={{pkgPathFor "chef/oc_erchef"}}/vendor/bundle
 export GEM_PATH={{pkgPathFor "chef/oc_erchef"}}/vendor/bundle

--- a/scripts/credentials
+++ b/scripts/credentials
@@ -3,6 +3,6 @@
 # Summary: Manage cluster credentials including ssl and passwords
 # Built-in help
 
-RUBY_PATH=$(HAB_LICENSE=accept-no-persist hab pkg list --origin core | grep ruby30 | tail -1)
+RUBY_PATH=$(HAB_LICENSE=accept-no-persist hab pkg list --origin core | grep ruby31 | tail -1)
 [ -d "./test/vendor/bundle" ] || (cd test && /hab/pkgs/$RUBY_PATH/bin/bundle install --path vendor/bundle)
 cd test && /hab/pkgs/$RUBY_PATH/bin/bundle exec /hab/pkgs/$RUBY_PATH/bin/ruby lib/credentials "$@"

--- a/scripts/gather-logs
+++ b/scripts/gather-logs
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 [ -d "./test/vendor/bundle" ] || (cd test && $(hab pkg path core30)/bin/bundle install --path vendor/bundle)
-cd test && $(hab pkg path core/ruby30)/bin/bundle exec $(hab pkg path core/ruby30)/bin/ruby lib/gather-logs "$@"
+cd test && $(hab pkg path core/ruby31)/bin/bundle exec $(hab pkg path core/ruby31)/bin/ruby lib/gather-logs "$@"

--- a/scripts/smoke-test
+++ b/scripts/smoke-test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-[ -d "./test/vendor/bundle" ] || (cd test && $(hab pkg path core/ruby30)/bin/bundle install --path vendor/bundle)
-cd test && $(hab pkg path core/ruby30)/bin/bundle exec $(hab pkg path core/ruby30)/bin/ruby lib/smoke-test "$@"
+[ -d "./test/vendor/bundle" ] || (cd test && $(hab pkg path core/ruby31)/bin/bundle install --path vendor/bundle)
+cd test && $(hab pkg path core/ruby31)/bin/bundle exec $(hab pkg path core/ruby31)/bin/ruby lib/smoke-test "$@"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->
package upgrade ruby
https://progresssoftware.atlassian.net/browse/CHEF-17460

inspec is commented in cluster-ctl because its pulling vulnerability affected ruby version 3.1.2

Automate team has to fix below issues:
- inspec with the vulnerable ruby(core/ruby31/3.1.2/20240107080752) is present in compliance service (we need inspec new build)
- erchef pulling ruby core/ruby30/3.0.6/20240107080023 in automate-cs-oc-service

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable


<img width="970" alt="Screenshot 2024-12-06 at 4 41 29 PM" src="https://github.com/user-attachments/assets/247431b7-e643-4152-ac1c-6ba110a69c68">
<img width="970" alt="Screenshot 2024-12-06 at 4 41 42 PM" src="https://github.com/user-attachments/assets/b48866e5-98d8-4854-bd0e-fda7d77937f4">
<img width="543" alt="Screenshot 2024-12-06 at 4 40 45 PM" src="https://github.com/user-attachments/assets/46d1c63a-ace2-4b8d-bf3e-8d3067ca4667">
