### PR TITLE
Generic Method to start the reindex process for given indexes

### DIFF
--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -92,6 +92,12 @@ type Client interface {
 	// @param (context, previousIndex)
 	// @return (taskID, error)
 	ReindexNodeStateToLatest(context.Context, string) (string, error)
+
+	// New method for reindexing indices
+	// @param (context, sourceIndex, destinationIndex)
+	// @return (taskID, error)
+	ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error)
+
 	GetActions(string, int, time.Time, string, bool) ([]InternalChefAction, int64, error)
 	DeleteAllIndexesWithPrefix(string, context.Context) error
 

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -389,7 +389,7 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
 	// Inherit the parent context to avoid premature cancellation
-	reindexCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+	reindexCtx, cancel := context.WithTimeout(ctx, 45*time.Minute)
 	defer cancel()
 
 	src := elastic.NewReindexSource().Index(srcIndex)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -389,7 +389,8 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
 	// Use context.Background() to ensure the request is not canceled prematurely
-	reindexCtx := context.Background()
+	reindexCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	src := elastic.NewReindexSource().Index(srcIndex)
 	dst := elastic.NewReindexDestination().Index(dstIndex)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -7,6 +7,7 @@ import (
 
 	elastic "github.com/olivere/elastic/v7"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/api/interservice/authz"
@@ -384,6 +385,33 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 	if err != nil {
 		return "", err
 	}
+	return startTaskResult.TaskId, nil
+}
+
+func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
+	logrus.WithFields(logrus.Fields{
+		"srcIndex": srcIndex,
+		"dstIndex": dstIndex,
+	}).Info("Starting reindex process")
+
+	// Use context.Background() to ensure the request is not canceled prematurely
+	reindexCtx := context.Background()
+
+	src := elastic.NewReindexSource().Index(srcIndex)
+	dst := elastic.NewReindexDestination().Index(dstIndex)
+
+	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(reindexCtx)
+	if err != nil {
+		logrus.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
+		return "", fmt.Errorf("failed to start reindex from %s to %s: %w", srcIndex, dstIndex, err)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"taskID": startTaskResult.TaskId,
+		"src":    srcIndex,
+		"dst":    dstIndex,
+	}).Info("Reindex task started successfully")
+
 	return startTaskResult.TaskId, nil
 }
 

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -387,15 +387,11 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 	return startTaskResult.TaskId, nil
 }
 
-func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
-	// Inherit the parent context to avoid premature cancellation
-	reindexCtx, cancel := context.WithTimeout(ctx, 45*time.Minute)
-	defer cancel()
-
+func (es *Backend) ReindexIndices(reindexctx context.Context, srcIndex, dstIndex string) (string, error) {
 	src := elastic.NewReindexSource().Index(srcIndex)
 	dst := elastic.NewReindexDestination().Index(dstIndex)
 
-	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(reindexCtx)
+	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(reindexctx)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
 		return "", fmt.Errorf("failed to start reindex from %s to %s: %w", srcIndex, dstIndex, err)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -388,7 +388,7 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 }
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
-	reindexCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	reindexCtx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
 	defer cancel()
 
 	src := elastic.NewReindexSource().Index(srcIndex)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -388,7 +388,8 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 }
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
-	reindexCtx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+	// Inherit the parent context to avoid premature cancellation
+	reindexCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 
 	src := elastic.NewReindexSource().Index(srcIndex)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -389,11 +389,6 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 }
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
-	logrus.WithFields(logrus.Fields{
-		"srcIndex": srcIndex,
-		"dstIndex": dstIndex,
-	}).Info("Starting reindex process")
-
 	// Use context.Background() to ensure the request is not canceled prematurely
 	reindexCtx := context.Background()
 
@@ -405,13 +400,6 @@ func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string
 		logrus.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
 		return "", fmt.Errorf("failed to start reindex from %s to %s: %w", srcIndex, dstIndex, err)
 	}
