### PR TITLE
Fix 'occured' -> 'occurred' typos across automate-cli (6 files, 31 instances)

### DIFF
--- a/components/automate-cli/cmd/chef-automate/certRotate_test.go
+++ b/components/automate-cli/cmd/chef-automate/certRotate_test.go
@@ -2441,9 +2441,9 @@ func TestPatchConfig(t *testing.T) {
 			ExpectedError: "",
 		},
 		{
-			description: "Error occured while reading infra details on backend",
+			description: "Error occurred while reading infra details on backend",
 			param: &patchFnParameters{
-				sshUtil:       getMockSSHUtil(&SSHConfig{}, nil, "", errors.Errorf("Error occured while reading infra details")),
+				sshUtil:       getMockSSHUtil(&SSHConfig{}, nil, "", errors.Errorf("Error occurred while reading infra details")),
 				config:        TestOpensearchAdminAndRootCA,
 				fileName:      "cert-rotate-os.toml",
 				timestamp:     time.Now().Format("20060102150405"),
@@ -2456,7 +2456,7 @@ func TestPatchConfig(t *testing.T) {
 				skipIpsList: []string{},
 			},
 			isError:       true,
-			ExpectedError: "Error occured while reading infra details",
+			ExpectedError: "Error occurred while reading infra details",
 		},
 	}
 	for _, testCase := range testCases {

--- a/components/automate-cli/cmd/chef-automate/restart_test.go
+++ b/components/automate-cli/cmd/chef-automate/restart_test.go
@@ -151,7 +151,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 			}(),
 			mockRestartCmdHelper: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-					return nil, &SSHConfig{}, errors.New("Error occured while reading infra details")
+					return nil, &SSHConfig{}, errors.New("Error occurred while reading infra details")
 				},
 				isManagedServicesOnFunc: func() bool {
 					return false
@@ -168,7 +168,7 @@ func TestRunRestartFromBastion(t *testing.T) {
 					return map[string][]*CmdResult{}, nil
 				},
 			},
-			errorWant: errors.New("Error occured while reading infra details"),
+			errorWant: errors.New("Error occurred while reading infra details"),
 		},
 		{
 			description: "Restart all node-types",
@@ -194,11 +194,11 @@ func TestRunRestartFromBastion(t *testing.T) {
 			mockRestartCmdHelper: mockNodeUtils,
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
 				ExecuteWithNodeMapFunc: func(nodemap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
-					return map[string][]*CmdResult{}, errors.New("Some error occured while remote execution")
+					return map[string][]*CmdResult{}, errors.New("Some error occurred while remote execution")
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: errors.New("Some error occured while remote execution"),
+			errorWant: errors.New("Some error occurred while remote execution"),
 		},
 		{
 			description: "Restarting all services with managed Infra",

--- a/components/automate-cli/cmd/chef-automate/service_versions_test.go
+++ b/components/automate-cli/cmd/chef-automate/service_versions_test.go
@@ -27,10 +27,10 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 			flags:       &ServiceVersionsCmdFlags{},
 			mockNodeOpUtils: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-					return nil, nil, errors.New("Error occured while reading infra details")
+					return nil, nil, errors.New("Error occurred while reading infra details")
 				},
 			},
-			errorWant: errors.New("Error occured while reading infra details"),
+			errorWant: errors.New("Error occurred while reading infra details"),
 		},
 		{
 			description: "Want service-versions of all services",
@@ -106,7 +106,7 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 			errorWant: nil,
 		},
 		{
-			description: "Want service-versions of all services but error occured while remote execution",
+			description: "Want service-versions of all services but error occurred while remote execution",
 			flags: &ServiceVersionsCmdFlags{
 				automate:   true,
 				chefServer: true,
@@ -123,11 +123,11 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
 				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
-					return map[string][]*CmdResult{}, errors.New("Some error occured while remote execution")
+					return map[string][]*CmdResult{}, errors.New("Some error occurred while remote execution")
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: errors.New("Some error occured while remote execution"),
+			errorWant: errors.New("Some error occurred while remote execution"),
 		},
 		{
 			description: "Managed services and pg flag provided",
@@ -153,7 +153,7 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 			errorWant: status.Errorf(status.InvalidCommandArgsError, SERVICE_VERSIONS_ERROR_ON_SELF_MANAGED, POSTGRESQL),
 		},
 		{
-			description: "Want service-versions of all services but error occured while remote execution",
+			description: "Want service-versions of all services but error occurred while remote execution",
 			flags: &ServiceVersionsCmdFlags{
 				automate: true,
 			},
@@ -174,11 +174,11 @@ func TestRunServiceVersionsFromBastion(t *testing.T) {
 					}
 					return map[string][]*CmdResult{
 						"1": {cmdResultWithError},
-					}, errors.New("Some error occured while remote execution")
+					}, errors.New("Some error occurred while remote execution")
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: errors.New("Some error occured while remote execution"),
+			errorWant: errors.New("Some error occurred while remote execution"),
 		},
 		{
 			description: "Want service_versions of backend services with --accept-hab-license",

--- a/components/automate-cli/cmd/chef-automate/status_test.go
+++ b/components/automate-cli/cmd/chef-automate/status_test.go
@@ -191,10 +191,10 @@ func TestRunStatusFromBastion(t *testing.T) {
 			flags:       &StatusCmdFlags{},
 			mockNodeOpUtils: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
-					return nil, nil, errors.New("Error occured while reading infra details")
+					return nil, nil, errors.New("Error occurred while reading infra details")
 				},
 			},
