### PR TITLE
Corrected server_name field value which was coming empty after upgrade

### DIFF
--- a/components/automate-backend-deployment/README.md
+++ b/components/automate-backend-deployment/README.md
@@ -2,7 +2,7 @@
 
 This provides the `automate-backend-deployment` package.
 
-This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile. 
+This package will build a package using terraform/a2ha-terraform, inspecs, test, certs and Makefile.
 
 This is the heart of the a2ha because this component will set up a workspace for a2ha and all the a2ha command will get available after installing this package.
 

--- a/components/docs-chef-io/content/automate/ha_cert_rotation.md
+++ b/components/docs-chef-io/content/automate/ha_cert_rotation.md
@@ -41,6 +41,7 @@ To understand how to generate certificates, refer to the [Certificate Generation
 - If you want to use certificates stored in another node of the HA cluster, you can provide the remote path to the certificates using the `<IP_ADDRESS_OF_NODE>:<ABSOLUTE_PATH_TO_THE_CERT_FILE>` format instead of the local path.
 - `--wait-timeout` This flag sets the operation timeout duration (in seconds) for each individual node during the certificate rotation process.
 - Certificate rotation should be done in down-time window as service will restart.
+- CN (Common Name) should be the same for all certificates in Opensearch nodes.
 {{< /note >}}
 
 ### Rotate Cluster Certificates

--- a/components/docs-chef-io/content/automate/ha_cert_selfsign.md
+++ b/components/docs-chef-io/content/automate/ha_cert_selfsign.md
@@ -82,7 +82,8 @@ You can create a self-signed key and certificate pair with the **OpenSSL** utili
 
 {{< note >}}
 
-To create self-signed certificate for FQDN make sure to provide proper DNS and CN value. The DNS in Subject Alternative Name should match with the CN (Comman Name) 
+- To create self-signed certificate for FQDN make sure to provide proper DNS and CN value. The DNS in Subject Alternative Name should match with the CN (Common Name).
+- CN (Common Name) should be the same for all certificates in Opensearch nodes.
 
 {{< /note >}}
 

--- a/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
+++ b/terraform/a2ha-terraform/modules/automate/files/config.toml.erb
@@ -32,7 +32,7 @@
         password = "<%= svc_configs[:opensearch]['opensearch_auth']['admin_password'] -%>"
     [global.v1.external.opensearch.ssl]
     <% if overrides[:opensearch_custom_certs_enabled] == true -%>
-      server_name = ""
+      server_name = "<%= cn(svc_configs[:opensearch]['tls']['ssl_cert']) -%>"
       root_cert = """<%= overrides[:opensearch_root_ca] -%>"""
     <% else %>
       server_name = "<%= cn(svc_configs[:opensearch]['tls']['ssl_cert']) -%>"


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Fixed the issue of server_name coming empty in both automate and chefserver configs after upgrade. 
server_name comes under the opensearch.ssl section

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

**Automate Config Before Fix**

<img width="1156" alt="AutomateConfigBeforeFix" src="https://github.com/user-attachments/assets/bd0a45b5-cb02-4ce6-831f-b8d810d88a51" />


**Chef Config Before Fix**

<img width="445" alt="CSConfigBeforeFix" src="https://github.com/user-attachments/assets/1186d38d-7f3d-473e-8f3b-841926c8eea0" />



**Automate Config After Fix**

<img width="986" alt="AutomateConfigAfterFix" src="https://github.com/user-attachments/assets/bf76a9e2-7b95-4997-bf45-f887bd259a7f" />


**Chef Config After Fix**

<img width="449" alt="CSConfigAfterFix" src="https://github.com/user-attachments/assets/2f3d01c2-3c1f-4c4a-97a3-a502cef9ab8b" />