-
-	logrus.WithFields(logrus.Fields{
-		"taskID": startTaskResult.TaskId,
-		"src":    srcIndex,
-		"dst":    dstIndex,
-	}).Info("Reindex task started successfully")
-
 	return startTaskResult.TaskId, nil
 }
 

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -388,8 +388,7 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 }
 
 func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error) {
-	// Use context.Background() to ensure the request is not canceled prematurely
-	reindexCtx, cancel := context.WithCancel(context.Background())
+	reindexCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	src := elastic.NewReindexSource().Index(srcIndex)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -7,7 +7,6 @@ import (
 
 	elastic "github.com/olivere/elastic/v7"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/chef/automate/api/interservice/authz"
@@ -397,7 +396,7 @@ func (es *Backend) ReindexIndices(ctx context.Context, srcIndex, dstIndex string
 
 	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(reindexCtx)
 	if err != nil {
-		logrus.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
+		log.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
 		return "", fmt.Errorf("failed to start reindex from %s to %s: %w", srcIndex, dstIndex, err)
 	}
 	return startTaskResult.TaskId, nil

--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -257,8 +257,6 @@ func (s *ChefIngestServer) GetIndicesEligableForReindexing(ctx context.Context) 
 		return nil, status.Errorf(codes.Internal, "failed to fetch indices: %s", err)
 	}
 
-	log.WithFields(log.Fields{"indices": indices}).Info("Fetched indices from OpenSearch")
-
 OuterLoop:
 	for _, index := range indices {
 		for prefix := range skipIndices {
@@ -282,25 +280,14 @@ OuterLoop:
 
 		eligableIndices[index.Index] = *versionSettings
 	}
-
-	log.WithFields(log.Fields{"eligible_indices": eligableIndices}).Info("Identified indices eligible for reindexing")
 	return eligableIndices, nil
 }
 
 func (s *ChefIngestServer) processReindexing(ctx context.Context, requestID int, indexList []string) {
-	logrus.WithFields(logrus.Fields{
-		"requestID": requestID,
-		"indexList": indexList,
-	}).Info("Starting reindexing process")
-
+	// Iterate over the list of indices and trigger reindexing for each
 	for _, index := range indexList {
 		srcIndex := index
 		dstIndex := index + "_temp"
-
-		logrus.WithFields(logrus.Fields{
-			"srcIndex": srcIndex,
-			"dstIndex": dstIndex,
-		}).Info("Initiating reindexing")
 
 		// Trigger the reindexing process asynchronously
 		taskID, err := s.client.ReindexIndices(ctx, srcIndex, dstIndex)
@@ -308,11 +295,6 @@ func (s *ChefIngestServer) processReindexing(ctx context.Context, requestID int,
 			logrus.WithError(err).Errorf("Failed to start reindexing for index %s", srcIndex)
 			continue // Move to the next index
 		}
-
-		logrus.WithFields(logrus.Fields{
-			"srcIndex": srcIndex,
-			"taskID":   taskID,
-		}).Info("Reindexing started successfully")
 
 		// Update the task ID in the database
 		err = s.db.UpdateTaskIDForReindexRequest(requestID, srcIndex, taskID, time.Now())
@@ -325,8 +307,6 @@ func (s *ChefIngestServer) processReindexing(ctx context.Context, requestID int,
 			}).Info("Task ID updated in the database")
 		}
 	}
-
-	logrus.Info("Reindexing process completed for all eligible indexes")
 }
 
 func (s *ChefIngestServer) StartReindex(ctx context.Context, req *ingest.StartReindexRequest) (*ingest.StartReindexResponse, error) {
@@ -350,9 +330,6 @@ func (s *ChefIngestServer) StartReindex(ctx context.Context, req *ingest.StartRe
 		indexList = append(indexList, index)
 	}
 
-	// Log the list of indices before proceeding
-	log.WithFields(log.Fields{"indexList": indexList}).Info("Final list of indices to be reindexed")
-
 	// Add to the database that indexing request is running
 	requestID, err := s.db.InsertReindexRequest("running", time.Now())
 	if err != nil {
@@ -373,10 +350,8 @@ func (s *ChefIngestServer) StartReindex(ctx context.Context, req *ingest.StartRe
 			return nil, status.Errorf(codes.Internal, "failed to add reindex request: %s", err)
 		}
 	}
-
 	// Call processReindexing to start the actual reindexing process
 	go s.processReindexing(ctx, requestID, indexList) // Run asynchronously
-	log.WithFields(log.Fields{"requestID": requestID}).Info("Reindexing started successfully")
 
 	return &ingest.StartReindexResponse{
 		Message: "Reindexing started successfully",

--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -316,19 +316,20 @@ func (s *ChefIngestServer) StartReindex(ctx context.Context, req *ingest.StartRe
 			return nil, status.Errorf(codes.Internal, "failed to add reindex request: %v", err)
 		}
 	}
+	reindexctx := context.Background()
 	// Run reindexing asynchronously
-	go s.processReindexing(ctx, requestID, indexList)
+	go s.processReindexing(reindexctx, requestID, indexList)
 
 	return &ingest.StartReindexResponse{
 		Message: "Reindexing started successfully",
 	}, nil
 }
 
