### PR TITLE
adding migration script to alter the data type

### DIFF
--- a/.studio/applications-service
+++ b/.studio/applications-service
@@ -25,7 +25,7 @@ document "applications_set_service_seq_to_int_max" <<DOC
   32bit to 64bit.
 DOC
 function applications_set_service_seq_to_int_max() {
-  chef-automate dev psql chef_applications_service -- -c "SELECT setval('service_full_id_seq', 2147483647)"
+  chef-automate dev psql chef_applications_service -- -c "SELECT setval('service_full_id_seq', 9223372036854775807)"
 }
 
 

--- a/components/applications-service/pkg/storage/postgres/schema/sql/19_service_full_id_seq.up.sql
+++ b/components/applications-service/pkg/storage/postgres/schema/sql/19_service_full_id_seq.up.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE service_full_id_seq AS BIGINT;


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
adding migration script to alter the data type of a sequence 

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://progresssoftware.atlassian.net/browse/CHEF-19124

### :+1: Definition of Done
adding migration script to alter the data type of a sequence 


### :athletic_shoe: How to Build and Test the Change

To build:
build components/application-service/

To test:
a) chef-automate dev psql postgres
b) \l 
c) \c chef_applications_service
d) \dt
e) \ds
f) \d service_full
g) \d service_full_id_seq


### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

Latest current:
![image](https://github.com/user-attachments/assets/7c74d192-026f-4730-b6ef-bfae2f090df8)

After adding migration script:
![image](https://github.com/user-attachments/assets/4b1fdabf-62e1-49d8-b900-654cfd2b0a20)

