### PR TITLE
[CHEF-10965] Fixing bundler config syntax change in bundler > v2.1

### DIFF
--- a/.studio/chef-server-collection
+++ b/.studio/chef-server-collection
@@ -392,21 +392,6 @@ function test_knife() {
   done
 }
 
-document "ohai_time" <<DOC
-  Gets ohai_time for a converged node. Assumes converge_chef_client has already run.
-DOC
-function ohai_time() {
-  set_up_chef_server_test_environment
-
-  CHEF_LICENSE=accept-no-persist hab pkg exec chef/chef-dk knife node show test-admin \
-    --server-url "${chef_server_url}" \
-    --key        "${chef_server_test_admin_key_path_path}" \
-    -c           "${chef_server_pivotal_rb_path}" \
-    --user       test-admin \
-    -a           ohai_time \
-      | grep ohai_time | cut -f2 -d":" | xargs
-}
-
 hab_curl() {
   hab pkg exec core/curl curl "$@";
 }
@@ -416,7 +401,7 @@ document "test_if_login_working_with_correct_credentials" <<DOC
 DOC
 test_if_login_working_with_correct_credentials() {
   bootstrap_chef_user_data || return 1
-  local url="https://${chef_server_hostname}/id/signin"
+  local url="https://${chef_server_hostname}/id/auth/chef/callback"
 
   res_code=$(hab_curl --insecure -H -s -o /dev/null -w "%{http_code}" "$url" \
               --header 'x-requested-with: XMLHttpRequest' \
@@ -439,7 +424,7 @@ document "test_if_login_failing_with_incorrect_credentials" <<DOC
 DOC
 test_if_login_failing_with_incorrect_credentials() {
   bootstrap_chef_user_data || return 1
-  local url="https://${chef_server_hostname}/id/signin"
+  local url="https://${chef_server_hostname}/id/auth/chef/callback"
   local incorrect_password='incorrect-password'
 
   res_code=$(hab_curl --insecure -H -s -o /dev/null -w "%{http_code}" "$url" \
@@ -540,6 +525,21 @@ test_if_webui_key_is_patched() {
     echo "The content of the PEM file does not match."
     return 1
   fi
+}
+
+document "ohai_time" <<DOC
+  Gets ohai_time for a converged node. Assumes converge_chef_client has already run.
+DOC
+function ohai_time() {
+  set_up_chef_server_test_environment
+
+  CHEF_LICENSE=accept-no-persist hab pkg exec chef/chef-dk knife node show test-admin \
+    --server-url "${chef_server_url}" \
+    --key        "${chef_server_test_admin_key_path_path}" \
+    -c           "${chef_server_pivotal_rb_path}" \
+    --user       test-admin \
+    -a           ohai_time \
+      | grep ohai_time | cut -f2 -d":" | xargs
 }
 
 document "test_if_env_vars_are_configured_after_patch" <<DOC

--- a/.studio/chef-server-collection
+++ b/.studio/chef-server-collection
@@ -392,6 +392,21 @@ function test_knife() {
   done
 }
 
+document "ohai_time" <<DOC
+  Gets ohai_time for a converged node. Assumes converge_chef_client has already run.
+DOC
+function ohai_time() {
+  set_up_chef_server_test_environment
+
+  CHEF_LICENSE=accept-no-persist hab pkg exec chef/chef-dk knife node show test-admin \
+    --server-url "${chef_server_url}" \
+    --key        "${chef_server_test_admin_key_path_path}" \
+    -c           "${chef_server_pivotal_rb_path}" \
+    --user       test-admin \
+    -a           ohai_time \
+      | grep ohai_time | cut -f2 -d":" | xargs
+}
+
 hab_curl() {
   hab pkg exec core/curl curl "$@";
 }
@@ -401,7 +416,7 @@ document "test_if_login_working_with_correct_credentials" <<DOC
 DOC
 test_if_login_working_with_correct_credentials() {
   bootstrap_chef_user_data || return 1
-  local url="https://${chef_server_hostname}/id/auth/chef/callback"
+  local url="https://${chef_server_hostname}/id/signin"
 
   res_code=$(hab_curl --insecure -H -s -o /dev/null -w "%{http_code}" "$url" \
               --header 'x-requested-with: XMLHttpRequest' \
@@ -424,7 +439,7 @@ document "test_if_login_failing_with_incorrect_credentials" <<DOC
 DOC
 test_if_login_failing_with_incorrect_credentials() {
   bootstrap_chef_user_data || return 1
-  local url="https://${chef_server_hostname}/id/auth/chef/callback"
+  local url="https://${chef_server_hostname}/id/signin"
   local incorrect_password='incorrect-password'
 
   res_code=$(hab_curl --insecure -H -s -o /dev/null -w "%{http_code}" "$url" \
@@ -525,21 +540,6 @@ test_if_webui_key_is_patched() {
     echo "The content of the PEM file does not match."
     return 1
   fi
-}
-
-document "ohai_time" <<DOC
-  Gets ohai_time for a converged node. Assumes converge_chef_client has already run.
-DOC
-function ohai_time() {
-  set_up_chef_server_test_environment
-
-  CHEF_LICENSE=accept-no-persist hab pkg exec chef/chef-dk knife node show test-admin \
-    --server-url "${chef_server_url}" \
-    --key        "${chef_server_test_admin_key_path_path}" \
-    -c           "${chef_server_pivotal_rb_path}" \
-    --user       test-admin \
-    -a           ohai_time \
-      | grep ohai_time | cut -f2 -d":" | xargs
 }
 
 document "test_if_env_vars_are_configured_after_patch" <<DOC

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -11,9 +11,8 @@ cp "{{pkg.svc_config_path}}/tasks/oauth_application.rake" $(hab pkg path "chef/o
 cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
 # Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
-# Set the BUNDLE_APP_CONFIG environment variable to a ocid directory
-# export BUNDLE_APP_CONFIG="{{pkgPathFor "chef/oc_id"}}/oc_id/.bundle"
-bundle config path "vendor/bundle"
+# Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
+bundle config set --local path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"
 export RACK_ENV="{{cfg.rack_env}}"

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -10,7 +10,8 @@ cp "{{pkg.svc_config_path}}/tasks/oauth_application.rake" $(hab pkg path "chef/o
 
 cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
-bundle config path "vendor/bundle"
+# Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
+# bundle config path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"
 export RACK_ENV="{{cfg.rack_env}}"

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -11,7 +11,9 @@ cp "{{pkg.svc_config_path}}/tasks/oauth_application.rake" $(hab pkg path "chef/o
 cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
 # Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
-# bundle config path "vendor/bundle"
+# Set the BUNDLE_APP_CONFIG environment variable to a ocid directory
+export BUNDLE_APP_CONFIG="{{pkgPathFor "chef/oc_id"}}/oc_id/.bundle"
+bundle config path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"
 export RACK_ENV="{{cfg.rack_env}}"

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -12,7 +12,7 @@ cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
 # Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
 # Set the BUNDLE_APP_CONFIG environment variable to a ocid directory
-export BUNDLE_APP_CONFIG="{{pkgPathFor "chef/oc_id"}}/oc_id/.bundle"
+# export BUNDLE_APP_CONFIG="{{pkgPathFor "chef/oc_id"}}/oc_id/.bundle"
 bundle config path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -11,7 +11,6 @@ cp "{{pkg.svc_config_path}}/tasks/oauth_application.rake" $(hab pkg path "chef/o
 cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
 # Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
-# Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
 bundle config set --local path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"

--- a/components/automate-cs-ocid/habitat/hooks/run
+++ b/components/automate-cs-ocid/habitat/hooks/run
@@ -10,7 +10,7 @@ cp "{{pkg.svc_config_path}}/tasks/oauth_application.rake" $(hab pkg path "chef/o
 
 cd {{pkgPathFor "chef/oc_id"}}/oc_id
 
-# Suspecting that the bundle path is not getting set correctly due to which .bundle is getting created in the root directory
+# upgrading the bundle config syntax as per the latest bundler version
 bundle config set --local path "vendor/bundle"
 
 export RAILS_ENV="{{cfg.rails_env}}"

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -51,3 +51,4 @@ do_build() {
 do_install() {
   return 0
 }
+

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -44,9 +44,10 @@ do_download() {
   return 0
 }
 
-do_build() {
-  return 0
-}
+# Testing with removing this callback as we don't need to build anything
+# do_build() {
+#   return 0
+# }
 
 do_install() {
   return 0

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -51,11 +51,3 @@ do_build() {
 do_install() {
   return 0
 }
-
-do_end() {
-  if [ -d "/root/.bundle" ]; then
-    # Remove the .bundle directory
-    rm -rf /root/.bundle
-    echo ".bundle directory in /root has been removed."
-  fi
-}

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -52,3 +52,10 @@ do_install() {
   return 0
 }
 
+do_end() {
+  if [ -d "/root/.bundle" ]; then
+    # Remove the .bundle directory
+    rm -rf /root/.bundle
+    echo ".bundle directory in /root has been removed."
+  fi
+}

--- a/components/automate-cs-ocid/habitat/plan.sh
+++ b/components/automate-cs-ocid/habitat/plan.sh
@@ -44,10 +44,9 @@ do_download() {
   return 0
 }
 
-# Testing with removing this callback as we don't need to build anything
-# do_build() {
-#   return 0
-# }
+do_build() {
+  return 0
+}
 
 do_install() {
   return 0


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Fixing bundler config syntax change in bundler > v2.1

 Ruby 3.0.1 came with Bundler 2.1.x (likely Bundler 2.1.4 or similar) where Bundler introduced several new features and improvements, one of which was syntactical change in the bundle config command.
With upgrade to Ruby 3.0.1 in Infra-server (ocid) 15.8.0 bundler doesn’t recognise this older command and ignores the local configuration and creates the ./bundle at the root which is the default bundler behaviour as we need to run automate as a root user.
This creates conflict with global environment variables like GEM_PATH and GEM_HOME.

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [x] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [x] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [x] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [x] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [x] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

