### PR TITLE
Fix bifrost log rotation

### DIFF
--- a/components/automate-cs-oc-bifrost/habitat/config/sys.config
+++ b/components/automate-cs-oc-bifrost/habitat/config/sys.config
@@ -67,7 +67,7 @@
  {webmachine, [
           {log_handlers, [
                {oc_wm_request_logger, [
-                       {file, "{{pkg.svc_var_path}}/logs/crash.log"},
+                       {file, "{{pkg.svc_var_path}}/logs/requests.log"},
                        {file_size, {{cfg.log.rotation_max_megabytes}}},  %% Size in MB
                        {files, {{cfg.log.rotation_max_files}}},
                        {annotations, [requestor_id, created_authz_id, perf_stats, msg]}


### PR DESCRIPTION
Point the automate-cs-oc-bifrost request logger at requests.log instead of crash.log. Before this change, request logging was bound to the crash log basename, so the actively written file would move from crash.log to numbered files such as crash.log.0, crash.log.1, and crash.log.2 as wrap-mode rotation advanced. After this change, request traffic rotates correctly under the requests.log family, while crash reporting continues to write to the stable crash.log basename and rotates older crash output into numbered crash.log files.

```
# crash.log has the newest timestamp: 2026-04-03 16:26:28...
# The rotated files .0, .1, and .2 all have progressively older timestamps: 2026-04-03 10:31:26...
# After generating fresh crash traffic at about 16:26 UTC, only crash.log advanced in both size and mtime. 
# The rotated files crash.log.0, crash.log.1, and crash.log.2 remained unchanged at their earlier 10:31 UTC
# timestamps. Therefore the active crash writer is the basename crash.log, which is the correct behavior.

$ sudo ls -l --full-time /hab/svc/automate-cs-oc-bifrost/var/logs/crash*
-rw-r--r-- 1 hab hab 291672 2026-04-03 16:26:28.068311740 +0000 /hab/svc/automate-cs-oc-bifrost/var/logs/crash.log
-rw-r--r-- 1 hab hab 4520 2026-04-03 10:31:26.273068386 +0000 /hab/svc/automate-cs-oc-bifrost/var/logs/crash.log.0
-rw-r--r-- 1 hab hab 4520 2026-04-03 10:31:26.241084386 +0000 /hab/svc/automate-cs-oc-bifrost/var/logs/crash.log.1
-rw-r--r-- 1 hab hab 4520 2026-04-03 10:31:26.217096388 +0000 /hab/svc/automate-cs-oc-bifrost/var/logs/crash.log.2
```

demo video: https://teams.microsoft.com/l/meetingrecap?driveId=b%21MuY0fKglxUaqtdHzJVP2bTCzT6bbfGxMtMHNzRDahrXmbeT78YSaQ7DzLQM26ecg&driveItemId=013Y7R2A2TE7GRQ7ZSHVG3QDAZAL6CAYMS&sitePath=https%3A%2F%2Fprogresssoftware-my.sharepoint.com%2F%3Av%3A%2Fg%2Fpersonal%2Fsabaker_progress_com%2FIQBTJ80YfzI9TbgMGQL8IGGSAYuHSOOgqTUh_KA3fwRzXtw&fileUrl=https%3A%2F%2Fprogresssoftware-my.sharepoint.com%2Fpersonal%2Fsabaker_progress_com%2FDocuments%2FRecordings%2FMeeting+with+Lincoln+Baker-20260406_091119-Meeting+Recording.mp4%3Fweb%3D1&threadId=19%3Ameeting_ZjU5MDkxOTQtNWFlMC00ZGYzLWFmNTktY2M1Nzk1YTU5MjUy%40thread.v2&organizerId=c86f4c5c-51ae-486d-8080-2b1452156933&tenantId=db266a67-cbe0-4d26-ae1a-d0581fe03535&callId=552c4351-229d-45f3-a782-606d086dfe98&threadType=Meeting&meetingType=MeetNow&subType=RecapSharingLink_RecapCore