### PR TITLE
Monitor the task created for reindex from opensearch

### DIFF
--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -546,8 +546,8 @@ func (s *ChefIngestServer) processReindexing(ctx context.Context, destIndex, src
 }
 
 func (s *ChefIngestServer) monitorReindexing(ctx context.Context, requestID int, index, taskID string) bool {
-	// Set a timeout for how long to wait for the task to complete (e.g., 30 minutes).
-	timeout := time.Now().Add(30 * time.Minute)
+	// Set a timeout for how long to wait for the task to complete
+	timeout := time.Now().Add(6 * time.Hour)
 
 	for {
 		// Check if we've exceeded the timeout

--- a/components/ingest-service/server/chef.go
+++ b/components/ingest-service/server/chef.go
@@ -527,13 +527,57 @@ func (s *ChefIngestServer) processReindexing(ctx context.Context, destIndex, src
 	}
 
 	// Wait for the reindexing to complete
+	taskCompleted := s.monitorReindexing(ctx, requestID, srcIndex, taskID) // Ensure monitoring is finished
 
-	err = s.db.CreateOrUpdateStageAndStatusForIndex(requestID, originalIndex, stage, STATUS_COMPLETED, time.Now())
-	if err != nil {
-		log.Errorf("Failed to update the status for stage %s with status %s with error %v", stage, STATUS_COMPLETED, err)
-		return err
+	// Only update status to COMPLETED if the task was successful
+	if taskCompleted {
+		err = s.db.CreateOrUpdateStageAndStatusForIndex(requestID, originalIndex, stage, STATUS_COMPLETED, time.Now())
+		if err != nil {
+			log.Errorf("Failed to update status for stage %s to COMPLETED: %v", stage, err)
+			return err
+		}
+	} else {
+		log.Warnf("Reindexing task %s for index %s did not complete successfully. Updating status to FAILED.", taskID, srcIndex)
+		if err := s.db.CreateOrUpdateStageAndStatusForIndex(requestID, originalIndex, stage, STATUS_FAILED, time.Now()); err != nil {
+			log.Errorf("Failed to update status for stage %s to FAILED: %v", stage, err)
+		}
 	}
 	return nil
+}
+
+func (s *ChefIngestServer) monitorReindexing(ctx context.Context, requestID int, index, taskID string) bool {
+	// Set a timeout for how long to wait for the task to complete (e.g., 30 minutes).
+	timeout := time.Now().Add(30 * time.Minute)
+
+	for {
+		// Check if we've exceeded the timeout
+		if time.Now().After(timeout) {
+			log.Warnf("Task %s for index %s timed out.", taskID, index)
+			return false // Task timed out
+		}
+
+		// Check the task status
+		jobStatus, err := s.client.JobStatus(ctx, taskID)
+		if err != nil {
+			log.WithError(err).Errorf("Error checking status for task %s", taskID)
+		}
+
+		// Update heartbeat only if the task is still running
+		if !jobStatus.Completed {
+			if err := s.db.UpdateReindexStatus(requestID, index, "heartbeat", time.Now()); err != nil {
+				log.WithError(err).Errorf("Failed to update heartbeat for index %s", index)
+			}
+		}
+
+		// If the job is completed, exit the loop
+		if jobStatus.Completed {
+			log.Infof("Reindexing task %s for index %s completed successfully.", taskID, index)
+			return true // Task completed successfully
+		}
+
+		// Wait for 15 seconds before checking again
+		time.Sleep(15 * time.Second)
+	}
 }
 
 func (s *ChefIngestServer) GetReindexStatus(ctx context.Context, req *ingest.GetReindexStatusRequest) (*ingest.GetReindexStatusResponse, error) {

--- a/components/ingest-service/storage/db.go
+++ b/components/ingest-service/storage/db.go
@@ -408,3 +408,17 @@ func getUpdatedStageDetails(stageDetails []*StageDetail, stage string, status st
 
 	return stageDetails
 }
+
+func (db *DB) UpdateReindexStatus(requestID int, index, status string, timestamp time.Time) error {
+	query := `UPDATE reindex_request_detailed 
+              SET heartbeat = $1,
+                  updated_at = $2
+              WHERE request_id = $3 AND index = $4`
+
+	_, err := db.Exec(query, timestamp, timestamp, requestID, index)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to update reindex status for requestID: %d, index: %s", requestID, index)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?
Monitor the task created for reindex from opensearch

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://progresssoftware.atlassian.net/browse/CHEF-19084

### :+1: Definition of Done
Monitor the task created for reindex from opensearch

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [x] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [x] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

![image](https://github.com/user-attachments/assets/e5963e91-28d4-4ba4-baf5-684a93a58826)

![image](https://github.com/user-attachments/assets/c4fd1da8-452c-4804-b848-5e160b63fce3)

