### PR TITLE
Generic Method to start the reindex process for given indexes

### DIFF
--- a/components/ingest-service/backend/client.go
+++ b/components/ingest-service/backend/client.go
@@ -92,6 +92,10 @@ type Client interface {
 	// @param (context, previousIndex)
 	// @return (taskID, error)
 	ReindexNodeStateToLatest(context.Context, string) (string, error)
+	// New method for reindexing indices
+	// @param (context, sourceIndex, destinationIndex)
+	// @return (taskID, error)
+	ReindexIndices(ctx context.Context, srcIndex, dstIndex string) (string, error)
 	GetActions(string, int, time.Time, string, bool) ([]InternalChefAction, int64, error)
 	DeleteAllIndexesWithPrefix(string, context.Context) error
 	GetIndices(ctx context.Context) ([]Index, error)

--- a/components/ingest-service/backend/elastic/elastic.go
+++ b/components/ingest-service/backend/elastic/elastic.go
@@ -387,6 +387,18 @@ func (es *Backend) ReindexNodeStateToLatest(ctx context.Context, previousIndex s
 	return startTaskResult.TaskId, nil
 }
 
+func (es *Backend) ReindexIndices(reindexctx context.Context, srcIndex, dstIndex string) (string, error) {
+	src := elastic.NewReindexSource().Index(srcIndex)
+	dst := elastic.NewReindexDestination().Index(dstIndex)
+
+	startTaskResult, err := es.client.Reindex().Source(src).Destination(dst).DoAsync(reindexctx)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to start reindex from %s to %s", srcIndex, dstIndex)
+		return "", fmt.Errorf("failed to start reindex from %s to %s: %w", srcIndex, dstIndex, err)
+	}
+	return startTaskResult.TaskId, nil
+}
+
 func (es *Backend) storeExists(ctx context.Context, indexName string) bool {
 	exists, err := es.client.IndexExists().Index([]string{indexName}).Do(ctx)
 

--- a/components/ingest-service/storage/db_test.go
+++ b/components/ingest-service/storage/db_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -378,4 +379,90 @@ func TestUpdateAliasesForIndexNoAliases(t *testing.T) {
 
 	err = db.UpdateAliasesForIndex("reindexing", false, []string{""}, 1, time)
 	assert.NoError(t, err)
+}
+
+func TestUpdateTaskIDForReindexRequestSuccess(t *testing.T) {
+	dbConn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	defer dbConn.Close()
+
+	db := &storage.DB{
+		DbMap: &gorp.DbMap{Db: dbConn, Dialect: gorp.PostgresDialect{}},
+	}
+
+	currentTime := time.Now()
+	requestID := 1
+	indexName := "index1"
+	taskID := "task123"
+
+	query := `
+        UPDATE reindex_request_detailed
+        SET os_task_id = $1, updated_at = $2
+        WHERE request_id = $3 AND "index" = $4
+        RETURNING request_id
+    `
+	mock.ExpectQuery(query).
+		WithArgs(taskID, currentTime, requestID, indexName).
+		WillReturnRows(sqlmock.NewRows([]string{"request_id"}).AddRow(requestID))
+
+	err = db.UpdateTaskIDForReindexRequest(requestID, indexName, taskID, currentTime)
+	assert.NoError(t, err)
+}
+
+func TestUpdateTaskIDForReindexRequestNoRowsFound(t *testing.T) {
+	dbConn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	defer dbConn.Close()
+
+	db := &storage.DB{
+		DbMap: &gorp.DbMap{Db: dbConn, Dialect: gorp.PostgresDialect{}},
+	}
+
+	currentTime := time.Now()
+	requestID := 1
+	indexName := "index1"
+	taskID := "task123"
+
+	query := `
+        UPDATE reindex_request_detailed
+        SET os_task_id = $1, updated_at = $2
+        WHERE request_id = $3 AND "index" = $4
+        RETURNING request_id
+    `
+	mock.ExpectQuery(query).
+		WithArgs(taskID, currentTime, requestID, indexName).
+		WillReturnError(sql.ErrNoRows)
+
+	err = db.UpdateTaskIDForReindexRequest(requestID, indexName, taskID, currentTime)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("no matching record found for request_id: %d, index: %s", requestID, indexName), err.Error())
+}
+
+func TestUpdateTaskIDForReindexRequestQueryFailure(t *testing.T) {
+	dbConn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	assert.NoError(t, err)
+	defer dbConn.Close()
+
+	db := &storage.DB{
+		DbMap: &gorp.DbMap{Db: dbConn, Dialect: gorp.PostgresDialect{}},
+	}
+
+	currentTime := time.Now()
+	requestID := 1
+	indexName := "index1"
+	taskID := "task123"
+
+	query := `
+        UPDATE reindex_request_detailed
+        SET os_task_id = $1, updated_at = $2
+        WHERE request_id = $3 AND "index" = $4
+        RETURNING request_id
+    `
+	mock.ExpectQuery(query).
+		WithArgs(taskID, currentTime, requestID, indexName).
+		WillReturnError(fmt.Errorf("database error"))
+
+	err = db.UpdateTaskIDForReindexRequest(requestID, indexName, taskID, currentTime)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update task ID")
 }


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Adding Generic Method to start the reindex process for given indexes

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://progresssoftware.atlassian.net/browse/CHEF-19083

### :+1: Definition of Done
Generic Method to start the reindex process for given indexes

### :athletic_shoe: How to Build and Test the Change
Build ingest service
Build deployment service
Build cli
Run chef-automate reindex start

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![image](https://github.com/user-attachments/assets/a33b5cfa-7c88-4555-99b7-d86e9d9b8d6b)![image](https://github.com/user-attachments/assets/c2524137-c8a8-43e5-8f95-3032c73ec844)


![image](https://github.com/user-attachments/assets/06dcf159-4750-41f4-a62b-2c0c0498760a)