-			errorWant: errors.New("Error occured while reading infra details"),
+			errorWant: errors.New("Error occurred while reading infra details"),
 		},
 		{
 			description: "Want status of all services",
@@ -216,7 +216,7 @@ func TestRunStatusFromBastion(t *testing.T) {
 			errorWant: nil,
 		},
 		{
-			description: "Want status of all services but error occured while remote execution",
+			description: "Want status of all services but error occurred while remote execution",
 			flags:       &StatusCmdFlags{},
 			mockNodeOpUtils: &MockNodeUtilsImpl{
 				getHaInfraDetailsfunc: func() (*AutomateHAInfraDetails, *SSHConfig, error) {
@@ -228,11 +228,11 @@ func TestRunStatusFromBastion(t *testing.T) {
 			},
 			mockRemoteCmdExec: &MockRemoteCmdExecutor{
 				ExecuteWithNodeMapFunc: func(nodeMap *NodeTypeAndCmd) (map[string][]*CmdResult, error) {
-					return map[string][]*CmdResult{}, errors.New("Some error occured while remote execution")
+					return map[string][]*CmdResult{}, errors.New("Some error occurred while remote execution")
 				},
 				SetWriterFunc: func(cli *cli.Writer) {},
 			},
-			errorWant: errors.New("Some error occured while remote execution"),
+			errorWant: errors.New("Some error occurred while remote execution"),
 		},
 		{
 			description: "Want status of all services with managed services",

--- a/components/automate-cli/pkg/verifyserver/services/systemresourceservice/systemresourcesservice.go
+++ b/components/automate-cli/pkg/verifyserver/services/systemresourceservice/systemresourcesservice.go
@@ -92,7 +92,7 @@ func (srs *SystemResourcesServiceImpl) CheckCpuSpeed() *models.Checks {
 	cpuSpeed, err := srs.SystemResourceInfo.GetCPUSpeed()
 
 	if err != nil {
-		srs.logger.Error("Error occured while getting cpu speed :", err)
+		srs.logger.Error("Error occurred while getting cpu speed :", err)
 		return srs.GetChecksModel(false, constants.CPU_SPEED_CHECK_TITLE, "", err.Error(), constants.RESOLUTION_MSG)
 	}
 	srs.logger.Debug("CPU speed is : ", cpuSpeed)
@@ -111,7 +111,7 @@ func (srs *SystemResourcesServiceImpl) CheckMemorySize() *models.Checks {
 	srs.logger.Debug("Current memory of system is :", memoryInGB)
 
 	if err != nil {
-		srs.logger.Error("Error occured while getting memory information : ", err.Error())
+		srs.logger.Error("Error occurred while getting memory information : ", err.Error())
 		return srs.GetChecksModel(false, constants.MEMORY_SIZE_CHECK_TITLE, "", err.Error(), constants.RESOLUTION_MSG)
 	}
 	srs.logger.Debugf("Current memory of system is :%vGB", memoryInGB)

--- a/components/automate-cli/pkg/verifyserver/services/systemresourceservice/systemresourcesservice_test.go
+++ b/components/automate-cli/pkg/verifyserver/services/systemresourceservice/systemresourcesservice_test.go
@@ -26,7 +26,7 @@ type testCase struct {
 }
 
 const (
-	DISK_SPACE_CALC_ERR = "error occured while fetching total and/or free disk space"
+	DISK_SPACE_CALC_ERR = "error occurred while fetching total and/or free disk space"
 )
 
 func TestGetCpuCountCheck(t *testing.T) {
@@ -87,10 +87,10 @@ func TestGetCpuSpeedCheck(t *testing.T) {
 		},
 		{
 			testCaseDescription: "System is not running on supported platform",
-			respWant:            srv.GetChecksModel(false, constants.CPU_SPEED_CHECK_TITLE, "", errors.New("error occured while fetching cpu speed").Error(), constants.RESOLUTION_MSG),
+			respWant:            srv.GetChecksModel(false, constants.CPU_SPEED_CHECK_TITLE, "", errors.New("error occurred while fetching cpu speed").Error(), constants.RESOLUTION_MSG),
 			mockSystemResource: &systemresource.MockSystemResourceInfoImpl{
 				GetCPUSpeedFunc: func() (float64, error) {
-					return 0, errors.New("error occured while fetching cpu speed")
+					return 0, errors.New("error occurred while fetching cpu speed")
 				},
 			},
 		},
@@ -129,10 +129,10 @@ func TestGetMemorySizeCheck(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Error while reading memory size",
-			respWant:            srv.GetChecksModel(false, constants.MEMORY_SIZE_CHECK_TITLE, "", "error occured while reading memory size", constants.RESOLUTION_MSG),
+			respWant:            srv.GetChecksModel(false, constants.MEMORY_SIZE_CHECK_TITLE, "", "error occurred while reading memory size", constants.RESOLUTION_MSG),
 			mockSystemResource: &systemresource.MockSystemResourceInfoImpl{
 				GetMemoryFunc: func() (float64, error) {
-					return float64(0), errors.New("error occured while reading memory size")
+					return float64(0), errors.New("error occurred while reading memory size")
 				},
 			},
 		},
@@ -217,10 +217,10 @@ func TestGetFreeDiskSpaceCheckOfDir(t *testing.T) {
 		},
 		{
 			testCaseDescription: "Checking free disk in /var/tmp | error",
-			respWant:            srv.GetChecksModel(false, fmt.Sprintf(constants.FREE_SPACE_CHECK, "Temp"), "", "error occured while fetching tmp disk space", constants.RESOLUTION_MSG),
+			respWant:            srv.GetChecksModel(false, fmt.Sprintf(constants.FREE_SPACE_CHECK, "Temp"), "", "error occurred while fetching tmp disk space", constants.RESOLUTION_MSG),
 			mockSystemResource: &systemresource.MockSystemResourceInfoImpl{
 				GetDiskSpaceInfoFunc: func(s string) (disk.UsageStat, error) {
-					return disk.UsageStat{}, errors.New("error occured while fetching tmp disk space")
+					return disk.UsageStat{}, errors.New("error occurred while fetching tmp disk space")
 				},
 			},
 			mockFileUtils: &fileutils.MockFileSystemUtils{
@@ -606,10 +606,10 @@ func TestGetHabFreeSpaceCheckPostDeployment(t *testing.T) {
 		{
 			testCaseDescription: "Post-deployment hab free space check | error case",
 			nodeType:            enums.NodeTypeAutomate,
-			respWant:            srv.GetChecksModel(false, fmt.Sprintf(constants.FREE_SPACE_CHECK, "Hab"), "", "error occured while fetching disk space info", constants.RESOLUTION_MSG),
+			respWant:            srv.GetChecksModel(false, fmt.Sprintf(constants.FREE_SPACE_CHECK, "Hab"), "", "error occurred while fetching disk space info", constants.RESOLUTION_MSG),
 			mockSystemResource: &systemresource.MockSystemResourceInfoImpl{
 				GetDiskSpaceInfoFunc: func(s string) (disk.UsageStat, error) {
-					return disk.UsageStat{}, errors.New("error occured while fetching disk space info")
+					return disk.UsageStat{}, errors.New("error occurred while fetching disk space info")
 				},
 			},
 			mockFileUtils: &fileutils.MockFileSystemUtils{


### PR DESCRIPTION
Fix 31 instances of `occured` → `occurred` across 6 files.

## Files

| File | Instances |
|------|-----------|
| `systemresourcesservice_test.go` | 9 |
| `service_versions_test.go` | 8 |
| `status_test.go` | 5 |
| `restart_test.go` | 4 |
| `certRotate_test.go` | 3 |
| `systemresourcesservice.go` | 2 |

Source file has 2 log strings; test files have independent assertion strings. All safely updated together.

Signed-off-by DCO.