-func (s *ChefIngestServer) processReindexing(ctx context.Context, requestID int, indexList []string) {
+func (s *ChefIngestServer) processReindexing(reindexctx context.Context, requestID int, indexList []string) {
 	for _, index := range indexList {
 		srcIndex, dstIndex := index, index+"_temp"
 
-		taskID, err := s.client.ReindexIndices(ctx, srcIndex, dstIndex)
+		taskID, err := s.client.ReindexIndices(reindexctx, srcIndex, dstIndex)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to start reindexing for index %s", srcIndex)
 			continue

--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -316,9 +316,9 @@ func (s *ChefIngestServer) StartReindex(ctx context.Context, req *ingest.StartRe
 			return nil, status.Errorf(codes.Internal, "failed to add reindex request: %v", err)
 		}
 	}
-	reindexctx := context.Background()
+
 	// Run reindexing asynchronously
-	go s.processReindexing(reindexctx, requestID, indexList)
+	s.processReindexing(ctx, requestID, indexList)
 
 	return &ingest.StartReindexResponse{
 		Message: "Reindexing started successfully",

--- a/components/ingest-service/storage/db.go
+++ b/components/ingest-service/storage/db.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"time"
 
@@ -254,6 +255,43 @@ func (db *DB) GetLatestReindexRequestID() (int, error) {
 	}).Info("Fetched latest reindex request ID")
 
 	return requestID, nil
+}
+
+func (db *DB) UpdateTaskIDForReindexRequest(requestID int, indexName string, taskID string, currentTime time.Time) error {
+	logrus.WithFields(logrus.Fields{
+		"requestID": requestID,
+		"indexName": indexName,
+		"taskID":    taskID,
+	}).Info("Updating task ID in database")
+
+	query := `
+        UPDATE reindex_request_detailed
+        SET os_task_id = $1, updated_at = $2
+        WHERE request_id = $3 AND "index" = $4
+        RETURNING request_id
+    `
+
+	var updatedRequestID int
+	err := db.QueryRow(query, taskID, currentTime, requestID, indexName).Scan(&updatedRequestID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			logrus.WithFields(logrus.Fields{
+				"requestID": requestID,
+				"indexName": indexName,
+			}).Warn("No matching record found for reindexing")
+			return fmt.Errorf("no matching record found for request_id: %d, index: %s", requestID, indexName)
+		}
+		logrus.WithError(err).Errorf("Failed to update task ID for request_id: %d, index: %s", requestID, indexName)
+		return errors.Wrapf(err, "failed to update task ID for request_id: %d, index: %s", requestID, indexName)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"requestID": requestID,
+		"indexName": indexName,
+		"taskID":    taskID,
+	}).Info("Task ID updated successfully in database")
+
+	return nil
 }
 
 // SQL Queries


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Added generic Method to start the reindex process for given indexes

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://progresssoftware.atlassian.net/browse/CHEF-19083

### :+1: Definition of Done
Added generic Method to start the reindex process for given indexes

### :athletic_shoe: How to Build and Test the Change

Build ingest service
Build deployment service
Build cli
Run chef-automate reindex start

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![image](https://github.com/user-attachments/assets/97bd30a9-4a5f-4214-8a35-4f5d9bd05d7c)

![image](https://github.com/user-attachments/assets/ba89c541-19b1-4f5c-89f0-6bf4c436ce12)



