### PR TITLE
Remove cert-rotate old cmd and fix home path in verify and other issues

### DIFF
--- a/components/automate-cli/cmd/chef-automate/automateConstants.go
+++ b/components/automate-cli/cmd/chef-automate/automateConstants.go
@@ -21,8 +21,10 @@ const DATE_FORMAT = "%Y%m%d%H%M%S"
 
 const PG_IDENT = "postgresql_pkg_ident"
 const PG_LEADER_IDENT = "pgleaderchk_pkg_ident"
+const OS_IDENT = "opensearch_pkg_ident"
 const HA_PROXY_IDENT = "proxy_pkg_ident"
 const MANIFEST_AUTO_TFVARS = "/hab/a2_deploy_workspace/terraform/a2ha_manifest.auto.tfvars"
+const AIB_BE_AUTO_TFVARS = "/hab/a2_deploy_workspace/terraform/a2ha_aib_be.auto.tfvars"
 const PG_SCRIPT_NAME = "pg-restart-script.sh"
 const PG_SCRIPT_PATH = "/hab/var/automate-ha"
 
@@ -102,4 +104,5 @@ const (
 	GET_OPENSEARCH_CLUSTER_SETTINGS = `curl --location --request GET 'http://localhost:10144/_cluster/settings'`
 
 	DEFAULT_BACKEND_CERTS = "/hab/a2_deploy_workspace/default_backend_certificates.toml"
+	VERSION_ERR           = "Version Undetermined. Please contact support."
 )

--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -2280,9 +2280,10 @@ func TestPatchConfig(t *testing.T) {
 				CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
 					return []sshutils.Result{
 						{
-							HostIP: "",
-							Error:  nil,
-							Output: "",
+							HostIP:  "",
+							Error:   nil,
+							Output:  "",
+							DestDir: "",
 						},
 					}
 				},

