### PR TITLE
CHEF-29307 - - standardize - remove_sla_from_readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ For more information see:
 - Documentation: https://docs.chef.io/automate/
 - Release Notes: https://docs.chef.io/release_notes_automate/
 
-**Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
-
-**Issues Response Time Maximum**: 5 business days
-
-**Pull Request Response Time Maximum**: 5 business days
-
 ## Components
 
 Chef Automate is a collection of microservices.  Each service is


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.
This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).