### PR TITLE
Update legacy Chef download URLs to commercial endpoints in HA docs

### DIFF
--- a/components/docs-chef-io/content/automate/ha_common.md
+++ b/components/docs-chef-io/content/automate/ha_common.md
@@ -322,7 +322,7 @@ This section elaborates the validation procedure that checks the firewall rules 
 
 Follow these steps to examine the firewall rules are stateful, and ports are open before Chef Automate High Availability (HA) backend cluster deployment in air-gapped environment (means no access to the internet):
 
-1. Download hab, *hab-x86_64-linux.tar.gz* by executing the command, `sudo wget https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-linux.tar.gz`.
+1. Download hab, *hab-x86_64-linux.tar.gz* by executing the command, `sudo wget --content-disposition "https://chefdownload-commercial.chef.io/stable/habitat/download?p=linux&pv=&m=x86_64&license_id=<LICENSE_ID>"`. Replace `<LICENSE_ID>` with your Chef commercial license ID.
 
 1. Install hab package in your internet environment by executing the following commands that generate *netcate package*:
 

--- a/components/docs-chef-io/content/automate/node_integrations.md
+++ b/components/docs-chef-io/content/automate/node_integrations.md
@@ -124,7 +124,7 @@ When running in EC2, AWS has the ability to use the IAM role associated with you
 
 The `ssm` Scan Job:
 
-1. Installs the latest stable InSpec from `packages.chef.io`
+1. Installs the latest stable InSpec from `chefdownload-commercial.chef.io` (requires license_id parameter)
 1. Executes InSpec locally, providing InSpec with the `fqdn` of Chef Automate and a data collector token, so each instance reports directly back to Chef Automate
 
 Your Automate instance must be reachable (open to incoming traffic) from the instances being scanned in order for the SSM scanning to work. You can filter the instances to be scanned by specifying tag key/value matches or regions.


### PR DESCRIPTION
Updates `packages.chef.io` references to `chefdownload-commercial.chef.io` in HA documentation per the legacy endpoint migration.

## Changes
- **ha_common.md**: Updated habitat binary download URL to commercial endpoint with license_id parameter and customer instructions
- **node_integrations.md**: Updated InSpec reference to commercial endpoint with license requirement note