--- a/components/automate-cli/cmd/chef-automate/status.go
+++ b/components/automate-cli/cmd/chef-automate/status.go
@@ -48,6 +48,7 @@ type FeStatusValue struct {
 	ipAddress   string
 	status      string
 	Opensearch  string
+	MaintStatus string
 }
 
 type BeStatusValue struct {

--- a/components/automate-cli/cmd/chef-automate/verify.go
+++ b/components/automate-cli/cmd/chef-automate/verify.go
@@ -598,7 +598,7 @@ func (v *verifyCmdFlow) copyCLIOnRemoteNodes(destFileName string, sshConfig sshu
 	if err != nil {
 		return err
 	}
-	copyResults := v.SSHUtil.CopyFileToRemoteConcurrently(sshConfig, currentBinaryPath, destFileName, destDir, false, hostIPs)
+	copyResults := v.SSHUtil.CopyFileToRemoteConcurrentlyInHomeDir(sshConfig, currentBinaryPath, destFileName, destDir, false, hostIPs)
 	isError := false
 	for _, result := range copyResults {
 		if result.Error != nil {

--- a/components/automate-cli/cmd/chef-automate/verify_test.go
+++ b/components/automate-cli/cmd/chef-automate/verify_test.go
@@ -93,6 +93,15 @@ func TestRunVerifyCmd(t *testing.T) {
 						},
 					}
 				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
 			},
 			configFile: CONFIG_AWS_TOML_PATH + AWS_CONFIG_FILE,
 			wantErr:    nil,
@@ -138,6 +147,15 @@ func TestRunVerifyCmd(t *testing.T) {
 					}
 				},
 				CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
 					return []sshutils.Result{
 						{
 							HostIP: "",
@@ -198,6 +216,15 @@ func TestRunVerifyCmd(t *testing.T) {
 						},
 					}
 				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
 			},
 			mockVerifyCmdDeps: &verifyCmdDeps{
 				getAutomateHAInfraDetails: func() (*AutomateHAInfraDetails, error) {
@@ -244,6 +271,15 @@ func TestRunVerifyCmd(t *testing.T) {
 					}
 				},
 				CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
 					return []sshutils.Result{
 						{
 							HostIP: "",
@@ -309,6 +345,15 @@ func TestRunVerifyCmd(t *testing.T) {
 						},
 					}
 				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
 			},
 			mockVerifyCmdDeps: &verifyCmdDeps{
 				getAutomateHAInfraDetails: func() (*AutomateHAInfraDetails, error) {
@@ -358,6 +403,15 @@ func TestRunVerifyCmd(t *testing.T) {
 					}
 				},
 				CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
 					return []sshutils.Result{
 						{
 							HostIP: "",
@@ -424,6 +478,15 @@ func TestRunVerifyCmd(t *testing.T) {
 						},
 					}
 				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
 			},
 			configFile: CONFIG_AWS_TOML_PATH + AWS_CONFIG_FILE,
 			wantErr:    nil,
@@ -477,6 +540,15 @@ func TestRunVerifyCmd(t *testing.T) {
 						},
 					}
 				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
 			},
 			configFile: CONFIG_AWS_TOML_PATH + AWS_CONFIG_FILE,
 			wantErr:    nil,
@@ -522,6 +594,15 @@ func TestRunVerifyCmd(t *testing.T) {
 					}
 				},
 				CopyFileToRemoteConcurrentlyFunc: func(sshConfig sshutils.SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
+					return []sshutils.Result{
+						{
+							HostIP: "",
+							Error:  nil,
+							Output: "",
+						},
+					}
+				},
+				CopyFileToRemoteConcurrentlyInHomeDirFunc: func(sshConfig sshutils.SSHConfig, srcFilePath, destFileName, destDir string, removeFile bool, hostIPs []string) []sshutils.Result {
 					return []sshutils.Result{
 						{
 							HostIP: "",

--- a/components/automate-cli/cmd/chef-automate/version_test.go
+++ b/components/automate-cli/cmd/chef-automate/version_test.go
@@ -343,7 +343,7 @@ func Test_getOpensearchVersion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, versionMap)
 		assert.Contains(t, versionMap, TEST_IP_1)
-		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1])
+		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1].ShortVersion)
 	})
 	t.Run("Error Chef Managed", func(t *testing.T) {
 		mockCmdExecutor := &MockRemoteCmdExecutor{
@@ -403,7 +403,7 @@ func Test_getOpensearchVersion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, versionMap)
 		assert.Contains(t, versionMap, TEST_IP_1)
-		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1])
+		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1].ShortVersion)
 	})
 	t.Run("Error Self Managed", func(t *testing.T) {
 		mockCmdExecutor := &MockRemoteCmdExecutor{
@@ -470,7 +470,7 @@ func Test_getPostgresqlVersion(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, versionMap)
 		assert.Contains(t, versionMap, TEST_IP_1)
-		assert.Equal(t, "13.5.0", versionMap[TEST_IP_1])
+		assert.Equal(t, "13.5.0", versionMap[TEST_IP_1].ShortVersion)
 	})
 	t.Run("Error Chef Managed", func(t *testing.T) {
 		mockCmdExecutor := &MockRemoteCmdExecutor{

--- a/components/automate-cli/cmd/chef-automate/version_test.go
+++ b/components/automate-cli/cmd/chef-automate/version_test.go
@@ -344,6 +344,7 @@ func Test_getOpensearchVersion(t *testing.T) {
 		assert.NotEmpty(t, versionMap)
 		assert.Contains(t, versionMap, TEST_IP_1)
 		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1].ShortVersion)
+		assert.Equal(t, "chef/automate-ha-opensearch/1.3.7/20230223065900", versionMap[TEST_IP_1].LongVersion)
 	})
 	t.Run("Error Chef Managed", func(t *testing.T) {
 		mockCmdExecutor := &MockRemoteCmdExecutor{
@@ -404,6 +405,7 @@ func Test_getOpensearchVersion(t *testing.T) {
 		assert.NotEmpty(t, versionMap)
 		assert.Contains(t, versionMap, TEST_IP_1)
 		assert.Equal(t, "1.3.7", versionMap[TEST_IP_1].ShortVersion)
+		assert.Equal(t, "NA", versionMap[TEST_IP_1].LongVersion)
 	})
 	t.Run("Error Self Managed", func(t *testing.T) {
 		mockCmdExecutor := &MockRemoteCmdExecutor{

--- a/lib/sshutils/mocksshutils.go
+++ b/lib/sshutils/mocksshutils.go
@@ -1,10 +1,11 @@
 package sshutils
 
 type MockSSHUtilsImpl struct {
-	Executefunc                      func(sshConfig SSHConfig, cmd string) (string, error)
-	ExecuteConcurrentlyFunc          func(sshConfig SSHConfig, cmd string, hostIPs []string) []Result
-	CopyFileToRemoteFunc             func(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool) error
-	CopyFileToRemoteConcurrentlyFunc func(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []Result
+	Executefunc                               func(sshConfig SSHConfig, cmd string) (string, error)
+	ExecuteConcurrentlyFunc                   func(sshConfig SSHConfig, cmd string, hostIPs []string) []Result
+	CopyFileToRemoteFunc                      func(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool) error
+	CopyFileToRemoteConcurrentlyFunc          func(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []Result
+	CopyFileToRemoteConcurrentlyInHomeDirFunc func(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []Result
 }
 
 func (mssh *MockSSHUtilsImpl) Execute(sshConfig SSHConfig, cmd string) (string, error) {
@@ -21,4 +22,8 @@ func (mssh *MockSSHUtilsImpl) CopyFileToRemote(sshConfig SSHConfig, srcFilePath 
 
 func (mssh *MockSSHUtilsImpl) CopyFileToRemoteConcurrently(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []Result {
 	return mssh.CopyFileToRemoteConcurrentlyFunc(sshConfig, srcFilePath, destFileName, destDir, removeFile, hostIPs)
+}
+
+func (mssh *MockSSHUtilsImpl) CopyFileToRemoteConcurrentlyInHomeDir(sshConfig SSHConfig, srcFilePath string, destFileName string, destDir string, removeFile bool, hostIPs []string) []Result {
+	return mssh.CopyFileToRemoteConcurrentlyInHomeDirFunc(sshConfig, srcFilePath, destFileName, destDir, removeFile, hostIPs)
 }

--- a/lib/sshutils/sshutils.go
+++ b/lib/sshutils/sshutils.go
@@ -297,7 +297,7 @@ func (s *SSHUtilImpl) CopyFileToRemoteConcurrentlyInHomeDir(sshConfig SSHConfig,
 		go func(sshConfig SSHConfig, srcFilePath string, destFileName string, removeFile bool, resultChan chan Result) {
 			rc := Result{sshConfig.HostIP, "", nil, destDir}
 
-			cmd := "sudo echo $HOME"
+			cmd := "sudo echo -n $HOME"
 			output, err := s.Execute(sshConfig, cmd)
 			if err != nil {
 				rc.Error = err


### PR DESCRIPTION
### :nut_and_bolt: Description: What code changed, and why?

Issues fixed:
- remove `cert-rotate` old cmd
- fix home path in verify. Automatically determines `$HOME `env, fallback to `/home/ssh-user` if `$HOME` not found or incorrect
- added maintenance mode status in `status summary` command
- Added airgap version for OS and PG in `chef-automate version` command

<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources

### :+1: Definition of Done

### :athletic_shoe: How to Build and Test the Change

### :white_check_mark: Checklist

**All PRs** must tick these:

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] All commits signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

With occasional exceptions, all PRs **from Progress employees** must tick these:

- [ ] Is the code clear? *(complicated code or lots of comments--subdivide and use well-named methods, meaningful variable names, etc.)*
- [ ] Consistency checked? *(user notifications, user prompts, visual patterns, code patterns, variable names)*
- [ ] Repeated code blocks eliminated? *(adapt and reuse existing components, blocks, functions, etc.)*
- [ ] Spelling, grammar, typos checked? *(at a minimum use `make spell` in any component directory)*
- [ ] Code well-formatted? *(indents, line breaks, etc. improve rather than hinder readability)*

All PRs **from Progress employees** should tick these if appropriate:

- [ ] Tests added/updated? (all new code needs new tests)
- [ ] Docs added/updated? (all customer-facing changes)

*Please add a note next to any checkbox above if you are NOT ticking it.*

### :camera: Screenshots, if applicable

Showing that custom home directory is supported now
<img width="1269" alt="Screenshot 2025-04-17 at 1 00 27 PM" src="https://github.com/user-attachments/assets/8ecd243f-b685-4638-8a5b-f08139cb9132" />

If version in backend is not latest or upgrade did not happen:
<img width="514" alt="Screenshot 2025-04-17 at 3 45 17 PM" src="https://github.com/user-attachments/assets/c26c4b40-986b-45ac-8695-b635a2e3a79d" />

If version of backend services match up with the deployed version:
<img width="514" alt="Screenshot 2025-04-17 at 6 01 19 PM" src="https://github.com/user-attachments/assets/dadb69aa-a948-4271-9a69-f44a582bd637" />

Maintenance mode in status summary command:
<img width="917" alt="Screenshot 2025-04-17 at 6 02 43 PM" src="https://github.com/user-attachments/assets/3f9a62d6-5415-4ff3-b7f6-b2894f0ebeca" />

